### PR TITLE
Check duplicate fields when building class definition

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -70,7 +70,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -82,7 +82,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -94,7 +94,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -106,7 +106,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -118,7 +118,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -130,7 +130,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -142,7 +142,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -154,7 +154,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -166,7 +166,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -178,7 +178,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -190,7 +190,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -202,7 +202,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -214,7 +214,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -226,7 +226,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -238,7 +238,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -250,7 +250,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -262,7 +262,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -274,7 +274,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
@@ -286,7 +286,7 @@ public final class ClassDefinitionBuilder {
     }
 
     /**
-     * @param fieldName name of the field that will be add to this class definition
+     * @param fieldName name of the field that will be added to this class definition
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -18,9 +18,12 @@ package com.hazelcast.nio.serialization;
 
 import com.hazelcast.internal.serialization.impl.portable.ClassDefinitionImpl;
 import com.hazelcast.internal.serialization.impl.portable.FieldDefinitionImpl;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * ClassDefinitionBuilder is used to build and register ClassDefinitions manually.
@@ -35,7 +38,7 @@ public final class ClassDefinitionBuilder {
     private final int classId;
     private final int version;
     private final List<FieldDefinitionImpl> fieldDefinitions = new ArrayList<FieldDefinitionImpl>();
-
+    private final Set<String> addedFieldNames = new HashSet<>();
     private int index;
     private boolean done;
 
@@ -66,116 +69,230 @@ public final class ClassDefinitionBuilder {
         this.version = version;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addIntField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.INT, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addLongField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.LONG, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addUTFField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.UTF, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addBooleanField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BOOLEAN, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addByteField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BYTE, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addBooleanArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BOOLEAN_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addCharField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.CHAR, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addDoubleField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DOUBLE, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addFloatField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.FLOAT, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addShortField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.SHORT, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addByteArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.BYTE_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addCharArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.CHAR_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addIntArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.INT_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addLongArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.LONG_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addDoubleArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.DOUBLE_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addFloatArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.FLOAT_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addShortArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.SHORT_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addUTFArrayField(String fieldName) {
-        check();
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.UTF_ARRAY, version));
         return this;
     }
 
+    /**
+     * @param fieldName name of the field that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
     public ClassDefinitionBuilder addPortableField(String fieldName, ClassDefinition def) {
-        check();
+        check(fieldName);
         if (def.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
         }
@@ -184,18 +301,26 @@ public final class ClassDefinitionBuilder {
         return this;
     }
 
-    public ClassDefinitionBuilder addPortableArrayField(String fieldName, ClassDefinition def) {
-        check();
-        if (def.getClassId() == 0) {
+    /**
+     * @param fieldName       name of the field that will be add to this class definition
+     * @param classDefinition class definition of the nested portable that will be add to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addPortableArrayField(String fieldName, ClassDefinition classDefinition) {
+        check(fieldName);
+        if (classDefinition.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
         }
-        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName,
-                FieldType.PORTABLE_ARRAY, def.getFactoryId(), def.getClassId(), def.getVersion()));
+        fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.PORTABLE_ARRAY,
+                classDefinition.getFactoryId(), classDefinition.getClassId(), classDefinition.getVersion()));
         return this;
     }
 
+    @PrivateApi
     public ClassDefinitionBuilder addField(FieldDefinitionImpl fieldDefinition) {
-        check();
+        check(fieldDefinition.getName());
         if (index != fieldDefinition.getIndex()) {
             throw new IllegalArgumentException("Invalid field index");
         }
@@ -204,6 +329,9 @@ public final class ClassDefinitionBuilder {
         return this;
     }
 
+    /**
+     * @return creates and returns a new ClassDefinition
+     */
     public ClassDefinition build() {
         done = true;
         final ClassDefinitionImpl cd = new ClassDefinitionImpl(factoryId, classId, version);
@@ -213,7 +341,10 @@ public final class ClassDefinitionBuilder {
         return cd;
     }
 
-    private void check() {
+    private void check(String fieldName) {
+        if (!addedFieldNames.add(fieldName)) {
+            throw new HazelcastSerializationException("Field with field name : " + fieldName + " already exists");
+        }
         if (done) {
             throw new HazelcastSerializationException("ClassDefinition is already built for " + classId);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -292,10 +292,10 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addPortableField(String fieldName, ClassDefinition def) {
-        check(fieldName);
         if (def.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
         }
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName,
                 FieldType.PORTABLE, def.getFactoryId(), def.getClassId(), def.getVersion()));
         return this;
@@ -309,10 +309,10 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
     public ClassDefinitionBuilder addPortableArrayField(String fieldName, ClassDefinition classDefinition) {
-        check(fieldName);
         if (classDefinition.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
         }
+        check(fieldName);
         fieldDefinitions.add(new FieldDefinitionImpl(index++, fieldName, FieldType.PORTABLE_ARRAY,
                 classDefinition.getFactoryId(), classDefinition.getClassId(), classDefinition.getVersion()));
         return this;
@@ -320,10 +320,10 @@ public final class ClassDefinitionBuilder {
 
     @PrivateApi
     public ClassDefinitionBuilder addField(FieldDefinitionImpl fieldDefinition) {
-        check(fieldDefinition.getName());
         if (index != fieldDefinition.getIndex()) {
             throw new IllegalArgumentException("Invalid field index");
         }
+        check(fieldDefinition.getName());
         index++;
         fieldDefinitions.add(fieldDefinition);
         return this;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ClassAndFieldDefinitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ClassAndFieldDefinitionTest.java
@@ -200,12 +200,12 @@ public class ClassAndFieldDefinitionTest {
     @Test(expected = HazelcastSerializationException.class)
     public void testClassDefinitionBuilder_addingSameFieldTwice() {
         new ClassDefinitionBuilder(1, 2, 1)
-                .addUTFField("name").addUTFField("name").build();
+                .addUTFField("name").addUTFField("name");
     }
 
     @Test(expected = HazelcastSerializationException.class)
     public void testClassDefinitionBuilder_addingSameFieldTwice_withDifferentType() {
         new ClassDefinitionBuilder(1, 2, 1)
-                .addUTFField("name").addIntField("name").build();
+                .addUTFField("name").addIntField("name");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ClassAndFieldDefinitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ClassAndFieldDefinitionTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.serialization.impl.portable;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -194,5 +195,17 @@ public class ClassAndFieldDefinitionTest {
     @Test
     public void testFieldDef_toString() throws Exception {
         assertNotNull(new FieldDefinitionImpl(0, "name", FieldType.BOOLEAN, portableVersion).toString());
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void testClassDefinitionBuilder_addingSameFieldTwice() {
+        new ClassDefinitionBuilder(1, 2, 1)
+                .addUTFField("name").addUTFField("name").build();
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void testClassDefinitionBuilder_addingSameFieldTwice_withDifferentType() {
+        new ClassDefinitionBuilder(1, 2, 1)
+                .addUTFField("name").addIntField("name").build();
     }
 }


### PR DESCRIPTION
ClassDefinitionBuider.addX methods checks if a field
is already added with same name and
throws HazelcastSerializatioException if already added.

fixes https://github.com/hazelcast/hazelcast/issues/17616