### PR TITLE
Fix NPE in the SQL client when null column value is passed

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -260,10 +260,12 @@ public class SqlBasicTest extends SqlTestSupport {
                     );
 
                     checkRowValue(SqlColumnType.OBJECT, val.getObjectVal(), row, "objectVal");
+                    checkRowValue(SqlColumnType.OBJECT, null, row, "nullVal");
                 }
 
                 if (portable) {
                     checkRowValue(SqlColumnType.OBJECT, ((PortablePojo) val).getPortableVal(), row, "portableVal");
+                    checkRowValue(SqlColumnType.VARCHAR, null, row, "nullVal");
                 }
 
                 uniqueKeys.add(key0);
@@ -365,7 +367,8 @@ public class SqlBasicTest extends SqlTestSupport {
                 "doubleVal",
                 "charVal",
                 "varcharVal",
-                "portableVal"
+                "portableVal",
+                "nullVal"
             );
         } else {
             return Arrays.asList(
@@ -389,7 +392,8 @@ public class SqlBasicTest extends SqlTestSupport {
                 "tsTzInstantVal",
                 "tsTzOffsetDateTimeVal",
                 "tsTzZonedDateTimeVal",
-                "objectVal"
+                "objectVal",
+                "nullVal"
             );
         }
     }
@@ -407,7 +411,8 @@ public class SqlBasicTest extends SqlTestSupport {
                 SqlColumnType.DOUBLE,
                 SqlColumnType.VARCHAR,
                 SqlColumnType.VARCHAR,
-                SqlColumnType.OBJECT
+                SqlColumnType.OBJECT,
+                SqlColumnType.VARCHAR
             );
         } else {
             return Arrays.asList(
@@ -431,6 +436,7 @@ public class SqlBasicTest extends SqlTestSupport {
                 SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
                 SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
                 SqlColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                SqlColumnType.OBJECT,
                 SqlColumnType.OBJECT
             );
         }
@@ -596,6 +602,8 @@ public class SqlBasicTest extends SqlTestSupport {
 
         protected List<Object> objectVal;
 
+        protected Object nullVal;
+
         protected AbstractPojo() {
             // No-op.
         }
@@ -709,6 +717,10 @@ public class SqlBasicTest extends SqlTestSupport {
         public List<Object> getObjectVal() {
             return objectVal;
         }
+
+        public Object getNullVal() {
+            return nullVal;
+        }
     }
 
     public static class SerializablePojoKey extends AbstractPojoKey implements Serializable {
@@ -780,6 +792,7 @@ public class SqlBasicTest extends SqlTestSupport {
             out.writeObject(tsTzZonedDateTimeVal);
 
             out.writeObject(objectVal);
+            out.writeObject(nullVal);
         }
 
         @Override
@@ -810,6 +823,7 @@ public class SqlBasicTest extends SqlTestSupport {
             tsTzZonedDateTimeVal = in.readObject();
 
             objectVal = in.readObject();
+            nullVal = in.readObject();
         }
     }
 
@@ -926,6 +940,8 @@ public class SqlBasicTest extends SqlTestSupport {
             writer.writeUTF(portableFieldName("varcharVal"), varcharVal);
 
             writer.writePortable(portableFieldName("portableVal"), portableVal);
+
+            writer.writeUTF(portableFieldName("nullVal"), null);
         }
 
         @Override
@@ -943,6 +959,7 @@ public class SqlBasicTest extends SqlTestSupport {
             varcharVal = reader.readUTF(portableFieldName("varcharVal"));
 
             portableVal = reader.readPortable(portableFieldName("portableVal"));
+            nullVal = reader.readUTF(portableFieldName("nullVal"));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecuteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecuteCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Starts execution of an SQL query.
  */
-@Generated("4967196f7319cc79e5e88b7e0607e219")
+@Generated("95508cca638171fab71c5c06d87241af")
 public final class SqlExecuteCodec {
     //hex: 0x210100
     public static final int REQUEST_MESSAGE_TYPE = 2162944;
@@ -139,7 +139,7 @@ public final class SqlExecuteCodec {
 
         CodecUtil.encodeNullable(clientMessage, queryId, SqlQueryIdCodec::encode);
         ListMultiFrameCodec.encodeNullable(clientMessage, rowMetadata, SqlColumnMetadataCodec::encode);
-        ListMultiFrameCodec.encodeNullable(clientMessage, rowPage, ListDataCodec::encode);
+        ListMultiFrameCodec.encodeNullable(clientMessage, rowPage, ListCNDataCodec::encode);
         CodecUtil.encodeNullable(clientMessage, error, SqlErrorCodec::encode);
         return clientMessage;
     }
@@ -152,7 +152,7 @@ public final class SqlExecuteCodec {
         response.updateCount = decodeLong(initialFrame.content, RESPONSE_UPDATE_COUNT_FIELD_OFFSET);
         response.queryId = CodecUtil.decodeNullable(iterator, SqlQueryIdCodec::decode);
         response.rowMetadata = ListMultiFrameCodec.decodeNullable(iterator, SqlColumnMetadataCodec::decode);
-        response.rowPage = ListMultiFrameCodec.decodeNullable(iterator, ListDataCodec::decode);
+        response.rowPage = ListMultiFrameCodec.decodeNullable(iterator, ListCNDataCodec::decode);
         response.error = CodecUtil.decodeNullable(iterator, SqlErrorCodec::decode);
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlFetchCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlFetchCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches the next row page.
  */
-@Generated("d1c884306ac5ed9b3c2952509bbcc7ff")
+@Generated("5cb985b672f036c8ba849a9ed635effd")
 public final class SqlFetchCodec {
     //hex: 0x210200
     public static final int REQUEST_MESSAGE_TYPE = 2163200;
@@ -108,7 +108,7 @@ public final class SqlFetchCodec {
         encodeBoolean(initialFrame.content, RESPONSE_ROW_PAGE_LAST_FIELD_OFFSET, rowPageLast);
         clientMessage.add(initialFrame);
 
-        ListMultiFrameCodec.encodeNullable(clientMessage, rowPage, ListDataCodec::encode);
+        ListMultiFrameCodec.encodeNullable(clientMessage, rowPage, ListCNDataCodec::encode);
         CodecUtil.encodeNullable(clientMessage, error, SqlErrorCodec::encode);
         return clientMessage;
     }
@@ -118,7 +118,7 @@ public final class SqlFetchCodec {
         ResponseParameters response = new ResponseParameters();
         ClientMessage.Frame initialFrame = iterator.next();
         response.rowPageLast = decodeBoolean(initialFrame.content, RESPONSE_ROW_PAGE_LAST_FIELD_OFFSET);
-        response.rowPage = ListMultiFrameCodec.decodeNullable(iterator, ListDataCodec::decode);
+        response.rowPage = ListMultiFrameCodec.decodeNullable(iterator, ListCNDataCodec::decode);
         response.error = CodecUtil.decodeNullable(iterator, SqlErrorCodec::decode);
         return response;
     }


### PR DESCRIPTION
This PR changes the SQL row data structure form List_List_Data to List_ListCN_Data to avoid NPE when a null column value is passed to the client.

Client protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/349

Closes https://github.com/hazelcast/hazelcast/issues/17608