### PR TITLE
Create equal connections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -62,9 +62,9 @@ import java.util.concurrent.ConcurrentMap;
  * A proxy around the actual HazelcastInstanceImpl. This class serves 2 purposes:
  * <ol>
  * <li>
- * if the HazelcastInstance is shutdown, the reference to the original HazelcastInstanceImpl is null'ed and
- * this HazelcastInstanceImpl and all its dependencies can be gc'ed. If the HazelcastInstanceImpl would
- * be exposed directly, it could still retain unusable objects due to its not null fields.</li>
+ * if the HazelcastInstance is shut down, the reference to the original HazelcastInstanceImpl is nulled and
+ * this HazelcastInstanceImpl and all its dependencies can be GCed. If the HazelcastInstanceImpl would
+ * be exposed directly, it could still retain unusable objects due to its not-null fields.</li>
  * <li>
  * it provides a barrier for accessing the HazelcastInstanceImpl internals. Otherwise a simple cast to HazelcastInstanceImpl
  * would be sufficient but now a bit of reflection is needed to get there.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -155,12 +155,12 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
     }
 
     private long invocationTimeoutMillis(HazelcastProperties properties) {
-        long heartbeatTimeoutMillis = properties.getMillis(OPERATION_CALL_TIMEOUT_MILLIS);
+        long invocationTimeoutMillis = properties.getMillis(OPERATION_CALL_TIMEOUT_MILLIS);
         if (logger.isFinestEnabled()) {
-            logger.finest("Operation invocation timeout is " + heartbeatTimeoutMillis + " ms");
+            logger.finest("Operation invocation timeout is " + invocationTimeoutMillis + " ms");
         }
 
-        return heartbeatTimeoutMillis;
+        return invocationTimeoutMillis;
     }
 
     private long backupTimeoutMillis(HazelcastProperties properties) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -49,7 +49,7 @@ import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallI
 /**
  * Responsible for the registration of all pending invocations.
  * <p>
- * Using the InvocationRegistry the Invocation and its response(s) can be linked to each other.
+ * By using the InvocationRegistry, the Invocation and its response(s) can be linked to each other.
  * <p>
  * When an invocation is registered, a callId is determined. Based on this call ID, when a
  * {@link com.hazelcast.spi.impl.operationservice.impl.responses.Response} comes in, the

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -400,6 +400,18 @@ public class FirewallingServer
         public Throwable getCloseCause() {
             return delegate.getCloseCause();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FirewallingConnection that = (FirewallingConnection) o;
+            return delegate == that.delegate;
+        }
     }
 
 }


### PR DESCRIPTION
Wrap into equal connections in FirewallingServer

Each call to `FirewallingServerConnectionManager.get()` wraps the
connection into a new instance of `FirewallingConnection`. Jet, to
guarantee exactly-once and in-order delivery, checks, that the
connection didn't change and restarts the job, if it did. This PR adds
an `equals` method so that even though the connection instance is
different, it's equal if the delegate is the same.

Also contains some unrelated grammar fixes.