### PR TITLE
Improve robustness of Diagnostics log writer and some plugins.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -62,7 +62,7 @@ final class DiagnosticsLogFile implements DiagnosticsLog {
         this.diagnostics = diagnostics;
         this.logger = diagnostics.logger;
         this.fileName = diagnostics.baseFileName + "-%03d.log";
-        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
+        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime, diagnostics.logger);
 
         this.maxRollingFileCount = diagnostics.properties.getInteger(MAX_ROLLED_FILE_COUNT);
         // we accept a float so it becomes easier to testing to create a small file

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
@@ -22,6 +22,9 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
 import static com.hazelcast.internal.util.StringUtil.LOCALE_INTERNAL;
 import static java.util.Calendar.DAY_OF_MONTH;
@@ -46,11 +49,13 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
             LINE_SEPARATOR + "                                  ",
             LINE_SEPARATOR + "                                          ",
             LINE_SEPARATOR + "                                                  ",
-            LINE_SEPARATOR + "                                                            ",
+            LINE_SEPARATOR + "                                                          ",
     };
 
     // 32 chars should be more than enough to encode primitives
     private static final int CHARS_LENGTH = 32;
+
+    private final ILogger logger;
 
     private final StringBuilder tmpSb = new StringBuilder();
     private final boolean includeEpochTime;
@@ -69,11 +74,12 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
     private StringBuilder stringBuilder = new StringBuilder();
 
     public DiagnosticsLogWriterImpl() {
-        this(false);
+        this(false, null);
     }
 
-    public DiagnosticsLogWriterImpl(boolean includeEpochTime) {
+    public DiagnosticsLogWriterImpl(boolean includeEpochTime, ILogger logger) {
         this.includeEpochTime = includeEpochTime;
+        this.logger = logger != null ? logger : Logger.getLogger(getClass());
     }
 
     @Override
@@ -125,14 +131,23 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
 
         write(name);
         write('[');
-        sectionLevel++;
+        if (sectionLevel < INDENTS.length - 1) {
+            sectionLevel++;
+        } else {
+            logger.warning("Diagnostics writer SectionLevel has overflown.", new Exception("Dumping stack trace"));
+            sectionLevel = INDENTS.length - 1;
+        }
     }
 
     @Override
     public void endSection() {
         write(']');
-        sectionLevel--;
-
+        if (sectionLevel > -1) {
+            sectionLevel--;
+        } else {
+            logger.warning("Diagnostics writer SectionLevel has underflown.", new Exception("Dumping stack trace"));
+            sectionLevel = -1;
+        }
         if (sectionLevel == -1) {
             write(LINE_SEPARATOR);
         }
@@ -140,7 +155,9 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
 
     @Override
     public void writeEntry(String s) {
-        write(INDENTS[sectionLevel]);
+        if (sectionLevel >= 0) {
+            write(INDENTS[sectionLevel]);
+        }
         write(s);
     }
 
@@ -208,12 +225,15 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
     }
 
     private void writeKeyValueHead(String key) {
-        write(INDENTS[sectionLevel]);
+        if (sectionLevel >= 0) {
+            write(INDENTS[sectionLevel]);
+        }
         write(key);
         write('=');
     }
 
     public void init(PrintWriter printWriter) {
+        sectionLevel = -1;
         this.printWriter = printWriter;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogger.java
@@ -36,7 +36,7 @@ final class DiagnosticsLogger implements DiagnosticsLog {
         this.diagnostics = diagnostics;
         this.logger = diagnostics.logger;
         this.diagnosticsLogger = diagnostics.loggingService.getLogger("com.hazelcast.diagnostics");
-        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
+        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime, diagnostics.logger);
         this.writer = new CharArrayWriter();
         logWriter.init(new PrintWriter(writer));
         logger.info("Sending diagnostics to the 'com.hazelcast.diagnostics' logger");

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsStdout.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsStdout.java
@@ -39,7 +39,7 @@ final class DiagnosticsStdout implements DiagnosticsLog {
     DiagnosticsStdout(Diagnostics diagnostics) {
         this.diagnostics = diagnostics;
         this.logger = diagnostics.logger;
-        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
+        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime, diagnostics.logger);
         this.printWriter = newWriter();
         logWriter.init(printWriter);
         logger.info("Sending diagnostics logs to the stdout");

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
@@ -197,16 +197,18 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
         if (members != null) {
             boolean first = true;
             for (Member member : members) {
-                if (member.getAddress().equals(thisAddress)) {
+                Address memberAddress = member.getAddress();
+                String addressStr = String.valueOf(memberAddress);
+                if (memberAddress.equals(thisAddress)) {
                     if (first) {
-                        writer.writeEntry(member.getAddress().toString() + ":this:master");
+                        writer.writeEntry(addressStr + ":this:master");
                     } else {
-                        writer.writeEntry(member.getAddress().toString() + ":this");
+                        writer.writeEntry(addressStr + ":this");
                     }
                 } else if (first) {
-                    writer.writeEntry(member.getAddress().toString() + ":master");
+                    writer.writeEntry(addressStr + ":master");
                 } else {
-                    writer.writeEntry(member.getAddress().toString());
+                    writer.writeEntry(addressStr);
                 }
                 first = false;
             }
@@ -291,7 +293,7 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
         writer.endSection();
     }
 
-    private class LifecycleListenerImpl implements LifecycleListener {
+    protected class LifecycleListenerImpl implements LifecycleListener {
         @Override
         public void stateChanged(LifecycleEvent event) {
             logQueue.add(event);
@@ -302,13 +304,13 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
         final boolean added;
         final Connection connection;
 
-        private ConnectionEvent(boolean added, Connection connection) {
+        ConnectionEvent(boolean added, Connection connection) {
             this.added = added;
             this.connection = connection;
         }
     }
 
-    private class ConnectionListenerImpl implements ConnectionListener {
+    protected class ConnectionListenerImpl implements ConnectionListener {
         @Override
         public void connectionAdded(Connection connection) {
             logQueue.add(new ConnectionEvent(true, connection));
@@ -320,7 +322,7 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
         }
     }
 
-    private class MembershipListenerImpl extends MembershipAdapter {
+    protected class MembershipListenerImpl extends MembershipAdapter {
         @Override
         public void memberAdded(MembershipEvent event) {
             logQueue.add(event);
@@ -332,7 +334,7 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
         }
     }
 
-    private class MigrationListenerImpl implements MigrationListener {
+    protected class MigrationListenerImpl implements MigrationListener {
         @Override
         public void migrationStarted(MigrationState state) {
             logQueue.add(state);
@@ -354,7 +356,7 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
         }
     }
 
-    private class ClusterVersionListenerImpl implements ClusterVersionListener {
+    protected class ClusterVersionListenerImpl implements ClusterVersionListener {
         @Override
         public void onClusterVersionChange(Version newVersion) {
             logQueue.add(newVersion);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ItemCounter.java
@@ -32,7 +32,7 @@ import static java.util.Collections.sort;
  */
 public final class ItemCounter<T> {
 
-    private final Map<T, MutableLong> map = new HashMap<T, MutableLong>();
+    protected final Map<T, MutableLong> map = new HashMap<T, MutableLong>();
     private long total;
 
     /**
@@ -110,7 +110,7 @@ public final class ItemCounter<T> {
     }
 
     /**
-     * Increases the count by on for the given item.
+     * Increases the count by one for the given item.
      *
      * @param item
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentItemCounter.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * Thread-Safe Counter of things. It allows to count items without worrying about nulls.
+ *
+ * @param <T>
+ */
+public final class ConcurrentItemCounter<T> {
+
+    protected final ConcurrentMap<T, AtomicLong> map = new ConcurrentHashMap<T, AtomicLong>();
+
+    /**
+     * Returns the total counts.
+     */
+    public long total() {
+        return map.values().parallelStream().collect(Collectors.summingLong(AtomicLong::get));
+    }
+
+    /**
+     * Returns an iterator over all keys.
+     *
+     * @return the key iterator.
+     */
+    public Set<T> keySet() {
+        return map.keySet();
+    }
+
+    /**
+     * Get current counter for an item item
+     *
+     * @param item
+     * @return current state of a counter for item
+     */
+    public long get(T item) {
+        AtomicLong count = map.get(item);
+        return count == null ? 0 : count.get();
+    }
+
+    /**
+     * Set counter of item to value
+     *
+     * @param item to set set the value for
+     * @param value a new value
+     */
+    public void set(T item, long value) {
+        getItemCounter(item).set(value);
+    }
+
+    /**
+     * Increases the count by one for the given item.
+     *
+     * @param item
+     */
+    public void inc(T item) {
+        add(item, 1);
+    }
+
+    /**
+     * Add delta to the item
+     *
+     * @param item
+     * @param delta
+     */
+    public void add(T item, long delta) {
+        getItemCounter(item).addAndGet(delta);
+    }
+
+    /**
+     * Reset state of the counter to 0.
+     */
+    public void reset() {
+        clear();
+    }
+
+    /**
+     * Clears the counter.
+     */
+    public void clear() {
+        map.clear();
+    }
+
+    /**
+     * Set counter for item and return previous value
+     */
+    public long getAndSet(T item, long value) {
+        return getItemCounter(item).getAndSet(value);
+    }
+
+    public void remove(T item) {
+        map.remove(item);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ConcurrentItemCounter<?> that = (ConcurrentItemCounter<?>) o;
+        if (!map.equals(that.map)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    private AtomicLong getItemCounter(T item) {
+        return map.computeIfAbsent(item, k -> new AtomicLong());
+    }
+
+}


### PR DESCRIPTION
Fixes #14973. 

Key changes:
* add checks to avoid `ArrayIndexOutOfBoundException` in the `DiagnosticsLogWriterImpl`, log warning is printed instead
* use a thread-safe variant of `ItemCounter` in the `OperationThreadSamplerPlugin` (access to the counter is from more threads)
* add value null-checks when iterating `instanceProbesMap` in the `StoreLatencyPlugin.ServiceProbes` - the Map is of type `ConcurrentReferenceHashMap<String, InstanceProbes>(ReferenceType.STRONG, ReferenceType.WEAK)` - i.e. the values are weakly referenced.

This PR also changes method/field visibility in some cases to prevent using synthetic accessors.