### PR TITLE
Fixes race in AbstractInvocationFuture#exceptionally

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
@@ -408,7 +408,7 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
     @Override
     public CompletableFuture<V> exceptionally(Function<Throwable, ? extends V> fn) {
-        return  new DelegatingCompletableFuture<>(serializationService,
+        return new DelegatingCompletableFuture<>(serializationService,
                 future.exceptionally(fn));
     }
 


### PR DESCRIPTION
Registration of any dependent action on a
non-complete `AbstractInvocationFuture` will result in
field `state` being an instance of an inner class like
`AbstractInvocationFuture$WhenCompleteNode`. When calling
exceptionally, it is possible that this non-complete
state is observed and then the `AbstractInvocationFuture`
will erroneously be considered as completed because
the condition checks a previously observed value of
`state` along with its current `isDone()` status.

Fixes #17566