### PR TITLE
Try load custom exceptions via class loader on client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -28,8 +28,8 @@ public class UndefinedErrorCodeException extends HazelcastException
 
     private final String className;
 
-    public UndefinedErrorCodeException(String message, String className) {
-        super("Class name: " + className + ", Message: " + message);
+    public UndefinedErrorCodeException(String message, String className, Throwable cause) {
+        super("Class name: " + className + ", Message: " + message, cause);
         this.className = className;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -20,8 +20,16 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.spi.impl.operationservice.WrappableException;
 
 /**
- * This exception is thrown when an exception that is coming from server is not recognized by the protocol.
- * Class name of the original exception is included in the exception
+ * This exception is thrown when an exception that is coming from server is not recognized by the protocol and
+ * it can not be constructed by the client via reflection.
+ * For the client to be able to recreate original exception it should be available on the classpath and
+ * it should have one of the following constructors publicly.
+ * new Throwable(String message, Throwable cause)
+ * new Throwable(Throwable cause)
+ * new Throwable(String message)
+ * new Throwable()
+ * <p>
+ * Class name of the original exception is included in the exception.
  */
 public class UndefinedErrorCodeException extends HazelcastException
         implements WrappableException<UndefinedErrorCodeException> {
@@ -36,6 +44,7 @@ public class UndefinedErrorCodeException extends HazelcastException
     /**
      * Construct a new {@code UndefinedErrorCodeException} with {@code other} as its
      * cause and {@code other}'s message.
+     *
      * @param other
      */
     private UndefinedErrorCodeException(UndefinedErrorCodeException other) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -20,7 +20,6 @@ import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes;
 import com.hazelcast.client.impl.protocol.codec.builtin.ErrorsCodec;
 import com.hazelcast.client.impl.protocol.exception.ErrorHolder;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
@@ -50,6 +49,7 @@ import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.util.AddressUtil;
+import com.hazelcast.internal.util.EmptyStatement;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
@@ -103,21 +103,105 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ACCESS_CONTROL;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ARRAY_STORE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ASSERTION_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.AUTHENTICATION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CACHE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CACHE_LOADER;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CACHE_NOT_EXISTS;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CACHE_WRITER;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CALLER_NOT_MEMBER;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CANCELLATION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CANNOT_REPLICATE_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CLASS_CAST;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CLASS_NOT_FOUND;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CONCURRENT_MODIFICATION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CONFIG_MISMATCH;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CP_GROUP_DESTROYED_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.DISTRIBUTED_OBJECT_DESTROYED;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.DUPLICATE_TASK;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ENTRY_PROCESSOR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.EOF;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.EXECUTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.HAZELCAST;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.HAZELCAST_INSTANCE_NOT_ACTIVE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.HAZELCAST_OVERLOAD;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.HAZELCAST_SERIALIZATION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ILLEGAL_ACCESS_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ILLEGAL_ACCESS_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ILLEGAL_ARGUMENT;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ILLEGAL_MONITOR_STATE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ILLEGAL_STATE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.ILLEGAL_THREAD_STATE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.INDETERMINATE_OPERATION_STATE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.INTERRUPTED;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.INVALID_ADDRESS;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.INVALID_CONFIGURATION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.IO;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LEADER_DEMOTED_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCAL_MEMBER_RESET;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_OWNERSHIP_LOST_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOGIN;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.MAX_MESSAGE_SIZE_EXCEEDED;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.MEMBER_LEFT;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.MUTATION_DISALLOWED_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NATIVE_OUT_OF_MEMORY_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NOT_SERIALIZABLE;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_CLASS_DEF_FOUND_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_DATA_MEMBER;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_ELEMENT;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_FIELD_ERROR;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_FIELD_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_METHOD_ERROR;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_METHOD_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NULL_POINTER;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.OPERATION_TIMEOUT;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.OUT_OF_MEMORY_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.PARTITION_MIGRATING;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.QUERY;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.REACHED_MAX_SIZE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.REJECTED_EXECUTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.REPLICATED_MAP_CANT_BE_CREATED;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.RESPONSE_ALREADY_SENT;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.RETRYABLE_HAZELCAST;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.RETRYABLE_IO;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.RUNTIME;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SECURITY;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SERVICE_NOT_FOUND;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SESSION_EXPIRED_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SOCKET;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.STACK_OVERFLOW_ERROR;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.STALE_APPEND_REQUEST_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.STALE_SEQUENCE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.STALE_TASK;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.STALE_TASK_ID;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TARGET_DISCONNECTED;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TARGET_NOT_MEMBER;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TARGET_NOT_REPLICA_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TIMEOUT;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TOPIC_OVERLOAD;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TRANSACTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.UNSUPPORTED_CALLBACK;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.UNSUPPORTED_OPERATION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.URI_SYNTAX;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.UTF_DATA_FORMAT;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.VERSION_MISMATCH_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.WAIT_KEY_CANCELLED_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.WAN_REPLICATION_QUEUE_FULL;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.WRONG_TARGET;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.XA;
 
 /**
  * This class has the error codes and means of
@@ -132,563 +216,100 @@ public class ClientExceptionFactory {
     public ClientExceptionFactory(boolean jcacheAvailable, ClassLoader classLoader) {
         this.classLoader = classLoader;
         if (jcacheAvailable) {
-            register(ClientProtocolErrorCodes.CACHE, CacheException.class, new ExceptionFactory() {
-                @Override
-                public Throwable createException(String message, Throwable cause) {
-                    return new CacheException(message, cause);
-                }
-            });
-            register(ClientProtocolErrorCodes.CACHE_LOADER, CacheLoaderException.class, new ExceptionFactory() {
-                @Override
-                public Throwable createException(String message, Throwable cause) {
-                    return new CacheLoaderException(message, cause);
-                }
-            });
-            register(ClientProtocolErrorCodes.CACHE_WRITER, CacheWriterException.class, new ExceptionFactory() {
-                @Override
-                public Throwable createException(String message, Throwable cause) {
-                    return new CacheWriterException(message, cause);
-                }
-            });
-
-            register(ClientProtocolErrorCodes.ENTRY_PROCESSOR, EntryProcessorException.class, new ExceptionFactory() {
-                @Override
-                public Throwable createException(String message, Throwable cause) {
-                    return new EntryProcessorException(message, cause);
-                }
-            });
+            register(CACHE, CacheException.class, CacheException::new);
+            register(CACHE_LOADER, CacheLoaderException.class, CacheLoaderException::new);
+            register(CACHE_WRITER, CacheWriterException.class, CacheWriterException::new);
+            register(ENTRY_PROCESSOR, EntryProcessorException.class, EntryProcessorException::new);
         }
 
-        register(ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS, ArrayIndexOutOfBoundsException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ArrayIndexOutOfBoundsException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.ARRAY_STORE, ArrayStoreException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ArrayStoreException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.AUTHENTICATION, AuthenticationException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new AuthenticationException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CACHE_NOT_EXISTS, CacheNotExistsException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new CacheNotExistsException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CALLER_NOT_MEMBER, CallerNotMemberException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new CallerNotMemberException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CANCELLATION, CancellationException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new CancellationException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CLASS_CAST, ClassCastException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ClassCastException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CLASS_NOT_FOUND, ClassNotFoundException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ClassNotFoundException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.CONCURRENT_MODIFICATION, ConcurrentModificationException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ConcurrentModificationException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CONFIG_MISMATCH, ConfigMismatchException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ConfigMismatchException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.DISTRIBUTED_OBJECT_DESTROYED, DistributedObjectDestroyedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new DistributedObjectDestroyedException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.EOF, EOFException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new EOFException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.EXECUTION, ExecutionException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ExecutionException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.HAZELCAST, HazelcastException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new HazelcastException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.HAZELCAST_INSTANCE_NOT_ACTIVE, HazelcastInstanceNotActiveException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new HazelcastInstanceNotActiveException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.HAZELCAST_OVERLOAD, HazelcastOverloadException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new HazelcastOverloadException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.HAZELCAST_SERIALIZATION, HazelcastSerializationException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new HazelcastSerializationException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.IO, IOException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IOException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.ILLEGAL_ARGUMENT, IllegalArgumentException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IllegalArgumentException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.ILLEGAL_ACCESS_EXCEPTION, IllegalAccessException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IllegalAccessException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.ILLEGAL_ACCESS_ERROR, IllegalAccessError.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IllegalAccessError(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.ILLEGAL_MONITOR_STATE, IllegalMonitorStateException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IllegalMonitorStateException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.ILLEGAL_STATE, IllegalStateException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IllegalStateException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.ILLEGAL_THREAD_STATE, IllegalThreadStateException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IllegalThreadStateException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS, IndexOutOfBoundsException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IndexOutOfBoundsException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.INTERRUPTED, InterruptedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new InterruptedException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.INVALID_ADDRESS, AddressUtil.InvalidAddressException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new AddressUtil.InvalidAddressException(message, false);
-            }
-        });
-        register(ClientProtocolErrorCodes.INVALID_CONFIGURATION, InvalidConfigurationException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new InvalidConfigurationException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.MEMBER_LEFT, MemberLeftException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new MemberLeftException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE, NegativeArraySizeException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NegativeArraySizeException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.NO_SUCH_ELEMENT, NoSuchElementException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NoSuchElementException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.NOT_SERIALIZABLE, NotSerializableException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NotSerializableException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.NULL_POINTER, NullPointerException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NullPointerException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.OPERATION_TIMEOUT, OperationTimeoutException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new OperationTimeoutException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.PARTITION_MIGRATING, PartitionMigratingException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new PartitionMigratingException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.QUERY, QueryException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new QueryException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED, QueryResultSizeExceededException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new QueryResultSizeExceededException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION, SplitBrainProtectionException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new SplitBrainProtectionException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.REACHED_MAX_SIZE, ReachedMaxSizeException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ReachedMaxSizeException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.REJECTED_EXECUTION, RejectedExecutionException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new RejectedExecutionException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.RESPONSE_ALREADY_SENT, ResponseAlreadySentException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ResponseAlreadySentException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.RETRYABLE_HAZELCAST, RetryableHazelcastException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new RetryableHazelcastException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.RETRYABLE_IO, RetryableIOException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new RetryableIOException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.RUNTIME, RuntimeException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new RuntimeException(message, cause);
-            }
-        });
-
-        register(ClientProtocolErrorCodes.SECURITY, SecurityException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new SecurityException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.SOCKET, SocketException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new SocketException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.STALE_SEQUENCE, StaleSequenceException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new StaleSequenceException(message, 0);
-            }
-        });
-        register(ClientProtocolErrorCodes.TARGET_DISCONNECTED, TargetDisconnectedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TargetDisconnectedException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.TARGET_NOT_MEMBER, TargetNotMemberException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TargetNotMemberException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.TIMEOUT, TimeoutException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TimeoutException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.TOPIC_OVERLOAD, TopicOverloadException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TopicOverloadException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.TRANSACTION, TransactionException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TransactionException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE, TransactionNotActiveException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TransactionNotActiveException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT, TransactionTimedOutException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TransactionTimedOutException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.URI_SYNTAX, URISyntaxException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new URISyntaxException("not available", message);
-            }
-        });
-        register(ClientProtocolErrorCodes.UTF_DATA_FORMAT, UTFDataFormatException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new UTFDataFormatException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.UNSUPPORTED_OPERATION, UnsupportedOperationException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new UnsupportedOperationException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.WRONG_TARGET, WrongTargetException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new WrongTargetException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.XA, XAException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new XAException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.ACCESS_CONTROL, AccessControlException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new AccessControlException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.LOGIN, LoginException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new LoginException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.UNSUPPORTED_CALLBACK, UnsupportedCallbackException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new UnsupportedCallbackException(null, message);
-            }
-        });
-        register(ClientProtocolErrorCodes.NO_DATA_MEMBER, NoDataMemberInClusterException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NoDataMemberInClusterException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.REPLICATED_MAP_CANT_BE_CREATED, ReplicatedMapCantBeCreatedOnLiteMemberException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ReplicatedMapCantBeCreatedOnLiteMemberException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.MAX_MESSAGE_SIZE_EXCEEDED, MaxMessageSizeExceeded.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new MaxMessageSizeExceeded(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.WAN_REPLICATION_QUEUE_FULL, WanQueueFullException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new WanQueueFullException(message);
-            }
-        });
-
-        register(ClientProtocolErrorCodes.ASSERTION_ERROR, AssertionError.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new AssertionError(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.OUT_OF_MEMORY_ERROR, OutOfMemoryError.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new OutOfMemoryError(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.STACK_OVERFLOW_ERROR, StackOverflowError.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new StackOverflowError(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.NATIVE_OUT_OF_MEMORY_ERROR, NativeOutOfMemoryError.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NativeOutOfMemoryError(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.SERVICE_NOT_FOUND, ServiceNotFoundException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ServiceNotFoundException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.STALE_TASK_ID, StaleTaskIdException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new StaleTaskIdException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.DUPLICATE_TASK, DuplicateTaskException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new DuplicateTaskException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.STALE_TASK, StaleTaskException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new StaleTaskException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.LOCAL_MEMBER_RESET, LocalMemberResetException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new LocalMemberResetException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.INDETERMINATE_OPERATION_STATE, IndeterminateOperationStateException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new IndeterminateOperationStateException(message, cause);
-            }
-        });
-        register(ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION, NodeIdOutOfRangeException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new NodeIdOutOfRangeException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.TARGET_NOT_REPLICA_EXCEPTION, TargetNotReplicaException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new TargetNotReplicaException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.MUTATION_DISALLOWED_EXCEPTION, MutationDisallowedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new MutationDisallowedException(message);
-            }
-        });
-        register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION, ConsistencyLostException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new ConsistencyLostException(message);
-            }
-        });
-        register(SESSION_EXPIRED_EXCEPTION, SessionExpiredException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new SessionExpiredException(message, cause);
-            }
-        });
-        register(WAIT_KEY_CANCELLED_EXCEPTION, WaitKeyCancelledException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new WaitKeyCancelledException(message, cause);
-            }
-        });
-        register(LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION, LockAcquireLimitReachedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new LockAcquireLimitReachedException(message);
-            }
-        });
-        register(LOCK_OWNERSHIP_LOST_EXCEPTION, LockOwnershipLostException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new LockOwnershipLostException(message);
-            }
-        });
-        register(CP_GROUP_DESTROYED_EXCEPTION, CPGroupDestroyedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new CPGroupDestroyedException();
-            }
-        });
-        register(CANNOT_REPLICATE_EXCEPTION, CannotReplicateException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new CannotReplicateException(null);
-            }
-        });
-        register(LEADER_DEMOTED_EXCEPTION, LeaderDemotedException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new LeaderDemotedException(null, null);
-            }
-        });
-        register(STALE_APPEND_REQUEST_EXCEPTION, StaleAppendRequestException.class, new ExceptionFactory() {
-            @Override
-            public Throwable createException(String message, Throwable cause) {
-                return new StaleAppendRequestException(null);
-            }
-        });
+        register(ARRAY_INDEX_OUT_OF_BOUNDS, ArrayIndexOutOfBoundsException.class, (message, cause) -> new ArrayIndexOutOfBoundsException(message));
+        register(ARRAY_STORE, ArrayStoreException.class, (message, cause) -> new ArrayStoreException(message));
+        register(AUTHENTICATION, AuthenticationException.class, (message, cause) -> new AuthenticationException(message));
+        register(CACHE_NOT_EXISTS, CacheNotExistsException.class, (message, cause) -> new CacheNotExistsException(message));
+        register(CALLER_NOT_MEMBER, CallerNotMemberException.class, (message, cause) -> new CallerNotMemberException(message));
+        register(CANCELLATION, CancellationException.class, (message, cause) -> new CancellationException(message));
+        register(CLASS_CAST, ClassCastException.class, (message, cause) -> new ClassCastException(message));
+        register(CLASS_NOT_FOUND, ClassNotFoundException.class, ClassNotFoundException::new);
+        register(CONCURRENT_MODIFICATION, ConcurrentModificationException.class, (message, cause) -> new ConcurrentModificationException(message));
+        register(CONFIG_MISMATCH, ConfigMismatchException.class, (message, cause) -> new ConfigMismatchException(message));
+        register(DISTRIBUTED_OBJECT_DESTROYED, DistributedObjectDestroyedException.class, (message, cause) -> new DistributedObjectDestroyedException(message));
+        register(EOF, EOFException.class, (message, cause) -> new EOFException(message));
+        register(EXECUTION, ExecutionException.class, ExecutionException::new);
+        register(HAZELCAST, HazelcastException.class, HazelcastException::new);
+        register(HAZELCAST_INSTANCE_NOT_ACTIVE, HazelcastInstanceNotActiveException.class, (message, cause) -> new HazelcastInstanceNotActiveException(message));
+        register(HAZELCAST_OVERLOAD, HazelcastOverloadException.class, (message, cause) -> new HazelcastOverloadException(message));
+        register(HAZELCAST_SERIALIZATION, HazelcastSerializationException.class, HazelcastSerializationException::new);
+        register(IO, IOException.class, IOException::new);
+        register(ILLEGAL_ARGUMENT, IllegalArgumentException.class, IllegalArgumentException::new);
+        register(ILLEGAL_ACCESS_EXCEPTION, IllegalAccessException.class, (message, cause) -> new IllegalAccessException(message));
+        register(ILLEGAL_ACCESS_ERROR, IllegalAccessError.class, (message, cause) -> new IllegalAccessError(message));
+        register(ILLEGAL_MONITOR_STATE, IllegalMonitorStateException.class, (message, cause) -> new IllegalMonitorStateException(message));
+        register(ILLEGAL_STATE, IllegalStateException.class, IllegalStateException::new);
+        register(ILLEGAL_THREAD_STATE, IllegalThreadStateException.class, (message, cause) -> new IllegalThreadStateException(message));
+        register(INDEX_OUT_OF_BOUNDS, IndexOutOfBoundsException.class, (message, cause) -> new IndexOutOfBoundsException(message));
+        register(INTERRUPTED, InterruptedException.class, (message, cause) -> new InterruptedException(message));
+        register(INVALID_ADDRESS, AddressUtil.InvalidAddressException.class, (message, cause) -> new AddressUtil.InvalidAddressException(message, false));
+        register(INVALID_CONFIGURATION, InvalidConfigurationException.class, InvalidConfigurationException::new);
+        register(MEMBER_LEFT, MemberLeftException.class, (message, cause) -> new MemberLeftException(message));
+        register(NEGATIVE_ARRAY_SIZE, NegativeArraySizeException.class, (message, cause) -> new NegativeArraySizeException(message));
+        register(NO_SUCH_ELEMENT, NoSuchElementException.class, (message, cause) -> new NoSuchElementException(message));
+        register(NOT_SERIALIZABLE, NotSerializableException.class, (message, cause) -> new NotSerializableException(message));
+        register(NULL_POINTER, NullPointerException.class, (message, cause) -> new NullPointerException(message));
+        register(OPERATION_TIMEOUT, OperationTimeoutException.class, (message, cause) -> new OperationTimeoutException(message));
+        register(PARTITION_MIGRATING, PartitionMigratingException.class, (message, cause) -> new PartitionMigratingException(message));
+        register(QUERY, QueryException.class, QueryException::new);
+        register(QUERY_RESULT_SIZE_EXCEEDED, QueryResultSizeExceededException.class, (message, cause) -> new QueryResultSizeExceededException(message));
+        register(SPLIT_BRAIN_PROTECTION, SplitBrainProtectionException.class, (message, cause) -> new SplitBrainProtectionException(message));
+        register(REACHED_MAX_SIZE, ReachedMaxSizeException.class, (message, cause) -> new ReachedMaxSizeException(message));
+        register(REJECTED_EXECUTION, RejectedExecutionException.class, RejectedExecutionException::new);
+        register(RESPONSE_ALREADY_SENT, ResponseAlreadySentException.class, (message, cause) -> new ResponseAlreadySentException(message));
+        register(RETRYABLE_HAZELCAST, RetryableHazelcastException.class, RetryableHazelcastException::new);
+        register(RETRYABLE_IO, RetryableIOException.class, RetryableIOException::new);
+        register(RUNTIME, RuntimeException.class, RuntimeException::new);
+        register(SECURITY, SecurityException.class, SecurityException::new);
+        register(SOCKET, SocketException.class, (message, cause) -> new SocketException(message));
+        register(STALE_SEQUENCE, StaleSequenceException.class, (message, cause) -> new StaleSequenceException(message, 0));
+        register(TARGET_DISCONNECTED, TargetDisconnectedException.class, (message, cause) -> new TargetDisconnectedException(message));
+        register(TARGET_NOT_MEMBER, TargetNotMemberException.class, (message, cause) -> new TargetNotMemberException(message));
+        register(TIMEOUT, TimeoutException.class, (message, cause) -> new TimeoutException(message));
+        register(TOPIC_OVERLOAD, TopicOverloadException.class, (message, cause) -> new TopicOverloadException(message));
+        register(TRANSACTION, TransactionException.class, TransactionException::new);
+        register(TRANSACTION_NOT_ACTIVE, TransactionNotActiveException.class, (message, cause) -> new TransactionNotActiveException(message));
+        register(TRANSACTION_TIMED_OUT, TransactionTimedOutException.class, TransactionTimedOutException::new);
+        register(URI_SYNTAX, URISyntaxException.class, (message, cause) -> new URISyntaxException("not available", message));
+        register(UTF_DATA_FORMAT, UTFDataFormatException.class, (message, cause) -> new UTFDataFormatException(message));
+        register(UNSUPPORTED_OPERATION, UnsupportedOperationException.class, UnsupportedOperationException::new);
+        register(WRONG_TARGET, WrongTargetException.class, (message, cause) -> new WrongTargetException(message));
+        register(XA, XAException.class, (message, cause) -> new XAException(message));
+        register(ACCESS_CONTROL, AccessControlException.class, (message, cause) -> new AccessControlException(message));
+        register(LOGIN, LoginException.class, (message, cause) -> new LoginException(message));
+        register(UNSUPPORTED_CALLBACK, UnsupportedCallbackException.class, (message, cause) -> new UnsupportedCallbackException(null, message));
+        register(NO_DATA_MEMBER, NoDataMemberInClusterException.class, (message, cause) -> new NoDataMemberInClusterException(message));
+        register(REPLICATED_MAP_CANT_BE_CREATED, ReplicatedMapCantBeCreatedOnLiteMemberException.class, (message, cause) -> new ReplicatedMapCantBeCreatedOnLiteMemberException(message));
+        register(MAX_MESSAGE_SIZE_EXCEEDED, MaxMessageSizeExceeded.class, (message, cause) -> new MaxMessageSizeExceeded(message));
+        register(WAN_REPLICATION_QUEUE_FULL, WanQueueFullException.class, (message, cause) -> new WanQueueFullException(message));
+        register(ASSERTION_ERROR, AssertionError.class, (message, cause) -> new AssertionError(message));
+        register(OUT_OF_MEMORY_ERROR, OutOfMemoryError.class, (message, cause) -> new OutOfMemoryError(message));
+        register(STACK_OVERFLOW_ERROR, StackOverflowError.class, (message, cause) -> new StackOverflowError(message));
+        register(NATIVE_OUT_OF_MEMORY_ERROR, NativeOutOfMemoryError.class, NativeOutOfMemoryError::new);
+        register(SERVICE_NOT_FOUND, ServiceNotFoundException.class, (message, cause) -> new ServiceNotFoundException(message));
+        register(STALE_TASK_ID, StaleTaskIdException.class, (message, cause) -> new StaleTaskIdException(message));
+        register(DUPLICATE_TASK, DuplicateTaskException.class, (message, cause) -> new DuplicateTaskException(message));
+        register(STALE_TASK, StaleTaskException.class, (message, cause) -> new StaleTaskException(message));
+        register(LOCAL_MEMBER_RESET, LocalMemberResetException.class, (message, cause) -> new LocalMemberResetException(message));
+        register(INDETERMINATE_OPERATION_STATE, IndeterminateOperationStateException.class, IndeterminateOperationStateException::new);
+        register(FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION, NodeIdOutOfRangeException.class, (message, cause) -> new NodeIdOutOfRangeException(message));
+        register(TARGET_NOT_REPLICA_EXCEPTION, TargetNotReplicaException.class, (message, cause) -> new TargetNotReplicaException(message));
+        register(MUTATION_DISALLOWED_EXCEPTION, MutationDisallowedException.class, (message, cause) -> new MutationDisallowedException(message));
+        register(CONSISTENCY_LOST_EXCEPTION, ConsistencyLostException.class, (message, cause) -> new ConsistencyLostException(message));
+        register(SESSION_EXPIRED_EXCEPTION, SessionExpiredException.class, SessionExpiredException::new);
+        register(WAIT_KEY_CANCELLED_EXCEPTION, WaitKeyCancelledException.class, WaitKeyCancelledException::new);
+        register(LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION, LockAcquireLimitReachedException.class, (message, cause) -> new LockAcquireLimitReachedException(message));
+        register(LOCK_OWNERSHIP_LOST_EXCEPTION, LockOwnershipLostException.class, (message, cause) -> new LockOwnershipLostException(message));
+        register(CP_GROUP_DESTROYED_EXCEPTION, CPGroupDestroyedException.class, (message, cause) -> new CPGroupDestroyedException());
+        register(CANNOT_REPLICATE_EXCEPTION, CannotReplicateException.class, (message, cause) -> new CannotReplicateException(null));
+        register(LEADER_DEMOTED_EXCEPTION, LeaderDemotedException.class, (message, cause) -> new LeaderDemotedException(null, null));
+        register(STALE_APPEND_REQUEST_EXCEPTION, StaleAppendRequestException.class, (message, cause) -> new StaleAppendRequestException(null));
         register(NOT_LEADER_EXCEPTION, NotLeaderException.class, (message, cause) -> new NotLeaderException(null, null, null));
         register(VERSION_MISMATCH_EXCEPTION, VersionMismatchException.class, ((message, cause) -> new VersionMismatchException(message)));
         register(NO_SUCH_METHOD_ERROR, NoSuchMethodError.class, ((message, cause) -> new NoSuchMethodError(message)));
@@ -709,7 +330,7 @@ public class ClientExceptionFactory {
         }
         ErrorHolder errorHolder = iterator.next();
         ExceptionFactory exceptionFactory = intToFactory.get(errorHolder.getErrorCode());
-        Throwable throwable;
+        Throwable throwable = null;
         if (exceptionFactory == null) {
             String className = errorHolder.getClassName();
             assert checkClassNameForValidity(className) : "Exception should be defined in the protocol : " + className;
@@ -718,7 +339,10 @@ public class ClientExceptionFactory {
                         (Class<? extends Throwable>) ClassLoaderUtil.loadClass(classLoader, className);
                 throwable = ExceptionUtil.tryCreateExceptionWithMessageAndCause(exceptionClass, errorHolder.getMessage(),
                         createException(iterator));
-            } catch (Exception e) {
+            } catch (ClassNotFoundException e) {
+                EmptyStatement.ignore(e);
+            }
+            if (throwable == null) {
                 throwable = new UndefinedErrorCodeException(errorHolder.getMessage(), className, createException(iterator));
             }
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -792,7 +792,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private ClientExceptionFactory initClientExceptionFactory() {
         boolean jCacheAvailable = JCacheDetector.isJCacheAvailable(getClientConfig().getClassLoader());
-        return new ClientExceptionFactory(jCacheAvailable);
+        return new ClientExceptionFactory(jCacheAvailable, config.getClassLoader());
     }
 
     public ClientExceptionFactory getClientExceptionFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
@@ -45,13 +45,13 @@ import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.flakeidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
+import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.scheduledexecutor.DuplicateTaskException;
@@ -66,11 +66,11 @@ import com.hazelcast.spi.exception.ServiceNotFoundException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
-import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.wan.WanQueueFullException;
 
 import javax.cache.CacheException;
@@ -209,6 +209,11 @@ public class ClientExceptions {
         register(ClientProtocolErrorCodes.STALE_APPEND_REQUEST_EXCEPTION, StaleAppendRequestException.class);
         register(ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION, NotLeaderException.class);
         register(ClientProtocolErrorCodes.VERSION_MISMATCH_EXCEPTION, VersionMismatchException.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_METHOD_ERROR, NoSuchMethodError.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_METHOD_EXCEPTION, NoSuchMethodException.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_FIELD_ERROR, NoSuchFieldError.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_FIELD_EXCEPTION, NoSuchFieldException.class);
+        register(ClientProtocolErrorCodes.NO_CLASS_DEF_FOUND_ERROR, NoClassDefFoundError.class);
     }
 
     public ClientMessage createExceptionMessage(Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -212,7 +212,7 @@ public final class ExceptionUtil {
 
     /**
      * Tries to create the exception with appropriate constructor in the following order.
-     * In all cases the cause is set(via constructor or via initCause)
+     * In all cases the cause is set (via constructor or via {@code initCause})
      * new Throwable(String message, Throwable cause)
      * new Throwable(Throwable cause)
      * new Throwable(String message)
@@ -221,7 +221,7 @@ public final class ExceptionUtil {
      * @param exceptionClass class of the exception
      * @param message        message to be pass to constructor of the exception
      * @param cause          cause to be set to the exception
-     * @return null if can not find a constructor as described above, otherwise return newly constructed expcetion
+     * @return {@code null} if can not find a constructor as described above, otherwise returns newly constructed exception
      */
     public static <T extends Throwable> T tryCreateExceptionWithMessageAndCause(Class<? extends Throwable> exceptionClass,
                                                                                 String message, @Nullable Throwable cause) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -38,7 +38,6 @@ import java.util.function.BiFunction;
 public final class ExceptionUtil {
 
     private static final String EXCEPTION_SEPARATOR = "------ submitted from ------";
-
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
     // new Throwable(String message, Throwable cause)
     private static final MethodType MT_INIT_STRING_THROWABLE = MethodType.methodType(void.class, String.class, Throwable.class);
@@ -281,5 +280,4 @@ public final class ExceptionUtil {
         System.arraycopy(localSideStackTrace, 1, newStackTrace, remoteStackTrace.length + 1, localSideStackTrace.length - 1);
         return newStackTrace;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -34,13 +34,13 @@ import com.hazelcast.crdt.MutationDisallowedException;
 import com.hazelcast.crdt.TargetNotReplicaException;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
+import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.spi.exception.CallerNotMemberException;
@@ -52,6 +52,7 @@ import com.hazelcast.spi.exception.RetryableIOException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -60,7 +61,6 @@ import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
-import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.wan.WanQueueFullException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -69,6 +69,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+import usercodedeployment.CustomExceptions;
 
 import javax.cache.CacheException;
 import javax.cache.integration.CacheLoaderException;
@@ -104,7 +105,8 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
     public Throwable throwable;
 
     private ClientExceptions exceptions = new ClientExceptions(true);
-    private ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(true);
+    private ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(true,
+            Thread.currentThread().getContextClassLoader());
 
     @Test
     public void testException() {
@@ -125,21 +127,20 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
             return false;
         }
 
-        if (exceptions.isKnownClass(expected.getClass())) {
-            if (!expected.getClass().equals(actual.getClass())) {
-                return false;
-            }
-
-            // We compare the message only for known exceptions.
-            // We also ignore it for URISyntaxException, as it is not possible to restore it without special, probably JVM-version specific logic.
-            if (expected.getClass() != URISyntaxException.class && !equals(expected.getMessage(), actual.getMessage())) {
+        if (UndefinedErrorCodeException.class.equals(actual.getClass())) {
+            if (!expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
                 return false;
             }
         } else {
-            if (!UndefinedErrorCodeException.class.equals(actual.getClass())
-                    || !expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
+            if (!expected.getClass().equals(actual.getClass())) {
                 return false;
             }
+        }
+
+        // We compare the message only for known exceptions.
+        // We also ignore it for URISyntaxException, as it is not possible to restore it without special, probably JVM-version specific logic.
+        if (expected.getClass() != URISyntaxException.class && !equals(expected.getMessage(), actual.getMessage())) {
+            return false;
         }
 
         if (!stackTraceArrayEquals(expected.getStackTrace(), actual.getStackTrace())) {
@@ -261,8 +262,6 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new RuntimeException(new RuntimeException("blabla"))},
                 // exception with message and cause without message
                 new Object[]{new RuntimeException("blabla", new NullPointerException())},
-                // custom exception in causes
-                new Object[]{new RuntimeException("blabla", new DummyUncheckedHazelcastTestException())},
                 new Object[]{new RuntimeException("fun", new RuntimeException("codec \n is \n not \n pwned"))},
                 new Object[]{
                         new RuntimeException("fun",
@@ -272,7 +271,13 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new IndeterminateOperationStateException(randomString())},
                 new Object[]{new TargetNotReplicaException(randomString())},
                 new Object[]{new MutationDisallowedException(randomString())},
-                new Object[]{new ConsistencyLostException(randomString())}
+                new Object[]{new ConsistencyLostException(randomString())},
+                new Object[]{new CustomExceptions.CustomException()},
+                new Object[]{new CustomExceptions.CustomExceptionWithMessage(randomString())},
+                new Object[]{new CustomExceptions.CustomExceptionWithMessageAndCause(randomString(),
+                        new CustomExceptions.CustomExceptionWithMessage(randomString()))},
+                new Object[]{new CustomExceptions.CustomExceptionWithCause(new RuntimeException())},
+                new Object[]{new RuntimeException("blabla", new CustomExceptions.CustomExceptionWithMessage(randomString()))}
         );
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.protocol;
 
 import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.client.AuthenticationException;
-import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.config.InvalidConfigurationException;
@@ -125,16 +124,6 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
 
         if (expected == null || actual == null) {
             return false;
-        }
-
-        if (UndefinedErrorCodeException.class.equals(actual.getClass())) {
-            if (!expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
-                return false;
-            }
-        } else {
-            if (!expected.getClass().equals(actual.getClass())) {
-                return false;
-            }
         }
 
         // We compare the message only for known exceptions.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.impl.protocol;
 
+import com.hazelcast.client.UndefinedErrorCodeException;
+import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -23,6 +25,9 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import testsubjects.CustomExceptions;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -30,5 +35,16 @@ public class ClientProtocolErrorCodesTest extends HazelcastTestSupport {
     @Test
     public void testConstructor() {
         assertUtilityConstructor(ClientProtocolErrorCodes.class);
+    }
+
+    @Test
+    public void testUndefinedException() {
+        ClientExceptions exceptions = new ClientExceptions(false);
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(false, contextClassLoader);
+
+        ClientMessage message = exceptions.createExceptionMessage(new CustomExceptions.CustomExceptionNonStandardSignature(1));
+        Throwable resurrectedThrowable = exceptionFactory.createException(message);
+        assertEquals(UndefinedErrorCodeException.class, resurrectedThrowable.getClass());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.client.impl.protocol;
 
-import com.hazelcast.client.UndefinedErrorCodeException;
-import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -26,26 +24,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static junit.framework.TestCase.assertEquals;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientProtocolErrorCodesTest extends HazelcastTestSupport {
-
     @Test
     public void testConstructor() {
         assertUtilityConstructor(ClientProtocolErrorCodes.class);
-    }
-
-    @Test
-    public void testUndefinedException() {
-        ClientExceptions exceptions = new ClientExceptions(false);
-        ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(false);
-        class MyException extends Exception {
-        }
-
-        ClientMessage exceptionMessage = exceptions.createExceptionMessage(new MyException());
-        Throwable resurrectedThrowable = exceptionFactory.createException(exceptionMessage);
-        assertEquals(UndefinedErrorCodeException.class, resurrectedThrowable.getClass());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import testsubjects.CustomExceptions;
+import usercodedeployment.CustomExceptions;
 
 import static org.junit.Assert.assertEquals;
 

--- a/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
+++ b/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package usercodedeployment;
+
+public class CustomExceptions {
+
+    public static class CustomException extends Exception {
+        public CustomException() {
+
+        }
+    }
+
+    public static class CustomExceptionWithMessage extends Exception {
+        public CustomExceptionWithMessage(String message) {
+            super(message);
+        }
+    }
+
+    public static class CustomExceptionWithMessageAndCause extends Exception {
+        public CustomExceptionWithMessageAndCause(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class CustomExceptionWithCause extends Exception {
+        public CustomExceptionWithCause(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
+++ b/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
@@ -41,4 +41,10 @@ public class CustomExceptions {
             super(cause);
         }
     }
+
+    public static class CustomExceptionNonStandardSignature extends Exception {
+        public CustomExceptionNonStandardSignature(int x) {
+            super();
+        }
+    }
 }


### PR DESCRIPTION
We are throwing UndefinedErrorCodeException if an exception is
not on the protocol list.

This causes poor experience as the behaviour is different between
the client and the member.

see  https://github.com/hazelcast/hazelcast/issues/9753

This pr does not introduce an ExceptionFactory API as discussed
on the issue.
The value of an ExceptionFactory API is debetable and left out
for now. If the client has the expcetion class on the classpath,
the client will create it. If it is not available on the classpath,
it is not clear what can a user do with ExceptionFactory API.
In that case, we are throwing UndefinedErrorCodeException as before.
The main problem seems to be the case where the client have the
exact same class on the classpath, so this fix should cover
most of the use cases.

Also added  assert to check if exception is defined in the protocol
When classLoading is introduced it is possible for us to forget
to put the exception in the protocol, because it will not longer
throw UndefinedErrorCodeException but it will be loaded
automatically.
Assertion is added to check and warn us.

fixes https://github.com/hazelcast/hazelcast/issues/9753

(cherry picked from commit 18dd1ddac9db67a1cfe6d044166b7e61b55ccb20)