### PR TITLE
Refactoring client deregister listener behaviour

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -80,8 +80,8 @@ public class ListenerLeakTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-    private void assertNoLeftOver(final Collection<Node> nodes, final HazelcastInstance client, final String id
-            , final Collection<ClientEventRegistration> registrations) {
+    private void assertNoLeftOver(final Collection<Node> nodes, final HazelcastInstance client, final String id,
+                                  final Collection<ClientEventRegistration> registrations) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -80,12 +80,17 @@ public class ListenerLeakTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-    private void assertNoLeftOver(Collection<Node> nodes, HazelcastInstance client, String id
-            , Collection<ClientEventRegistration> registrations) {
-        for (Node node : nodes) {
-            assertNoLeftOverOnNode(node, registrations);
-        }
-        assertEquals(0, getClientEventRegistrations(client, id).size());
+    private void assertNoLeftOver(final Collection<Node> nodes, final HazelcastInstance client, final String id
+            , final Collection<ClientEventRegistration> registrations) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                for (Node node : nodes) {
+                    assertNoLeftOverOnNode(node, registrations);
+                }
+                assertEquals(0, getClientEventRegistrations(client, id).size());
+            }
+        });
     }
 
     private Collection<Node> createNodes() {


### PR DESCRIPTION
We were returning `false` as the return value if we were not
successuflly deregister from any member and events was able to
continue to delivered for non deregistered members.

We have changed the behaviour so that we return `true` if a
registration is found always. And after this point, user will not
get any event. We will cleanup all the local handlers right away
to make sure of that.

Secondly we have set invocation timeout as infinite so that the
deregistartion from a connection is retried as long as the
connection is there until it is succesful.

I have left logging the exception when there is an unexpected
failure. We do not expect any but this is to be able to diagnose
if the unexpected happens.

(cherry picked from commit 54da2f065830e235e78e206236323e19ab317e25)