### PR TITLE
Update partition stamp after manually incrementing partition version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
@@ -87,10 +87,6 @@ public class InternalPartitionImpl extends AbstractInternalPartition implements 
         return version;
     }
 
-    void incrementVersion(int delta) {
-        version += delta;
-    }
-
     @Override
     public PartitionReplica getReplica(int replicaIndex) {
         return replicas[replicaIndex];
@@ -115,7 +111,6 @@ public class InternalPartitionImpl extends AbstractInternalPartition implements 
         version = partition.version();
     }
 
-    //RU_COMPAT_4_0
     void setVersion(int version) {
         this.version = version;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1551,7 +1551,7 @@ public class MigrationManager {
                         // timeouts. Still this is safer...
                         int delta = migration.getPartitionVersionIncrement() + 1;
                         migration.setPartitionVersionIncrement(delta);
-                        partition.incrementVersion(delta);
+                        partitionStateManager.incrementPartitionVersion(partition.getPartitionId(), delta);
 
                         if (!migration.getDestination().isIdentical(node.getLocalMember())) {
                             partitionService.sendPartitionRuntimeState(migration.getDestination().address());

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -382,8 +382,13 @@ public class PartitionStateManager implements ClusterVersionListener {
         return partitions[partitionId].version();
     }
 
-    public void incrementPartitionVersion(int partitionId, int delta) {
-        partitions[partitionId].incrementVersion(delta);
+    /**
+     * Increments partition version by delta and updates partition state stamp.
+     */
+    void incrementPartitionVersion(int partitionId, int delta) {
+        InternalPartitionImpl partition = partitions[partitionId];
+        partition.setVersion(partition.version() + delta);
+        updateStamp();
     }
 
     // called under partition service lock


### PR DESCRIPTION
Partition version is manually incremented when migration or promotion fails.
In this case, partition state stamp must be updated with new partition versions.

Closes #12788