### PR TITLE
Use "default" when nearcache name is empty on client xml

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -277,6 +277,7 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleNearCacheNode(Node node) {
         String name = getName(node);
+        name = name == null ? "default" : name;
         NearCacheConfig nearCacheConfig = new NearCacheConfig(name);
         Boolean serializeKeys = null;
         for (Node child : childElements(node)) {

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -272,7 +272,7 @@
     <xs:complexType name="near-cache-client">
         <xs:complexContent>
             <xs:extension base="near-cache">
-                <xs:attribute name="name" use="required">
+                <xs:attribute name="name" use="optional" default="default">
                     <xs:simpleType>
                         <xs:restriction base="xs:string"/>
                     </xs:simpleType>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -550,7 +550,7 @@ hazelcast-client:
   #
   # Configuration element's name is "near-cache".
   # It has the following attribute:
-  #   - name: You can give a name for your Near Cache. It is optional and its default value is "default".
+  #   - name: You can give a name for your Near Cache. It is mandatory.
   #
   # It has the following sub-nodes:
   #   - "max-size":

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -224,6 +224,22 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         buildConfig(xml);
     }
 
+    @Test
+    public void testNearCacheDefaultName() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "  <near-cache>\n"
+                + "    <in-memory-format>NATIVE</in-memory-format>\n"
+                + "    <serialize-keys>false</serialize-keys>\n"
+                + "  </near-cache>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        ClientConfig clientConfig = buildConfig(xml);
+        NearCacheConfig ncConfig = clientConfig.getNearCacheConfig("default");
+
+        assertEquals(InMemoryFormat.NATIVE, ncConfig.getInMemoryFormat());
+        assertTrue(ncConfig.isSerializeKeys());
+    }
+
     @Override
     @Test
     public void testNearCacheInMemoryFormatNative_withKeysByReference() {


### PR DESCRIPTION
I have also checked yaml. It is not valid to give empty name
on yaml. So there is no change made for that.

fixes https://github.com/hazelcast/hazelcast/issues/16768