### PR TITLE
Fix SqlIntegrationTestSuite

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlIntegrationTestSuite.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlIntegrationTestSuite.java
@@ -16,7 +16,12 @@
 
 package com.hazelcast.sql;
 
+import com.googlecode.junittoolbox.ExcludeCategories;
+import com.googlecode.junittoolbox.IncludeCategories;
 import com.googlecode.junittoolbox.WildcardPatternSuite;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.runner.RunWith;
 
 /**
@@ -25,5 +30,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(WildcardPatternSuite.class)
 @com.googlecode.junittoolbox.SuiteClasses("**/*Test.class")
+@IncludeCategories(QuickTest.class)
+@ExcludeCategories({SlowTest.class, NightlyTest.class})
 public class SqlIntegrationTestSuite {
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlTestInstanceFactory.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlTestInstanceFactory.java
@@ -118,7 +118,7 @@ public abstract class SqlTestInstanceFactory {
                 if (clientConfig != null) {
                     clientConfig.setClusterName("jet");
                 }
-                Object jetInstance = jetFactory.getClass().getMethod("newClient", clientConfig.getClass())
+                Object jetInstance = jetFactory.getClass().getMethod("newClient", ClientConfig.class)
                                                .invoke(jetFactory, clientConfig);
                 return (HazelcastInstance) jetInstance.getClass().getMethod("getHazelcastInstance").invoke(jetInstance);
             } catch (Exception e) {


### PR DESCRIPTION
The included and excluded categories copy those from the default surefire configuration.