### PR TITLE
Add support for JAAS logout on member side

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -380,6 +380,7 @@ public class ClusterJoinManager {
                 LoginContext loginContext = node.securityContext.createMemberLoginContext(remoteClusterName, credentials,
                         connection);
                 loginContext.login();
+                connection.attributeMap().put(LoginContext.class, loginContext);
                 passed = Boolean.TRUE;
             } catch (LoginException e) {
                 throw new SecurityException(format("Authentication has failed for %s @%s, cause: %s",

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -38,6 +38,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_CONNECTION_CONNECTION_TYPE;
 import static com.hazelcast.internal.metrics.ProbeUnit.ENUM;
 import static com.hazelcast.internal.nio.ConnectionType.MEMBER;
@@ -246,6 +249,15 @@ public class TcpServerConnection implements ServerConnection {
 
         lifecycleListener.onConnectionClose(this, null, false);
         serverContext.onDisconnect(remoteAddress, cause);
+
+        LoginContext lc = (LoginContext) attributeMap.remove(LoginContext.class);
+        if (lc != null) {
+            try {
+                lc.logout();
+            } catch (LoginException e) {
+                logger.warning("Logout failed", e);
+            }
+        }
         if (cause != null && errorHandler != null) {
             errorHandler.onError(cause);
         }


### PR DESCRIPTION
Resolves hazelcast/hazelcast-enterprise#3777.

The PR adds JAAS login context to Connection's attribute map and uses it to call `logout()` when the Connection is closed.