### PR TITLE
[Backport] https://github.com/hazelcast/hazelcast/pull/17639 Correctly decrement the permits in the session during `drainPermits` call

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
@@ -200,7 +200,7 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
                 HazelcastClientInstanceImpl client = getClient();
                 ClientMessage response = new ClientInvocation(client, request, objectName).invoke().joinInternal();
                 int count = SemaphoreDrainCodec.decodeResponse(response).response;
-                sessionManager.releaseSession(groupId, DRAIN_SESSION_ACQ_COUNT - count);
+                sessionManager.releaseSession(groupId, sessionId, DRAIN_SESSION_ACQ_COUNT - count);
                 return count;
             } catch (SessionExpiredException e) {
                 sessionManager.invalidateSession(this.groupId, sessionId);


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast/pull/17639 Fix to correctly decrement the permits in the session during `drainPermits` call.