### PR TITLE
Send -1 instead Long.Max for leasetime by default

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -744,7 +744,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
 
     @Override
     public boolean tryLock(@Nonnull K key, long time, @Nullable TimeUnit timeunit) throws InterruptedException {
-        return tryLock(key, time, timeunit, Long.MAX_VALUE, null);
+        return tryLock(key, time, timeunit, UNSET, null);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -17,9 +17,11 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -54,13 +56,21 @@ public class ClientMapLockTest {
 
     @Before
     public void setup() {
-        hazelcastFactory.newHazelcastInstance();
+        Config config = new Config();
+        config.setProperty(ClusterProperty.LOCK_MAX_LEASE_TIME_SECONDS.getName(), String.valueOf(Long.MAX_VALUE / 1000));
+        hazelcastFactory.newHazelcastInstance(config);
         client = hazelcastFactory.newHazelcastClient();
     }
 
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testTryLock() {
+        IMap map = client.getMap(randomString());
+        assertTrue(map.tryLock("key"));
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/17637

(cherry picked from commit 2d0c8b1edf98b018c3f2e5fc175d11074e05d3bc)