### PR TITLE
Fixed a data loss issue on lite member promotion

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -305,6 +305,8 @@ public class MembershipManager {
 
         MemberImpl[] members = new MemberImpl[membersView.size()];
         int memberIndex = 0;
+        // Indicates whether we received a notification on lite member membership change
+        // (e.g. its promotion to a data member)
         boolean updatedLiteMember = false;
         for (MemberInfo memberInfo : membersView.getMembers()) {
             Address address = memberInfo.getAddress();
@@ -347,7 +349,7 @@ public class MembershipManager {
         setMembers(MemberMap.createNew(membersView.getVersion(), members));
 
         if (updatedLiteMember) {
-            updateMembersGroupSize();
+            node.partitionService.updateMemberGroupSize();
         }
 
         for (MemberImpl member : removedMembers) {
@@ -416,10 +418,6 @@ public class MembershipManager {
                       .memberListJoinVersion(memberInfo.getMemberListJoinVersion())
                       .instance(node.hazelcastInstance)
                       .build();
-    }
-
-    private void updateMembersGroupSize() {
-        node.partitionService.updateMemberGroupSize();
     }
 
     private void repairPartitionTableIfReturningMember(MemberImpl member) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -367,6 +367,7 @@ public class MembershipManager {
                 member = clusterService.promoteAndGetLocalMember();
             } else {
                 member = createMember(newMemberInfo, member.getAttributes());
+                node.partitionService.memberAdded(member);
             }
         } else if (member.getMemberListJoinVersion() != newMemberInfo.getMemberListJoinVersion()) {
             if (member.getMemberListJoinVersion() != NA_MEMBER_LIST_JOIN_VERSION) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -376,7 +376,6 @@ public class MembershipManager {
             } else {
                 member = createMember(newMemberInfo, member.getAttributes());
             }
-            node.partitionService.memberAdded(member);
         } else if (member.getMemberListJoinVersion() != newMemberInfo.getMemberListJoinVersion()) {
             if (member.getMemberListJoinVersion() != NA_MEMBER_LIST_JOIN_VERSION) {
                 if (logger.isFineEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -346,6 +346,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         return max(min(getMemberGroupsSize() - 1, InternalPartition.MAX_BACKUP_COUNT), 0);
     }
 
+    public void updateMemberGroupSize() {
+        partitionStateManager.updateMemberGroupsSize();
+    }
+
     @Override
     public void memberAdded(Member member) {
         logger.fine("Adding " + member);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -327,7 +327,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void lite_member_promotion_data_loss() throws InterruptedException {
+    public void test_lite_member_promotion_causes_no_data_loss_on_three_members() throws InterruptedException {
         int entryCount = 1000;
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
@@ -368,7 +368,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void lite_member_promotion_data_loss2() throws InterruptedException {
+    public void test_lite_member_promotion_causes_no_data_loss_on_two_members() throws InterruptedException {
         int entryCount = 1000;
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.cluster.impl.operations.PromoteLiteMemberOp;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.internal.util.UuidUtil;
+import com.hazelcast.map.IMap;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.impl.Invocation;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
@@ -64,9 +65,11 @@ import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -321,6 +324,47 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         } catch (ExecutionException e) {
             assertInstanceOf(IllegalStateException.class, e.getCause());
         }
+    }
+
+    @Test
+    public void lite_member_promotion_data_loss() throws InterruptedException {
+        int entryCount = 1000;
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        Config config = new Config().setLiteMember(true);
+
+        // start first hazelcast instance as a lite member
+        HazelcastInstance firstHazelcastInstance = factory.newHazelcastInstance(config);
+
+        // start second and third hazelcast instances as a lite member
+        HazelcastInstance secondHazelcastInstance = factory.newHazelcastInstance(config);
+        HazelcastInstance thirdHazelcastInstance = factory.newHazelcastInstance(config);
+
+        // promote all instances to data members
+        firstHazelcastInstance.getCluster().promoteLocalLiteMember();
+        secondHazelcastInstance.getCluster().promoteLocalLiteMember();
+        thirdHazelcastInstance.getCluster().promoteLocalLiteMember();
+
+        // check if cluster is in a good shape
+        assertTrueEventually(() -> assertTrue(firstHazelcastInstance.getPartitionService().isClusterSafe()));
+
+        // insert some dummy data into the testing map
+        String mapName = randomMapName();
+        IMap<String, String> testMap = firstHazelcastInstance.getMap(mapName);
+        for (int i = 0; i < entryCount; ++i) {
+            testMap.put("key" + i, "value" + i);
+        }
+
+        // check all data is correctly inserted
+        assertEquals(entryCount, testMap.size());
+
+        // kill second instance
+        secondHazelcastInstance.getLifecycleService().terminate();
+
+        // backup count for the map is set to 1
+        // even with 1 node down, no data loss is expected
+        assertTrueEventually(() -> assertEquals(entryCount, firstHazelcastInstance.getMap(mapName).size()));
+        assertTrueEventually(() -> assertEquals(entryCount, thirdHazelcastInstance.getMap(mapName).size()));
     }
 
     private void assertPromotionInvocationStarted(HazelcastInstance instance) {


### PR DESCRIPTION
Notify cluster members on lite member promotion to update
memberGroupSize. Otherwise, a data member might be not aware of other
promoted data members, and it may cause backup operations
not being issued to other data members.

Closes https://github.com/hazelcast/hazelcast/issues/17621