### PR TITLE
Fixes race during connection establishment

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -318,6 +318,7 @@ public class TcpServerConnection implements ServerConnection {
                 + ", endpoint=" + remoteAddress
                 + ", alive=" + alive
                 + ", connectionType=" + connectionType
+                + ", planeIndex=" + planeIndex
                 + "]";
     }
 }


### PR DESCRIPTION
`TcpServerConnection#planeIndex` is set after processing
the `MemberHandshake`. In case the connection is closed
quickly, the `planeIndex` may be left unset on the originating
member, resulting in that member not being able to
create a connection to the same remote address again
because the address is leftover in
`Plane#connectionsInProgress`.

See also https://github.com/hazelcast/hazelcast/issues/17238#issuecomment-694241589

Fixes #17238 