### PR TITLE
Reset missing members map during split-brain merge

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -234,6 +234,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
 
     @Override
     public void reset() {
+        missingMembers.clear();
     }
 
     @Override


### PR DESCRIPTION
`missingMembers` map tracks the missing members from the CP subsystem,
and used to auto-remove a missing CP member after a timeout if it does
not join meanwhile.

It's updated when a new membership event is received, only if node is
already joined the cluster. While a member is joining the cluster,
`missingMembers` map is not touched. Because we don't expect any missing
members at this point.
But during a split-brain merge, there may be some registered missing
members already. That's why these entries should be cleared before
joining the cluster.

PS: Normally `CPMemberAutoRemoveTest` verifies this but because of another
change, this issue doesn't appear in 4.x versions.