### PR TITLE
Try load custom exceptions via class loader on client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -19,8 +19,16 @@ package com.hazelcast.client;
 import com.hazelcast.core.HazelcastException;
 
 /**
- * This exception is thrown when an exception that is coming from server is not recognized by the protocol.
- * Class name of the original exception is included in the exception
+ * This exception is thrown when an exception that is coming from server is not recognized by the protocol and
+ * it can not be constructed by the client via reflection.
+ * For the client to be able to recreate original exception it should be available on the classpath and
+ * it should have one of the following constructors publicly.
+ * new Throwable(String message, Throwable cause)
+ * new Throwable(Throwable cause)
+ * new Throwable(String message)
+ * new Throwable()
+ * <p>
+ * Class name of the original exception is included in the exception.
  */
 public class UndefinedErrorCodeException extends HazelcastException {
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -77,6 +77,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.AddressUtil;
+import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.wan.WANReplicationQueueFullException;
 
@@ -838,13 +839,16 @@ public class ClientExceptionFactory {
 
     private Throwable createException(int errorCode, String className, String message, Throwable cause) {
         ExceptionFactory exceptionFactory = intToFactory.get(errorCode);
-        Throwable throwable;
+        Throwable throwable = null;
         if (exceptionFactory == null) {
             try {
                 Class<? extends Throwable> exceptionClass =
                         (Class<? extends Throwable>) ClassLoaderUtil.loadClass(classLoader, className);
                 throwable = ExceptionUtil.tryCreateExceptionWithMessageAndCause(exceptionClass, message, cause);
             } catch (Exception e) {
+                EmptyStatement.ignore(e);
+            }
+            if (throwable == null) {
                 throwable = new UndefinedErrorCodeException(message, className);
             }
         } else {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -53,6 +53,7 @@ import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.mapreduce.RemoteMapReduceException;
 import com.hazelcast.mapreduce.TopologyChangedException;
 import com.hazelcast.memory.NativeOutOfMemoryError;
+import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.query.QueryException;
@@ -76,6 +77,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.AddressUtil;
+import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.wan.WANReplicationQueueFullException;
 
 import javax.cache.CacheException;
@@ -111,6 +113,11 @@ import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LEADER
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_OWNERSHIP_LOST_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_CLASS_DEF_FOUND_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_FIELD_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_FIELD_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_METHOD_ERROR;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NO_SUCH_METHOD_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SESSION_EXPIRED_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.STALE_APPEND_REQUEST_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.WAIT_KEY_CANCELLED_EXCEPTION;
@@ -128,15 +135,15 @@ public class ClientExceptionFactory {
      * This pattern extracts errorCode and exception message from the encoded Caused-by marker.
      * It has the form:
      * <pre>    ###### Caused by: (&lt;errorCode>) &lt;cause.toString()> ------</pre>
-     *
+     * <p>
      * As per {@link Throwable#toString()}, this has the form
      * <pre>&lt;exception class>: &lt;message></pre>
-     *
+     * <p>
      * if message is present, or just {@code &lt;exception class>}, if message is null.
      *
      * <p>Commonly, exceptions with causes are created like this:
      * <pre>new RuntimeException("Additional message: " + e, e);</pre>
-     *
+     * <p>
      * Thus, this pattern matches the marker, error code in parentheses, text up to the semicolon
      * (reluctantly, as to find the first one), and optional semicolon and the rest of message.
      */
@@ -147,8 +154,10 @@ public class ClientExceptionFactory {
     private static final int CAUSED_BY_STACKTRACE_PARSER_MESSAGE_GROUP = 4;
 
     private final Map<Integer, ExceptionFactory> intToFactory = new HashMap<Integer, ExceptionFactory>();
+    private final ClassLoader classLoader;
 
-    public ClientExceptionFactory(boolean jcacheAvailable) {
+    public ClientExceptionFactory(boolean jcacheAvailable, ClassLoader classLoader) {
+        this.classLoader = classLoader;
         if (jcacheAvailable) {
             register(ClientProtocolErrorCodes.CACHE, CacheException.class, new ExceptionFactory() {
                 @Override
@@ -737,6 +746,36 @@ public class ClientExceptionFactory {
                 return new NotLeaderException(null, null, null);
             }
         });
+        register(NO_SUCH_METHOD_ERROR, NoSuchMethodError.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new NoSuchMethodError(message);
+            }
+        });
+        register(NO_SUCH_METHOD_EXCEPTION, NoSuchMethodException.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new NoSuchMethodException(message);
+            }
+        });
+        register(NO_SUCH_FIELD_ERROR, NoSuchFieldError.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new NoSuchFieldError(message);
+            }
+        });
+        register(NO_SUCH_FIELD_EXCEPTION, NoSuchFieldException.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new NoSuchFieldException(message);
+            }
+        });
+        register(NO_CLASS_DEF_FOUND_ERROR, NoClassDefFoundError.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new NoClassDefFoundError(message);
+            }
+        });
     }
 
     public Throwable createException(ClientMessage clientMessage) {
@@ -744,7 +783,7 @@ public class ClientExceptionFactory {
 
         // first, try to search for the marker to see, if there are any "hidden" causes
         boolean causedByMarkerFound = false;
-        for (int i = 0; ! causedByMarkerFound && i < parameters.stackTrace.length; i++) {
+        for (int i = 0; !causedByMarkerFound && i < parameters.stackTrace.length; i++) {
             causedByMarkerFound = parameters.stackTrace[i].getClassName().startsWith(CAUSED_BY_STACKTRACE_MARKER);
         }
 
@@ -801,11 +840,28 @@ public class ClientExceptionFactory {
         ExceptionFactory exceptionFactory = intToFactory.get(errorCode);
         Throwable throwable;
         if (exceptionFactory == null) {
-            throwable = new UndefinedErrorCodeException(message, className);
+            try {
+                Class<? extends Throwable> exceptionClass =
+                        (Class<? extends Throwable>) ClassLoaderUtil.loadClass(classLoader, className);
+                throwable = ExceptionUtil.tryCreateExceptionWithMessageAndCause(exceptionClass, message, cause);
+            } catch (Exception e) {
+                throwable = new UndefinedErrorCodeException(message, className);
+            }
         } else {
             throwable = exceptionFactory.createException(message, cause);
         }
         return throwable;
+    }
+
+    /**
+     * hazelcast and jdk exceptions should always be defined
+     * in {@link com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes} and
+     * in {@link com.hazelcast.client.impl.clientside.ClientExceptionFactory}
+     * so that a well defined error code could be delivered to non-java clients.
+     * So we don't try to load them via ClassLoader to be able to catch the missing exceptions
+     */
+    private boolean checkClassNameForValidity(String exceptionClassName) {
+        return !exceptionClassName.startsWith("com.hazelcast") && !exceptionClassName.startsWith("java");
     }
 
     // method is used by Jet

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -837,7 +837,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private ClientExceptionFactory initClientExceptionFactory() {
         boolean jCacheAvailable = JCacheDetector.isJCacheAvailable(getClientConfig().getClassLoader());
-        return new ClientExceptionFactory(jCacheAvailable);
+        return new ClientExceptionFactory(jCacheAvailable, config.getClassLoader());
     }
 
     public ClientExceptionFactory getClientExceptionFactory() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/atomiclong/ClientAtomicLongTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/atomiclong/ClientAtomicLongTest.java
@@ -16,18 +16,17 @@
 
 package com.hazelcast.client.atomiclong;
 
-import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IFunction;
-import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import custom.CustomRuntimeException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -171,8 +170,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         try {
             ref.apply(new FailingFunction());
             fail();
-        } catch (UndefinedErrorCodeException expected) {
-            assertEquals(expected.getOriginClassName(), ExpectedRuntimeException.class.getName());
+        } catch (CustomRuntimeException expected) {
         }
 
         assertEquals(1, ref.get());
@@ -188,9 +186,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         } catch (InterruptedException e) {
             fail();
         } catch (ExecutionException e) {
-            assertEquals(e.getCause().getClass(), UndefinedErrorCodeException.class);
-            assertEquals(((UndefinedErrorCodeException) e.getCause()).getOriginClassName(),
-                    ExpectedRuntimeException.class.getName());
+            assertEquals(CustomRuntimeException.class.getName(), e.getCause().getClass().getName());
         }
 
         assertEquals(1, ref.get());
@@ -211,8 +207,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         try {
             ref.alter(new FailingFunction());
             fail();
-        } catch (UndefinedErrorCodeException expected) {
-            assertEquals(expected.getOriginClassName(), ExpectedRuntimeException.class.getName());
+        } catch (CustomRuntimeException expected) {
         }
 
         assertEquals(10, ref.get());
@@ -229,9 +224,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         } catch (InterruptedException e) {
             fail();
         } catch (ExecutionException e) {
-            assertEquals(e.getCause().getClass(), UndefinedErrorCodeException.class);
-            assertEquals(((UndefinedErrorCodeException) e.getCause()).getOriginClassName(),
-                    ExpectedRuntimeException.class.getName());
+            assertEquals(CustomRuntimeException.class.getName(), e.getCause().getClass().getName());
         }
 
         assertEquals(10, ref.get());
@@ -274,8 +267,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         try {
             ref.alterAndGet(new FailingFunction());
             fail();
-        } catch (UndefinedErrorCodeException expected) {
-            assertEquals(expected.getOriginClassName(), ExpectedRuntimeException.class.getName());
+        } catch (CustomRuntimeException expected) {
         }
 
         assertEquals(10, ref.get());
@@ -292,9 +284,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         } catch (InterruptedException e) {
             fail();
         } catch (ExecutionException e) {
-            assertEquals(e.getCause().getClass(), UndefinedErrorCodeException.class);
-            assertEquals(((UndefinedErrorCodeException) e.getCause()).getOriginClassName(),
-                    ExpectedRuntimeException.class.getName());
+            assertEquals(CustomRuntimeException.class.getName(), e.getCause().getClass().getName());
         }
 
         assertEquals(10, ref.get());
@@ -334,8 +324,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         try {
             ref.getAndAlter(new FailingFunction());
             fail();
-        } catch (UndefinedErrorCodeException expected) {
-            assertEquals(expected.getOriginClassName(), ExpectedRuntimeException.class.getName());
+        } catch (CustomRuntimeException expected) {
         }
 
         assertEquals(10, ref.get());
@@ -351,11 +340,9 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
             future.get();
             fail();
         } catch (InterruptedException e) {
-            assertEquals(e.getCause().getClass().getName(), UndefinedErrorCodeException.class.getName());
-            assertEquals(((UndefinedErrorCodeException) e.getCause()).getOriginClassName(), ExpectedRuntimeException.class.getName());
+            fail();
         } catch (ExecutionException e) {
-            assertEquals(e.getCause().getClass().getName(), UndefinedErrorCodeException.class.getName());
-            assertEquals(((UndefinedErrorCodeException) e.getCause()).getOriginClassName(), ExpectedRuntimeException.class.getName());
+            assertEquals(CustomRuntimeException.class.getName(), e.getCause().getClass().getName());
         }
 
         assertEquals(10, ref.get());
@@ -399,7 +386,7 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
     private static class FailingFunction implements IFunction<Long, Long> {
         @Override
         public Long apply(Long input) {
-            throw new ExpectedRuntimeException();
+            throw new CustomRuntimeException();
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.impl.protocol;
 
 import com.hazelcast.cache.CacheNotExistsException;
-import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.config.ConfigurationException;
@@ -130,16 +129,6 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
 
         if (expected == null || actual == null) {
             return false;
-        }
-
-        if (UndefinedErrorCodeException.class.equals(actual.getClass())) {
-            if (!expected.getClass().getName().equals(((UndefinedErrorCodeException) actual).getOriginClassName())) {
-                return false;
-            }
-        } else {
-            if (!expected.getClass().equals(actual.getClass())) {
-                return false;
-            }
         }
 
         // We compare the message only for known exceptions.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.impl.protocol;
 
+import com.hazelcast.client.UndefinedErrorCodeException;
+import com.hazelcast.client.impl.clientside.ClientExceptionFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -23,6 +25,9 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import usercodedeployment.CustomExceptions;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -33,4 +38,14 @@ public class ClientProtocolErrorCodesTest extends HazelcastTestSupport {
         assertUtilityConstructor(ClientProtocolErrorCodes.class);
     }
 
+    @Test
+    public void testUndefinedException() {
+        ClientExceptions exceptions = new ClientExceptions(false);
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(false, contextClassLoader);
+
+        ClientMessage message = exceptions.createExceptionMessage(new CustomExceptions.CustomExceptionNonStandardSignature(1));
+        Throwable resurrectedThrowable = exceptionFactory.createException(message);
+        assertEquals(UndefinedErrorCodeException.class, resurrectedThrowable.getClass());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
@@ -216,6 +216,11 @@ public class ClientExceptions {
         register(ClientProtocolErrorCodes.LEADER_DEMOTED_EXCEPTION, LeaderDemotedException.class);
         register(ClientProtocolErrorCodes.STALE_APPEND_REQUEST_EXCEPTION, StaleAppendRequestException.class);
         register(ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION, NotLeaderException.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_METHOD_ERROR, NoSuchMethodError.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_METHOD_EXCEPTION, NoSuchMethodException.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_FIELD_ERROR, NoSuchFieldError.class);
+        register(ClientProtocolErrorCodes.NO_SUCH_FIELD_EXCEPTION, NoSuchFieldException.class);
+        register(ClientProtocolErrorCodes.NO_CLASS_DEF_FOUND_ERROR, NoClassDefFoundError.class);
     }
 
     public ClientMessage createExceptionMessage(Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -120,6 +120,11 @@ public final class ClientProtocolErrorCodes {
     public static final int LEADER_DEMOTED_EXCEPTION = 95;
     public static final int STALE_APPEND_REQUEST_EXCEPTION = 96;
     public static final int NOT_LEADER_EXCEPTION = 97;
+    public static final int NO_SUCH_METHOD_ERROR = 98;
+    public static final int NO_SUCH_METHOD_EXCEPTION = 99;
+    public static final int NO_SUCH_FIELD_ERROR = 100;
+    public static final int NO_SUCH_FIELD_EXCEPTION = 101;
+    public static final int NO_CLASS_DEF_FOUND_ERROR = 102;
 
     // These exception codes are reserved to by used by hazelcast-jet project
     public static final int JET_EXCEPTIONS_RANGE_START = 500;

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -236,7 +236,7 @@ public final class ExceptionUtil {
 
     /**
      * Tries to create the exception with appropriate constructor in the following order.
-     * In all cases the cause is set(via constructor or via initCause)
+     * In all cases the cause is set (via constructor or via {@code initCause})
      * new Throwable(String message, Throwable cause)
      * new Throwable(Throwable cause)
      * new Throwable(String message)
@@ -245,11 +245,10 @@ public final class ExceptionUtil {
      * @param exceptionClass class of the exception
      * @param message        message to be pass to constructor of the exception
      * @param cause          cause to be set to the exception
-     * @return null if can not find a constructor as described above, otherwise return newly constructed expcetion
+     * @return {@code null} if can not find a constructor as described above, otherwise returns newly constructed exception
      */
     public static <T extends Throwable> T tryCreateExceptionWithMessageAndCause(Class<? extends Throwable> exceptionClass,
                                                                                 String message, @Nullable Throwable cause) {
-
         try {
             Constructor<? extends Throwable> constructor = exceptionClass.getConstructor(String.class, Throwable.class);
             T clone = (T) constructor.newInstance(message, cause);

--- a/hazelcast/src/test/java/custom/CustomRuntimeException.java
+++ b/hazelcast/src/test/java/custom/CustomRuntimeException.java
@@ -14,23 +14,17 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.impl.protocol;
+package custom;
 
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+public class CustomRuntimeException extends RuntimeException {
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
-public class ClientProtocolErrorCodesTest extends HazelcastTestSupport {
+    private static final long serialVersionUID = 83105880382695411L;
 
-    @Test
-    public void testConstructor() {
-        assertUtilityConstructor(ClientProtocolErrorCodes.class);
+    public CustomRuntimeException() {
+        this("Expected exception");
     }
 
+    public CustomRuntimeException(String msg) {
+        super(msg);
+    }
 }

--- a/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
+++ b/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package usercodedeployment;
+
+public class CustomExceptions {
+
+    public static class CustomException extends Exception {
+        public CustomException() {
+
+        }
+    }
+
+    public static class CustomExceptionWithMessage extends Exception {
+        public CustomExceptionWithMessage(String message) {
+            super(message);
+        }
+    }
+
+    public static class CustomExceptionWithMessageAndCause extends Exception {
+        public CustomExceptionWithMessageAndCause(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class CustomExceptionWithCause extends Exception {
+        public CustomExceptionWithCause(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
+++ b/hazelcast/src/test/java/usercodedeployment/CustomExceptions.java
@@ -41,4 +41,9 @@ public class CustomExceptions {
             super(cause);
         }
     }
+
+    public static class CustomExceptionNonStandardSignature extends Throwable {
+        public CustomExceptionNonStandardSignature(int i) {
+        }
+    }
 }


### PR DESCRIPTION
We are throwing UndefinedErrorCodeException if an exception is
not on the protocol list.

This causes poor experience as the behaviour is different between
the client and the member.

see  https://github.com/hazelcast/hazelcast/issues/9753

This pr does not introduce an ExceptionFactory API as discussed
on the issue.
The value of an ExceptionFactory API is debetable and left out
for now. If the client has the expcetion class on the classpath,
the client will create it. If it is not available on the classpath,
it is not clear what can a user do with ExceptionFactory API.
In that case, we are throwing UndefinedErrorCodeException as before.
The main problem seems to be the case where the client have the
exact same class on the classpath, so this fix should cover
most of the use cases.

Also added  assert to check if exception is defined in the protocol
When classLoading is introduced it is possible for us to forget
to put the exception in the protocol, because it will not longer
throw UndefinedErrorCodeException but it will be loaded
automatically.
Assertion is added to check and warn us.

fixes https://github.com/hazelcast/hazelcast/issues/9753