### PR TITLE
Calculate the new partition state stamp after applying partition table update

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -367,16 +367,10 @@ public class PartitionStateManager implements ClusterVersionListener {
         return partitions[partitionId].isMigrating();
     }
 
-    /** Sets the replica members for the {@code partitionId}. */
-    void updateReplicas(int partitionId, InternalPartition replicas) {
-        InternalPartitionImpl partition = partitions[partitionId];
-        partition.setReplicasAndVersion(replicas);
-    }
-
     public void updateStamp() {
         stateStamp = calculateStamp(partitions);
         if (logger.isFinestEnabled()) {
-            logger.finest("New partition state stamp is: " + stateStamp);
+            logger.finest("New calculated partition state stamp is: " + stateStamp);
         }
     }
 
@@ -434,7 +428,7 @@ public class PartitionStateManager implements ClusterVersionListener {
 
     void reset() {
         initialized = false;
-        stateStamp = 0;
+        stateStamp = INITIAL_STAMP;
         stateVersion.set(0);
         // local member uuid changes during ClusterService reset
         PartitionReplica localReplica = PartitionReplica.from(node.getLocalMember());

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionInitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionInitTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -52,8 +53,10 @@ public class ClusterVersionInitTest extends HazelcastTestSupport {
     public void test_clusterVersion_isEventuallySet_whenNoJoinerConfiguredSingleNode() {
         Config config = new Config();
         config.setClusterName(randomName());
-        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+        join.getAutoDetectionConfig().setEnabled(false);
         setupInstance(config);
         assertEqualsEventually(() -> cluster.getClusterVersion(), codebaseVersion.asVersion());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -46,7 +46,9 @@ import static com.hazelcast.instance.impl.TestUtil.terminateInstance;
 import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
 import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
 import static com.hazelcast.test.Accessors.getNode;
+import static com.hazelcast.test.Accessors.getPartitionService;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -97,6 +99,9 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(2, instances[2]);
         assertAllPartitionsAreAssigned(instances[2], 1);
+
+        assertEquals(getPartitionService(instances[1]).getPartitionStateStamp(),
+                getPartitionService(instances[2]).getPartitionStateStamp());
     }
 
     @Test
@@ -166,6 +171,11 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         for (HazelcastInstance instance : newInstances) {
             assertClusterSizeEventually(newInstances.length, instance);
             assertAllPartitionsAreAssigned(instance, newInstances.length);
+        }
+
+        long partitionStamp = getPartitionService(newInstances[0]).getPartitionStateStamp();
+        for (HazelcastInstance instance : newInstances) {
+            assertEquals(partitionStamp, getPartitionService(instance).getPartitionStateStamp());
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -64,6 +64,7 @@ import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
@@ -197,6 +198,11 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         hz1.getCluster().promoteLocalLiteMember();
 
         assertPartitionsAssignedEventually(hz1);
+        waitAllForSafeState(hz1, hz2, hz3);
+
+        long partitionStamp = getPartitionService(hz1).getPartitionStateStamp();
+        assertEquals(partitionStamp, getPartitionService(hz2).getPartitionStateStamp());
+        assertEquals(partitionStamp, getPartitionService(hz3).getPartitionStateStamp());
     }
 
     @Test
@@ -213,6 +219,12 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         hz2.getCluster().promoteLocalLiteMember();
 
         assertPartitionsAssignedEventually(hz2);
+
+        waitAllForSafeState(hz1, hz2, hz3);
+
+        long partitionStamp = getPartitionService(hz1).getPartitionStateStamp();
+        assertEquals(partitionStamp, getPartitionService(hz2).getPartitionStateStamp());
+        assertEquals(partitionStamp, getPartitionService(hz3).getPartitionStateStamp());
     }
 
     @Test


### PR DESCRIPTION
Fixes hazelcast/hazelcast-enterprise#3791
Fixes https://github.com/hazelcast/hazelcast/issues/17577