### PR TITLE
Add new JAAS Callback to access HazelcastInstance (member only)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/security/HazelcastInstanceCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/HazelcastInstanceCallback.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security;
+
+import javax.security.auth.callback.Callback;
+
+import com.hazelcast.core.HazelcastInstance;
+
+/**
+ * This JAAS {@link Callback} is used to retrieve the current {@link HazelcastInstance}.
+ * <p>
+ * This {@link Callback} is only supported on Hazelcast member side.
+ */
+public class HazelcastInstanceCallback implements Callback {
+
+    private HazelcastInstance hazelcastInstance;
+
+    public HazelcastInstance getHazelcastInstance() {
+        return hazelcastInstance;
+    }
+
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        this.hazelcastInstance = hazelcastInstance;
+    }
+}


### PR DESCRIPTION
Related to EE request: hazelcast/hazelcast-enterprise#3769
Allow access to HazelcastInstance (e.g. to retrieve the instance name) in login modules and credential factories:

```java
HazelcastInstanceCallback cb = new HazelcastInstanceCallback();
try {
    callbackHandler.handle(new Callback[] { cb });
} catch (IOException | UnsupportedCallbackException e) {
    e.printStackTrace();
}
HazelcastInstance hz = cb.getHazelcastInstance();
name = hz != null ? hz.getName() : null;
```