### PR TITLE
Improve performance of PartitionIdSet.equals

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/PartitionIdSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/PartitionIdSet.java
@@ -219,10 +219,6 @@ public class PartitionIdSet extends AbstractSet<Integer> {
             return false;
         }
 
-        if (!super.equals(o)) {
-            return false;
-        }
-
         PartitionIdSet other = (PartitionIdSet) o;
 
         return partitionCount == other.partitionCount && bitSet.equals(other.bitSet);


### PR DESCRIPTION
This PR removes an unnecessary call to the `super.equals` in the `equals` method. This redundant call caused performance degradation in the SQL engine that relies on partition IDs equality.