### PR TITLE
Make IndexStatsChangingNumberOfMembersTest more reliable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -160,15 +160,19 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable {
 
                 final Indexes indexes = mapContainer.getIndexes(partitionContainer.getPartitionId());
                 final boolean populateIndexes = indexesMustBePopulated(indexes, operation);
+
+                InternalIndex[] indexesSnapshot = null;
+
                 if (populateIndexes) {
                     // defensively clear possible stale leftovers in non-global indexes from the previous failed promotion attempt
+                    indexesSnapshot = indexes.getIndexes();
+
+                    Indexes.beginPartitionUpdate(indexesSnapshot);
+
                     indexes.clearAll();
                 }
 
                 long nowInMillis = Clock.currentTimeMillis();
-                final InternalIndex[] indexesSnapshot = indexes.getIndexes();
-
-                Indexes.beginPartitionUpdate(indexesSnapshot);
 
                 for (int i = 0; i < keyRecord.size(); i += 2) {
                     Data dataKey = (Data) keyRecord.get(i);

--- a/hazelcast/src/test/java/com/hazelcast/map/IndexStatsChangingNumberOfMembersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IndexStatsChangingNumberOfMembersTest.java
@@ -92,7 +92,6 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
         IMap<Integer, Integer> map2 = instance2.getMap(mapName);
 
         addIndex(map1);
-        addIndex(map2);
 
         awaitStable(mapName, instance1, instance2);
 
@@ -136,7 +135,6 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
         // let's add another member
         HazelcastInstance instance3 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map3 = instance3.getMap(mapName);
-        addIndex(map3);
 
         awaitStable(mapName, instance1, instance2, instance3);
 
@@ -244,7 +242,6 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
         IMap<Integer, Integer> map2 = instance2.getMap(mapName);
 
         addIndex(map1);
-        addIndex(map2);
 
         awaitStable(mapName, instance1, instance2);
 
@@ -299,7 +296,6 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
         // let's add another member
         HazelcastInstance instance3 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map3 = instance3.getMap(mapName);
-        addIndex(map3);
 
         awaitStable(mapName, instance1, instance2, instance3);
 


### PR DESCRIPTION
This PR attempts to improve the reliability of the `IndexStatsChangingNumberOfMembersTest`. The test has intermittent failures caused by the insert metrics by greater than expected. The analysis of the code shown that it could be possible in theory if the index creation is executed concurrently with rebalance. The following changes were made to the test:
1. Remove unnecessary `IMap.createIndex` calls.
1. Wait for the full index rebuild on all members before proceeding with asserts

During the implementation of the second step, a severe bug was found in `MapReplicationStateHolder` - the index rebuild counter was not managed properly, which could lead to the index that is unavailable for SQL querying forever. Fixed as well.