### PR TITLE
Disabled QueryOperationHandlerTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerTest.java
@@ -82,6 +82,7 @@ import static org.junit.Assert.fail;
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
+@Ignore("https://github.com/hazelcast/hazelcast/issues/16929#issuecomment-699819103")
 public class QueryOperationHandlerTest extends SqlTestSupport {
 
     private static final int EDGE_ID = 1;


### PR DESCRIPTION
This PR disables the flaky test class `QueryOperationHandlerTest`. The problem is that the whole test class is written in an unreliable way. The only way to fix it - rewrite the test completely. However, we are going to change the threading model soon in https://github.com/hazelcast/hazelcast/issues/17563 that will make this test obsolete. 

Therefore, we disable the test for now.