### PR TITLE
Fix ChangeLoggingRule

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
@@ -31,7 +31,7 @@ public class Log4j2Factory extends LoggerFactorySupport {
     private static final String FQCN = Log4j2Logger.class.getName();
 
     protected ILogger createLogger(String name) {
-        return new Log4j2Logger(LogManager.getContext().getLogger(name));
+        return new Log4j2Logger(LogManager.getContext(false).getLogger(name));
     }
 
     @PrivateApi


### PR DESCRIPTION
`ChangeLoggingRule` is not working after latest changes. 

__Modifications__:
Set `currentContext` parameter to false when creating `Log4j2Logger`.
When it is true LogManager#getContext may not return the correct LoggerContext
which was used to create a Logger for the calling class. This warning is from the method's javaDoc:

```
WARNING - The LoggerContext returned by this method may not be the LoggerContext used to create a 
Logger for the calling class.
```
