### PR TITLE
Try load custom exceptions via class loader on client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -28,8 +28,8 @@ public class UndefinedErrorCodeException extends HazelcastException
 
     private final String className;
 
-    public UndefinedErrorCodeException(String message, String className) {
-        super("Class name: " + className + ", Message: " + message);
+    public UndefinedErrorCodeException(String message, String className, Throwable cause) {
+        super("Class name: " + className + ", Message: " + message, cause);
         this.className = className;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -20,8 +20,16 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.spi.impl.operationservice.WrappableException;
 
 /**
- * This exception is thrown when an exception that is coming from server is not recognized by the protocol.
- * Class name of the original exception is included in the exception
+ * This exception is thrown when an exception that is coming from server is not recognized by the protocol and
+ * it can not be constructed by the client via reflection.
+ * For the client to be able to recreate original exception it should be available on the classpath and
+ * it should have one of the following constructors publicly.
+ * new Throwable(String message, Throwable cause)
+ * new Throwable(Throwable cause)
+ * new Throwable(String message)
+ * new Throwable()
+ * <p>
+ * Class name of the original exception is included in the exception.
  */
 public class UndefinedErrorCodeException extends HazelcastException
         implements WrappableException<UndefinedErrorCodeException> {
@@ -36,6 +44,7 @@ public class UndefinedErrorCodeException extends HazelcastException
     /**
      * Construct a new {@code UndefinedErrorCodeException} with {@code other} as its
      * cause and {@code other}'s message.
+     *
      * @param other
      */
     private UndefinedErrorCodeException(UndefinedErrorCodeException other) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -47,7 +47,9 @@ import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.flakeidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.util.AddressUtil;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
@@ -208,8 +210,10 @@ import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.XA;
 public class ClientExceptionFactory {
 
     private final Map<Integer, ExceptionFactory> intToFactory = new HashMap<Integer, ExceptionFactory>();
+    private final ClassLoader classLoader;
 
-    public ClientExceptionFactory(boolean jcacheAvailable) {
+    public ClientExceptionFactory(boolean jcacheAvailable, ClassLoader classLoader) {
+        this.classLoader = classLoader;
         if (jcacheAvailable) {
             register(CACHE, CacheException.class, CacheException::new);
             register(CACHE_LOADER, CacheLoaderException.class, CacheLoaderException::new);
@@ -327,12 +331,32 @@ public class ClientExceptionFactory {
         ExceptionFactory exceptionFactory = intToFactory.get(errorHolder.getErrorCode());
         Throwable throwable;
         if (exceptionFactory == null) {
-            throwable = new UndefinedErrorCodeException(errorHolder.getMessage(), errorHolder.getClassName());
+            String className = errorHolder.getClassName();
+            assert checkClassNameForValidity(className) : "Exception should be defined in the protocol : " + className;
+            try {
+                Class<? extends Throwable> exceptionClass =
+                        (Class<? extends Throwable>) ClassLoaderUtil.loadClass(classLoader, className);
+                throwable = ExceptionUtil.tryCreateExceptionWithMessageAndCause(exceptionClass, errorHolder.getMessage(),
+                        createException(iterator));
+            } catch (Exception e) {
+                throwable = new UndefinedErrorCodeException(errorHolder.getMessage(), className, createException(iterator));
+            }
         } else {
             throwable = exceptionFactory.createException(errorHolder.getMessage(), createException(iterator));
         }
         throwable.setStackTrace(errorHolder.getStackTraceElements().toArray(new StackTraceElement[0]));
         return throwable;
+    }
+
+    /**
+     * hazelcast and jdk exceptions should always be defined
+     * in {@link com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes} and
+     * in {@link com.hazelcast.client.impl.clientside.ClientExceptionFactory}
+     * so that a well defined error code could be delivered to non-java clients.
+     * So we don't try to load them via ClassLoader to be able to catch the missing exceptions
+     */
+    private boolean checkClassNameForValidity(String exceptionClassName) {
+        return !exceptionClassName.startsWith("com.hazelcast") && !exceptionClassName.startsWith("java");
     }
 
     // method is used by Jet

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -793,7 +793,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private ClientExceptionFactory initClientExceptionFactory() {
         boolean jCacheAvailable = JCacheDetector.isJCacheAvailable(getClientConfig().getClassLoader());
-        return new ClientExceptionFactory(jCacheAvailable);
+        return new ClientExceptionFactory(jCacheAvailable, config.getClassLoader());
     }
 
     public ClientExceptionFactory getClientExceptionFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
@@ -45,13 +45,13 @@ import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.flakeidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
+import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.scheduledexecutor.DuplicateTaskException;
@@ -66,11 +66,11 @@ import com.hazelcast.spi.exception.ServiceNotFoundException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
-import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.wan.WanQueueFullException;
 
 import javax.cache.CacheException;
@@ -209,6 +209,11 @@ public class ClientExceptions {
         register(ClientProtocolErrorCodes.STALE_APPEND_REQUEST_EXCEPTION, StaleAppendRequestException.class);
         register(ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION, NotLeaderException.class);
         register(ClientProtocolErrorCodes.VERSION_MISMATCH_EXCEPTION, VersionMismatchException.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_METHOD_ERROR, NoSuchMethodError.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_METHOD_EXCEPTION, NoSuchMethodException.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_FIELD_ERROR, NoSuchFieldError.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_FIELD_EXCEPTION, NoSuchFieldException.class);
+        register(ClientProtocolErrorCodes.NO_CLASS_DEF_FOUND_ERROR, NoClassDefFoundError.class);
     }
 
     public ClientMessage createExceptionMessage(Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -212,7 +212,7 @@ public final class ExceptionUtil {
 
     /**
      * Tries to create the exception with appropriate constructor in the following order.
-     * In all cases the cause is set(via constructor or via initCause)
+     * In all cases the cause is set (via constructor or via {@code initCause})
      * new Throwable(String message, Throwable cause)
      * new Throwable(Throwable cause)
      * new Throwable(String message)
@@ -221,7 +221,7 @@ public final class ExceptionUtil {
      * @param exceptionClass class of the exception
      * @param message        message to be pass to constructor of the exception
      * @param cause          cause to be set to the exception
-     * @return null if can not find a constructor as described above, otherwise return newly constructed expcetion
+     * @return {@code null} if can not find a constructor as described above, otherwise returns newly constructed exception
      */
     public static <T extends Throwable> T tryCreateExceptionWithMessageAndCause(Class<? extends Throwable> exceptionClass,
                                                                                 String message, @Nullable Throwable cause) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -38,7 +38,6 @@ import java.util.function.BiFunction;
 public final class ExceptionUtil {
 
     private static final String EXCEPTION_SEPARATOR = "------ submitted from ------";
-
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
     // new Throwable(String message, Throwable cause)
     private static final MethodType MT_INIT_STRING_THROWABLE = MethodType.methodType(void.class, String.class, Throwable.class);
@@ -281,5 +280,4 @@ public final class ExceptionUtil {
         System.arraycopy(localSideStackTrace, 1, newStackTrace, remoteStackTrace.length + 1, localSideStackTrace.length - 1);
         return newStackTrace;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.protocol;
 
 import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.client.AuthenticationException;
-import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.config.InvalidConfigurationException;
@@ -125,16 +124,6 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
 
         if (expected == null || actual == null) {
             return false;
-        }
-
-        if (UndefinedErrorCodeException.class.equals(actual.getClass())) {
-            if (!expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
-                return false;
-            }
-        } else {
-            if (!expected.getClass().equals(actual.getClass())) {
-                return false;
-            }
         }
 
         // We compare the message only for known exceptions.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -34,13 +34,13 @@ import com.hazelcast.crdt.MutationDisallowedException;
 import com.hazelcast.crdt.TargetNotReplicaException;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
+import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.spi.exception.CallerNotMemberException;
@@ -52,6 +52,7 @@ import com.hazelcast.spi.exception.RetryableIOException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -60,7 +61,6 @@ import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
-import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.wan.WanQueueFullException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -69,6 +69,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+import testsubjects.CustomExceptions;
 
 import javax.cache.CacheException;
 import javax.cache.integration.CacheLoaderException;
@@ -104,7 +105,8 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
     public Throwable throwable;
 
     private ClientExceptions exceptions = new ClientExceptions(true);
-    private ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(true);
+    private ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(true,
+            Thread.currentThread().getContextClassLoader());
 
     @Test
     public void testException() {
@@ -125,21 +127,20 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
             return false;
         }
 
-        if (exceptions.isKnownClass(expected.getClass())) {
-            if (!expected.getClass().equals(actual.getClass())) {
-                return false;
-            }
-
-            // We compare the message only for known exceptions.
-            // We also ignore it for URISyntaxException, as it is not possible to restore it without special, probably JVM-version specific logic.
-            if (expected.getClass() != URISyntaxException.class && !equals(expected.getMessage(), actual.getMessage())) {
+        if (UndefinedErrorCodeException.class.equals(actual.getClass())) {
+            if (!expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
                 return false;
             }
         } else {
-            if (!UndefinedErrorCodeException.class.equals(actual.getClass())
-                    || !expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
+            if (!expected.getClass().equals(actual.getClass())) {
                 return false;
             }
+        }
+
+        // We compare the message only for known exceptions.
+        // We also ignore it for URISyntaxException, as it is not possible to restore it without special, probably JVM-version specific logic.
+        if (expected.getClass() != URISyntaxException.class && !equals(expected.getMessage(), actual.getMessage())) {
+            return false;
         }
 
         if (!stackTraceArrayEquals(expected.getStackTrace(), actual.getStackTrace())) {
@@ -261,8 +262,6 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new RuntimeException(new RuntimeException("blabla"))},
                 // exception with message and cause without message
                 new Object[]{new RuntimeException("blabla", new NullPointerException())},
-                // custom exception in causes
-                new Object[]{new RuntimeException("blabla", new DummyUncheckedHazelcastTestException())},
                 new Object[]{new RuntimeException("fun", new RuntimeException("codec \n is \n not \n pwned"))},
                 new Object[]{
                         new RuntimeException("fun",
@@ -272,7 +271,13 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new IndeterminateOperationStateException(randomString())},
                 new Object[]{new TargetNotReplicaException(randomString())},
                 new Object[]{new MutationDisallowedException(randomString())},
-                new Object[]{new ConsistencyLostException(randomString())}
+                new Object[]{new ConsistencyLostException(randomString())},
+                new Object[]{new CustomExceptions.CustomException()},
+                new Object[]{new CustomExceptions.CustomExceptionWithMessage(randomString())},
+                new Object[]{new CustomExceptions.CustomExceptionWithMessageAndCause(randomString(),
+                        new CustomExceptions.CustomExceptionWithMessage(randomString()))},
+                new Object[]{new CustomExceptions.CustomExceptionWithCause(new RuntimeException())},
+                new Object[]{new RuntimeException("blabla", new CustomExceptions.CustomExceptionWithMessage(randomString()))}
         );
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.impl.protocol;
 
+import com.hazelcast.client.UndefinedErrorCodeException;
+import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -23,6 +25,9 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import testsubjects.CustomExceptions;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -30,5 +35,16 @@ public class ClientProtocolErrorCodesTest extends HazelcastTestSupport {
     @Test
     public void testConstructor() {
         assertUtilityConstructor(ClientProtocolErrorCodes.class);
+    }
+
+    @Test
+    public void testUndefinedException() {
+        ClientExceptions exceptions = new ClientExceptions(false);
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(false, contextClassLoader);
+
+        ClientMessage message = exceptions.createExceptionMessage(new CustomExceptions.CustomExceptionNonStandardSignature(1));
+        Throwable resurrectedThrowable = exceptionFactory.createException(message);
+        assertEquals(UndefinedErrorCodeException.class, resurrectedThrowable.getClass());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.client.impl.protocol;
 
-import com.hazelcast.client.UndefinedErrorCodeException;
-import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -26,26 +24,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static junit.framework.TestCase.assertEquals;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientProtocolErrorCodesTest extends HazelcastTestSupport {
-
     @Test
     public void testConstructor() {
         assertUtilityConstructor(ClientProtocolErrorCodes.class);
-    }
-
-    @Test
-    public void testUndefinedException() {
-        ClientExceptions exceptions = new ClientExceptions(false);
-        ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(false);
-        class MyException extends Exception {
-        }
-
-        ClientMessage exceptionMessage = exceptions.createExceptionMessage(new MyException());
-        Throwable resurrectedThrowable = exceptionFactory.createException(exceptionMessage);
-        assertEquals(UndefinedErrorCodeException.class, resurrectedThrowable.getClass());
     }
 }

--- a/hazelcast/src/test/java/testsubjects/CustomExceptions.java
+++ b/hazelcast/src/test/java/testsubjects/CustomExceptions.java
@@ -41,4 +41,10 @@ public class CustomExceptions {
             super(cause);
         }
     }
+
+    public static class CustomExceptionNonStandardSignature extends Exception {
+        public CustomExceptionNonStandardSignature(int x) {
+            super();
+        }
+    }
 }

--- a/hazelcast/src/test/java/testsubjects/CustomExceptions.java
+++ b/hazelcast/src/test/java/testsubjects/CustomExceptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testsubjects;
+
+public class CustomExceptions {
+
+    public static class CustomException extends Exception {
+        public CustomException() {
+
+        }
+    }
+
+    public static class CustomExceptionWithMessage extends Exception {
+        public CustomExceptionWithMessage(String message) {
+            super(message);
+        }
+    }
+
+    public static class CustomExceptionWithMessageAndCause extends Exception {
+        public CustomExceptionWithMessageAndCause(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class CustomExceptionWithCause extends Exception {
+        public CustomExceptionWithCause(Throwable cause) {
+            super(cause);
+        }
+    }
+}


### PR DESCRIPTION
We are throwing UndefinedErrorCodeException if an exception is
not on the protocol list.

This causes poor experience as the behaviour is different between
the client and the member.

see  https://github.com/hazelcast/hazelcast/issues/9753

This pr does not introduce an ExceptionFactory API as discussed
on the issue.
The value of an ExceptionFactory API is debetable and left out
for now. If the client has the expcetion class on the classpath,
the client will create it. If it is not available on the classpath,
it is not clear what can a user do with ExceptionFactory API.
In that case, we are throwing UndefinedErrorCodeException as before.
The main problem seems to be the case where the client have the
exact same class on the classpath, so this fix should cover
most of the use cases.

fixes https://github.com/hazelcast/hazelcast/issues/9753