### PR TITLE
Allow ClassSource to provide package private parent classes and implemented interfaces

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassLocator.java
@@ -131,6 +131,9 @@ public final class ClassLocator {
                     classSource = doPrivileged((PrivilegedAction<ClassSource>) ()
                             -> new ClassSource(parent, ClassLocator.this, bundledClassDefinitions));
                     clientClassSourceMap.put(mainClassName, classSource);
+                    for (String budledName : bundledClassDefinitions.keySet()) {
+                        clientClassSourceMap.put(budledName, classSource);
+                    }
                 }
                 return classSource.define(name, classDef);
             }
@@ -162,16 +165,14 @@ public final class ClassLocator {
                     classSource = doPrivileged(
                             (PrivilegedAction<ClassSource>) () -> new ClassSource(parent, this, Collections.emptyMap()));
                 }
-                ClassData classData = fetchBytecodeFromRemote(mainClassName);
+                ClassData classData = fetchBytecodeFromRemote(name);
                 if (classData == null) {
                     throw new ClassNotFoundException("Failed to load class " + name + " from other members");
                 }
 
                 Map<String, byte[]> innerClassDefinitions = classData.getInnerClassDefinitions();
-                classSource.define(mainClassName, classData.getMainClassDefinition());
-                for (Map.Entry<String, byte[]> entry : innerClassDefinitions.entrySet()) {
-                    classSource.define(entry.getKey(), entry.getValue());
-                }
+                classSource.setUndefinedClasses(innerClassDefinitions);
+                classSource.define(name, classData.getMainClassDefinition());
                 cacheClass(classSource, mainClassName);
                 return classSource.getClazz(name);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassSource.java
@@ -40,6 +40,7 @@ public final class ClassSource extends ClassLoader {
     private final Map<String, Class> classes = new ConcurrentHashMap<String, Class>();
     private final Map<String, byte[]> classDefinitions = new ConcurrentHashMap<String, byte[]>();
     private final Map<String, byte[]> bundledClassDefinitions;
+    private final Map<String, byte[]> undefinedClasses = new ConcurrentHashMap<String, byte[]>();
     private final ClassLocator classLocator;
 
     public ClassSource(ClassLoader parent, ClassLocator classLocator, Map<String, byte[]> bundledClassDefinitions) {
@@ -49,7 +50,7 @@ public final class ClassSource extends ClassLoader {
     }
 
     public Class<?> define(String name, byte[] bytecode) {
-        Class clazz = defineClass(name, bytecode, 0, bytecode.length);
+        Class<?> clazz = defineClass(name, bytecode, 0, bytecode.length);
         classDefinitions.put(name, bytecode);
         classes.put(name, clazz);
         return clazz;
@@ -57,11 +58,22 @@ public final class ClassSource extends ClassLoader {
 
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
+        Class cl = classes.get(name);
+        if (cl != null) {
+            return cl;
+        }
         byte[] classDefinition = bundledClassDefinitions.get(name);
         if (classDefinition != null) {
-            return classLocator.defineClassFromClient(name, classDefinition, bundledClassDefinitions);
+            return define(name, classDefinition);
+//            return classLocator.defineClassFromClient(name, classDefinition, bundledClassDefinitions);
         } else {
             return super.findClass(name);
+        }
+    }
+
+    public void setUndefinedClasses(Map<String, byte[]> undefinedEnvironmentClasses) {
+        if (undefinedEnvironmentClasses != null) {
+            this.undefinedClasses.putAll(undefinedEnvironmentClasses);
         }
     }
 
@@ -70,6 +82,12 @@ public final class ClassSource extends ClassLoader {
         Class aClass = classes.get(name);
         if (aClass != null) {
             return aClass;
+        }
+        if (undefinedClasses.containsKey(name)) {
+            aClass = define(name, undefinedClasses.remove(name));
+            if (aClass != null) {
+                return aClass;
+            }
         }
         try {
             return super.loadClass(name, resolve);

--- a/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -98,6 +98,10 @@ public class ClientUserCodeDeploymentTest extends ClientTestSupport {
         ClientConfig config = new ClientConfig();
         ClientUserCodeDeploymentConfig clientUserCodeDeploymentConfig = new ClientUserCodeDeploymentConfig();
         clientUserCodeDeploymentConfig.addClass("usercodedeployment.IncrementingEntryProcessor");
+        clientUserCodeDeploymentConfig.addClass("usercodedeployment.AbstractProtectedEntryProcessor");
+        clientUserCodeDeploymentConfig.addClass("usercodedeployment.PublicInterface");
+        clientUserCodeDeploymentConfig.addClass("usercodedeployment.ProtectedInterface");
+        clientUserCodeDeploymentConfig.addClass("usercodedeployment.ProtectedParentInterface");
         config.setUserCodeDeploymentConfig(clientUserCodeDeploymentConfig.setEnabled(true));
         config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
         return config;

--- a/hazelcast/src/test/java/usercodedeployment/AbstractProtectedEntryProcessor.java
+++ b/hazelcast/src/test/java/usercodedeployment/AbstractProtectedEntryProcessor.java
@@ -16,21 +16,14 @@
 
 package usercodedeployment;
 
-import java.util.Map;
+import com.hazelcast.map.EntryProcessor;
 
 /**
- * This test class is intentionally in its own package
- * as Hazelcast has special rules for loading classes
- * from the {@code com.hazelcast.*} package.
+ * This class allows to test the user code deployment behavior in situations where a parent class of some deployed class is
+ * package private.
  */
-public class IncrementingEntryProcessor extends AbstractProtectedEntryProcessor {
+abstract class AbstractProtectedEntryProcessor
+        implements EntryProcessor<Integer, Integer, Integer>, ProtectedInterface, PublicInterface {
 
-    @Override
-    public Integer process(Map.Entry<Integer, Integer> entry) {
-        Integer origValue = entry.getValue();
-        Integer newValue = origValue + 1;
-        entry.setValue(newValue);
-
-        return newValue;
-    }
+    private static final long serialVersionUID = 1L;
 }

--- a/hazelcast/src/test/java/usercodedeployment/ProtectedInterface.java
+++ b/hazelcast/src/test/java/usercodedeployment/ProtectedInterface.java
@@ -16,21 +16,10 @@
 
 package usercodedeployment;
 
-import java.util.Map;
-
 /**
- * This test class is intentionally in its own package
- * as Hazelcast has special rules for loading classes
- * from the {@code com.hazelcast.*} package.
+ * This interface allows to test the user code deployment behavior in situations where a parent class of some deployed class is
+ * package private.
  */
-public class IncrementingEntryProcessor extends AbstractProtectedEntryProcessor {
+interface ProtectedInterface {
 
-    @Override
-    public Integer process(Map.Entry<Integer, Integer> entry) {
-        Integer origValue = entry.getValue();
-        Integer newValue = origValue + 1;
-        entry.setValue(newValue);
-
-        return newValue;
-    }
 }

--- a/hazelcast/src/test/java/usercodedeployment/ProtectedParentInterface.java
+++ b/hazelcast/src/test/java/usercodedeployment/ProtectedParentInterface.java
@@ -16,21 +16,10 @@
 
 package usercodedeployment;
 
-import java.util.Map;
-
 /**
- * This test class is intentionally in its own package
- * as Hazelcast has special rules for loading classes
- * from the {@code com.hazelcast.*} package.
+ * This interface allows to test the user code deployment behavior in situations where a parent class of some deployed class is
+ * package private.
  */
-public class IncrementingEntryProcessor extends AbstractProtectedEntryProcessor {
+interface ProtectedParentInterface {
 
-    @Override
-    public Integer process(Map.Entry<Integer, Integer> entry) {
-        Integer origValue = entry.getValue();
-        Integer newValue = origValue + 1;
-        entry.setValue(newValue);
-
-        return newValue;
-    }
 }

--- a/hazelcast/src/test/java/usercodedeployment/PublicInterface.java
+++ b/hazelcast/src/test/java/usercodedeployment/PublicInterface.java
@@ -16,21 +16,10 @@
 
 package usercodedeployment;
 
-import java.util.Map;
-
 /**
- * This test class is intentionally in its own package
- * as Hazelcast has special rules for loading classes
- * from the {@code com.hazelcast.*} package.
+ * This interface allows to test the user code deployment behavior in situations where a parent class of some deployed class is
+ * package private.
  */
-public class IncrementingEntryProcessor extends AbstractProtectedEntryProcessor {
+interface PublicInterface extends ProtectedParentInterface {
 
-    @Override
-    public Integer process(Map.Entry<Integer, Integer> entry) {
-        Integer origValue = entry.getValue();
-        Integer newValue = origValue + 1;
-        entry.setValue(newValue);
-
-        return newValue;
-    }
 }


### PR DESCRIPTION
Resolves #17023

This PR improves User Code Deployment behavior in cases where package-private classes are involved.

It doesn't resolve all scenarios (see https://github.com/hazelcast/hazelcast/issues/17023#issuecomment-638287749 for instance), but I think we could mark the #17023 as resolved for now. 