### PR TITLE
Try context classloader even the classname starts with 'com.hazelcast'

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -246,10 +246,7 @@ public final class ClassLoaderUtil {
         // Try to load it using context class loader if not null
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         if (contextClassLoader != null) {
-            try {
-                return tryLoadClass(className, contextClassLoader);
-            } catch (ClassNotFoundException ignore) {
-            }
+            return tryLoadClass(className, contextClassLoader);
         }
         return Class.forName(className);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -225,19 +225,20 @@ public final class ClassLoaderUtil {
         if (primitiveClass != null) {
             return primitiveClass;
         }
-        // If this is a Hazelcast class, try to load it using our classloader first
-        ClassLoader theClassLoader = ClassLoaderUtil.class.getClassLoader();
-        if (theClassLoader != null && belongsToHazelcastPackage(className)) {
-            try {
-                return tryLoadClass(className, ClassLoaderUtil.class.getClassLoader());
-            } catch (ClassNotFoundException ignore) {
-            }
-        }
 
         // Try to load it using the hinted classloader if not null
         if (classLoaderHint != null) {
             try {
                 return tryLoadClass(className, classLoaderHint);
+            } catch (ClassNotFoundException ignore) {
+            }
+        }
+
+        // If this is a Hazelcast class, try to load it using our classloader
+        ClassLoader theClassLoader = ClassLoaderUtil.class.getClassLoader();
+        if (theClassLoader != null && belongsToHazelcastPackage(className)) {
+            try {
+                return tryLoadClass(className, ClassLoaderUtil.class.getClassLoader());
             } catch (ClassNotFoundException ignore) {
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -226,7 +226,8 @@ public final class ClassLoaderUtil {
             return primitiveClass;
         }
         // If this is a Hazelcast class, try to load it using our classloader first
-        if (className.startsWith(HAZELCAST_BASE_PACKAGE) || className.startsWith(HAZELCAST_ARRAY)) {
+        ClassLoader theClassLoader = ClassLoaderUtil.class.getClassLoader();
+        if (theClassLoader != null && belongsToHazelcastPackage(className)) {
             try {
                 return tryLoadClass(className, ClassLoaderUtil.class.getClassLoader());
             } catch (ClassNotFoundException ignore) {
@@ -250,6 +251,10 @@ public final class ClassLoaderUtil {
             }
         }
         return Class.forName(className);
+    }
+
+    private static boolean belongsToHazelcastPackage(String className) {
+        return className.startsWith(HAZELCAST_BASE_PACKAGE) || className.startsWith(HAZELCAST_ARRAY);
     }
 
     private static Class<?> tryPrimitiveClass(String className) {


### PR DESCRIPTION
Current behavior: 

If hinted classloader is not null (for example `UserCodeDeploymentClassLoader`)
we first try to load the class using hinted classloader. If it fails and the classname
starts with `com.hazelcast` we try to load it using our classloader. If that fails too
(means this is not one of our classes but belongs to user) we don't try to load it
using the context classloader (for example JetClassloader).

The new desired behaviour:

After trying to load the class using hinted classloader, try our classloader if the
classname starts with `com.hazelcast`. And then try to load the class using context
classloader.


fixes https://github.com/hazelcast/hazelcast-jet/issues/2392
