### PR TITLE
Outbound responses are spread over connections

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -55,6 +55,7 @@ import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setConne
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,7 +100,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(response.getCallId());
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, response);
@@ -114,7 +115,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(10);
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, response);
@@ -130,7 +131,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(10);
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, response);
@@ -145,7 +146,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(10);
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, null);
@@ -162,7 +163,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(10);
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, response);
@@ -178,7 +179,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(10);
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, response);
@@ -194,7 +195,7 @@ public class OutboundResponseHandlerTest {
         Operation op = createDummyOperation(10);
 
         ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
-        when(connectionManager.transmit(argument.capture(), eq(thatAddress))).thenReturn(true);
+        when(connectionManager.transmit(argument.capture(), eq(thatAddress), anyInt())).thenReturn(true);
 
         // make the call
         handler.sendResponse(op, exception);


### PR DESCRIPTION
If multiple connections are used, the outbound responses are now
properly (random) spread over the connections.

This will prevent a single connection from becoming a bottleneck.