### PR TITLE
Replace System Rules with System Lambda

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -352,8 +352,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <artifactId>system-lambda</artifactId>
+            <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalClientConfigurationOverrideTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalClientConfigurationOverrideTest.java
@@ -20,12 +20,11 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -33,17 +32,12 @@ import static org.junit.Assert.assertFalse;
 @Category(QuickTest.class)
 public class ExternalClientConfigurationOverrideTest extends HazelcastTestSupport {
 
-    @ClassRule
-    public static final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
     @Test
-    public void shouldExtractConfigFromEnv() {
-        environmentVariables
-          .set("HZCLIENT_INSTANCENAME", "test")
-          .set("HZCLIENT_NETWORK_AUTODETECTION_ENABLED", "false");
-
+    public void shouldExtractConfigFromEnv() throws Exception {
         ClientConfig config = new ClientConfig();
-        new ExternalConfigurationOverride().overwriteClientConfig(config);
+        withEnvironmentVariable("HZCLIENT_INSTANCENAME", "test")
+          .and("HZCLIENT_NETWORK_AUTODETECTION_ENABLED", "false")
+          .execute(() -> new ExternalConfigurationOverride().overwriteClientConfig(config));
 
         assertEquals("test", config.getInstanceName());
         assertFalse(config.getNetworkConfig().isAutoDetectionEnabled());


### PR DESCRIPTION
System Lambda is more specific. It only wraps the part of the code that
reads the environment variables. In addition System Lambda is
independent from the test framework and no obstacle for moving to
another test framework (e.g. JUnit Lambda).