### PR TITLE
Send -1 instead Long.Max for leasetime by default

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -774,7 +774,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
 
     @Override
     public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
-        return tryLock(key, time, timeunit, Long.MAX_VALUE, null);
+        return tryLock(key, time, timeunit, -1, null);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -17,10 +17,12 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -55,13 +57,21 @@ public class ClientMapLockTest {
 
     @Before
     public void setup() {
-        hazelcastFactory.newHazelcastInstance();
+        Config config = new Config();
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS.getName(), String.valueOf(Long.MAX_VALUE / 1000));
+        hazelcastFactory.newHazelcastInstance(config);
         client = hazelcastFactory.newHazelcastClient();
     }
 
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testTryLock() {
+        IMap map = client.getMap(randomString());
+        assertTrue(map.tryLock("key"));
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/17637

(cherry picked from commit 2d0c8b1edf98b018c3f2e5fc175d11074e05d3bc)