### PR TITLE
Fix wrong codec in AtomicRefProxy client impl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/atomicref/AtomicRefProxy.java
@@ -135,7 +135,7 @@ public class AtomicRefProxy<T> extends ClientProxy implements IAtomicReference<T
         Data data = getContext().getSerializationService().toData(newValue);
         ClientMessage request = AtomicRefSetCodec.encodeRequest(groupId, objectName, data, false);
         ClientInvocationFuture future = new ClientInvocation(getClient(), request, name).invoke();
-        return new ClientDelegatingFuture<>(future, getSerializationService(), AtomicRefGetCodec::decodeResponse);
+        return new ClientDelegatingFuture<>(future, getSerializationService(), AtomicRefSetCodec::decodeResponse);
     }
 
     @Override
@@ -143,7 +143,7 @@ public class AtomicRefProxy<T> extends ClientProxy implements IAtomicReference<T
         Data data = getContext().getSerializationService().toData(newValue);
         ClientMessage request = AtomicRefSetCodec.encodeRequest(groupId, objectName, data, true);
         ClientInvocationFuture future = new ClientInvocation(getClient(), request, name).invoke();
-        return new ClientDelegatingFuture<>(future, getSerializationService(), AtomicRefGetCodec::decodeResponse);
+        return new ClientDelegatingFuture<>(future, getSerializationService(), AtomicRefSetCodec::decodeResponse);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomicref/AbstractAtomicRefBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomicref/AbstractAtomicRefBasicTest.java
@@ -96,6 +96,13 @@ public abstract class AbstractAtomicRefBasicTest extends HazelcastRaftTestSuppor
     }
 
     @Test
+    public void test_getAndSet() {
+        assertNull(atomicRef.getAndSet("str1"));
+        assertEquals("str1", atomicRef.getAndSet("str2"));
+        assertEquals("str2", atomicRef.get());
+    }
+
+    @Test
     public void test_setAsync() throws ExecutionException, InterruptedException {
         atomicRef.setAsync("str1").toCompletableFuture().get();
         assertEquals("str1", atomicRef.get());


### PR DESCRIPTION
* Fixes wrong codec in `AtomicRefProxy` client implementation
* Also adds dedicated test for `IAtomicReference#getAndSet`