### PR TITLE
Refactoring client deregister listener behaviour

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -165,7 +165,6 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
                 invocationService.checkInvocationAllowed();
             }
 
-
             if (isBindToSingleConnection()) {
                 boolean invoked = invocationService.invokeOnConnection(this, (ClientConnection) connection);
                 if (!invoked) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
@@ -46,7 +46,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -307,39 +306,33 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
         //This method should only be called from registrationExecutor
         assert (Thread.currentThread().getName().contains("eventRegistration"));
 
-        ClientListenerRegistration listenerRegistration = registrations.get(userRegistrationId);
+        ClientListenerRegistration listenerRegistration = registrations.remove(userRegistrationId);
         if (listenerRegistration == null) {
             return false;
         }
-        boolean successful = true;
 
         Map<Connection, ClientConnectionRegistration> registrations = listenerRegistration.getConnectionRegistrations();
-        Iterator<Map.Entry<Connection, ClientConnectionRegistration>> iterator = registrations.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Connection, ClientConnectionRegistration> entry = iterator.next();
+        for (Map.Entry<Connection, ClientConnectionRegistration> entry : registrations.entrySet()) {
             ClientConnectionRegistration registration = entry.getValue();
-            Connection subscriber = entry.getKey();
-            try {
-                ListenerMessageCodec listenerMessageCodec = listenerRegistration.getCodec();
-                UUID serverRegistrationId = registration.getServerRegistrationId();
-                ClientMessage request = listenerMessageCodec.encodeRemoveRequest(serverRegistrationId);
-                if (request != null) {
-                    new ClientInvocation(client, request, null, subscriber).invoke().get();
-                }
-                ((ClientConnection) subscriber).removeEventHandler(registration.getCallId());
-                iterator.remove();
-            } catch (Exception e) {
-                if (subscriber.isAlive()) {
-                    successful = false;
-                    logger.warning("Deregistration of listener with ID " + userRegistrationId
-                            + " has failed to address " + subscriber.getRemoteAddress(), e);
-                }
+            ClientConnection subscriber = (ClientConnection) entry.getKey();
+            //remove local handler
+            subscriber.removeEventHandler(registration.getCallId());
+            //the rest is for deleting remote registration
+            ListenerMessageCodec listenerMessageCodec = listenerRegistration.getCodec();
+            UUID serverRegistrationId = registration.getServerRegistrationId();
+            ClientMessage request = listenerMessageCodec.encodeRemoveRequest(serverRegistrationId);
+            if (request == null) {
+                continue;
             }
+            ClientInvocation clientInvocation = new ClientInvocation(client, request, null, subscriber);
+            clientInvocation.setInvocationTimeoutMillis(Long.MAX_VALUE);
+            clientInvocation.invokeUrgent().exceptionally(throwable -> {
+                logger.warning("Deregistration of listener with ID " + userRegistrationId
+                        + " has failed to address " + subscriber.getRemoteAddress(), throwable);
+                return null;
+            });
         }
-        if (successful) {
-            this.registrations.remove(userRegistrationId);
-        }
-        return successful;
+        return true;
     }
 
     private final class ClientEventProcessor implements StripedRunnable {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.spi.impl.listener;
 
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.connection.ClientConnectionManager;
@@ -40,10 +41,12 @@ import com.hazelcast.internal.util.executor.SingleExecutorThreadFactory;
 import com.hazelcast.internal.util.executor.StripedExecutor;
 import com.hazelcast.internal.util.executor.StripedRunnable;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -177,7 +180,9 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
         ClientConnection connection = (ClientConnection) clientMessage.getConnection();
         EventHandler eventHandler = connection.getEventHandler(correlationId);
         if (eventHandler == null) {
-            logger.warning("No eventHandler for callId: " + correlationId + ", event: " + clientMessage);
+            if (logger.isFineEnabled()) {
+                logger.fine("No eventHandler for callId: " + correlationId + ", event: " + clientMessage);
+            }
             return;
         }
 
@@ -327,8 +332,12 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
             ClientInvocation clientInvocation = new ClientInvocation(client, request, null, subscriber);
             clientInvocation.setInvocationTimeoutMillis(Long.MAX_VALUE);
             clientInvocation.invokeUrgent().exceptionally(throwable -> {
-                logger.warning("Deregistration of listener with ID " + userRegistrationId
-                        + " has failed to address " + subscriber.getRemoteAddress(), throwable);
+                if (!(throwable instanceof HazelcastClientNotActiveException
+                        || throwable instanceof IOException
+                        || throwable instanceof TargetDisconnectedException)) {
+                    logger.warning("Deregistration of listener with ID " + userRegistrationId
+                            + " has failed for address " + subscriber.getRemoteAddress(), throwable);
+                }
                 return null;
             });
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -83,8 +83,8 @@ public class ListenerLeakTest extends ClientTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-    private void assertNoLeftOver(Collection<Node> nodes, HazelcastInstance client, UUID id
-            , Collection<ClientConnectionRegistration> registrations) {
+    private void assertNoLeftOver(Collection<Node> nodes, HazelcastInstance client, UUID id,
+                                  Collection<ClientConnectionRegistration> registrations) {
         assertTrueEventually(() -> {
             for (Node node : nodes) {
                 assertNoLeftOverOnNode(node, registrations);

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -85,10 +85,12 @@ public class ListenerLeakTest extends ClientTestSupport {
 
     private void assertNoLeftOver(Collection<Node> nodes, HazelcastInstance client, UUID id
             , Collection<ClientConnectionRegistration> registrations) {
-        for (Node node : nodes) {
-            assertNoLeftOverOnNode(node, registrations);
-        }
-        assertEquals(0, getClientEventRegistrations(client, id).size());
+        assertTrueEventually(() -> {
+            for (Node node : nodes) {
+                assertNoLeftOverOnNode(node, registrations);
+            }
+            assertEquals(0, getClientEventRegistrations(client, id).size());
+        });
     }
 
     private Collection<Node> createNodes() {


### PR DESCRIPTION
We were returning `false` as the return value if we were not
successuflly deregister from any member and events was able to
continue to delivered for non deregistered members.

We have changed the behaviour so that we return `true` if a
registration is found always. And after this point, user will not
get any event. We will cleanup all the local handlers right away
to make sure of that.

Secondly we have set invocation timeout as infinite so that the
deregistartion from a connection is retried as long as the
connection is there until it is succesful.

I have left logging the exception when there is an unexpected
failure. We do not expect any but this is to be able to diagnose
if the unexpected happens.