### PR TITLE
Adding clientname tag to client metrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -53,6 +53,7 @@ import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
 public final class ClientEndpointImpl implements ClientEndpoint {
     private static final String METRICS_TAG_CLIENT = "client";
     private static final String METRICS_TAG_TIMESTAMP = "timestamp";
+    private static final String METRICS_TAG_CLIENTNAME = "clientname";
 
     private final ClientEngine clientEngine;
     private final ILogger logger;
@@ -307,6 +308,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
                             .withIncludedTarget(MANAGEMENT_CENTER)
                             // we add "client" and "timestamp" tags for MC
                             .withTag(METRICS_TAG_CLIENT, getUuid().toString())
+                            .withTag(METRICS_TAG_CLIENTNAME, clientName)
                             .withTag(METRICS_TAG_TIMESTAMP, Long.toString(timestamp));
                 }
             };

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -306,7 +306,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
                             // since we want to send the client-side metrics only to MC
                             .withExcludedTargets(MetricTarget.ALL_TARGETS)
                             .withIncludedTarget(MANAGEMENT_CENTER)
-                            // we add "client" and "timestamp" tags for MC
+                            // we add "client", "clientname" and "timestamp" tags for MC
                             .withTag(METRICS_TAG_CLIENT, getUuid().toString())
                             .withTag(METRICS_TAG_CLIENTNAME, clientName)
                             .withTag(METRICS_TAG_TIMESTAMP, Long.toString(timestamp));

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsTest.java
@@ -114,6 +114,7 @@ public class ClientMetricsTest extends HazelcastTestSupport {
                         .withMetric(metric)
                         .withUnit(unit)
                         .withTag("client", clientUuid.toString())
+                        .withTag("clientname", client.getName())
                         .withTag("timestamp", Long.toString(timestamp))
                         .withExcludedTargets(asList(MetricTarget.values()))
                         .withIncludedTarget(MANAGEMENT_CENTER);


### PR DESCRIPTION
Adds the client name to every metric related to clients. It was requested in https://hazelcast.zendesk.com/agent/tickets/6637