### PR TITLE
Introduce mode for persistent-memory configuration

### DIFF
--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -433,12 +433,26 @@
                           min-block-size="10"
                           page-size="20">
             <hz:size unit="GIGABYTES" value="256"/>
-            <hz:persistent-memory>
+            <hz:persistent-memory enabled="false" mode="MOUNTED">
                 <hz:directories>
                     <hz:directory numa-node="0">/mnt/pmem0</hz:directory>
                     <hz:directory numa-node="1">/mnt/pmem1</hz:directory>
                 </hz:directories>
             </hz:persistent-memory>
+        </hz:native-memory>
+    </hz:client>
+
+    <hz:client id="client21-persistent-memory-system-memory">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
+        <hz:network>
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+        </hz:network>
+        <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
+                          min-block-size="10"
+                          page-size="20">
+            <hz:size unit="GIGABYTES" value="256"/>
+            <hz:persistent-memory enabled="true" mode="SYSTEM_MEMORY"/>
         </hz:native-memory>
     </hz:client>
 

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -3873,11 +3873,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="directories">
+            <xs:element name="directories" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         List of directories where the persistent memory
-                        is mounted to.
+                        is mounted to. Requires the mode attribute of persistent-memory
+                        to be MOUNTED (default).
 
                         If the specified directories are not unique either in the directories
                         themselves or in the NUMA nodes specified for them,
@@ -3893,7 +3894,40 @@
                 </xs:complexType>
             </xs:element>
         </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets if using persistent memory as Hazelcast native memory is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mode" default="MOUNTED" type="persistent-memory-mode">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the operational mode of the persistent memory configured
+                    on the machine.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="persistent-memory-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="MOUNTED">
+                <xs:annotation>
+                    <xs:documentation>
+                        The persistent memory is mounted into the file system (also known as FS DAX mode).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SYSTEM_MEMORY">
+                <xs:annotation>
+                    <xs:documentation>
+                        The persistent memory is onlined as system memory (also known as KMEM DAX mode).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="persistent-memory-directory">
         <xs:annotation>
             <xs:documentation>

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -34,6 +34,7 @@ import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
+import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
@@ -382,17 +383,19 @@ public final class ClientConfigXmlGenerator {
     private static void nativeMemory(XmlGenerator gen, NativeMemoryConfig nativeMemory) {
         gen.open("native-memory", "enabled", nativeMemory.isEnabled(),
                 "allocator-type", nativeMemory.getAllocatorType())
-           .node("size", null, "value", nativeMemory.getSize().getValue(),
-                   "unit", nativeMemory.getSize().getUnit())
-           .node("min-block-size", nativeMemory.getMinBlockSize())
-           .node("page-size", nativeMemory.getPageSize())
-           .node("metadata-space-percentage", nativeMemory.getMetadataSpacePercentage());
+                .node("size", null, "value", nativeMemory.getSize().getValue(),
+                        "unit", nativeMemory.getSize().getUnit())
+                .node("min-block-size", nativeMemory.getMinBlockSize())
+                .node("page-size", nativeMemory.getPageSize())
+                .node("metadata-space-percentage", nativeMemory.getMetadataSpacePercentage());
 
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemory.getPersistentMemoryConfig()
-                                                                             .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = nativeMemory.getPersistentMemoryConfig();
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
+        gen.open("persistent-memory",
+                "enabled", pmemConfig.isEnabled(),
+                "mode", pmemConfig.getMode().name());
         if (!directoryConfigs.isEmpty()) {
-            gen.open("persistent-memory")
-               .open("directories");
+            gen.open("directories");
             for (PersistentMemoryDirectoryConfig dirConfig : directoryConfigs) {
                 if (dirConfig.isNumaNodeSet()) {
                     gen.node("directory", dirConfig.getDirectory(),
@@ -401,11 +404,9 @@ public final class ClientConfigXmlGenerator {
                     gen.node("directory", dirConfig.getDirectory());
                 }
             }
-            gen.close()
-               .close();
+            gen.close();
         }
-
-        gen.close();
+        gen.close().close();
     }
 
     private static void proxyFactory(XmlGenerator gen, List<ProxyFactoryConfig> proxyFactories) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
+import com.hazelcast.config.PersistentMemoryMode;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
@@ -317,21 +318,16 @@ public class YamlClientDomConfigProcessor extends ClientDomConfigProcessor {
     }
 
     @Override
-    protected void handlePersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig, Node n) {
-        for (Node dirsNode : childElements(n)) {
-            String nodeName = cleanNodeName(dirsNode);
-            if (matches("directories", nodeName)) {
-                for (Node dirNode : childElements(dirsNode)) {
-                    String directory = getTextContent(getNamedItemNode(dirNode, "directory"));
-                    String numaNodeIdStr = getTextContent(getNamedItemNode(dirNode, "numa-node"));
-                    if (!StringUtil.isNullOrEmptyAfterTrim(numaNodeIdStr)) {
-                        int numaNodeId = getIntegerValue("numa-node", numaNodeIdStr);
-                        persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory, numaNodeId));
-                    } else {
-                        persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
-                    }
-                }
-            }
+    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig,
+                                                   PersistentMemoryMode mode, Node dirNode) {
+        String directory = getTextContent(getNamedItemNode(dirNode, "directory"));
+        String numaNodeIdStr = getTextContent(getNamedItemNode(dirNode, "numa-node"));
+        if (!StringUtil.isNullOrEmptyAfterTrim(numaNodeIdStr)) {
+            int numaNodeId = getIntegerValue("numa-node", numaNodeIdStr);
+            persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory, numaNodeId));
+        } else {
+            persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
         }
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
@@ -318,8 +318,7 @@ public class YamlClientDomConfigProcessor extends ClientDomConfigProcessor {
     }
 
     @Override
-    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig,
-                                                   PersistentMemoryMode mode, Node dirNode) {
+    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig, Node dirNode) {
         String directory = getTextContent(getNamedItemNode(dirNode, "directory"));
         String numaNodeIdStr = getTextContent(getNamedItemNode(dirNode, "numa-node"));
         if (!StringUtil.isNullOrEmptyAfterTrim(numaNodeIdStr)) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
@@ -26,7 +26,6 @@ import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
-import com.hazelcast.config.PersistentMemoryMode;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1688,11 +1688,14 @@ public class ConfigXmlGenerator {
                 .node("page-size", nativeMemoryConfig.getPageSize())
                 .node("metadata-space-percentage", nativeMemoryConfig.getMetadataSpacePercentage());
 
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = nativeMemoryConfig.getPersistentMemoryConfig()
-                .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = nativeMemoryConfig.getPersistentMemoryConfig();
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
+        gen.open("persistent-memory",
+                "enabled", pmemConfig.isEnabled(),
+                "mode", pmemConfig.getMode().name()
+        );
         if (!directoryConfigs.isEmpty()) {
-            gen.open("persistent-memory")
-                    .open("directories");
+            gen.open("directories");
             for (PersistentMemoryDirectoryConfig dirConfig : directoryConfigs) {
                 if (dirConfig.isNumaNodeSet()) {
                     gen.node("directory", dirConfig.getDirectory(),
@@ -1701,11 +1704,9 @@ public class ConfigXmlGenerator {
                     gen.node("directory", dirConfig.getDirectory());
                 }
             }
-            gen.close()
-                    .close();
+            gen.close();
         }
-
-        gen.close();
+        gen.close().close();
     }
 
     private static void liteMemberXmlGenerator(XmlGenerator gen, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
@@ -28,6 +28,10 @@ import static java.util.Objects.requireNonNull;
  * Configuration class for persistent memory devices (e.g. Intel Optane).
  */
 public class PersistentMemoryConfig {
+
+    /**
+     * Indicates if the persistent memory is enabled.
+     */
     private boolean enabled;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
@@ -172,11 +172,12 @@ public class PersistentMemoryConfig {
         }
     }
 
-    void setDirectoryConfig(@Nonnull PersistentMemoryDirectoryConfig directoryConfig) {
+    PersistentMemoryConfig setDirectoryConfig(@Nonnull PersistentMemoryDirectoryConfig directoryConfig) {
         requireNonNull(directoryConfig);
         // method to support 4.0 API of NativeMemoryConfig
         this.directoryConfigs.clear();
         this.directoryConfigs.add(directoryConfig);
+        return this;
     }
 
     /**
@@ -194,8 +195,9 @@ public class PersistentMemoryConfig {
      * @param mode The mode of the persistent memory
      * @throws NullPointerException if {@code mode} is {@code null}
      */
-    public void setMode(@Nonnull PersistentMemoryMode mode) {
+    public PersistentMemoryConfig setMode(@Nonnull PersistentMemoryMode mode) {
         this.mode = requireNonNull(mode);
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
@@ -28,10 +28,17 @@ import static java.util.Objects.requireNonNull;
  * Configuration class for persistent memory devices (e.g. Intel Optane).
  */
 public class PersistentMemoryConfig {
+    private boolean enabled;
+
     /**
      * Paths to the non-volatile memory directory.
      */
     private List<PersistentMemoryDirectoryConfig> directoryConfigs = new LinkedList<>();
+
+    /**
+     * The operational mode of the persistent memory configured on the machine.
+     */
+    private PersistentMemoryMode mode = PersistentMemoryMode.MOUNTED;
 
     public PersistentMemoryConfig() {
     }
@@ -46,6 +53,27 @@ public class PersistentMemoryConfig {
     public PersistentMemoryConfig(@Nonnull PersistentMemoryConfig persistentMemoryConfig) {
         requireNonNull(persistentMemoryConfig).directoryConfigs
                 .forEach(directoryConfig -> addDirectoryConfig(new PersistentMemoryDirectoryConfig(directoryConfig)));
+        enabled = persistentMemoryConfig.enabled;
+        mode = persistentMemoryConfig.mode;
+    }
+
+    /**
+     * Returns if the persistent memory is enabled.
+     *
+     * @return {@code true} if persistent memory allocation is enabled, {@code false} otherwise.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables or disables persistent memory.
+     *
+     * @return this {@link NativeMemoryConfig} instance
+     */
+    public PersistentMemoryConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
     }
 
     /**
@@ -147,6 +175,25 @@ public class PersistentMemoryConfig {
         this.directoryConfigs.add(directoryConfig);
     }
 
+    /**
+     * Returns the mode in which the persistent memory should be used.
+     * @return the mode
+     */
+    @Nonnull
+    public PersistentMemoryMode getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets the mode in which the persistent memory should be used.
+     *
+     * @param mode The mode of the persistent memory
+     * @throws NullPointerException if {@code mode} is {@code null}
+     */
+    public void setMode(@Nonnull PersistentMemoryMode mode) {
+        this.mode = requireNonNull(mode);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -158,18 +205,29 @@ public class PersistentMemoryConfig {
 
         PersistentMemoryConfig that = (PersistentMemoryConfig) o;
 
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (mode != that.mode) {
+            return false;
+        }
         return Objects.equals(directoryConfigs, that.directoryConfigs);
     }
 
     @Override
     public int hashCode() {
-        return directoryConfigs.hashCode();
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (mode != null ? mode.hashCode() : 0);
+        result = 31 * result + (directoryConfigs != null ? directoryConfigs.hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
         return "PersistentMemoryConfig{"
-                + "directoryConfigs=" + directoryConfigs
+                + "enabled=" + enabled
+                + ", mode=" + mode
+                + ", directoryConfigs=" + directoryConfigs
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryConfig.java
@@ -190,7 +190,8 @@ public class PersistentMemoryConfig {
     }
 
     /**
-     * Sets the mode in which the persistent memory should be used.
+     * Sets the mode in which the persistent memory should be used. The default
+     * mode is {@link PersistentMemoryMode#MOUNTED}.
      *
      * @param mode The mode of the persistent memory
      * @throws NullPointerException if {@code mode} is {@code null}

--- a/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PersistentMemoryMode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * The enumeration of the supported persistent memory operational modes.
+ */
+public enum PersistentMemoryMode {
+    /**
+     * The persistent memory is mounted into the file system (aka FS DAX mode).
+     */
+    MOUNTED,
+
+    /**
+     * The persistent memory is onlined as system memory (aka KMEM DAX mode).
+     */
+    SYSTEM_MEMORY;
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -20,17 +20,20 @@ import com.hazelcast.config.AbstractFactoryWithPropertiesConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.InstanceTrackingConfig;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
+import com.hazelcast.config.PersistentMemoryMode;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import org.w3c.dom.Node;
@@ -312,30 +315,60 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
                 String value = getTextContent(n);
                 nativeMemoryConfig.setMetadataSpacePercentage(Float.parseFloat(value));
             } else if (matches("persistent-memory-directory", nodeName)) {
-                nativeMemoryConfig.getPersistentMemoryConfig()
-                                  .addDirectoryConfig(new PersistentMemoryDirectoryConfig(getTextContent(n).trim()));
+                PersistentMemoryConfig pmemConfig = nativeMemoryConfig.getPersistentMemoryConfig();
+                pmemConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(getTextContent(n).trim()));
+                // we enable the persistent memory configuration for legacy reasons
+                pmemConfig.setEnabled(true);
             } else if (matches("persistent-memory", nodeName)) {
                 handlePersistentMemoryConfig(nativeMemoryConfig.getPersistentMemoryConfig(), n);
             }
         }
     }
 
-    protected void handlePersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig, Node node) {
+    private void handlePersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig, Node node) {
+        Node enabledNode = getNamedItemNode(node, "enabled");
+            if (enabledNode != null) {
+            boolean enabled = getBooleanValue(getTextContent(enabledNode));
+            persistentMemoryConfig.setEnabled(enabled);
+        }
+
+        final Node modeNode = getNamedItemNode(node, "mode");
+        final String modeStr = getTextContent(modeNode);
+        PersistentMemoryMode mode = PersistentMemoryMode.MOUNTED;
+        if (!StringUtil.isNullOrEmptyAfterTrim(modeStr)) {
+            try {
+                mode = PersistentMemoryMode.valueOf(modeStr);
+                persistentMemoryConfig.setMode(mode);
+            } catch (Exception ex) {
+                throw new InvalidConfigurationException("Invalid 'mode' for 'persistent-memory': " + modeStr);
+            }
+        }
+
         for (Node parent : childElements(node)) {
             final String nodeName = cleanNodeName(parent);
             if (matches("directories", nodeName)) {
+                if (PersistentMemoryMode.SYSTEM_MEMORY == mode) {
+                    throw new InvalidConfigurationException("Directories for 'persistent-memory' should only be"
+                            + " defined if the 'mode' is set to '" + PersistentMemoryMode.MOUNTED.name() + "'");
+                }
+
                 for (Node dirNode : childElements(parent)) {
-                    final String childNodeName = cleanNodeName(dirNode);
-                    if (matches("directory", childNodeName)) {
-                        Node numaNodeIdNode = getNamedItemNode(dirNode, "numa-node");
-                        int numaNodeId = numaNodeIdNode != null
-                                ? getIntegerValue("numa-node", getTextContent(numaNodeIdNode))
-                                : -1;
-                        String directory = getTextContent(dirNode).trim();
-                        persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory, numaNodeId));
-                    }
+                    handlePersistentMemoryDirectory(persistentMemoryConfig, mode, dirNode);
                 }
             }
+        }
+    }
+
+    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig,
+                                                PersistentMemoryMode mode, Node dirNode) {
+        final String childNodeName = cleanNodeName(dirNode);
+        if (matches("directory", childNodeName)) {
+            Node numaNodeIdNode = getNamedItemNode(dirNode, "numa-node");
+            int numaNodeId = numaNodeIdNode != null
+                    ? getIntegerValue("numa-node", getTextContent(numaNodeIdNode))
+                    : -1;
+            String directory = getTextContent(dirNode).trim();
+            persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory, numaNodeId));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -353,14 +353,13 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
                 }
 
                 for (Node dirNode : childElements(parent)) {
-                    handlePersistentMemoryDirectory(persistentMemoryConfig, mode, dirNode);
+                    handlePersistentMemoryDirectory(persistentMemoryConfig, dirNode);
                 }
             }
         }
     }
 
-    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig,
-                                                PersistentMemoryMode mode, Node dirNode) {
+    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig, Node dirNode) {
         final String childNodeName = cleanNodeName(dirNode);
         if (matches("directory", childNodeName)) {
             Node numaNodeIdNode = getNamedItemNode(dirNode, "numa-node");

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -48,7 +48,6 @@ import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionConfig.PermissionType;
 import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
-import com.hazelcast.config.PersistentMemoryMode;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -48,6 +48,7 @@ import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionConfig.PermissionType;
 import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
+import com.hazelcast.config.PersistentMemoryMode;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
@@ -872,21 +873,15 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     }
 
     @Override
-    protected void handlePersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig, Node n) {
-        for (Node dirsNode : childElements(n)) {
-            String nodeName = cleanNodeName(dirsNode);
-            if (matches("directories", nodeName)) {
-                for (Node dirNode : childElements(dirsNode)) {
-                    String directory = getTextContent(getNamedItemNode(dirNode, "directory"));
-                    String numaNodeIdStr = getTextContent(getNamedItemNode(dirNode, "numa-node"));
-                    if (!StringUtil.isNullOrEmptyAfterTrim(numaNodeIdStr)) {
-                        int numaNodeId = getIntegerValue("numa-node", numaNodeIdStr);
-                        persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory, numaNodeId));
-                    } else {
-                        persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
-                    }
-                }
-            }
+    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig,
+                                                   PersistentMemoryMode mode, Node dirNode) {
+        String directory = getTextContent(getNamedItemNode(dirNode, "directory"));
+        String numaNodeIdStr = getTextContent(getNamedItemNode(dirNode, "numa-node"));
+        if (!StringUtil.isNullOrEmptyAfterTrim(numaNodeIdStr)) {
+            int numaNodeId = getIntegerValue("numa-node", numaNodeIdStr);
+            persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory, numaNodeId));
+        } else {
+            persistentMemoryConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig(directory));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -873,8 +873,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     }
 
     @Override
-    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig,
-                                                   PersistentMemoryMode mode, Node dirNode) {
+    protected void handlePersistentMemoryDirectory(PersistentMemoryConfig persistentMemoryConfig, Node dirNode) {
         String directory = getTextContent(getNamedItemNode(dirNode, "directory"));
         String numaNodeIdStr = getTextContent(getNamedItemNode(dirNode, "numa-node"));
         if (!StringUtil.isNullOrEmptyAfterTrim(numaNodeIdStr)) {

--- a/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-4.1.xsd
@@ -738,11 +738,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="directories">
+            <xs:element name="directories" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         List of directories where the persistent memory
-                        is mounted to.
+                        is mounted to. Requires the mode attribute of persistent-memory
+                        to be MOUNTED (default).
 
                         If the specified directories are not unique either in the directories
                         themselves or in the NUMA nodes specified for them,
@@ -758,7 +759,40 @@
                 </xs:complexType>
             </xs:element>
         </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets if using persistent memory as Hazelcast native memory is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mode" default="MOUNTED" type="persistent-memory-mode">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the operational mode of the persistent memory configured
+                    on the machine.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="persistent-memory-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="MOUNTED">
+                <xs:annotation>
+                    <xs:documentation>
+                        The persistent memory is mounted into the file system (also known as FS DAX mode).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SYSTEM_MEMORY">
+                <xs:annotation>
+                    <xs:documentation>
+                        The persistent memory is onlined as system memory (also known as KMEM DAX mode).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="persistent-memory-directory">
         <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -568,7 +568,7 @@
         <!-- Simple configuration for single-socket machines with non-volatile memory -->
         <!-- <persistent-memory-directory>/mnt/optane</persistent-memory-directory> -->
         <!-- Advanced configuration for non-volatile memory -->
-        <persistent-memory>
+        <persistent-memory enabled="true" mode="MOUNTED">
             <directories>
                 <directory numa-node="0">/mnt/pmem0</directory>
                 <directory numa-node="1">/mnt/pmem1</directory>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -512,6 +512,8 @@ hazelcast-client:
     # persistent-memory-directory: /mnt/optane
     # Advanced configuration for non-volatile memory
     persistent-memory:
+      enabled: true
+      mode: MOUNTED
       directories:
         - directory: /mnt/pmem0
           numa-node: 0

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -3181,11 +3181,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="directories">
+            <xs:element name="directories" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         List of directories where the persistent memory
-                        is mounted to.
+                        is mounted to. Requires the mode attribute of persistent-memory
+                        to be MOUNTED (default).
 
                         If the specified directories are not unique either in the directories
                         themselves or in the NUMA nodes specified for them,
@@ -3201,7 +3202,40 @@
                 </xs:complexType>
             </xs:element>
         </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets if using persistent memory as Hazelcast native memory is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mode" default="MOUNTED" type="persistent-memory-mode">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the operational mode of the persistent memory configured
+                    on the machine.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="persistent-memory-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="MOUNTED">
+                <xs:annotation>
+                    <xs:documentation>
+                        The persistent memory is mounted into the file system (also known as FS DAX mode).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SYSTEM_MEMORY">
+                <xs:annotation>
+                    <xs:documentation>
+                        The persistent memory is onlined as system memory (also known as KMEM DAX mode).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="persistent-memory-directory">
         <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2152,7 +2152,7 @@
         <!-- Simple configuration for single-socket machines with non-volatile memory -->
         <!-- <persistent-memory-directory>/mnt/optane</persistent-memory-directory> -->
         <!-- Advanced configuration for non-volatile memory -->
-        <persistent-memory>
+        <persistent-memory enabled="true" mode="MOUNTED">
             <directories>
                 <directory numa-node="0">/mnt/pmem0</directory>
                 <directory numa-node="1">/mnt/pmem1</directory>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2132,6 +2132,8 @@ hazelcast:
     # persistent-memory-directory: /mnt/optane
     # Advanced configuration for non-volatile memory
     persistent-memory:
+      enabled: true
+      mode: MOUNTED
       directories:
         - directory: /mnt/pmem0
           numa-node: 0

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -495,15 +495,24 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     @Test
     public abstract void testPersistentMemoryDirectoryConfigurationSimple();
 
-    @Test
+    @Test(expected = InvalidConfigurationException.class)
     public abstract void testPersistentMemoryDirectoryConfiguration_uniqueDirViolationThrows();
 
-    @Test
+    @Test(expected = InvalidConfigurationException.class)
     public abstract void testPersistentMemoryDirectoryConfiguration_uniqueNumaNodeViolationThrows();
 
-    @Test
+    @Test(expected = InvalidConfigurationException.class)
     public abstract void testPersistentMemoryDirectoryConfiguration_numaNodeConsistencyViolationThrows();
 
     @Test
     public abstract void testPersistentMemoryDirectoryConfiguration_simpleAndAdvancedPasses();
+
+    @Test
+    public abstract void testPersistentMemoryConfiguration_SystemMemoryMode();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryConfiguration_NotExistingModeThrows();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryDirectoryConfiguration_SystemMemoryModeThrows();
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -39,6 +39,7 @@ import com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
+import com.hazelcast.config.PersistentMemoryMode;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.SSLConfig;
@@ -472,8 +473,26 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
                 .setPageSize(randomInt())
                 .setSize(new MemorySize(randomInt(), MemoryUnit.BYTES))
                 .getPersistentMemoryConfig()
+                .setEnabled(true)
                 .addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem0", 0))
                 .addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem1", 1));
+        clientConfig.setNativeMemoryConfig(expected);
+
+        NativeMemoryConfig actual = newConfigViaGenerator().getNativeMemoryConfig();
+        assertEquals(clientConfig.getNativeMemoryConfig(), actual);
+    }
+
+    @Test
+    public void nativeMemoryWithPersistentMemory_SystemMemoryMode() {
+        NativeMemoryConfig expected = new NativeMemoryConfig();
+        expected.setEnabled(true)
+                .setAllocatorType(MemoryAllocatorType.STANDARD)
+                .setMetadataSpacePercentage(70)
+                .setMinBlockSize(randomInt())
+                .setPageSize(randomInt())
+                .setSize(new MemorySize(randomInt(), MemoryUnit.BYTES))
+                .getPersistentMemoryConfig()
+                .setMode(PersistentMemoryMode.SYSTEM_MEMORY);
         clientConfig.setNativeMemoryConfig(expected);
 
         NativeMemoryConfig actual = newConfigViaGenerator().getNativeMemoryConfig();

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.XMLConfigBuilderTest;
 import com.hazelcast.config.security.KerberosIdentityConfig;
@@ -56,6 +57,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 
+import static com.hazelcast.config.PersistentMemoryMode.MOUNTED;
+import static com.hazelcast.config.PersistentMemoryMode.SYSTEM_MEMORY;
 import static com.hazelcast.internal.nio.IOUtil.delete;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -538,9 +541,10 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
 
         ClientConfig xmlConfig = buildConfig(xml);
 
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = xmlConfig.getNativeMemoryConfig()
-                                                                          .getPersistentMemoryConfig()
-                                                                          .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = xmlConfig.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(1, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         assertEquals("/mnt/pmem0", dir0Config.getDirectory());
@@ -604,7 +608,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "<native-memory>\n"
                 + "  <persistent-memory-directory>/mnt/optane</persistent-memory-directory>\n"
-                + "  <persistent-memory>\n"
+                + "  <persistent-memory enabled=\"false\">\n"
                 + "    <directories>\n"
                 + "      <directory>/mnt/pmem0</directory>\n"
                 + "      <directory>/mnt/pmem1</directory>\n"
@@ -614,9 +618,11 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
                 + HAZELCAST_CLIENT_END_TAG;
 
         ClientConfig config = buildConfig(xml);
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig()
-                                                                       .getPersistentMemoryConfig()
-                                                                       .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertFalse(pmemConfig.isEnabled());
+        assertEquals(MOUNTED, pmemConfig.getMode());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(3, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         PersistentMemoryDirectoryConfig dir1Config = directoryConfigs.get(1);
@@ -627,6 +633,49 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         assertFalse(dir1Config.isNumaNodeSet());
         assertEquals("/mnt/pmem1", dir2Config.getDirectory());
         assertFalse(dir2Config.isNumaNodeSet());
+    }
+
+    @Override
+    @Test
+    public void testPersistentMemoryConfiguration_SystemMemoryMode() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<native-memory>\n"
+                + "  <persistent-memory enabled=\"true\" mode=\"SYSTEM_MEMORY\" />\n"
+                + "</native-memory>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        ClientConfig config = buildConfig(xml);
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+        assertEquals(SYSTEM_MEMORY, pmemConfig.getMode());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryConfiguration_NotExistingModeThrows() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<native-memory>\n"
+                + "  <persistent-memory mode=\"NOT_EXISTING_MODE\" />\n"
+                + "</native-memory>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        buildConfig(xml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryDirectoryConfiguration_SystemMemoryModeThrows() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<native-memory>\n"
+                + "  <persistent-memory mode=\"SYSTEM_MEMORY\">\n"
+                + "    <directories>\n"
+                + "      <directory>/mnt/pmem0</directory>\n"
+                + "    </directories>\n"
+                + "  </persistent-memory>\n"
+                + "</native-memory>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        buildConfig(xml);
     }
 
     static ClientConfig buildConfig(String xml, Properties properties) {

--- a/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.PersistentMemoryConfig;
 import com.hazelcast.config.PersistentMemoryDirectoryConfig;
 import com.hazelcast.config.YamlConfigBuilderTest;
 import com.hazelcast.config.security.KerberosIdentityConfig;
@@ -52,6 +53,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 
+import static com.hazelcast.config.PersistentMemoryMode.MOUNTED;
+import static com.hazelcast.config.PersistentMemoryMode.SYSTEM_MEMORY;
 import static com.hazelcast.internal.nio.IOUtil.delete;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -552,8 +555,10 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
                 + "    persistent-memory-directory: /mnt/pmem0";
 
         ClientConfig config = buildConfig(yaml);
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig().getPersistentMemoryConfig()
-                                                                       .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(1, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         assertEquals("/mnt/pmem0", dir0Config.getDirectory());
@@ -615,15 +620,18 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
                 + "  native-memory:\n"
                 + "    persistent-memory-directory: /mnt/optane\n"
                 + "    persistent-memory:\n"
+                + "      enabled: false\n"
                 + "      directories:\n"
                 + "        - directory: /mnt/pmem0\n"
                 + "        - directory: /mnt/pmem1\n";
 
         ClientConfig config = buildConfig(yaml);
 
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig()
-                                                                       .getPersistentMemoryConfig()
-                                                                       .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertFalse(pmemConfig.isEnabled());
+        assertEquals(MOUNTED, pmemConfig.getMode());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(3, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         PersistentMemoryDirectoryConfig dir1Config = directoryConfigs.get(1);
@@ -634,6 +642,46 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         assertFalse(dir1Config.isNumaNodeSet());
         assertEquals("/mnt/pmem1", dir2Config.getDirectory());
         assertFalse(dir2Config.isNumaNodeSet());
+    }
+
+    @Override
+    @Test
+    public void testPersistentMemoryConfiguration_SystemMemoryMode() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      mode: SYSTEM_MEMORY\n";
+
+        ClientConfig config = buildConfig(yaml);
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertEquals(SYSTEM_MEMORY, pmemConfig.getMode());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryConfiguration_NotExistingModeThrows() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      mode: NOT_EXISTING_MODE\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryDirectoryConfiguration_SystemMemoryModeThrows() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      mode: SYSTEM_MEMORY\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n";
+
+        buildConfig(yaml);
     }
 
     public static ClientConfig buildConfig(String yaml) {

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -594,6 +594,15 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     @Test
     public abstract void testPersistentMemoryDirectoryConfiguration_simpleAndAdvancedPasses();
 
+    @Test
+    public abstract void testPersistentMemoryConfiguration_SystemMemoryMode();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryConfiguration_NotExistingModeThrows();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testPersistentMemoryDirectoryConfiguration_SystemMemoryModeThrows();
+
     protected abstract Config buildAuditlogConfig();
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -803,6 +803,8 @@ public class ConfigCompatibilityChecker {
                     && c1.getMetadataSpacePercentage() == c2.getMetadataSpacePercentage()
                     && c1.getMinBlockSize() == c2.getMinBlockSize()
                     && c1.getPageSize() == c2.getPageSize()
+                    && c1.getPersistentMemoryConfig().isEnabled() == c2.getPersistentMemoryConfig().isEnabled()
+                    && c1.getPersistentMemoryConfig().getMode() == c2.getPersistentMemoryConfig().getMode()
                     && c1.getPersistentMemoryConfig().getDirectoryConfigs()
                          .equals(c2.getPersistentMemoryConfig().getDirectoryConfigs());
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1342,8 +1342,10 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         expectedConfig.setMinBlockSize(50);
         expectedConfig.setPageSize(100);
         expectedConfig.setSize(new MemorySize(20, MemoryUnit.MEGABYTES));
-        expectedConfig.getPersistentMemoryConfig().addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem0", 0));
-        expectedConfig.getPersistentMemoryConfig().addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem1", 1));
+        PersistentMemoryConfig origPmemConfig = expectedConfig.getPersistentMemoryConfig();
+        origPmemConfig.setEnabled(true);
+        origPmemConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem0", 0));
+        origPmemConfig.addDirectoryConfig(new PersistentMemoryDirectoryConfig("/mnt/pmem1", 1));
 
         Config config = new Config().setNativeMemoryConfig(expectedConfig);
         Config xmlConfig = getNewConfigViaXMLGenerator(config);
@@ -1356,13 +1358,46 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         assertEquals(100, actualConfig.getPageSize());
         assertEquals(new MemorySize(20, MemoryUnit.MEGABYTES).getUnit(), actualConfig.getSize().getUnit());
         assertEquals(new MemorySize(20, MemoryUnit.MEGABYTES).getValue(), actualConfig.getSize().getValue());
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = actualConfig.getPersistentMemoryConfig().getDirectoryConfigs();
+
+        PersistentMemoryConfig pmemConfig = actualConfig.getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+        assertEquals(PersistentMemoryMode.MOUNTED, pmemConfig.getMode());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(2, directoryConfigs.size());
         assertEquals("/mnt/pmem0", directoryConfigs.get(0).getDirectory());
         assertEquals(0, directoryConfigs.get(0).getNumaNode());
         assertEquals("/mnt/pmem1", directoryConfigs.get(1).getDirectory());
         assertEquals(1, directoryConfigs.get(1).getNumaNode());
         assertEquals(expectedConfig, actualConfig);
+    }
+
+    @Test
+    public void testNativeMemoryWithPersistentMemory_SystemMemoryMode() {
+        NativeMemoryConfig expectedConfig = new NativeMemoryConfig();
+        expectedConfig.setEnabled(true);
+        expectedConfig.setAllocatorType(NativeMemoryConfig.MemoryAllocatorType.STANDARD);
+        expectedConfig.setMetadataSpacePercentage(12.5f);
+        expectedConfig.setMinBlockSize(50);
+        expectedConfig.setPageSize(100);
+        expectedConfig.setSize(new MemorySize(20, MemoryUnit.MEGABYTES));
+        expectedConfig.getPersistentMemoryConfig().setMode(PersistentMemoryMode.SYSTEM_MEMORY);
+
+        Config config = new Config().setNativeMemoryConfig(expectedConfig);
+        Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        NativeMemoryConfig actualConfig = xmlConfig.getNativeMemoryConfig();
+        assertTrue(actualConfig.isEnabled());
+        assertEquals(NativeMemoryConfig.MemoryAllocatorType.STANDARD, actualConfig.getAllocatorType());
+        assertEquals(12.5, actualConfig.getMetadataSpacePercentage(), 0.0001);
+        assertEquals(50, actualConfig.getMinBlockSize());
+        assertEquals(100, actualConfig.getPageSize());
+        assertEquals(new MemorySize(20, MemoryUnit.MEGABYTES).getUnit(), actualConfig.getSize().getUnit());
+        assertEquals(new MemorySize(20, MemoryUnit.MEGABYTES).getValue(), actualConfig.getSize().getValue());
+
+        PersistentMemoryConfig pmemConfig = actualConfig.getPersistentMemoryConfig();
+        assertFalse(pmemConfig.isEnabled());
+        assertEquals(PersistentMemoryMode.SYSTEM_MEMORY, pmemConfig.getMode());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -61,6 +61,8 @@ import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
+import static com.hazelcast.config.PersistentMemoryMode.MOUNTED;
+import static com.hazelcast.config.PersistentMemoryMode.SYSTEM_MEMORY;
 import static com.hazelcast.config.WanQueueFullBehavior.DISCARD_AFTER_MUTATION;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static java.io.File.createTempFile;
@@ -3451,9 +3453,12 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
         Config yamlConfig = new InMemoryYamlConfig(yaml);
 
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = yamlConfig.getNativeMemoryConfig()
-                                                                           .getPersistentMemoryConfig()
+        PersistentMemoryConfig pmemConfig = yamlConfig.getNativeMemoryConfig()
+                .getPersistentMemoryConfig();
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig
                                                                            .getDirectoryConfigs();
+        assertFalse(pmemConfig.isEnabled());
+        assertEquals(MOUNTED, pmemConfig.getMode());
         assertEquals(2, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         PersistentMemoryDirectoryConfig dir1Config = directoryConfigs.get(1);
@@ -3472,9 +3477,10 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    persistent-memory-directory: /mnt/pmem0";
 
         Config config = buildConfig(yaml);
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig()
-                                                                       .getPersistentMemoryConfig()
-                                                                       .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(1, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         assertEquals("/mnt/pmem0", dir0Config.getDirectory());
@@ -3542,9 +3548,11 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
         Config config = buildConfig(yaml);
 
-        List<PersistentMemoryDirectoryConfig> directoryConfigs = config.getNativeMemoryConfig()
-                                                                       .getPersistentMemoryConfig()
-                                                                       .getDirectoryConfigs();
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+        assertEquals(MOUNTED, pmemConfig.getMode());
+
+        List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig.getDirectoryConfigs();
         assertEquals(3, directoryConfigs.size());
         PersistentMemoryDirectoryConfig dir0Config = directoryConfigs.get(0);
         PersistentMemoryDirectoryConfig dir1Config = directoryConfigs.get(1);
@@ -3555,6 +3563,48 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertFalse(dir1Config.isNumaNodeSet());
         assertEquals("/mnt/pmem1", dir2Config.getDirectory());
         assertFalse(dir2Config.isNumaNodeSet());
+    }
+
+    @Override
+    @Test
+    public void testPersistentMemoryConfiguration_SystemMemoryMode() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      enabled: true\n"
+                + "      mode: SYSTEM_MEMORY\n";
+
+        Config config = buildConfig(yaml);
+        PersistentMemoryConfig pmemConfig = config.getNativeMemoryConfig().getPersistentMemoryConfig();
+        assertTrue(pmemConfig.isEnabled());
+        assertEquals(SYSTEM_MEMORY, pmemConfig.getMode());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryConfiguration_NotExistingModeThrows() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      mode: NOT_EXISTING_MODE\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testPersistentMemoryDirectoryConfiguration_SystemMemoryModeThrows() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  native-memory:\n"
+                + "    persistent-memory:\n"
+                + "      mode: SYSTEM_MEMORY\n"
+                + "      directories:\n"
+                + "        - directory: /mnt/pmem0\n";
+
+        buildConfig(yaml);
     }
 
     @Override

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -607,7 +607,7 @@
         <min-block-size>123</min-block-size>
         <page-size>123</page-size>
         <metadata-space-percentage>12.5</metadata-space-percentage>
-        <persistent-memory>
+        <persistent-memory enabled="true" mode="MOUNTED">
             <directories>
                 <directory numa-node="0">/mnt/pmem0</directory>
                 <directory numa-node="1">/mnt/pmem1</directory>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -593,6 +593,8 @@ hazelcast:
     page-size: 123
     metadata-space-percentage: 12.5
     persistent-memory:
+      enabled: true
+      mode: MOUNTED
       directories:
         - directory: /mnt/pmem0
           numa-node: 0


### PR DESCRIPTION
Introduce config attribute for the operational mode of the persistent memory. Two modes supported: `MOUNTED (FS DAX)` and `SYSTEM_MEMORY (KMEM DAX)`. With this setting, the user can define to use PMEM in the KMEM DAX mode. Additionally, an `enabled` toggle is added to `persistent-memory`, which makes it explicit when persisten memory is used. For legacy reasons, if the `persistent-memory-directory` that was introduced in 4.0 is set, `enabled` is set to `true`, so the users already using persistent memory don't need to change their configs. Otherwise, the persistent memory should be explicitly enabled by setting `enabled` to
`true`, since the default is `false`.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/3814