### PR TITLE
Use shutdownAll instead of terminate in CacheStatsTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.util.Timer;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CacheStatsTest extends CacheTestSupport {
 
@@ -57,7 +57,7 @@ public class CacheStatsTest extends CacheTestSupport {
 
     @Override
     protected void onTearDown() {
-        factory.terminateAll();
+        factory.shutdownAll();
     }
 
     @Override


### PR DESCRIPTION
Reasoning: CacheService only cleans up stats or
management MBeans when gracefully shutting down.
Terminating may result in leftover MBeans affecting
other subsequent tests.

Even though I was not able to reproduce the failure in https://github.com/hazelcast/hazelcast/issues/17461#issuecomment-701353794 and the caches seem to be cleaned up properly in the test body, `CacheStatsTest` is the only test that preceded the test failure, uses the "cache1" test cache name and has statistics enabled.

Fixes #17461