### PR TITLE
Add selectionKey null check in NioOutboundPipeline.executePipeline to prevent NPE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -232,7 +232,7 @@ public final class NioOutboundPipeline
 
     // executes the pipeline. Either on the calling thread or on the owning NIO thread.
     private void executePipeline() {
-         if (writeThroughEnabled && !concurrencyDetection.isDetected()) {
+        if (writeThroughEnabled && !concurrencyDetection.isDetected()) {
             // we are allowed to do a write through, so lets process the request on the calling thread
             try {
                 process();
@@ -245,7 +245,8 @@ public final class NioOutboundPipeline
                 registerOp(OP_WRITE);
                 selectionKey.selector().wakeup();
             } else {
-                owner.addTaskAndWakeup(this);
+                // the owner can be also null during the Pipeline migration, so let's use the helper method
+                ownerAddTaskAndWakeup(this);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -30,6 +30,7 @@ import com.hazelcast.logging.ILogger;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -229,7 +230,7 @@ public final class NioOutboundPipeline
         }
     }
 
-    // executes the pipeline. Either on the calling thread or on th owning NIO thread.
+    // executes the pipeline. Either on the calling thread or on the owning NIO thread.
     private void executePipeline() {
          if (writeThroughEnabled && !concurrencyDetection.isDetected()) {
             // we are allowed to do a write through, so lets process the request on the calling thread
@@ -239,7 +240,8 @@ public final class NioOutboundPipeline
                 onError(t);
             }
         } else {
-            if (selectionKeyWakeupEnabled) {
+            SelectionKey selectionKey = this.selectionKey;
+            if (selectionKeyWakeupEnabled && selectionKey != null) {
                 registerOp(OP_WRITE);
                 selectionKey.selector().wakeup();
             } else {


### PR DESCRIPTION
Fixes #16754

The `selectionKey` can be `null` in two cases - either before the `initSelectionKey()` is called or after the `startMigration()` is called.
Other places handling with the `selectionKey` field already have the null-check implemented.