### PR TITLE
Improve connection close logic in HeartbeatManager

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
@@ -88,13 +88,16 @@ public class HeartbeatManager implements Runnable {
             if (connection.isAlive()) {
                 logger.warning("Heartbeat failed over the connection: " + connection);
                 onHeartbeatStopped(connection, "Heartbeat timed out");
+                return;
             }
         }
 
         if (now - connection.lastWriteTimeMillis() > heartbeatInterval) {
-            ClientMessage request = ClientPingCodec.encodeRequest();
-            ClientInvocation clientInvocation = new ClientInvocation(client, request, null, connection);
-            clientInvocation.invokeUrgent();
+            if (connection.isAlive()) {
+                ClientMessage request = ClientPingCodec.encodeRequest();
+                ClientInvocation clientInvocation = new ClientInvocation(client, request, null, connection);
+                clientInvocation.invokeUrgent();
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
@@ -85,19 +85,15 @@ public class HeartbeatManager implements Runnable {
         }
 
         if (now - connection.lastReadTimeMillis() > heartbeatTimeout) {
-            if (connection.isAlive()) {
-                logger.warning("Heartbeat failed over the connection: " + connection);
-                onHeartbeatStopped(connection, "Heartbeat timed out");
-                return;
-            }
+            logger.warning("Heartbeat failed over the connection: " + connection);
+            onHeartbeatStopped(connection, "Heartbeat timed out");
+            return;
         }
 
         if (now - connection.lastWriteTimeMillis() > heartbeatInterval) {
-            if (connection.isAlive()) {
-                ClientMessage request = ClientPingCodec.encodeRequest();
-                ClientInvocation clientInvocation = new ClientInvocation(client, request, null, connection);
-                clientInvocation.invokeUrgent();
-            }
+            ClientMessage request = ClientPingCodec.encodeRequest();
+            ClientInvocation clientInvocation = new ClientInvocation(client, request, null, connection);
+            clientInvocation.invokeUrgent();
         }
     }
 


### PR DESCRIPTION
* `HeartbeatManager#checkConnection` could try to send ping message over a connection which it closed in `#onHeartbeatStopped` method. This PR fixes the logic by adding an early `return`
* Also gets rid of redundant `connection.isAlive()` check