### PR TITLE
SqlErrorAbstractTest should wait for partition assignment

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.sql;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.partition.Partition;
+import com.hazelcast.partition.PartitionService;
 import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.exec.BlockingExec;
@@ -29,9 +32,13 @@ import org.junit.After;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
@@ -65,8 +72,8 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected void checkTimeout(boolean useClient, int dataSetSize) {
         // Start two instances and fill them with data
-        instance1 = factory.newHazelcastInstance();
-        instance2 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(false);
+        instance2 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1, dataSetSize);
@@ -93,8 +100,8 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected void checkExecutionError(boolean useClient, boolean fromFirstMember) {
         // Start two instances and fill them with data
-        instance1 = factory.newHazelcastInstance();
-        instance2 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(false);
+        instance2 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1);
@@ -123,7 +130,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected void checkMapMigration(boolean useClient) {
         // Start one instance and fill it with data
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1);
@@ -144,7 +151,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
             try {
                 blocker.awaitReached();
 
-                factory.newHazelcastInstance();
+                newHazelcastInstance(true);
             } finally {
                 blocker.unblockAfter(2000);
             }
@@ -157,8 +164,8 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected void checkMapDestroy(boolean useClient, boolean firstMember) {
         // Start two instances and fill them with data
-        instance1 = factory.newHazelcastInstance();
-        instance2 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(false);
+        instance2 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1);
@@ -194,8 +201,8 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected void checkDataTypeMismatch(boolean useClient) {
         // Start two instances and fill them with data
-        instance1 = factory.newHazelcastInstance();
-        instance2 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(false);
+        instance2 = newHazelcastInstance(true);
         client = newClient();
 
         IMap<Long, Object> map = instance1.getMap(MAP_NAME);
@@ -218,7 +225,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
     }
 
     protected void checkParsingError(boolean useClient) {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         IMap<Long, Long> map = instance1.getMap(MAP_NAME);
@@ -232,7 +239,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     @SuppressWarnings("StatementWithEmptyBody")
     protected void checkUserCancel(boolean useClient) {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         IMap<Long, Long> map = instance1.getMap(MAP_NAME);
@@ -312,5 +319,44 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected static void assertErrorCode(int expected, HazelcastSqlException error) {
         assertEquals(error.getCode() + ": " + error.getMessage(), expected, error.getCode());
+    }
+
+    /**
+     * Start the new Hazelcast instance.
+     *
+     * @param awaitAssignment whether to wait for a partition assignment to a new member
+     * @return created instance
+     */
+    protected HazelcastInstance newHazelcastInstance(boolean awaitAssignment) {
+        HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
+
+        assertTrueEventually(() -> {
+            Set<UUID> memberIds = new HashSet<>();
+
+            for (Member member : instance.getCluster().getMembers()) {
+                memberIds.add(member.getUuid());
+            }
+
+            PartitionService partitionService = instance.getPartitionService();
+
+            Set<UUID> assignedMemberIds = new HashSet<>();
+
+            for (Partition partition : partitionService.getPartitions()) {
+                Member owner = partition.getOwner();
+
+                assertNotNull(partition.getOwner());
+
+                assignedMemberIds.add(owner.getUuid());
+            }
+
+            assertEquals(memberIds, assignedMemberIds);
+        });
+
+
+        if (awaitAssignment) {
+            instance.getCluster().getMembers();
+        }
+
+        return instance;
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -85,7 +85,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
         // Execute query on the instance1.
         try {
             HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query().setTimeoutMillis(100L));
-            assertEquals(SqlErrorCode.TIMEOUT, error.getCode());
+            assertErrorCode(SqlErrorCode.TIMEOUT, error);
         } finally {
             blocker.unblock();
         }
@@ -116,7 +116,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
         // Execute query.
         HazelcastSqlException error = assertSqlException(target, query());
 
-        assertEquals(SqlErrorCode.GENERIC, error.getCode());
+        assertErrorCode(SqlErrorCode.GENERIC, error);
         assertEquals(member.getLocalEndpoint().getUuid(), error.getOriginatingMemberId());
         assertTrue(error.getMessage().contains(errorMessage));
     }
@@ -152,7 +152,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
         // Start query
         HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query());
-        assertEquals(SqlErrorCode.PARTITION_DISTRIBUTION, error.getCode());
+        assertErrorCode(SqlErrorCode.PARTITION_DISTRIBUTION, error);
     }
 
     protected void checkMapDestroy(boolean useClient, boolean firstMember) {
@@ -189,7 +189,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
         // Start query
         HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query());
-        assertEquals(SqlErrorCode.MAP_DESTROYED, error.getCode());
+        assertErrorCode(SqlErrorCode.MAP_DESTROYED, error);
     }
 
     protected void checkDataTypeMismatch(boolean useClient) {
@@ -209,7 +209,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
         // Execute query.
         HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query());
 
-        assertEquals(SqlErrorCode.DATA_EXCEPTION, error.getCode());
+        assertErrorCode(SqlErrorCode.DATA_EXCEPTION, error);
         assertEquals(
             "Failed to extract map entry value because of type mismatch "
                 + "[expectedClass=java.lang.Long, actualClass=java.lang.String]",
@@ -227,7 +227,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
         HazelcastInstance target = useClient ? client : instance1;
 
         HazelcastSqlException error = assertSqlException(target, new SqlStatement("SELECT bad_field FROM " + MAP_NAME));
-        assertEquals(SqlErrorCode.PARSING, error.getCode());
+        assertErrorCode(SqlErrorCode.PARSING, error);
     }
 
     @SuppressWarnings("StatementWithEmptyBody")
@@ -251,7 +251,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
                 fail("Exception is not thrown");
             } catch (HazelcastSqlException e) {
-                assertEquals(SqlErrorCode.CANCELLED_BY_USER, e.getCode());
+                assertErrorCode(SqlErrorCode.CANCELLED_BY_USER, e);
             }
         }
     }
@@ -308,5 +308,9 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
 
     protected ClientConfig clientConfig() {
         return new ClientConfig();
+    }
+
+    protected static void assertErrorCode(int expected, HazelcastSqlException error) {
+        assertEquals(error.getCode() + ": " + error.getMessage(), expected, error.getCode());
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -330,31 +330,28 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
     protected HazelcastInstance newHazelcastInstance(boolean awaitAssignment) {
         HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
 
-        assertTrueEventually(() -> {
-            Set<UUID> memberIds = new HashSet<>();
-
-            for (Member member : instance.getCluster().getMembers()) {
-                memberIds.add(member.getUuid());
-            }
-
-            PartitionService partitionService = instance.getPartitionService();
-
-            Set<UUID> assignedMemberIds = new HashSet<>();
-
-            for (Partition partition : partitionService.getPartitions()) {
-                Member owner = partition.getOwner();
-
-                assertNotNull(partition.getOwner());
-
-                assignedMemberIds.add(owner.getUuid());
-            }
-
-            assertEquals(memberIds, assignedMemberIds);
-        });
-
-
         if (awaitAssignment) {
-            instance.getCluster().getMembers();
+            assertTrueEventually(() -> {
+                Set<UUID> memberIds = new HashSet<>();
+
+                for (Member member : instance.getCluster().getMembers()) {
+                    memberIds.add(member.getUuid());
+                }
+
+                PartitionService partitionService = instance.getPartitionService();
+
+                Set<UUID> assignedMemberIds = new HashSet<>();
+
+                for (Partition partition : partitionService.getPartitions()) {
+                    Member owner = partition.getOwner();
+
+                    assertNotNull(partition.getOwner());
+
+                    assignedMemberIds.add(owner.getUuid());
+                }
+
+                assertEquals(memberIds, assignedMemberIds);
+            });
         }
 
         return instance;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorClientTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorClientTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.sql.impl.client.SqlClientService;
 import com.hazelcast.sql.impl.state.QueryClientStateRegistry;
 import com.hazelcast.sql.impl.exec.BlockingExec;
 import com.hazelcast.sql.impl.exec.scan.MapScanExec;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -52,7 +52,7 @@ import static org.junit.runners.Parameterized.UseParametersRunnerFactory;
  * Test for different error conditions (client).
  */
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
@@ -123,7 +123,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
         client = factory.newHazelcastClient(null);
 
         HazelcastSqlException error = assertSqlException(client, query());
-        assertEquals(SqlErrorCode.CONNECTION_PROBLEM, error.getCode());
+        assertErrorCode(SqlErrorCode.CONNECTION_PROBLEM, error);
         assertEquals("Client must be connected to at least one data member to execute SQL queries", error.getMessage());
     }
 
@@ -168,7 +168,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
         }).start();
 
         HazelcastSqlException error = assertSqlException(client, query());
-        assertEquals(SqlErrorCode.CONNECTION_PROBLEM, error.getCode());
+        assertErrorCode(SqlErrorCode.CONNECTION_PROBLEM, error);
     }
 
     @Test
@@ -193,7 +193,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
             fail("Should fail");
         } catch (HazelcastSqlException e) {
-            assertEquals(SqlErrorCode.CONNECTION_PROBLEM, e.getCode());
+            assertErrorCode(SqlErrorCode.CONNECTION_PROBLEM, e);
         }
     }
 
@@ -213,7 +213,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
             fail("Should fail");
         } catch (HazelcastSqlException e) {
-            assertEquals(SqlErrorCode.CONNECTION_PROBLEM, e.getCode());
+            assertErrorCode(SqlErrorCode.CONNECTION_PROBLEM, e);
         }
     }
 
@@ -253,7 +253,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
         SqlStatement query = new SqlStatement("SELECT * FROM map").addParameter(new BadParameter(true, false));
 
         HazelcastSqlException error = assertSqlException(client, query);
-        assertEquals(SqlErrorCode.GENERIC, error.getCode());
+        assertErrorCode(SqlErrorCode.GENERIC, error);
         assertTrue(error.getMessage().contains("Failed to serialize query parameter"));
     }
 
@@ -265,7 +265,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
         SqlStatement query = new SqlStatement("SELECT * FROM map").addParameter(new BadParameter(false, true));
 
         HazelcastSqlException error = assertSqlException(client, query);
-        assertEquals(SqlErrorCode.GENERIC, error.getCode());
+        assertErrorCode(SqlErrorCode.GENERIC, error);
         assertTrue(error.getMessage().contains("Read error"));
     }
 
@@ -297,7 +297,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
                 fail("Should fail");
             } catch (HazelcastSqlException e) {
-                assertEquals(SqlErrorCode.GENERIC, e.getCode());
+                assertErrorCode(SqlErrorCode.GENERIC, e);
                 assertEquals(client.getLocalEndpoint().getUuid(), e.getOriginatingMemberId());
                 assertTrue(e.getMessage().contains("Failed to deserialize query result value"));
             }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorClientTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorClientTest.java
@@ -23,9 +23,9 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.client.SqlClientService;
-import com.hazelcast.sql.impl.state.QueryClientStateRegistry;
 import com.hazelcast.sql.impl.exec.BlockingExec;
 import com.hazelcast.sql.impl.exec.scan.MapScanExec;
+import com.hazelcast.sql.impl.state.QueryClientStateRegistry;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -142,7 +142,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
      */
     @Test
     public void testMemberDisconnect_execute() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1);
@@ -173,7 +173,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
     @Test
     public void testMemberDisconnect_fetch() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1, SqlStatement.DEFAULT_CURSOR_BUFFER_SIZE + 1);
@@ -199,7 +199,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
     @Test
     public void testMemberDisconnect_close() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         populate(instance1, SqlStatement.DEFAULT_CURSOR_BUFFER_SIZE + 1);
@@ -222,7 +222,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
      */
     @Test
     public void testCursorCleanupOnClientLeave() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         Map<Integer, Integer> localMap = new HashMap<>();
@@ -247,7 +247,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
     @Test
     public void testParameterError_serialization() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         SqlStatement query = new SqlStatement("SELECT * FROM map").addParameter(new BadParameter(true, false));
@@ -259,7 +259,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
     @Test
     public void testParameterError_deserialization() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         SqlStatement query = new SqlStatement("SELECT * FROM map").addParameter(new BadParameter(false, true));
@@ -272,7 +272,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
     @Test
     public void testRowError_deserialization() {
         try {
-            instance1 = factory.newHazelcastInstance();
+            instance1 = newHazelcastInstance(true);
             client = newClient();
 
             Map<Integer, BadValue> localMap = new HashMap<>();
@@ -308,7 +308,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
     @Test
     public void testMissingHandler() {
-        instance1 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(true);
         client = newClient();
 
         try {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.exec.BlockingExec;
 import com.hazelcast.sql.impl.exec.scan.MapScanExec;
-import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -70,8 +69,8 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
     @Test
     public void testMemberLeave() {
         // Start two instances and fill them with data
-        instance1 = factory.newHazelcastInstance();
-        instance2 = factory.newHazelcastInstance();
+        instance1 = newHazelcastInstance(false);
+        instance2 = newHazelcastInstance(true);
 
         populate(instance1);
 
@@ -114,7 +113,7 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
     @Test
     public void testExecuteOnLiteMember() {
         // Start one normal member and one local member.
-        factory.newHazelcastInstance(getConfig());
+        newHazelcastInstance(true);
         HazelcastInstance liteMember = factory.newHazelcastInstance(getConfig().setLiteMember(true));
 
         // Insert data

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.exec.BlockingExec;
 import com.hazelcast.sql.impl.exec.scan.MapScanExec;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -33,7 +34,7 @@ import static junit.framework.TestCase.assertTrue;
 /**
  * Test for different error conditions.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SqlErrorTest extends SqlErrorAbstractTest {
     @Test
@@ -121,7 +122,7 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
 
         // Try query from the lite member.
         HazelcastSqlException error = assertSqlException(liteMember, query());
-        assertEquals(SqlErrorCode.GENERIC, error.getCode());
+        assertErrorCode(SqlErrorCode.GENERIC, error);
         assertEquals("SQL queries cannot be executed on lite members", error.getMessage());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -186,11 +186,16 @@ public abstract class HazelcastTestSupport {
 
     public static Config smallInstanceConfig() {
         // make the test instances consume less resources per default
-        return new Config()
+        Config config = new Config()
                 .setProperty(ClusterProperty.PARTITION_COUNT.getName(), "11")
                 .setProperty(ClusterProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.EVENT_THREAD_COUNT.getName(), "1");
+
+        config.getSqlConfig().setExecutorPoolSize(2);
+        config.getSqlConfig().setOperationPoolSize(2);
+
+        return config;
     }
 
     public static Config regularInstanceConfig() {


### PR DESCRIPTION
Two flaky test failures were observed in https://github.com/hazelcast/hazelcast/issues/17347#issuecomment-694821796 and https://github.com/hazelcast/hazelcast/issues/17347#issuecomment-695190161. 
They are very different, but have a common root cause - we do not wait for a specific partition distribution in tests:
1. `testMapDestroy_secondMember` failed because there was an unassigned partition that didn't allow a query execution to start
1. `testMapMigration` failed because it expected that a partition should be re-assigned to a newly started member in no more than 2 seconds, but it didn't happen

In both cases, the trigger is likely to be a GC pauses or so. The test class uses a parallel runner, so tens of members start at the same time.

The fix is two-fold:
1. Await for all partitions to be assigned and await for all members to have at least one partition assigned
1. Change parallel runner to serial, to make hiccups less frequent

Closes https://github.com/hazelcast/hazelcast/issues/17347