### PR TITLE
QueryUtils.createPartitionMap may throw NPE if a partition is not assigned

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlBackend.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlBackend.java
@@ -122,7 +122,7 @@ public class HazelcastSqlBackend implements SqlBackend {
 
         PlanCreateVisitor visitor = new PlanCreateVisitor(
             localMember.getUuid(),
-            QueryUtils.createPartitionMap(nodeEngine, localMember.getVersion()),
+            QueryUtils.createPartitionMap(nodeEngine, localMember.getVersion(), true),
             relIdMap,
             new PlanCacheKey(task.getSearchPaths(), sql),
             convertResult.getFieldNames(),

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -146,7 +146,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
         // Start query
         HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query());
-        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, error.getCode());
+        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION, error.getCode());
     }
 
     protected void checkMapDestroy(boolean useClient, boolean firstMember) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -100,7 +100,7 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
         HazelcastSqlException error = assertSqlException(instance1, query());
         assertTrue(
             "Error code: " + error.getCode(),
-            error.getCode() == SqlErrorCode.CONNECTION_PROBLEM || error.getCode() == SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED
+            error.getCode() == SqlErrorCode.CONNECTION_PROBLEM || error.getCode() == SqlErrorCode.PARTITION_DISTRIBUTION
         );
         assertEquals(instance1.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -195,7 +195,10 @@ public final class QueryUtils {
 
             if (owner == null) {
                 if (failOnUnassignedPartition) {
-                    throw QueryException.error("Partition is not assigned to any member: " + part.getPartitionId());
+                    throw QueryException.error(
+                        SqlErrorCode.PARTITION_DISTRIBUTION,
+                        "Partition is not assigned to any member: " + part.getPartitionId()
+                    ).withInvalidate();
                 } else {
                     continue;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryUtils.java
@@ -20,9 +20,9 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlColumnMetadata;
 import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.impl.schema.TableResolver;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.version.MemberVersion;
@@ -175,11 +175,14 @@ public final class QueryUtils {
      * @param nodeEngine node engine
      * @param localMemberVersion version of the local member. If any of partition owners have a different version, an exception
      *                           is thrown. The check is ignored if passed version is {@code null}
+     * @param failOnUnassignedPartition whether the call should fail in case an unassigned partition is found; when set to
+     *                                  {@code false} the missing partitions will not be included in the result
      * @return partition mapping
      */
     public static Map<UUID, PartitionIdSet> createPartitionMap(
         NodeEngine nodeEngine,
-        @Nullable MemberVersion localMemberVersion
+        @Nullable MemberVersion localMemberVersion,
+        boolean failOnUnassignedPartition
     ) {
         Collection<Partition> parts = nodeEngine.getHazelcastInstance().getPartitionService().getPartitions();
 
@@ -189,6 +192,14 @@ public final class QueryUtils {
 
         for (Partition part : parts) {
             Member owner = part.getOwner();
+
+            if (owner == null) {
+                if (failOnUnassignedPartition) {
+                    throw QueryException.error("Partition is not assigned to any member: " + part.getPartitionId());
+                } else {
+                    continue;
+                }
+            }
 
             if (localMemberVersion != null) {
                 if (!localMemberVersion.equals(owner.getVersion())) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlErrorCode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlErrorCode.java
@@ -32,8 +32,8 @@ public final class SqlErrorCode {
     /** Query was cancelled due to timeout. */
     public static final int TIMEOUT = 1004;
 
-    /** Partition distribution has changed. */
-    public static final int PARTITION_DISTRIBUTION_CHANGED = 1005;
+    /** A problem with partition distribution. */
+    public static final int PARTITION_DISTRIBUTION = 1005;
 
     /** An error caused by a concurrent destroy of a map. */
     public static final int MAP_DESTROYED = 1006;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -127,7 +127,7 @@ public abstract class AbstractMapScanExec extends AbstractExec {
         // Check for concurrent migration
         if (!validateMigrationStamp(migrationStamp)) {
             throw QueryException.error(
-                SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, "Map scan failed due to concurrent partition migration "
+                SqlErrorCode.PARTITION_DISTRIBUTION, "Map scan failed due to concurrent partition migration "
                 + "(result consistency cannot be guaranteed)"
             ).withInvalidate();
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -92,7 +92,7 @@ public class MapScanExecIterator implements KeyValueIterator {
 
                     if (!isOwned) {
                         throw QueryException.error(
-                            SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED,
+                            SqlErrorCode.PARTITION_DISTRIBUTION,
                             "Partition is not owned by member: " + nextPart
                         ).withInvalidate();
                     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PlanCacheChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PlanCacheChecker.java
@@ -65,7 +65,7 @@ public class PlanCacheChecker {
         }
 
         // Prepare partition distribution
-        Map<UUID, PartitionIdSet> partitions = QueryUtils.createPartitionMap(nodeEngine, null);
+        Map<UUID, PartitionIdSet> partitions = QueryUtils.createPartitionMap(nodeEngine, null, false);
 
         // Do check
         planCache.check(new PlanCheckContext(objectIds, partitions));

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryUtilsTest.java
@@ -51,7 +51,7 @@ public class QueryUtilsTest extends SqlTestSupport {
         String memberVersion = nodeEngine.getLocalMember().getVersion().toString();
 
         try {
-            QueryUtils.createPartitionMap(nodeEngine, new MemberVersion(0, 0, 0));
+            QueryUtils.createPartitionMap(nodeEngine, new MemberVersion(0, 0, 0), false);
 
             fail("Must fail");
         } catch (QueryException e) {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryUtilsTest.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.sql.impl;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -28,7 +30,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+import java.util.UUID;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -59,6 +65,33 @@ public class QueryUtilsTest extends SqlTestSupport {
             assertEquals("Cannot execute SQL query when members have different versions (make sure that all members "
                 + "have the same version) {localMemberId=" + memberId + ", localMemberVersion=0.0.0, remoteMemberId="
                 + memberId + ", remoteMemberVersion=" + memberVersion + "}", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUnassignedPartition_ignore() {
+        HazelcastInstance member = factory.newHazelcastInstance();
+
+        member.getCluster().changeClusterState(ClusterState.FROZEN);
+
+        Map<UUID, PartitionIdSet> map = QueryUtils.createPartitionMap(nodeEngine(member), null, false);
+
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testUnassignedPartition_exception() {
+        HazelcastInstance member = factory.newHazelcastInstance();
+
+        member.getCluster().changeClusterState(ClusterState.FROZEN);
+
+        try {
+            QueryUtils.createPartitionMap(nodeEngine(member), null, true);
+
+            fail("Must fail");
+        } catch (QueryException e) {
+            assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION, e.getCode());
+            assertTrue(e.getMessage(), e.getMessage().startsWith("Partition is not assigned to any member"));
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/MapScanExecTest.java
@@ -423,7 +423,7 @@ public class MapScanExecTest extends SqlTestSupport {
         );
 
         QueryException exception = assertThrows(QueryException.class, () -> exec.setup(emptyFragmentContext()));
-        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, exception.getCode());
+        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION, exception.getCode());
         assertTrue(exception.isInvalidatePlan());
     }
 
@@ -502,7 +502,7 @@ public class MapScanExecTest extends SqlTestSupport {
 
             // Try advance, should fail.
             QueryException exception = assertThrows(QueryException.class, exec::advance);
-            assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION_CHANGED, exception.getCode());
+            assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION, exception.getCode());
             assertTrue(exception.isInvalidatePlan());
         } finally {
             instance3.shutdown();


### PR DESCRIPTION
`QueryUtils.createPartitionMap` creates a map from member ID to owned partitions. This map is used in several parts of the SQL engine: to create the plan, and to invalidate obsolete plans.

Previously this method doesn't check the partition owner for `null`, so NPE could have been thrown from it. This NPE could lead to either user-facing exception, or kill the query checker thread completely, leading to query hangs in case of a concurrent kill of a member.

This PR fixes the problem making NPE impossible. Now, if the partition is not assigned, our reaction depends on the context - we either throw an exception if we cannot proceed (similarly to `Invocation.initInvocationTarget`), or ignore it.