### PR TITLE
Fixes for issues in partitioning/migration system

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
@@ -195,6 +195,10 @@ public class MigrationInfo implements IdentifiedDataSerializable {
         throw new IllegalStateException("Initial partition version is not set!");
     }
 
+    public UUID getUid() {
+        return uuid;
+    }
+
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         UUIDSerializationUtil.writeUUID(out, uuid);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionMigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionMigrationEvent.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.partition;
 
+import java.util.UUID;
+
 /**
  * An {@link java.util.EventObject} for a partition migration. Can be used by SPI services to get a callback
  * to listen to partition migration.  See {@link MigrationAwareService} for more info.
@@ -30,12 +32,15 @@ public class PartitionMigrationEvent {
 
     private final int newReplicaIndex;
 
-    public PartitionMigrationEvent(MigrationEndpoint migrationEndpoint, int partitionId,
-            int currentReplicaIndex, int newReplicaIndex) {
+    private final UUID migrationUid;
+
+    public PartitionMigrationEvent(MigrationEndpoint migrationEndpoint, int partitionId, int currentReplicaIndex,
+            int newReplicaIndex, UUID migrationUid) {
         this.migrationEndpoint = migrationEndpoint;
         this.partitionId = partitionId;
         this.currentReplicaIndex = currentReplicaIndex;
         this.newReplicaIndex = newReplicaIndex;
+        this.migrationUid = migrationUid;
     }
 
     /**
@@ -74,6 +79,13 @@ public class PartitionMigrationEvent {
      */
     public int getNewReplicaIndex() {
         return newReplicaIndex;
+    }
+
+    /**
+     * Returns the uid of the specific migration.
+     */
+    public UUID getMigrationUid() {
+        return migrationUid;
     }
 
     @Override
@@ -116,6 +128,7 @@ public class PartitionMigrationEvent {
                 + ", partitionId=" + partitionId
                 + ", currentReplicaIndex=" + currentReplicaIndex
                 + ", newReplicaIndex=" + newReplicaIndex
+                + ", uuid=" + migrationUid
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -215,12 +215,13 @@ public class PartitionServiceProxy implements PartitionService {
         @Override
         public Member getOwner() {
             // triggers initial partition assignment
-            final Address address = partitionService.getPartitionOwner(partitionId);
-            if (address == null) {
+            InternalPartition partition = partitionService.getPartition(partitionId);
+            PartitionReplica owner = partition.getOwnerReplicaOrNull();
+            if (owner == null) {
                 return null;
             }
 
-            return nodeEngine.getClusterService().getMember(address);
+            return nodeEngine.getClusterService().getMember(owner.address(), owner.uuid());
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -79,6 +79,12 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
 
         PartitionReplicaManager replicaManager = partitionService.getReplicaManager();
         replicaManager.retainNamespaces(partitionId, namespaces);
+
+        ILogger logger = nodeEngine.getLogger(getClass());
+        if (logger.isFinestEnabled()) {
+            logger.finest("Retained namespaces for partitionId=" + partitionId + ". Service namespaces="
+                    + namespaces + ", retained namespaces=" + replicaManager.getNamespaces(partitionId));
+        }
         return replicaManager.getNamespaces(partitionId);
     }
 
@@ -94,10 +100,7 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
         for (ServiceNamespace ns : namespaces) {
             long[] versions = replicaManager.getPartitionReplicaVersions(partitionId, ns);
             long currentReplicaVersion = versions[replicaIndex - 1];
-
-            if (currentReplicaVersion > 0) {
-                versionMap.put(ns, currentReplicaVersion);
-            }
+            versionMap.put(ns, currentReplicaVersion);
         }
 
         boolean hasCallback = (callback != null);
@@ -105,6 +108,12 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
         PartitionBackupReplicaAntiEntropyOperation op = new PartitionBackupReplicaAntiEntropyOperation(versionMap, hasCallback);
         op.setPartitionId(partitionId).setReplicaIndex(replicaIndex).setServiceName(SERVICE_NAME);
         OperationService operationService = nodeEngine.getOperationService();
+
+        ILogger logger = nodeEngine.getLogger(getClass());
+        if (logger.isFinestEnabled()) {
+            logger.finest("Sending anti-entropy operation to " + target + " for partitionId=" + partitionId
+                    + ", replicaIndex=" + replicaIndex + ", namespaces=" + versionMap);
+        }
 
         if (hasCallback) {
             operationService.createInvocationBuilder(SERVICE_NAME, op, target.address())

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -780,8 +780,9 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
 
             if (newVersion < currentVersion) {
                 if (logger.isFinestEnabled()) {
-                    logger.finest("Already applied partition state change. Local version: " + currentVersion
-                            + ", Master version: " + newVersion + " Master: " + sender);
+                    logger.finest("Already applied partition update. partitionId=" + partitionId
+                            + ", local version: " + currentVersion
+                            + ", master version: " + newVersion + ", master: " + sender);
                 }
                 continue;
             } else if (newVersion == currentVersion) {
@@ -790,7 +791,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                              + ", Received: " + newPartition);
                 }
                 if (logger.isFinestEnabled()) {
-                    logger.finest("Already applied partition state change. Version: " + currentVersion + ", Master: " + sender);
+                    logger.finest("Already applied partition update. partitionId=" + partitionId
+                            + ", version: " + currentVersion + ", master: " + sender);
                 }
                 accepted = true;
                 continue;
@@ -1442,7 +1444,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             activeMigration.setStatus(migration.getStatus());
             migrationManager.finalizeMigration(migration);
             if (logger.isFineEnabled()) {
-                logger.fine("Committed " + migration + " on destination with partition state version: " + finalVersion);
+                logger.fine("Committed " + migration + " on destination with partition version: " + finalVersion);
             }
             return true;
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaFragmentVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaFragmentVersions.java
@@ -100,9 +100,7 @@ final class PartitionReplicaFragmentVersions {
     }
 
     void clear() {
-        for (int i = 0; i < versions.length; i++) {
-            versions[i] = 0;
-        }
+        Arrays.fill(versions, 0);
         dirty = false;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -491,13 +491,11 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
     }
 
     @Override
-    public Collection<ServiceNamespace> getNamespaces(
-            int partitionId) {
+    public Collection<ServiceNamespace> getNamespaces(int partitionId) {
         return replicaVersions[partitionId].getNamespaces();
     }
 
-    public void retainNamespaces(int partitionId, Collection<
-            ServiceNamespace> namespaces) {
+    public void retainNamespaces(int partitionId, Collection<ServiceNamespace> namespaces) {
         PartitionReplicaVersions versions = replicaVersions[partitionId];
         versions.retainNamespaces(namespaces);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.partition.impl;
 import com.hazelcast.internal.services.ServiceNamespace;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -90,7 +91,7 @@ final class PartitionReplicaVersions {
     }
 
     Collection<ServiceNamespace> getNamespaces() {
-        return fragmentVersionsMap.keySet();
+        return Collections.unmodifiableCollection(fragmentVersionsMap.keySet());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
@@ -39,7 +39,8 @@ abstract class AbstractPromotionOperation extends AbstractPartitionOperation
     }
 
     PartitionMigrationEvent getPartitionMigrationEvent() {
-        return new PartitionMigrationEvent(DESTINATION, getPartitionId(), migrationInfo.getDestinationCurrentReplicaIndex(), 0);
+        return new PartitionMigrationEvent(DESTINATION, getPartitionId(), migrationInfo.getDestinationCurrentReplicaIndex(),
+                0, migrationInfo.getUid());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -133,7 +133,8 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
                 endpoint == MigrationEndpoint.SOURCE
                         ? migrationInfo.getSourceCurrentReplicaIndex() : migrationInfo.getDestinationCurrentReplicaIndex(),
                 endpoint == MigrationEndpoint.SOURCE
-                        ? migrationInfo.getSourceNewReplicaIndex() : migrationInfo.getDestinationNewReplicaIndex());
+                        ? migrationInfo.getSourceNewReplicaIndex() : migrationInfo.getDestinationNewReplicaIndex(),
+                migrationInfo.getUid());
     }
 
     /** Updates the replica versions on the migration source if the replica index has changed. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -158,15 +158,13 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
                 replicaManager.setPartitionReplicaVersions(migrationInfo.getPartitionId(), namespace,
                                                            replicaVersions, replicaOffset);
                 if (logger.isFinestEnabled()) {
-                    logger.finest("ReplicaVersions are set after migration. partitionId="
-                            + migrationInfo.getPartitionId() + " namespace: " + namespace
-                            + " replicaVersions=" + Arrays.toString(replicaVersions));
+                    logger.finest("ReplicaVersions are set after migration. " + migrationInfo
+                            + ", namespace=" + namespace + ", replicaVersions=" + Arrays.toString(replicaVersions));
                 }
             }
 
         } else if (logger.isFinestEnabled()) {
-            logger.finest("ReplicaVersions are not set since migration failed. partitionId="
-                    + migrationInfo.getPartitionId());
+            logger.finest("ReplicaVersions are not set since migration failed. " + migrationInfo);
         }
     }
 
@@ -183,7 +181,7 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
     protected PartitionMigrationEvent getMigrationEvent() {
         return new PartitionMigrationEvent(MigrationEndpoint.DESTINATION,
                 migrationInfo.getPartitionId(), migrationInfo.getDestinationCurrentReplicaIndex(),
-                migrationInfo.getDestinationNewReplicaIndex());
+                migrationInfo.getDestinationNewReplicaIndex(), migrationInfo.getUid());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -243,7 +243,7 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
     protected PartitionMigrationEvent getMigrationEvent() {
         return new PartitionMigrationEvent(MigrationEndpoint.SOURCE,
                 migrationInfo.getPartitionId(), migrationInfo.getSourceCurrentReplicaIndex(),
-                migrationInfo.getSourceNewReplicaIndex());
+                migrationInfo.getSourceNewReplicaIndex(), migrationInfo.getUid());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -16,17 +16,20 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.PartitionReplica;
 import com.hazelcast.internal.partition.ReplicaErrorLogger;
+import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
+import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
-import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -63,8 +66,34 @@ public final class PartitionBackupReplicaAntiEntropyOperation
         int partitionId = getPartitionId();
         int replicaIndex = getReplicaIndex();
 
+        InternalPartitionImpl partition = partitionService.getPartitionStateManager().getPartitionImpl(partitionId);
+        int currentReplicaIndex = partition.getReplicaIndex(PartitionReplica.from(getNodeEngine().getLocalMember()));
+
+        ILogger logger = getLogger();
+        if (replicaIndex != currentReplicaIndex) {
+            logger.fine("Anti-entropy operation for partitionId=" + getPartitionId() + ", replicaIndex=" + getReplicaIndex()
+                    + " is received, but this node is not the expected backup replica!"
+                    + " Current replicaIndex=" + currentReplicaIndex);
+            response = false;
+            return;
+        }
+
+        Address ownerAddress = partition.getOwnerOrNull();
+        if (!getCallerAddress().equals(ownerAddress)) {
+            logger.fine("Anti-entropy operation for partitionId=" + getPartitionId() + ", replicaIndex=" + getReplicaIndex()
+                    + " is received from " + getCallerAddress() + ", but it's not the known primary replica owner: "
+                    + ownerAddress);
+            response = false;
+            return;
+        }
+
         PartitionReplicaManager replicaManager = partitionService.getReplicaManager();
         replicaManager.retainNamespaces(partitionId, versions.keySet());
+
+        if (logger.isFinestEnabled()) {
+            logger.finest("Retained namespaces for partitionId=" + partitionId + ", replicaIndex=" + replicaIndex
+                    + ". Namespaces=" + replicaManager.getNamespaces(partitionId));
+        }
 
         Iterator<Map.Entry<ServiceNamespace, Long>> iter = versions.entrySet().iterator();
         while (iter.hasNext()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -194,11 +194,16 @@ public final class SerializationUtil {
     }
 
     public static <K, V> void writeMap(@Nonnull Map<K, V> map, ObjectDataOutput out) throws IOException {
-        out.writeInt(map.size());
+        int size = map.size();
+        out.writeInt(size);
+
+        int k = 0;
         for (Map.Entry<K, V> entry : map.entrySet()) {
             out.writeObject(entry.getKey());
             out.writeObject(entry.getValue());
+            k++;
         }
+        assert size == k : "Map has been updated during serialization! Initial size: " + size + ", written size: " + k;
     }
 
     /**
@@ -277,10 +282,15 @@ public final class SerializationUtil {
      * @throws IOException when an error occurs while writing to the output
      */
     public static <T> void writeCollection(Collection<T> items, ObjectDataOutput out) throws IOException {
-        out.writeInt(items.size());
+        int size = items.size();
+        out.writeInt(size);
+
+        int k = 0;
         for (T item : items) {
             out.writeObject(item);
+            k++;
         }
+        assert size == k : "Collection has been updated during serialization! Initial size: " + size + ", written size: " + k;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
@@ -46,11 +46,8 @@ public class MigrationCorrectnessTest extends AbstractMigrationCorrectnessTest {
                 {1, 2, true},
                 {1, 2, false},
                 {2, 3, true},
-                // These variants are failing frequently.
-                // Ignored these below until we find the cause and fix.
-                // See https://github.com/hazelcast/hazelcast/issues/17377
-                // {3, 4, true},
-                // {3, 4, false},
+                {3, 4, true},
+                {3, 4, false},
         });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -326,8 +326,8 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
                     PartitionReplicaVersionsView backupReplicaVersionsView
                             = getPartitionReplicaVersionsView(backupNode, partitionId);
                     long[] backupReplicaVersions = backupReplicaVersionsView.getVersions(namespace);
-                    assertNotNull("Versions null on " + backupNode.address + ", partitionId: " + partitionId,
-                            backupReplicaVersions);
+                    assertNotNull(namespace + " replica versions are null on " + backupNode.address
+                                    + ", partitionId: " + partitionId + ", replicaIndex: " + replica, backupReplicaVersions);
 
                     for (int i = replica - 1; i < actualBackupCount; i++) {
                         assertEquals("Replica version mismatch! Owner: " + thisAddress + ", Backup: " + address

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestAbstractMigrationAwareService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestAbstractMigrationAwareService.java
@@ -42,7 +42,7 @@ public abstract class TestAbstractMigrationAwareService<N> implements ManagedSer
 
     public volatile int backupCount;
 
-    private volatile ILogger logger;
+    protected volatile ILogger logger;
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -39,6 +39,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Set;
+import java.util.UUID;
 
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.Accessors.getSerializationService;
@@ -101,7 +102,7 @@ public class QueryRunnerTest extends HazelcastTestSupport {
         map.addIndex(IndexType.HASH, "this");
         Predicate predicate = new EqualPredicate("this", value);
 
-        mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
+        mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1, UUID.randomUUID()));
 
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();
         QueryResult result = (QueryResult) queryRunner.runIndexOrPartitionScanQueryOnOwnedPartitions(query);
@@ -116,7 +117,8 @@ public class QueryRunnerTest extends HazelcastTestSupport {
             @Override
             public Set<QueryableEntry> filter(QueryContext queryContext) {
                 // start a new migration while executing an indexed query
-                mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
+                mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1,
+                        UUID.randomUUID()));
                 return super.filter(queryContext);
             }
         };
@@ -129,7 +131,7 @@ public class QueryRunnerTest extends HazelcastTestSupport {
     public void verifyFullScanFailureWhileMigrating() {
         Predicate predicate = new EqualPredicate("this", value);
 
-        mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
+        mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1, UUID.randomUUID()));
 
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();
         QueryResult result = (QueryResult) queryRunner.runIndexOrPartitionScanQueryOnOwnedPartitions(query);
@@ -142,7 +144,8 @@ public class QueryRunnerTest extends HazelcastTestSupport {
             @Override
             protected boolean applyForSingleAttributeValue(Comparable attributeValue) {
                 // start a new migration while executing a full scan
-                mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1));
+                mapService.beforeMigration(new PartitionMigrationEvent(MigrationEndpoint.SOURCE, partitionId, 0, 1,
+                        UUID.randomUUID()));
                 return super.applyForSingleAttributeValue(attributeValue);
             }
         };

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
 import static com.hazelcast.internal.partition.MigrationEndpoint.DESTINATION;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
@@ -49,7 +51,7 @@ public class RingbufferServiceTest extends HazelcastTestSupport {
     public void rollbackMigration() {
         Ringbuffer ringbuffer = hz.getRingbuffer("foo");
         int partitionId = getPartitionId(hz, ringbuffer.getName());
-        PartitionMigrationEvent partitionEvent = new PartitionMigrationEvent(DESTINATION, partitionId, -1, 0);
+        PartitionMigrationEvent partitionEvent = new PartitionMigrationEvent(DESTINATION, partitionId, -1, 0, UUID.randomUUID());
 
         service.rollbackMigration(partitionEvent);
 


### PR DESCRIPTION
- _Avoid duplicate migration finalization on former backup replica_:
Former backup owner does not participate in migration transaction, data always copied
from the primary replica. Former backup replica is notified after the migration is
committed on the destination. So in some cases, finalization operation for the same
migration can be scheduled multiple times. To fix that, we validate the migration
against the local partition table to determine whether migration is stale or not.

- Anti-entropy operation submitted to the backup replicas should verify the local
partition table whether the local member is the owner of the given replica and
sender is the primary replica of the partition. Normally this is verified
while processing backup replication operation. But a prior verification is needed
because otherwise it can cause removal of replica namespaces accidentally.

- Added more debug/trace logs.

- Also added an assertion to check whether a collection/map is modified while
serializing.

Fixes #17377
Fixes #17021
Fixes #8063