### PR TITLE
Add The caller stacktrace to rethrown async Runtime exceptions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFuture.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
 
 import javax.annotation.Nonnull;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -35,6 +34,8 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import static com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.returnOrThrowWithGetConventions;
 
 public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessage> {
 
@@ -91,25 +92,7 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
 
     @Override
     public ClientMessage resolveAndThrowIfException(Object response) throws ExecutionException, InterruptedException {
-        if (response instanceof ExceptionalResult) {
-            response = ((ExceptionalResult) response).getCause();
-        }
-        if (response instanceof Throwable) {
-            if (response instanceof ExecutionException) {
-                throw (ExecutionException) response;
-            }
-            if (response instanceof Error) {
-                throw (Error) response;
-            }
-            if (response instanceof InterruptedException) {
-                throw (InterruptedException) response;
-            }
-            if (response instanceof CancellationException) {
-                throw (CancellationException) response;
-            }
-            throw new ExecutionException((Throwable) response);
-        }
-        return (ClientMessage) response;
+        return returnOrThrowWithGetConventions(response);
     }
 
     public ClientInvocation getInvocation() {

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -17,13 +17,15 @@
 package com.hazelcast.ringbuffer;
 
 import com.hazelcast.spi.exception.SilentException;
+import com.hazelcast.spi.impl.operationservice.WrappableException;
 
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller
  * than the current head sequence and that the ringbuffer store is disabled. This means that the item isn't available in the
  * ringbuffer and it cannot be loaded from the store either, thus being completely unavailable.
  */
-public class StaleSequenceException extends RuntimeException implements SilentException {
+public class StaleSequenceException extends RuntimeException implements SilentException,
+        WrappableException<StaleSequenceException> {
 
     private final long headSeq;
 
@@ -38,6 +40,11 @@ public class StaleSequenceException extends RuntimeException implements SilentEx
         this.headSeq = headSeq;
     }
 
+    public StaleSequenceException(String message, long headSeq, Throwable cause) {
+        super(message, cause);
+        this.headSeq = headSeq;
+    }
+
     /**
      * Returns the last known head sequence. Beware that this sequence could already be stale again if you want to use it
      * to do a {@link com.hazelcast.ringbuffer.Ringbuffer#readOne(long)}.
@@ -46,5 +53,10 @@ public class StaleSequenceException extends RuntimeException implements SilentEx
      */
     public long getHeadSeq() {
         return headSeq;
+    }
+
+    @Override
+    public StaleSequenceException wrap() {
+        return new StaleSequenceException(getMessage(), headSeq, this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -27,10 +27,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -50,6 +46,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
+import static com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -71,13 +68,6 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
             return "UNRESOLVED";
         }
     };
-    private static final Lookup LOOKUP = MethodHandles.publicLookup();
-    // new Throwable(String message, Throwable cause)
-    private static final MethodType MT_INIT_STRING_THROWABLE = MethodType.methodType(void.class, String.class, Throwable.class);
-    // new Throwable(Throwable cause)
-    private static final MethodType MT_INIT_THROWABLE = MethodType.methodType(void.class, Throwable.class);
-    // new Throwable(String message)
-    private static final MethodType MT_INIT_STRING = MethodType.methodType(void.class, String.class);
 
     private static final AtomicReferenceFieldUpdater<AbstractInvocationFuture, Object> STATE_UPDATER =
             newUpdater(AbstractInvocationFuture.class, Object.class, "state");
@@ -1368,7 +1358,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
          * Wraps the {@link #cause} so that the remote/async throwable is not lost,
          * however is delivered as the cause to an throwable with a local stack trace
          * that makes sense to user code that is synchronizing on {@code joinInternal()}.
-         *
+         * <p>
          * Exception wrapping rules:
          * <ul>
          *     <li>
@@ -1376,17 +1366,16 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
          *         are returned as-is, since they anyway only report the local stack trace.
          *     </li>
          *     <li>
-         *         if cause is an instance of {@link RuntimeException} then the cause
-         *         is wrapped in a new throwable of the same class. The resulting throwable has the local
-         *         stack trace and reports the async stack trace as the cause
+         *         if cause is an instance of {@link RuntimeException} then the cause is cloned
+         *         The clone throwable has the local stack trace merged into to the original stack trace
          *     </li>
          *     <li>
          *         if cause is an instance of {@link ExecutionException} or {@link InvocationTargetException}
          *         with a non-null cause, then unwrap and apply the rules for the cause
          *     </li>
          *     <li>
-         *         if cause is an {@link Error}, then it is wrapped in an {@link Error} of the same class
-         *         with a local stack trace.
+         *         if cause is an {@link Error}, then the cause is cloned.
+         *         The clone throwable has the local stack trace merged into to the original stack trace
          *     </li>
          *     <li>
          *         otherwise, wrap cause in a {@link HazelcastException} reporting the local stack trace,
@@ -1935,37 +1924,14 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     private static RuntimeException wrapRuntimeException(RuntimeException cause) {
         if (cause instanceof WrappableException) {
-            return  ((WrappableException) cause).wrap();
+            return ((WrappableException) cause).wrap();
         }
-        RuntimeException wrapped = tryWrapInSameClass(cause);
-        return wrapped == null ?  new HazelcastException(cause) : wrapped;
+        RuntimeException wrapped = cloneExceptionWithFixedAsyncStackTrace(cause);
+        return wrapped == null ? new HazelcastException(cause) : wrapped;
     }
 
     private static Error wrapError(Error cause) {
-        Error result = tryWrapInSameClass(cause);
+        Error result = cloneExceptionWithFixedAsyncStackTrace(cause);
         return result == null ? cause : result;
-    }
-
-    private static <T extends Throwable> T tryWrapInSameClass(T cause) {
-        Class<? extends Throwable> exceptionClass = cause.getClass();
-        MethodHandle constructor;
-        try {
-            constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING_THROWABLE);
-            return (T) constructor.invokeWithArguments(cause.getMessage(), cause);
-        } catch (Throwable ignored) {
-        }
-        try {
-            constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_THROWABLE);
-            return (T) constructor.invokeWithArguments(cause);
-        } catch (Throwable ignored) {
-        }
-        try {
-            constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING);
-            T result = (T) constructor.invokeWithArguments(cause.getMessage());
-            result.initCause(cause);
-            return result;
-        } catch (Throwable ignored) {
-        }
-        return null;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFutureTest.java
@@ -117,7 +117,6 @@ public class ClientDelegatingFutureTest {
         invocationFuture.completeExceptionally(new IllegalArgumentException());
 
         expected.expect(IllegalArgumentException.class);
-        expected.expectCause(new RootCauseMatcher(IllegalArgumentException.class));
         delegatingFuture.joinInternal();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFutureTest.java
@@ -123,7 +123,6 @@ public class ClientInvocationFutureTest {
         invocationFuture.completeExceptionally(new IllegalArgumentException());
 
         expected.expect(IllegalArgumentException.class);
-        expected.expectCause(new RootCauseMatcher(IllegalArgumentException.class));
         invocationFuture.joinInternal();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocation_ExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocation_ExceptionTest.java
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationservice.impl;
+package com.hazelcast.client.impl.spi.impl;
 
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
-import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.IsNull;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,6 +37,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.Serializable;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -43,7 +46,7 @@ import java.util.concurrent.ExecutionException;
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class Invocation_ExceptionTest extends HazelcastTestSupport {
+public class ClientInvocation_ExceptionTest extends HazelcastTestSupport {
 
     private static final int GET = 0;
     private static final int JOIN = 1;
@@ -51,70 +54,70 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
 
     @Parameterized.Parameters(name = "{0} - {1}")
     public static Object[] parameters() {
-        return new Object[] {
+        return new Object[]{
                 // params: synchronization type, exception thrown, class of expected exception, cause matcher
 
                 //// joinInternal()
                 // RuntimeException with a constructor accepting a Throwable cause
-                new Object[] {JOIN_INTERNAL, new IllegalStateException("message"), IllegalStateException.class,
+                new Object[]{JOIN_INTERNAL, new IllegalStateException("message"), IllegalStateException.class,
                         IsNull.nullValue(Throwable.class)},
                 // RuntimeException with no constructor accepting a Throwable cause
-                new Object[] {JOIN_INTERNAL, new IllegalThreadStateException("message"), IllegalThreadStateException.class,
+                new Object[]{JOIN_INTERNAL, new IllegalThreadStateException("message"), IllegalThreadStateException.class,
                         IsNull.nullValue(Throwable.class)},
                 // OperationTimeoutException: OperationTimeoutException is only expected to be
                 // thrown with a local stack trace; this test is about verifying the exception remains unwrapped
-                new Object[] {JOIN_INTERNAL, new OperationTimeoutException("message"), OperationTimeoutException.class,
-                              IsNull.nullValue(Throwable.class)},
+                new Object[]{JOIN_INTERNAL, new OperationTimeoutException("message"), OperationTimeoutException.class,
+                        IsNull.nullValue(Throwable.class)},
                 // CancellationException: CancellationException is only expected to be
                 // thrown with a local stack trace; this test is about verifying the exception remains unwrapped
-                new Object[] {JOIN_INTERNAL, new CancellationException("message"), CancellationException.class,
-                              IsNull.nullValue(Throwable.class)},
+                new Object[]{JOIN_INTERNAL, new CancellationException("message"), CancellationException.class,
+                        IsNull.nullValue(Throwable.class)},
                 // Checked exception is wrapped in HazelcastException
-                new Object[] {JOIN_INTERNAL, new Exception("message"), HazelcastException.class,
-                              new RootCauseMatcher(Exception.class, "message")},
-                // Error subclass rethrown as same type without wrapping
-                new Object[] {JOIN_INTERNAL, new ExceptionInInitializerError("message"), ExceptionInInitializerError.class,
+                new Object[]{JOIN_INTERNAL, new ClassNotFoundException("message"), HazelcastException.class,
+                        new RootCauseMatcher(ClassNotFoundException.class, "message")},
+                // Error subclass rethrown as same type
+                new Object[]{JOIN_INTERNAL, new OutOfMemoryError("message"), OutOfMemoryError.class,
                         IsNull.nullValue(Throwable.class)},
 
                 //// join()
                 // RuntimeException with a constructor accepting a Throwable cause
-                new Object[] {JOIN, new IllegalStateException("message"), CompletionException.class,
-                              new RootCauseMatcher(IllegalStateException.class, "message")},
+                new Object[]{JOIN, new IllegalStateException("message"), CompletionException.class,
+                        new RootCauseMatcher(IllegalStateException.class, "message")},
                 // RuntimeException with no constructor accepting a Throwable cause
-                new Object[] {JOIN, new IllegalThreadStateException("message"), CompletionException.class,
-                              new RootCauseMatcher(IllegalThreadStateException.class, "message")},
+                new Object[]{JOIN, new IllegalThreadStateException("message"), CompletionException.class,
+                        new RootCauseMatcher(IllegalThreadStateException.class, "message")},
                 // OperationTimeoutException is wrapped in CompletionException
-                new Object[] {JOIN, new OperationTimeoutException("message"), CompletionException.class,
-                              new RootCauseMatcher(OperationTimeoutException.class, "message")},
+                new Object[]{JOIN, new OperationTimeoutException("message"), CompletionException.class,
+                        new RootCauseMatcher(OperationTimeoutException.class, "message")},
                 // CancellationException is expected to be thrown from join() unwrapped
-                new Object[] {JOIN, new CancellationException("message"), CancellationException.class,
-                              IsNull.nullValue(Throwable.class)},
+                new Object[]{JOIN, new CancellationException("message"), CancellationException.class,
+                        IsNull.nullValue(Throwable.class)},
                 // Checked exception is wrapped in CompletionException
-                new Object[] {JOIN, new Exception("message"), CompletionException.class,
-                              new RootCauseMatcher(Exception.class, "message")},
+                new Object[]{JOIN, new ClassNotFoundException("message"), CompletionException.class,
+                        new RootCauseMatcher(ClassNotFoundException.class, "message")},
                 // Error subclass is wrapped in CompletionException
-                new Object[] {JOIN, new ExceptionInInitializerError("message"), CompletionException.class,
-                              new RootCauseMatcher(ExceptionInInitializerError.class, "message")},
+                new Object[]{JOIN, new OutOfMemoryError("message"), CompletionException.class,
+                        new RootCauseMatcher(OutOfMemoryError.class, "message")},
 
                 //// get()
                 // RuntimeException with a constructor accepting a Throwable cause
-                new Object[] {GET, new IllegalStateException("message"), ExecutionException.class,
-                              new RootCauseMatcher(IllegalStateException.class, "message")},
+                new Object[]{GET, new IllegalStateException("message"), ExecutionException.class,
+                        new RootCauseMatcher(IllegalStateException.class, "message")},
                 // RuntimeException with no constructor accepting a Throwable cause
-                new Object[] {GET, new IllegalThreadStateException("message"), ExecutionException.class,
-                              new RootCauseMatcher(IllegalThreadStateException.class, "message")},
+                new Object[]{GET, new IllegalThreadStateException("message"), ExecutionException.class,
+                        new RootCauseMatcher(IllegalThreadStateException.class, "message")},
                 // OperationTimeoutException is wrapped in ExecutionException
-                new Object[] {GET, new OperationTimeoutException("message"), ExecutionException.class,
-                              new RootCauseMatcher(OperationTimeoutException.class, "message")},
+                new Object[]{GET, new OperationTimeoutException("message"), ExecutionException.class,
+                        new RootCauseMatcher(OperationTimeoutException.class, "message")},
                 // CancellationException is expected to be thrown from get() unwrapped
-                new Object[] {GET, new CancellationException("message"), CancellationException.class,
-                              IsNull.nullValue(Throwable.class)},
+                new Object[]{GET, new CancellationException("message"), CancellationException.class,
+                        IsNull.nullValue(Throwable.class)},
                 // Checked exception is wrapped in HazelcastException
-                new Object[] {GET, new Exception("message"), ExecutionException.class,
-                              new RootCauseMatcher(Exception.class, "message")},
+                new Object[]{GET, new ClassNotFoundException("message"), ExecutionException.class,
+                        new RootCauseMatcher(ClassNotFoundException.class, "message")},
                 // Error subclass is wrapped in ExecutionException
-                new Object[] {GET, new ExceptionInInitializerError("message"), ExecutionException.class,
-                              new RootCauseMatcher(ExceptionInInitializerError.class, null)},
+                new Object[]{GET, new OutOfMemoryError("message"), ExecutionException.class,
+                        new RootCauseMatcher(OutOfMemoryError.class, null)},
 
         };
     }
@@ -134,12 +137,21 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
     @Rule
     public ExpectedException expected = ExpectedException.none();
 
+    TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
     @Test
     public void test() throws Exception {
-        HazelcastInstance local = createHazelcastInstance();
-        OperationService operationService = getOperationService(local);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, new OperationsReturnsNoResponse(
-                exception), 0);
+
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        IExecutorService executorService = client.getExecutorService("test");
+
+        InternalCompletableFuture f = (InternalCompletableFuture) executorService.submit(new ExceptionThrowingCallable(exception));
         assertCompletesEventually(f);
 
         expected.expect(expectedExceptionClass);
@@ -163,16 +175,16 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
         }
     }
 
-    public class OperationsReturnsNoResponse extends Operation {
+    public static class ExceptionThrowingCallable implements Callable, Serializable {
 
         private final Throwable t;
 
-        public OperationsReturnsNoResponse(Throwable t) {
+        public ExceptionThrowingCallable(Throwable t) {
             this.t = t;
         }
 
         @Override
-        public void run() throws Exception {
+        public Object call() throws Exception {
             if (t instanceof Error) {
                 throw (Error) t;
             } else if (t instanceof RuntimeException) {
@@ -181,11 +193,6 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 throw (Exception) t;
             }
             throw new AssertionError("Unknown exception type " + t);
-        }
-
-        @Override
-        public boolean returnsResponse() {
-            return false;
         }
     }
 }


### PR DESCRIPTION
Client and Member stacktrace is missing the caller stacktrace.
This results with a  bad debugging analysis experience.
A user exception without the fix is as follows:
```
java.lang.RuntimeException: BOOM
at com.hazelcast.map.impl.operation.PutOperation.runInternal(PutOperation.java:36)
at com.hazelcast.map.impl.operation.MapOperation.run(MapOperation.java:112)
at com.hazelcast.spi.impl.operationservice.Operation.call(Operation.java:184)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:256)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:237)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:452)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:166)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:136)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
```

In this pr, as a solution, we are cloning the original exception on the caller side.
The message and the cause is the same as the original one.
Only difference is that the caller stacktrace is added on top of the async stacktrace.

Note that this is different than the solution before 4.x.
We were not cloning the exception and it was causing race conditions.
see https://github.com/hazelcast/hazelcast/issues/6247

Also note that this solution is different than the solution we have in future.joinInternal.
In https://github.com/hazelcast/hazelcast/pull/17212, we tried to apply the same solution
in `joinInternal` but changing the cause hierarchy caused problems.
Instead we have changed both future.joinInternal and future.get logic to do the clone.

Client stack trace when future.get is used on the proxy.
```
java.lang.RuntimeException: BOOM
at com.hazelcast.map.impl.operation.PutOperation.runInternal(PutOperation.java:36)
at com.hazelcast.map.impl.operation.MapOperation.run(MapOperation.java:112)
at com.hazelcast.spi.impl.operationservice.Operation.call(Operation.java:184)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:256)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:237)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:213)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl.run(OperationExecutorImpl.java:411)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl.runOrExecute(OperationExecutorImpl.java:438)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.doInvokeLocal(Invocation.java:603)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.doInvoke(Invocation.java:588)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.invoke0(Invocation.java:547)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.invoke(Invocation.java:244)
at com.hazelcast.spi.impl.operationservice.impl.InvocationBuilderImpl.invoke(InvocationBuilderImpl.java:59)
at com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask.processInternal(AbstractPartitionMessageTask.java:51)
at com.hazelcast.client.impl.protocol.task.AbstractAsyncMessageTask.processMessage(AbstractAsyncMessageTask.java:71)
at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.initializeAndProcessMessage(AbstractMessageTask.java:153)
at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.run(AbstractMessageTask.java:116)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:192)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:172)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:140)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
at ------ submitted from ------.()
at com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(ExceptionUtil.java:218)
at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.returnOrThrowWithGetConventions(InvocationFuture.java:108)
at com.hazelcast.client.impl.spi.impl.ClientInvocationFuture.resolveAndThrowIfException(ClientInvocationFuture.java:95)
at com.hazelcast.client.impl.spi.impl.ClientInvocationFuture.resolveAndThrowIfException(ClientInvocationFuture.java:40)
at com.hazelcast.spi.impl.AbstractInvocationFuture.get(AbstractInvocationFuture.java:601)
at com.hazelcast.client.impl.spi.ClientProxy.invokeOnPartition(ClientProxy.java:188)
at com.hazelcast.client.impl.spi.ClientProxy.invoke(ClientProxy.java:182)
at com.hazelcast.client.impl.proxy.ClientMapProxy.putInternal(ClientMapProxy.java:529)
at com.hazelcast.client.impl.proxy.ClientMapProxy.put(ClientMapProxy.java:261)
at XOutOfThinAirStackTrace.onClient(XOutOfThinAirStackTrace.java:42)
at XOutOfThinAirStackTrace.main(XOutOfThinAirStackTrace.java:16)
```

Client stacktrace when InvocationFuture.joinInternal is used on the proxy.
```
java.lang.RuntimeException: BOOM
at com.hazelcast.map.impl.operation.PutOperation.runInternal(PutOperation.java:36)
at com.hazelcast.map.impl.operation.MapOperation.run(MapOperation.java:112)
at com.hazelcast.spi.impl.operationservice.Operation.call(Operation.java:184)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:256)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:237)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:213)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl.run(OperationExecutorImpl.java:411)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl.runOrExecute(OperationExecutorImpl.java:438)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.doInvokeLocal(Invocation.java:603)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.doInvoke(Invocation.java:588)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.invoke0(Invocation.java:547)
at com.hazelcast.spi.impl.operationservice.impl.Invocation.invoke(Invocation.java:244)
at com.hazelcast.spi.impl.operationservice.impl.InvocationBuilderImpl.invoke(InvocationBuilderImpl.java:59)
at com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask.processInternal(AbstractPartitionMessageTask.java:51)
at com.hazelcast.client.impl.protocol.task.AbstractAsyncMessageTask.processMessage(AbstractAsyncMessageTask.java:71)
at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.initializeAndProcessMessage(AbstractMessageTask.java:153)
at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.run(AbstractMessageTask.java:116)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:192)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:172)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:140)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
at ------ submitted from ------.()
at com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(ExceptionUtil.java:218)
at com.hazelcast.spi.impl.AbstractInvocationFuture.wrapRuntimeException(AbstractInvocationFuture.java:1931)
at com.hazelcast.spi.impl.AbstractInvocationFuture.wrapOrPeel(AbstractInvocationFuture.java:1912)
at com.hazelcast.spi.impl.AbstractInvocationFuture$ExceptionalResult.wrapForJoinInternal(AbstractInvocationFuture.java:1391)
at com.hazelcast.spi.impl.AbstractInvocationFuture.resolveAndThrowForJoinInternal(AbstractInvocationFuture.java:584)
at com.hazelcast.spi.impl.AbstractInvocationFuture.joinInternal(AbstractInvocationFuture.java:568)
at com.hazelcast.client.impl.spi.ClientProxy.invokeOnPartition(ClientProxy.java:188)
at com.hazelcast.client.impl.spi.ClientProxy.invoke(ClientProxy.java:183)
at com.hazelcast.client.impl.proxy.ClientMapProxy.putInternal(ClientMapProxy.java:525)
at com.hazelcast.client.impl.proxy.ClientMapProxy.put(ClientMapProxy.java:261)
at XOutOfThinAirStackTrace.onClient(XOutOfThinAirStackTrace.java:42)
at XOutOfThinAirStackTrace.main(XOutOfThinAirStackTrace.java:16)
```

Member stack trace when future.get is used on the proxy.
```
java.lang.RuntimeException: BOOM
at com.hazelcast.map.impl.operation.PutOperation.runInternal(PutOperation.java:36)
at com.hazelcast.map.impl.operation.MapOperation.run(MapOperation.java:112)
at com.hazelcast.spi.impl.operationservice.Operation.call(Operation.java:184)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:256)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:237)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:452)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:166)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:136)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
at ------ submitted from ------.()
at com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(ExceptionUtil.java:218)
at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.returnOrThrowWithGetConventions(InvocationFuture.java:108)
at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.resolveAndThrowIfException(InvocationFuture.java:99)
at com.hazelcast.spi.impl.AbstractInvocationFuture.get(AbstractInvocationFuture.java:601)
at com.hazelcast.map.impl.proxy.MapProxySupport.invokeOperation(MapProxySupport.java:473)
at com.hazelcast.map.impl.proxy.MapProxySupport.putInternal(MapProxySupport.java:411)
at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:131)
at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:121)
at XOutOfThinAirStackTrace.onliteMember(XOutOfThinAirStackTrace.java:29)
at XOutOfThinAirStackTrace.main(XOutOfThinAirStackTrace.java:15)
```

Member stacktrace when InvocationFuture.joinInternal is used on the proxy.
```
java.lang.RuntimeException: BOOM
at com.hazelcast.map.impl.operation.PutOperation.runInternal(PutOperation.java:36)
at com.hazelcast.map.impl.operation.MapOperation.run(MapOperation.java:112)
at com.hazelcast.spi.impl.operationservice.Operation.call(Operation.java:184)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:256)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:237)
at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:452)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:166)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:136)
at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
at ------ submitted from ------.()
at com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(ExceptionUtil.java:218)
at com.hazelcast.spi.impl.AbstractInvocationFuture.wrapRuntimeException(AbstractInvocationFuture.java:1931)
at com.hazelcast.spi.impl.AbstractInvocationFuture.wrapOrPeel(AbstractInvocationFuture.java:1912)
at com.hazelcast.spi.impl.AbstractInvocationFuture$ExceptionalResult.wrapForJoinInternal(AbstractInvocationFuture.java:1391)
at com.hazelcast.spi.impl.AbstractInvocationFuture.resolveAndThrowForJoinInternal(AbstractInvocationFuture.java:584)
at com.hazelcast.spi.impl.AbstractInvocationFuture.joinInternal(AbstractInvocationFuture.java:568)
at com.hazelcast.map.impl.proxy.MapProxySupport.invokeOperation(MapProxySupport.java:473)
at com.hazelcast.map.impl.proxy.MapProxySupport.putInternal(MapProxySupport.java:411)
at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:131)
at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:121)
at XOutOfThinAirStackTrace.onliteMember(XOutOfThinAirStackTrace.java:29)
at XOutOfThinAirStackTrace.main(XOutOfThinAirStackTrace.java:15)
```

(cherry picked from commit a32ad0970e0118dd8ae3bf94b9b782ca4b63268e)