### PR TITLE
Remove redundant session id check from session-aware Semaphores

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
@@ -243,10 +243,6 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
 
     private void doChangePermits(int delta) {
         long sessionId = sessionManager.acquireSession(groupId);
-        if (sessionId == NO_SESSION_ID) {
-            throw newIllegalStateException(null);
-        }
-
         long threadId = getThreadId();
         UUID invocationUid = newUnsecureUUID();
 


### PR DESCRIPTION
* Removes redundant `NO_SESSION_ID` check from session-aware Semaphores. This check seems to be redundant as the underlying `AbstractProxySessionManager#acquireSession` method never returns `NO_SESSION_ID`.
* Also simplifies member-side session-aware change permits methods