### PR TITLE
Add local checks for count argument of CountDownLatch#trySetCount

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/countdownlatch/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/countdownlatch/CountDownLatchProxy.java
@@ -17,18 +17,18 @@
 package com.hazelcast.client.cp.internal.datastructures.countdownlatch;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CPGroupDestroyCPObjectCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchAwaitCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchCountDownCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchGetCountCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchGetRoundCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchTrySetCountCodec;
-import com.hazelcast.client.impl.protocol.codec.CPGroupDestroyCPObjectCodec;
 import com.hazelcast.client.impl.spi.ClientContext;
 import com.hazelcast.client.impl.spi.ClientProxy;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
-import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
 import com.hazelcast.internal.util.EmptyStatement;
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.UuidUtil.newUnsecureUUID;
 
 /**
@@ -102,6 +103,8 @@ public class CountDownLatchProxy extends ClientProxy implements ICountDownLatch 
 
     @Override
     public boolean trySetCount(int count) {
+        checkPositive(count, "Count must be positive!");
+
         ClientMessage request = CountDownLatchTrySetCountCodec.encodeRequest(groupId, objectName, count);
         ClientMessage response = new ClientInvocation(getClient(), request, name).invoke().joinInternal();
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/ICountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/ICountDownLatch.java
@@ -130,7 +130,7 @@ public interface ICountDownLatch extends DistributedObject {
      * @param count the number of times {@link #countDown} must be invoked
      *              before threads can pass through {@link #await}
      * @return {@code true} if the new count was set, {@code false} if the current count is not zero
-     * @throws IllegalArgumentException if {@code count} is negative
+     * @throws IllegalArgumentException if {@code count} is negative or zero
      */
     boolean trySetCount(int count);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/ISemaphore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/ISemaphore.java
@@ -131,6 +131,7 @@ public interface ISemaphore extends DistributedObject {
      *
      * @param permits the given permit count
      * @return true if initialization success. false if already initialized
+     * @throws IllegalArgumentException if {@code permits} is negative
      */
     boolean init(int permits);
 
@@ -187,7 +188,7 @@ public interface ISemaphore extends DistributedObject {
      *
      * @param permits the number of permits to acquire
      * @throws InterruptedException     if the current thread is interrupted
-     * @throws IllegalArgumentException if {@code permits} is negative
+     * @throws IllegalArgumentException if {@code permits} is negative or zero
      * @throws IllegalStateException    if hazelcast instance is shutdown while waiting
      */
     void acquire(int permits) throws InterruptedException;
@@ -271,7 +272,7 @@ public interface ISemaphore extends DistributedObject {
      * of a semaphore is established by programming convention in the application.
      *
      * @param permits the number of permits to release
-     * @throws IllegalArgumentException if {@code permits} is negative
+     * @throws IllegalArgumentException if {@code permits} is negative or zero
      * @throws IllegalStateException if the Semaphore is non-JDK-compatible
      *         and the caller does not have a permit
      */
@@ -378,7 +379,7 @@ public interface ISemaphore extends DistributedObject {
      * @return {@code true} if all permits were acquired,
      * {@code false} if the waiting time elapsed before all permits could be acquired
      * @throws InterruptedException     if the current thread is interrupted
-     * @throws IllegalArgumentException if {@code permits} is negative
+     * @throws IllegalArgumentException if {@code permits} is negative or zero
      * @throws IllegalStateException    if hazelcast instance is shutdown while waiting
      */
     boolean tryAcquire(int permits, long timeout, TimeUnit unit) throws InterruptedException;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatch.java
@@ -88,11 +88,11 @@ public class CountDownLatch extends BlockingResource<AwaitInvocationKey> impleme
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "'round' field is updated only by a single thread.")
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
     boolean trySetCount(int count) {
+        checkTrue(count > 0, "cannot set non-positive count: " + count);
+
         if (getRemainingCount() > 0) {
             return false;
         }
-
-        checkTrue(count > 0, "cannot set non-positive count: " + count);
 
         countDownFrom = count;
         round++;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/proxy/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/proxy/CountDownLatchProxy.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.UuidUtil.newUnsecureUUID;
 
 /**
@@ -76,6 +77,8 @@ public class CountDownLatchProxy implements ICountDownLatch {
 
     @Override
     public boolean trySetCount(int count) {
+        checkPositive(count, "Count must be positive!");
+
         return invocationManager.<Boolean>invoke(groupId, new TrySetCountOp(objectName, count)).joinInternal();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/AbstractCountDownLatchBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/AbstractCountDownLatchBasicTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractCountDownLatchBasicTest extends HazelcastRaftTestS
         latch.trySetCount(10);
 
         assertFalse(latch.trySetCount(20));
-        assertFalse(latch.trySetCount(0));
+        assertFalse(latch.trySetCount(1));
         assertEquals(10, latch.getCount());
     }
 
@@ -96,7 +96,7 @@ public abstract class AbstractCountDownLatchBasicTest extends HazelcastRaftTestS
 
         assertFalse(latch.trySetCount(20));
         assertFalse(latch.trySetCount(100));
-        assertFalse(latch.trySetCount(0));
+        assertFalse(latch.trySetCount(1));
         assertEquals(10, latch.getCount());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/AbstractCountDownLatchBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/AbstractCountDownLatchBasicTest.java
@@ -61,6 +61,11 @@ public abstract class AbstractCountDownLatchBasicTest extends HazelcastRaftTestS
         latch.trySetCount(-20);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testTrySetCount_whenArgumentZero() {
+        latch.trySetCount(0);
+    }
+
     @Test
     public void testTrySetCount_whenCountIsZero() {
         assertTrue(latch.trySetCount(40));


### PR DESCRIPTION
* `CountDownLatch#trySetCount` implementations were doing a remote call even when called with a non-positive `count`. This PR adds local checks to mitigate the problem
* Also improves javadoc consistency for some CP data structures