### PR TITLE
[WIP] Disable COR on certain IMap operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Immutable.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Immutable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+import com.hazelcast.spi.annotation.Beta;
+
+/**
+ * Allows notifying Hazelcast code that the object implementing this interface
+ * is effectively immutable.
+ * This may mean that it either does not have any state (e.g. pure function)
+ * or the state is not mutated at any point.
+ * This interface allows for performance optimisations where applicable such
+ * as avoiding cloning user supplied objects or cloning hazelcast internal
+ * objects supplied to the user.
+ * It is important that the user follows the rules:
+ * <ul>
+ * <li>the object must not have any state which is changed by cloning the object</li>
+ * <li>the existing state must not be changed</li>
+ * </ul>
+ * If an object implements this interface but does not follow these rules,
+ * the results of the execution are undefined.
+ */
+@Beta
+public interface Immutable {
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -36,26 +36,27 @@ import java.util.Map.Entry;
  *
  * @see com.hazelcast.map.impl.proxy.MapProxyImpl#iterator
  */
-public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Data>> {
+public class MapEntriesWithCursor extends AbstractCursor<Map.Entry<Data, Object>> {
 
     public MapEntriesWithCursor() {
     }
 
-    public MapEntriesWithCursor(List<Map.Entry<Data, Data>> entries, IterationPointer[] pointers) {
+    public MapEntriesWithCursor(List<Map.Entry<Data, Object>> entries,
+                                IterationPointer[] pointers) {
         super(entries, pointers);
     }
 
     @Override
-    void writeElement(ObjectDataOutput out, Entry<Data, Data> entry) throws IOException {
+    void writeElement(ObjectDataOutput out, Entry<Data, Object> entry) throws IOException {
         IOUtil.writeData(out, entry.getKey());
-        IOUtil.writeData(out, entry.getValue());
+        IOUtil.writeObject(out, entry.getValue());
     }
 
     @Override
-    Entry<Data, Data> readElement(ObjectDataInput in) throws IOException {
+    Entry<Data, Object> readElement(ObjectDataInput in) throws IOException {
         final Data key = IOUtil.readData(in);
-        final Data value = IOUtil.readData(in);
-        return new AbstractMap.SimpleEntry<>(key, value);
+        final Object value = IOUtil.readObject(in);
+        return new AbstractMap.SimpleEntry<Data, Object>(key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.core.Immutable;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
 import com.hazelcast.map.impl.MapDataSerializerHook;
@@ -25,7 +26,7 @@ import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
 
 public final class GetOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
 
-    private Data result;
+    private Object result;
 
     public GetOperation() {
     }
@@ -44,7 +45,9 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
             result = (Data) currentValue;
         } else {
             // in case of a local call, we do make a copy so we can safely share it with e.g. near cache invalidation
-            result = mapService.getMapServiceContext().toData(currentValue);
+            result = (currentValue instanceof Immutable)
+                    ? currentValue
+                    : mapServiceContext.toData(currentValue);
         }
     }
 
@@ -72,7 +75,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
     }
 
     @Override
-    public Data getResponse() {
+    public Object getResponse() {
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
@@ -162,11 +162,11 @@ public class PartitionScanRunner {
         while (resultList.size() < fetchSize && pointers[pointers.length - 1].getIndex() >= 0) {
             MapEntriesWithCursor cursor = recordStore.fetchEntries(pointers, fetchSize - resultList.size());
             pointers = cursor.getIterationPointers();
-            Collection<? extends Entry<Data, Data>> entries = cursor.getBatch();
+            Collection<? extends Entry<Data, Object>> entries = cursor.getBatch();
             if (entries.isEmpty()) {
                 break;
             }
-            for (Entry<Data, Data> entry : entries) {
+            for (Entry<Data, Object> entry : entries) {
                 QueryableEntry queryEntry = new LazyMapEntry(entry.getKey(), entry.getValue(), ss, extractors);
                 if (predicate.apply(queryEntry)) {
                     resultList.add(queryEntry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -155,7 +155,7 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
     public MapEntriesWithCursor fetchEntries(IterationPointer[] pointers, int size) {
         List<Map.Entry<Data, R>> entries = new ArrayList<>(size);
         IterationPointer[] newPointers = records.fetchEntries(pointers, size, entries);
-        List<Map.Entry<Data, Data>> entriesData = new ArrayList<>(entries.size());
+        List<Map.Entry<Data, Object>> entriesData = new ArrayList<>(entries.size());
         for (Map.Entry<Data, R> entry : entries) {
             R record = entry.getValue();
             Data dataValue = serializationService.toData(record.getValue());

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
@@ -17,7 +17,9 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Immutable;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
@@ -25,6 +27,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import junit.framework.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,12 +35,14 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -200,6 +205,31 @@ public class MapPartitionIteratorTest extends HazelcastTestSupport {
         assertUniques(readKeysP2, iteratorP2);
     }
 
+    @Test
+    public void test_iterating_immutable_values() {
+        Config config = getConfig();
+        config.getMapConfig("default")
+              .setInMemoryFormat(InMemoryFormat.OBJECT);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+
+        int partitionCount = getNodeEngineImpl(instance).getPartitionService().getPartitionCount();
+        String value = randomString();
+        for (int i = 0; i < partitionCount; i++) {
+            String key = generateKeyForPartition(instance, i);
+            proxy.put(key, new ImmutableValue(value));
+        }
+
+        for (int i = 0; i < partitionCount; i++) {
+            Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, i, prefetchValues);
+            Assert.assertTrue(iterator.hasNext());
+            assertEquals(value, ((ImmutableValue) iterator.next().getValue()).value);
+        }
+    }
+
     private void assertUniques(HashSet<String> readKeys, Iterator<Map.Entry<String, String>> iterator) {
         while (iterator.hasNext()) {
             Map.Entry<String, String> entry = iterator.next();
@@ -224,6 +254,17 @@ public class MapPartitionIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < count; i++) {
             String key = generateKeyForPartition(instance, partitionId);
             proxy.put(key, value);
+        }
+    }
+
+    public static class ImmutableValue implements Immutable, Serializable {
+        public String value;
+
+        public ImmutableValue(String value) {
+            this.value = value;
+        }
+
+        public ImmutableValue() {
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapDisableCopyOnReadTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.partition.PartitionService;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class MapDisableCopyOnReadTest extends HazelcastTestSupport {
+
+    private MapProxyImpl<String, TestEntityImmutable> immutableMapProxy;
+    private MapProxyImpl<String, TestEntity> mutableMapProxy;
+    private PartitionService partitionService;
+
+    @Before
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void setup() {
+        Config config = smallInstanceConfig()
+                .addMapConfig(new MapConfig("myMap*").setInMemoryFormat(InMemoryFormat.OBJECT));
+        HazelcastInstance instance = createHazelcastInstance(config);
+        partitionService = instance.getPartitionService();
+        immutableMapProxy = (MapProxyImpl) instance.getMap("myMapImmutable");
+        mutableMapProxy = (MapProxyImpl) instance.getMap("myMapMutable");
+    }
+
+    @Test
+    public void testGetImmutable() {
+        TestEntityImmutable tc = new TestEntityImmutable("hello");
+        immutableMapProxy.put("testCor", tc);
+        TestEntityImmutable result1 = immutableMapProxy.get("testCor");
+        TestEntityImmutable result2 = immutableMapProxy.get("testCor");
+        assertSame(result1, result2);
+    }
+
+    @Test
+    public void testGetMutable() {
+        TestEntity tc = new TestEntity("hello");
+        mutableMapProxy.put("testCor", tc);
+        TestEntity result1 = mutableMapProxy.get("testCor");
+        TestEntity result2 = mutableMapProxy.get("testCor");
+        assertNotSame(result1, result2);
+    }
+
+    @Test
+    public void testMapIteratorImmutable() {
+        String key = "testCorKey";
+        TestEntityImmutable tc = new TestEntityImmutable("hello");
+        immutableMapProxy.put(key, tc);
+        int partitionId = partitionService.getPartition(key).getPartitionId();
+
+        TestEntityImmutable result1 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        TestEntityImmutable result2 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        assertSame(result1, result2);
+    }
+
+    @Test
+    public void testMapIteratorForMutable() {
+        String key = "testCorKey";
+        TestEntity tc = new TestEntity("hello");
+        mutableMapProxy.put(key, tc);
+        int partitionId = partitionService.getPartition(key).getPartitionId();
+
+        TestEntity result1 =  mutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        TestEntity result2 =  mutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        assertNotSame(result1, result2);
+    }
+
+    @Test
+    public void testClassCastException() {
+        String key = "testCorKey";
+        TestEntityImmutable tc = new TestEntityImmutable("hello");
+        immutableMapProxy.put(key, tc);
+        int partitionId = partitionService.getPartition(key).getPartitionId();
+
+        TestEntityImmutable result1 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        TestEntityImmutable result2 =  immutableMapProxy.iterator(10, partitionId, false).next().getValue();
+        assertSame(result1, result2);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntity.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import java.io.Serializable;
+
+class TestEntity implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private String test;
+
+    public TestEntity(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntityImmutable.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TestEntityImmutable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.Immutable;
+
+import java.io.Serializable;
+
+class TestEntityImmutable implements Immutable, Serializable {
+    private static final long serialVersionUID = 1L;
+    private String test;
+
+    public TestEntityImmutable(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
+}


### PR DESCRIPTION
This PR is introducing a marker interface as a "hint" when reading data that defensive copying can be avoided. Here disable copy on read for selected entities while read from IMap. This only covers the changes needed for a single use case and is not a general purpose fix.

Based off of: https://github.com/hazelcast/hazelcast/pull/16736