### PR TITLE
Fixes InternalPartitionImplConstructor for 4.0

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/InternalPartitionImplConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/InternalPartitionImplConstructor.java
@@ -45,7 +45,13 @@ public class InternalPartitionImplConstructor extends AbstractStarterObjectConst
         Integer partitionId = getFieldValueReflectively(delegate, "partitionId");
         Object interceptor = getFieldValueReflectively(delegate, "interceptor");
         Object localReplica = getFieldValueReflectively(delegate, "localReplica");
-        Integer version = getFieldValueReflectively(delegate, "version");
+        // RU_COMPAT_4_0: no field InternalPartitionImpl#version in 4.0
+        Integer version = 0;
+        try {
+            version = getFieldValueReflectively(delegate, "version");
+        } catch (NoSuchFieldError e) {
+            // ignore
+        }
         Object replicas = getFieldValueReflectively(delegate, "replicas");
 
         Object[] args = new Object[] {partitionId, localReplica, replicas, version, interceptor};


### PR DESCRIPTION
When cloning an `InternalPartitionImpl` instance
from a 4.0 source HZ instance, there is no `version`
field -> `getFieldValueReflectively` fails.

Fixes EE-side compatibility tests like [`HDCacheSplitBrainCompatibilityTest`](http://jenkins.hazelcast.com/job/Hazelcast-EE-4.master-compatibility/134/testReport/com.hazelcast.cache.merge/HDCacheSplitBrainCompatibilityTest/testSplitBrain_format_NATIVE__mergePolicy_class_com_hazelcast_spi_merge_DiscardMergePolicy_/) currently failing with:

```
java.lang.NoSuchFieldError: 
Field version does not exist on object Partition [0]{
}
	at com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively(ReflectionUtils.java:140)
	at com.hazelcast.test.starter.constructor.InternalPartitionImplConstructor.createNew0(InternalPartitionImplConstructor.java:48)
	at com.hazelcast.test.starter.constructor.AbstractStarterObjectConstructor.createNew(AbstractStarterObjectConstructor.java:49)
	at com.hazelcast.test.starter.HazelcastProxyFactory.construct(HazelcastProxyFactory.java:307)
...
```