### PR TITLE
Fix LinearizableQueryTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LinearizableQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LinearizableQueryTest.java
@@ -40,9 +40,11 @@ import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getCommitIndex;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderQueryRound;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -176,7 +178,7 @@ public class LinearizableQueryTest extends HazelcastTestSupport {
         group.start();
 
         RaftNodeImpl leader = group.waitUntilLeaderElected();
-        assertTrueEventually(() -> assertEquals(1, getCommitIndex(leader)));
+        assertTrueEventually(() -> assertThat(getCommitIndex(leader), greaterThanOrEqualTo(1L)));
 
         RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
         group.dropMessagesToMember(leader.getLocalMember(), followers[0].getLocalMember(), AppendRequest.class);


### PR DESCRIPTION
Commit index may be greater than or equal to 1, depending on how many
leader election rounds are done. Sometimes due to timing, more than one
leader election rounds may be needed.

Fixes #17597