### PR TITLE
Use "smallInstanceConfig" in SqlErrorAbstractTest

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.sql.impl.SqlErrorCode;
@@ -51,6 +52,11 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
         client = null;
 
         factory.shutdownAll();
+    }
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
     }
 
     protected void checkTimeout(boolean useClient) {


### PR DESCRIPTION
This PR changes the config used in the child classes of the `SqlErrorAbstractTest` in the hope that it will eliminate (or minimize) the probability of the spurious failure in the https://github.com/hazelcast/hazelcast/issues/17504

Note that the root cause of the test failure is not known. Most likely this was some concurrent event on the client-side that caused an unexpected exception to happen (rather than an exception with the expected message). 

Closes https://github.com/hazelcast/hazelcast/issues/17504