### PR TITLE
Do not create an exception object when closing the SQL result

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/AbstractSqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/AbstractSqlResult.java
@@ -20,18 +20,24 @@ import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class AbstractSqlResult implements SqlResult {
 
     public abstract QueryId getQueryId();
 
-    public abstract void closeOnError(QueryException exception);
+    /**
+     * Closes the result, releasing all the resources.
+     *
+     * @param exception exception that cause the close operation or {@code null} if the query is closed due to user request
+     */
+    public abstract void close(@Nullable QueryException exception);
 
     @Nonnull @Override
     public abstract ResultIterator<SqlRow> iterator();
 
     @Override
     public void close() {
-        closeOnError(QueryException.cancelledByUser());
+        close(null);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/AbstractSqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/AbstractSqlResult.java
@@ -29,7 +29,7 @@ public abstract class AbstractSqlResult implements SqlResult {
     /**
      * Closes the result, releasing all the resources.
      *
-     * @param exception exception that cause the close operation or {@code null} if the query is closed due to user request
+     * @param exception exception that caused the close operation or {@code null} if the query is closed due to user request
      */
     public abstract void close(@Nullable QueryException exception);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
@@ -95,7 +95,8 @@ public final class SqlResultImpl extends AbstractSqlResult {
         }
     }
 
-    public void closeOnError(QueryException error) {
+    @Override
+    public void close(@Nullable QueryException error) {
         if (state != null) {
             state.cancel(error);
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
@@ -159,7 +159,7 @@ public class QueryClientStateRegistry {
         for (QueryClientState victim : victims) {
             QueryException error = QueryException.clientMemberConnection(victim.getClientId());
 
-            victim.getSqlResult().closeOnError(error);
+            victim.getSqlResult().close(error);
 
             deleteClientCursor(victim);
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
@@ -25,6 +25,7 @@ import com.hazelcast.sql.impl.QueryResultProducer;
 import com.hazelcast.sql.impl.plan.cache.CachedPlanInvalidationCallback;
 import com.hazelcast.sql.impl.plan.Plan;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -189,10 +190,14 @@ public final class QueryState implements QueryStateCallback {
     }
 
     @Override
-    public void cancel(Exception error) {
+    public void cancel(@Nullable Exception error) {
         // Make sure that this thread changes the state.
         if (!completionGuard.compareAndSet(false, true)) {
             return;
+        }
+
+        if (error == null) {
+            error = QueryException.cancelledByUser();
         }
 
         QueryException error0 = prepareCancelError(error);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateCallback.java
@@ -28,7 +28,7 @@ public interface QueryStateCallback {
     /**
      * Cancel the query with error.
      *
-     * @param e Error.
+     * @param e error that caused the cancel, or {@code null} if cancellation is trigerred by the user request
      */
     void cancel(Exception e);
 


### PR DESCRIPTION
This PR introduces a minor performance improvement to the `SqlResult.close` routine. Previously we closed the SQL result by creating a specific `QueryException` upfront, even if the result set is fully consumed, and the result is already closed. After the fix, this exception is created only if the user calls `close` on the result set that is not closed yet. This brings marginal, but visible improvement to the SQL engine performance.