### PR TITLE
Fix codec Javadocs and remove leftover field definitions for single r…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAddAndGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAddAndGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically adds the given value to the current value.
  */
-@Generated("9f245921abd21ae1f13b02fa25375e1b")
+@Generated("6371abd926d3735f254d22d17d894cc2")
 public final class AtomicLongAddAndGetCodec {
     //hex: 0x090300
     public static final int REQUEST_MESSAGE_TYPE = 590592;
@@ -104,8 +104,8 @@ public final class AtomicLongAddAndGetCodec {
     }
 
     /**
-    * the updated value, the given value added to the current value
-    */
+     * the updated value, the given value added to the current value
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAlterCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAlterCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Alters the currently stored value by applying a function on it.
  */
-@Generated("01abe0b71c221d34e8689cef9b2b58f1")
+@Generated("cd34c43f1e2183af39c67bf687cf7775")
 public final class AtomicLongAlterCodec {
     //hex: 0x090200
     public static final int REQUEST_MESSAGE_TYPE = 590336;
@@ -111,8 +111,8 @@ public final class AtomicLongAlterCodec {
     }
 
     /**
-    * The old or the new value depending on the returnValueType parameter.
-    */
+     * The old or the new value depending on the returnValueType parameter.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongApplyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongApplyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies a function on the value, the actual stored value will not change
  */
-@Generated("f7730cf6538688482a98ad2e1bb28288")
+@Generated("e3b20a504541ea190dea4fa4df6cd929")
 public final class AtomicLongApplyCodec {
     //hex: 0x090100
     public static final int REQUEST_MESSAGE_TYPE = 590080;
@@ -104,8 +104,8 @@ public final class AtomicLongApplyCodec {
     }
 
     /**
-    * The result of the function application.
-    */
+     * The result of the function application.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongCompareAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongCompareAndSetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Atomically sets the value to the given updated value only if the current
  * value the expected value.
  */
-@Generated("27ceb296b20b0341fa91c230a9892c9a")
+@Generated("8516a875551e26a0bcaf375854c38b40")
 public final class AtomicLongCompareAndSetCodec {
     //hex: 0x090400
     public static final int REQUEST_MESSAGE_TYPE = 590848;
@@ -113,9 +113,9 @@ public final class AtomicLongCompareAndSetCodec {
     }
 
     /**
-    * true if successful; or false if the actual value
-    * was not equal to the expected value.
-    */
+     * true if successful; or false if the actual value
+     * was not equal to the expected value.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndAddCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically adds the given value to the current value.
  */
-@Generated("f189081c49ff750b41058622c0cfd122")
+@Generated("c2f51253c1175ee0c94dace0044c818a")
 public final class AtomicLongGetAndAddCodec {
     //hex: 0x090600
     public static final int REQUEST_MESSAGE_TYPE = 591360;
@@ -104,8 +104,8 @@ public final class AtomicLongGetAndAddCodec {
     }
 
     /**
-    * the old value before the add
-    */
+     * the old value before the add
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetAndSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value and returns the old value.
  */
-@Generated("6c3816cbb11c6565c75c57bc2f6b4cc7")
+@Generated("5c218b88ae385ec7877c14b7e8963610")
 public final class AtomicLongGetAndSetCodec {
     //hex: 0x090700
     public static final int REQUEST_MESSAGE_TYPE = 591616;
@@ -104,8 +104,8 @@ public final class AtomicLongGetAndSetCodec {
     }
 
     /**
-    * the old value
-    */
+     * the old value
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the current value.
  */
-@Generated("516c77daaeb4d7a40b9ceadb2020454e")
+@Generated("237a2fb321f9ece3fe6dd6833d298700")
 public final class AtomicLongGetCodec {
     //hex: 0x090500
     public static final int REQUEST_MESSAGE_TYPE = 591104;
@@ -97,8 +97,8 @@ public final class AtomicLongGetCodec {
     }
 
     /**
-    * The current value
-    */
+     * The current value
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefApplyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefApplyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies a function on the value
  */
-@Generated("97abf4d30262dd4fe4d52063e388b8c3")
+@Generated("d0dfb1a215a164f47bc63468a0b63144")
 public final class AtomicRefApplyCodec {
     //hex: 0x0A0100
     public static final int REQUEST_MESSAGE_TYPE = 655616;
@@ -120,8 +120,8 @@ public final class AtomicRefApplyCodec {
     }
 
     /**
-    * The result of the function application.
-    */
+     * The result of the function application.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefCompareAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefCompareAndSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Alters the currently stored value by applying a function on it.
  */
-@Generated("0da74531a2fbcb4b59ff1b4e0cb3c7f7")
+@Generated("124f935371ecd007b416db4ba2f8b55e")
 public final class AtomicRefCompareAndSetCodec {
     //hex: 0x0A0200
     public static final int REQUEST_MESSAGE_TYPE = 655872;
@@ -111,9 +111,9 @@ public final class AtomicRefCompareAndSetCodec {
     }
 
     /**
-    * true if successful; or false if the actual value
-    * was not equal to the expected value.
-    */
+     * true if successful; or false if the actual value
+     * was not equal to the expected value.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefContainsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks if the reference contains the value.
  */
-@Generated("22e366b255c93b6b57600782a1e380ca")
+@Generated("4d73b86a9e64c5fb5c8da1d6d1a1308c")
 public final class AtomicRefContainsCodec {
     //hex: 0x0A0300
     public static final int REQUEST_MESSAGE_TYPE = 656128;
@@ -104,8 +104,8 @@ public final class AtomicRefContainsCodec {
     }
 
     /**
-    * true if the value is found, false otherwise.
-    */
+     * true if the value is found, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the current value.
  */
-@Generated("41d79517967886d17f1b22600aac48cf")
+@Generated("8e3265949e566c6b9058dfd57e431885")
 public final class AtomicRefGetCodec {
     //hex: 0x0A0400
     public static final int REQUEST_MESSAGE_TYPE = 656384;
@@ -96,8 +96,8 @@ public final class AtomicRefGetCodec {
     }
 
     /**
-    * The current value
-    */
+     * The current value
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value
  */
-@Generated("a38383a91d55b4f5430dd28568d68d4d")
+@Generated("170b4ec8aff644821296faf1b7bee432")
 public final class AtomicRefSetCodec {
     //hex: 0x0A0500
     public static final int REQUEST_MESSAGE_TYPE = 656640;
@@ -110,9 +110,9 @@ public final class AtomicRefSetCodec {
     }
 
     /**
-    * the old value or null, depending on
-    * the {
-    */
+     * the old value or null, depending on
+     * the {
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPGroupCreateCPGroupCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPGroupCreateCPGroupCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a new CP group with the given name
  */
-@Generated("8c71ae8afb174b0578e79f74d1eae391")
+@Generated("02d6f66aee586a605c3e86d7adeef411")
 public final class CPGroupCreateCPGroupCodec {
     //hex: 0x1E0100
     public static final int REQUEST_MESSAGE_TYPE = 1966336;
@@ -47,12 +47,6 @@ public final class CPGroupCreateCPGroupCodec {
 
     private CPGroupCreateCPGroupCodec() {
     }
-
-    /**
-     * The proxy name of this data structure instance
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String proxyName;
 
     public static ClientMessage encodeRequest(java.lang.String proxyName) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class CPGroupCreateCPGroupCodec {
         return clientMessage;
     }
 
+    /**
+     * The proxy name of this data structure instance
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class CPGroupCreateCPGroupCodec {
     }
 
     /**
-    * ID of the CP group that contains the CP object
-    */
+     * ID of the CP group that contains the CP object
+     */
     public static com.hazelcast.cp.internal.RaftGroupId decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCloseSessionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCloseSessionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Closes the given session on the given CP group
  */
-@Generated("4279a0c20dc40f09645690994ddf7091")
+@Generated("37e21c792c65c5b65ef4fe75ac198bed")
 public final class CPSessionCloseSessionCodec {
     //hex: 0x1F0200
     public static final int REQUEST_MESSAGE_TYPE = 2032128;
@@ -97,9 +97,9 @@ public final class CPSessionCloseSessionCodec {
     }
 
     /**
-    * true if the session is found & closed,
-    * false otherwise.
-    */
+     * true if the session is found & closed,
+     * false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCreateSessionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionCreateSessionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a session for the caller on the given CP group.
  */
-@Generated("8b19b65ccbe129df1efda58e75a148c2")
+@Generated("c5948db7f338cee48772b3f742e76264")
 public final class CPSessionCreateSessionCodec {
     //hex: 0x1F0100
     public static final int REQUEST_MESSAGE_TYPE = 2031872;
@@ -90,14 +90,17 @@ public final class CPSessionCreateSessionCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Id of the session.
          */
         public long sessionId;
+
         /**
          * Time to live value in milliseconds that must be respected by the caller.
          */
         public long ttlMillis;
+
         /**
          * Time between heartbeats in milliseconds that must be respected by the caller.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionGenerateThreadIdCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSessionGenerateThreadIdCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Generates a new ID for the caller thread. The ID is unique in the given
  * CP group.
  */
-@Generated("5c8569ed132144792102705be779a1c9")
+@Generated("bbac66bd574790dc1113d914d41d89b3")
 public final class CPSessionGenerateThreadIdCodec {
     //hex: 0x1F0400
     public static final int REQUEST_MESSAGE_TYPE = 2032640;
@@ -49,12 +49,6 @@ public final class CPSessionGenerateThreadIdCodec {
 
     private CPSessionGenerateThreadIdCodec() {
     }
-
-    /**
-     * ID of the CP group
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public com.hazelcast.cp.internal.RaftGroupId groupId;
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class CPSessionGenerateThreadIdCodec {
         return clientMessage;
     }
 
+    /**
+     * ID of the CP group
+     */
     public static com.hazelcast.cp.internal.RaftGroupId decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class CPSessionGenerateThreadIdCodec {
     }
 
     /**
-    * A unique ID for the caller thread
-    */
+     * A unique ID for the caller thread
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemAddGroupAvailabilityListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemAddGroupAvailabilityListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Registers a new CP group availability listener.
  */
-@Generated("301af08455e8d6a4d5dd4bf9f4abeaff")
+@Generated("50f41213c3feee3460232d08ec934646")
 public final class CPSubsystemAddGroupAvailabilityListenerCodec {
     //hex: 0x220300
     public static final int REQUEST_MESSAGE_TYPE = 2228992;
@@ -54,12 +54,6 @@ public final class CPSubsystemAddGroupAvailabilityListenerCodec {
     private CPSubsystemAddGroupAvailabilityListenerCodec() {
     }
 
-    /**
-     * Denotes whether register a local listener or not.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public boolean local;
-
     public static ClientMessage encodeRequest(boolean local) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
@@ -72,6 +66,9 @@ public final class CPSubsystemAddGroupAvailabilityListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * Denotes whether register a local listener or not.
+     */
     public static boolean decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -89,8 +86,8 @@ public final class CPSubsystemAddGroupAvailabilityListenerCodec {
     }
 
     /**
-    * Registration id for the listener.
-    */
+     * Registration id for the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -132,7 +129,7 @@ public final class CPSubsystemAddGroupAvailabilityListenerCodec {
          * @param groupId Group id whose availability is reported.
          * @param members All members.
          * @param unavailableMembers Missing members.
-        */
+         */
         public abstract void handleGroupAvailabilityEventEvent(com.hazelcast.cp.internal.RaftGroupId groupId, java.util.Collection<com.hazelcast.cp.CPMember> members, java.util.Collection<com.hazelcast.cp.CPMember> unavailableMembers);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemAddMembershipListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemAddMembershipListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Registers a new CP membership listener.
  */
-@Generated("abce754aa3e8e37d20018507a5740865")
+@Generated("96abf0fde2b5d46955d8c88195ae5f41")
 public final class CPSubsystemAddMembershipListenerCodec {
     //hex: 0x220100
     public static final int REQUEST_MESSAGE_TYPE = 2228480;
@@ -55,12 +55,6 @@ public final class CPSubsystemAddMembershipListenerCodec {
     private CPSubsystemAddMembershipListenerCodec() {
     }
 
-    /**
-     * Denotes whether register a local listener or not.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public boolean local;
-
     public static ClientMessage encodeRequest(boolean local) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
@@ -73,6 +67,9 @@ public final class CPSubsystemAddMembershipListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * Denotes whether register a local listener or not.
+     */
     public static boolean decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -90,8 +87,8 @@ public final class CPSubsystemAddMembershipListenerCodec {
     }
 
     /**
-    * Registration id for the listener.
-    */
+     * Registration id for the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -129,7 +126,7 @@ public final class CPSubsystemAddMembershipListenerCodec {
         /**
          * @param member Member which is added or removed.
          * @param type Type of the event. It is either ADDED(1) or REMOVED(2).
-        */
+         */
         public abstract void handleMembershipEventEvent(com.hazelcast.cp.CPMember member, byte type);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemRemoveGroupAvailabilityListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemRemoveGroupAvailabilityListenerCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Deregisters CP availability listener.
  */
-@Generated("3a322bfa1335ff5fd8ec3bcc7bc89ec9")
+@Generated("1d11f935b102b79b298c0df3a6279f09")
 public final class CPSubsystemRemoveGroupAvailabilityListenerCodec {
     //hex: 0x220400
     public static final int REQUEST_MESSAGE_TYPE = 2229248;
@@ -50,12 +50,6 @@ public final class CPSubsystemRemoveGroupAvailabilityListenerCodec {
     private CPSubsystemRemoveGroupAvailabilityListenerCodec() {
     }
 
-    /**
-     * The id of the listener which was provided during registration.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID registrationId;
-
     public static ClientMessage encodeRequest(java.util.UUID registrationId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -68,6 +62,9 @@ public final class CPSubsystemRemoveGroupAvailabilityListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * The id of the listener which was provided during registration.
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -85,8 +82,8 @@ public final class CPSubsystemRemoveGroupAvailabilityListenerCodec {
     }
 
     /**
-    * True if unregistered, false otherwise.
-    */
+     * True if unregistered, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemRemoveMembershipListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CPSubsystemRemoveMembershipListenerCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Deregisters CP membership listener.
  */
-@Generated("60ac47bf7e499af73b8b4acff2862cd2")
+@Generated("11dd6f846d2d0490a131fc7cd2d873bb")
 public final class CPSubsystemRemoveMembershipListenerCodec {
     //hex: 0x220200
     public static final int REQUEST_MESSAGE_TYPE = 2228736;
@@ -50,12 +50,6 @@ public final class CPSubsystemRemoveMembershipListenerCodec {
     private CPSubsystemRemoveMembershipListenerCodec() {
     }
 
-    /**
-     * The id of the listener which was provided during registration.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID registrationId;
-
     public static ClientMessage encodeRequest(java.util.UUID registrationId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -68,6 +62,9 @@ public final class CPSubsystemRemoveMembershipListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * The id of the listener which was provided during registration.
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -85,8 +82,8 @@ public final class CPSubsystemRemoveMembershipListenerCodec {
     }
 
     /**
-    * True if unregistered, false otherwise.
-    */
+     * True if unregistered, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddEntryListenerCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an entry listener for this cache. For the types of events that the listener
  * will be notified for, see the documentation of the type field of the Cache event below.
  */
-@Generated("e5b08e560dc8ad6bcea41c7cda211aca")
+@Generated("cf8cd425693f464d8fa7210e48bb071a")
 public final class CacheAddEntryListenerCodec {
     //hex: 0x130100
     public static final int REQUEST_MESSAGE_TYPE = 1245440;
@@ -104,8 +104,8 @@ public final class CacheAddEntryListenerCodec {
     }
 
     /**
-    * Registration id for the registered listener.
-    */
+     * Registration id for the registered listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -156,7 +156,7 @@ public final class CacheAddEntryListenerCodec {
          * @param keys The keys of the entries in the cache.
          * @param completionId User generated id which shall be received as a field of the cache event upon completion of the
          *                     request in the cluster.
-        */
+         */
         public abstract void handleCacheEvent(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddNearCacheInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddNearCacheInvalidationListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds listener to cache. This listener will be used to listen near cache invalidation events.
  */
-@Generated("50409bd5bad48fe6e0ed926b085eae80")
+@Generated("45724f701bd4792555e78c2f074cc3a7")
 public final class CacheAddNearCacheInvalidationListenerCodec {
     //hex: 0x131D00
     public static final int REQUEST_MESSAGE_TYPE = 1252608;
@@ -107,8 +107,8 @@ public final class CacheAddNearCacheInvalidationListenerCodec {
     }
 
     /**
-    * Registration id for the registered listener.
-    */
+     * Registration id for the registered listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -181,7 +181,7 @@ public final class CacheAddNearCacheInvalidationListenerCodec {
          * @param sourceUuid UUID of the member who fired this event.
          * @param partitionUuid UUID of the source partition that invalidated entry belongs to.
          * @param sequence Sequence number of the invalidation event.
-        */
+         */
         public abstract void handleCacheInvalidationEvent(java.lang.String name, @Nullable com.hazelcast.internal.serialization.Data key, @Nullable java.util.UUID sourceUuid, java.util.UUID partitionUuid, long sequence);
 
         /**
@@ -190,7 +190,7 @@ public final class CacheAddNearCacheInvalidationListenerCodec {
          * @param sourceUuids List of UUIDs of the members who fired these events.
          * @param partitionUuids List of UUIDs of the source partitions that invalidated entries belong to.
          * @param sequences List of sequence numbers of the invalidation events.
-        */
+         */
         public abstract void handleCacheBatchInvalidationEvent(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys, java.util.Collection<java.util.UUID> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddPartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheAddPartitionLostListenerCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * registrations, so if you register the listener twice, it will get events twice.Listeners registered from
  * HazelcastClient may miss some of the cache partition lost events due to design limitations.
  */
-@Generated("8da8a8df040abc4fd16d2fbe2009a5cf")
+@Generated("b3b270075656e80b37e79644490a4216")
 public final class CacheAddPartitionLostListenerCodec {
     //hex: 0x131900
     public static final int REQUEST_MESSAGE_TYPE = 1251584;
@@ -107,8 +107,8 @@ public final class CacheAddPartitionLostListenerCodec {
     }
 
     /**
-    * returns the registration id for the CachePartitionLostListener.
-    */
+     * returns the registration id for the CachePartitionLostListener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -146,7 +146,7 @@ public final class CacheAddPartitionLostListenerCodec {
         /**
          * @param partitionId Id of the lost partition.
          * @param uuid UUID of the member that owns the lost partition.
-        */
+         */
         public abstract void handleCachePartitionLostEvent(int partitionId, java.util.UUID uuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheClearCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Clears the contents of the cache, without notifying listeners or CacheWriters.
  */
-@Generated("527f6df7bcf1bd441b37d430bf255b48")
+@Generated("98eca89af7c7591f5b54cbe7bc1dde39")
 public final class CacheClearCodec {
     //hex: 0x130200
     public static final int REQUEST_MESSAGE_TYPE = 1245696;
@@ -47,12 +47,6 @@ public final class CacheClearCodec {
 
     private CacheClearCodec() {
     }
-
-    /**
-     * Name of the cache.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class CacheClearCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the cache.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheContainsKeyCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Determines if the Cache contains an entry for the specified key. More formally, returns true if and only if this
  * cache contains a mapping for a key k such that key.equals(k). (There can be at most one such mapping.)
  */
-@Generated("062e05ff7116dd9b78108c298c99f51f")
+@Generated("a9d903dedfe9943d796ca99abf1e216d")
 public final class CacheContainsKeyCodec {
     //hex: 0x130500
     public static final int REQUEST_MESSAGE_TYPE = 1246464;
@@ -98,8 +98,8 @@ public final class CacheContainsKeyCodec {
     }
 
     /**
-    * Returns true if cache value for the key exists, false otherwise.
-    */
+     * Returns true if cache value for the key exists, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheCreateConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheCreateConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates the given cache configuration on Hazelcast members.
  */
-@Generated("d0fdf3cee97eab66d65090bf4f1d0daa")
+@Generated("c46c6a6cfe0a22e9e3dd6b3089d97a22")
 public final class CacheCreateConfigCodec {
     //hex: 0x130600
     public static final int REQUEST_MESSAGE_TYPE = 1246720;
@@ -96,8 +96,8 @@ public final class CacheCreateConfigCodec {
     }
 
     /**
-    * The created configuration object.
-    */
+     * The created configuration object.
+     */
     public static com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheDestroyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheDestroyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Closes the cache. Clears the internal content and releases any resource.
  */
-@Generated("f48fbab868e6de23cffe0c4a591dd7a8")
+@Generated("9503153512fa23548083ca2daad44084")
 public final class CacheDestroyCodec {
     //hex: 0x130700
     public static final int REQUEST_MESSAGE_TYPE = 1246976;
@@ -47,12 +47,6 @@ public final class CacheDestroyCodec {
 
     private CacheDestroyCodec() {
     }
-
-    /**
-     * Name of the cache.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class CacheDestroyCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the cache.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEntryProcessorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEntryProcessorCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to entry mapped by the key.
  * Returns the result of the processing, if any, defined by the implementation.
  */
-@Generated("c6cdb65b7d796545619588eb2fb40158")
+@Generated("bc8d97eca9a3b60f8f73349579fd1764")
 public final class CacheEntryProcessorCodec {
     //hex: 0x130800
     public static final int REQUEST_MESSAGE_TYPE = 1247232;
@@ -120,8 +120,8 @@ public final class CacheEntryProcessorCodec {
     }
 
     /**
-    * the result of the processing, if any, defined by the EntryProcessor implementation
-    */
+     * the result of the processing, if any, defined by the EntryProcessor implementation
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("f6346af4e2127d1a5f6acb00dbb90214")
+@Generated("8b4fca14c81b0766e500b111215f6700")
 public final class CacheEventJournalReadCodec {
     //hex: 0x132000
     public static final int REQUEST_MESSAGE_TYPE = 1253376;
@@ -126,18 +126,22 @@ public final class CacheEventJournalReadCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Number of items that have been read.
          */
         public int readCount;
+
         /**
          * List of items that have been read.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> items;
+
         /**
          * Sequence numbers of items in the event journal.
          */
         public @Nullable long[] itemSeqs;
+
         /**
          * Sequence number of the item following the last read item.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalSubscribeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalSubscribeCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This includes retrieving the event journal sequences of the
  * oldest and newest event in the journal.
  */
-@Generated("09e28fcabc5d4217510c68e6530b04e9")
+@Generated("c02d2c67cac8137574e0d474b8c5c727")
 public final class CacheEventJournalSubscribeCodec {
     //hex: 0x131F00
     public static final int REQUEST_MESSAGE_TYPE = 1253120;
@@ -52,12 +52,6 @@ public final class CacheEventJournalSubscribeCodec {
     private CacheEventJournalSubscribeCodec() {
     }
 
-    /**
-     * name of the cache
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
-
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -70,6 +64,9 @@ public final class CacheEventJournalSubscribeCodec {
         return clientMessage;
     }
 
+    /**
+     * name of the cache
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -79,10 +76,12 @@ public final class CacheEventJournalSubscribeCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Sequence id of the oldest event in the event journal.
          */
         public long oldestSequence;
+
         /**
          * Sequence id of the newest event in the event journal.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheFetchNearCacheInvalidationMetadataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheFetchNearCacheInvalidationMetadataCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches invalidation metadata from partitions of map.
  */
-@Generated("34053dbb0678fb82c4341714a441e496")
+@Generated("f8d391b2c4527e23893995af535a88d1")
 public final class CacheFetchNearCacheInvalidationMetadataCodec {
     //hex: 0x131E00
     public static final int REQUEST_MESSAGE_TYPE = 1252864;
@@ -87,10 +87,12 @@ public final class CacheFetchNearCacheInvalidationMetadataCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Map of partition ids and sequence number of invalidations mapped by the cache name.
          */
         public java.util.List<java.util.Map.Entry<java.lang.String, java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Long>>>> namePartitionSequenceList;
+
         /**
          * Map of member UUIDs mapped by the partition ids of invalidations.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * configured javax.cache.integration.CacheLoader might be called to retrieve the values of the keys from any kind
  * of external resource.
  */
-@Generated("971482091094574aef70809b5c6ba61e")
+@Generated("fabe2f44b89a2fd382ea92a4dcc9396b")
 public final class CacheGetAllCodec {
     //hex: 0x130900
     public static final int REQUEST_MESSAGE_TYPE = 1247488;
@@ -107,9 +107,9 @@ public final class CacheGetAllCodec {
     }
 
     /**
-    * A map of entries that were found for the given keys. Keys not found
-    * in the cache are not in the returned map.
-    */
+     * A map of entries that were found for the given keys. Keys not found
+     * in the cache are not in the returned map.
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically removes the entry for a key only if currently mapped to some value.
  */
-@Generated("4b1b25935ed3db2a38f322b6c90c556d")
+@Generated("7d74638e49efa7a485caf81c7722b0f6")
 public final class CacheGetAndRemoveCodec {
     //hex: 0x130A00
     public static final int REQUEST_MESSAGE_TYPE = 1247744;
@@ -104,8 +104,8 @@ public final class CacheGetAndRemoveCodec {
     }
 
     /**
-    * the value if one existed or null if no mapping existed for this key
-    */
+     * the value if one existed or null if no mapping existed for this key
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndReplaceCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * write-through operation mode, the underlying configured javax.cache.integration.CacheWriter might be called to
  * store the value of the key to any kind of external resource.
  */
-@Generated("391ac71bc8aca51ecfcff9e5c5c63e9e")
+@Generated("76f20ca985e29e5eb4f8c7d478aef644")
 public final class CacheGetAndReplaceCodec {
     //hex: 0x130B00
     public static final int REQUEST_MESSAGE_TYPE = 1248000;
@@ -122,8 +122,8 @@ public final class CacheGetAndReplaceCodec {
     }
 
     /**
-    * The old value previously assigned to the given key.
-    */
+     * The old value previously assigned to the given key.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * null is returned. If the cache is configured for read-through operation mode, the underlying configured
  * javax.cache.integration.CacheLoader might be called to retrieve the value of the key from any kind of external resource.
  */
-@Generated("b2de09782d7cd1e162028004b4c13026")
+@Generated("07dc5f01fd31a357325669bd39850ab1")
 public final class CacheGetCodec {
     //hex: 0x130D00
     public static final int REQUEST_MESSAGE_TYPE = 1248512;
@@ -106,8 +106,8 @@ public final class CacheGetCodec {
     }
 
     /**
-    * The value assigned to the given key, or null if not assigned.
-    */
+     * The value assigned to the given key, or null if not assigned.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the cache configuration with the given name from members.
  */
-@Generated("26132e594075044e7897b6853a1a4372")
+@Generated("2bdfe57dca7c785e43d7b8a0eac0cdcf")
 public final class CacheGetConfigCodec {
     //hex: 0x130C00
     public static final int REQUEST_MESSAGE_TYPE = 1248256;
@@ -96,8 +96,8 @@ public final class CacheGetConfigCodec {
     }
 
     /**
-    * The cache configuration.
-    */
+     * The cache configuration.
+     */
     public static com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * CacheEntryRemoveListeners notified. java.util.Iterator#next() may return null if the entry is no longer present,
  * has expired or has been evicted.
  */
-@Generated("7527ba98aad238bc3065e5bb20e7b4b6")
+@Generated("9d8753f258c150a1201f186592c46365")
 public final class CacheIterateCodec {
     //hex: 0x130E00
     public static final int REQUEST_MESSAGE_TYPE = 1248768;
@@ -97,10 +97,12 @@ public final class CacheIterateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * The index-size pairs that define the state of iteration
          */
         public java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Integer>> iterationPointers;
+
         /**
          * The keys fetched from the cache.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateEntriesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheIterateEntriesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of entries from the specified partition starting from specified table index.
  */
-@Generated("196bb6ab1fbedbd1fe3cd14494457146")
+@Generated("f64b72a6c44347c64dfb9ad7f4351a78")
 public final class CacheIterateEntriesCodec {
     //hex: 0x131C00
     public static final int REQUEST_MESSAGE_TYPE = 1252352;
@@ -94,10 +94,12 @@ public final class CacheIterateEntriesCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * The index-size pairs that define the state of iteration
          */
         public java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Integer>> iterationPointers;
+
         /**
          * The entries fetched from the cache.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Puts the entry with the given key, value and the expiry policy to the cache.
  */
-@Generated("9bccedc587a4591e388236999be1b173")
+@Generated("5901455e14ac8f9c41c533f068de1771")
 public final class CachePutCodec {
     //hex: 0x131300
     public static final int REQUEST_MESSAGE_TYPE = 1250048;
@@ -127,8 +127,8 @@ public final class CachePutCodec {
     }
 
     /**
-    * The value previously assigned to the given key, or null if not assigned.
-    */
+     * The value previously assigned to the given key, or null if not assigned.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutIfAbsentCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * specified key. If the cache is configured for write-through operation mode, the underlying configured
  * javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
  */
-@Generated("3812cc59e4680b8c9c380123359ec1f1")
+@Generated("5f892955ddefc1b58344d85c7c4a4976")
 public final class CachePutIfAbsentCodec {
     //hex: 0x131200
     public static final int REQUEST_MESSAGE_TYPE = 1249792;
@@ -122,8 +122,8 @@ public final class CachePutIfAbsentCodec {
     }
 
     /**
-    * true if a value was set, false otherwise.
-    */
+     * true if a value was set, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically removes the mapping for a key only if currently mapped to the given value.
  */
-@Generated("ad27d93098aa756069dec9a4ca3eb965")
+@Generated("5369be15318ee0b74486b571282e0b24")
 public final class CacheRemoveCodec {
     //hex: 0x131600
     public static final int REQUEST_MESSAGE_TYPE = 1250816;
@@ -112,8 +112,8 @@ public final class CacheRemoveCodec {
     }
 
     /**
-    * returns false if there was no matching key
-    */
+     * returns false if there was no matching key
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("fc7c09e6c9c4e31621ee935d00726a7f")
+@Generated("5dd5779f38cb6b1aa4900d5a0dfa02ec")
 public final class CacheRemoveEntryListenerCodec {
     //hex: 0x131400
     public static final int REQUEST_MESSAGE_TYPE = 1250304;
@@ -98,8 +98,8 @@ public final class CacheRemoveEntryListenerCodec {
     }
 
     /**
-    * true if the listener is de-registered, false otherwise
-    */
+     * true if the listener is de-registered, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveInvalidationListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified invalidation listener. If there is no such listener added before, this call does no change
  * in the cluster and returns false.
  */
-@Generated("36aa72adad1f50f8cfb7a9bcc35cb863")
+@Generated("99d3332373f2a6de34b50693688f68e2")
 public final class CacheRemoveInvalidationListenerCodec {
     //hex: 0x131500
     public static final int REQUEST_MESSAGE_TYPE = 1250560;
@@ -98,8 +98,8 @@ public final class CacheRemoveInvalidationListenerCodec {
     }
 
     /**
-    * true if the listener is de-registered, false otherwise
-    */
+     * true if the listener is de-registered, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemovePartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemovePartitionLostListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified cache partition lost listener. If there is no such listener added before, this call does no
  * change in the cluster and returns false.
  */
-@Generated("401bdaf1489bbbf82100ef11837db620")
+@Generated("3452d680dd439e69a50156fe01c78340")
 public final class CacheRemovePartitionLostListenerCodec {
     //hex: 0x131A00
     public static final int REQUEST_MESSAGE_TYPE = 1251840;
@@ -98,8 +98,8 @@ public final class CacheRemovePartitionLostListenerCodec {
     }
 
     /**
-    * true if registration is removed, false otherwise.
-    */
+     * true if registration is removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheReplaceCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the cache is configured for write-through operation mode, the underlying configured
  * javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
  */
-@Generated("2e7f061e042f02af704f7b47f90f2d06")
+@Generated("826e6803c20bc4c4d1ec5e8fa5b10d16")
 public final class CacheReplaceCodec {
     //hex: 0x131700
     public static final int REQUEST_MESSAGE_TYPE = 1251072;
@@ -129,8 +129,8 @@ public final class CacheReplaceCodec {
     }
 
     /**
-    * The replaced value.
-    */
+     * The replaced value.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSetExpiryPolicyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSetExpiryPolicyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
  * If some keys in {@code keys} do not exist or are already expired, this call has no effect for those.
  */
-@Generated("3222084ade35f432912b7b5a33e16cdf")
+@Generated("2f1822acbd9d9b66551aa8eb4fb2ad05")
 public final class CacheSetExpiryPolicyCodec {
     //hex: 0x132100
     public static final int REQUEST_MESSAGE_TYPE = 1253632;
@@ -106,8 +106,8 @@ public final class CacheSetExpiryPolicyCodec {
     }
 
     /**
-    * {
-    */
+     * {
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSizeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Total entry count
  */
-@Generated("b31fb4c67281efde900e7ec63226a20a")
+@Generated("d8ddcbc8f659c07c37704241ed5b1d55")
 public final class CacheSizeCodec {
     //hex: 0x131800
     public static final int REQUEST_MESSAGE_TYPE = 1251328;
@@ -48,12 +48,6 @@ public final class CacheSizeCodec {
 
     private CacheSizeCodec() {
     }
-
-    /**
-     * Name of the cache.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class CacheSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the cache.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class CacheSizeCodec {
     }
 
     /**
-    * total entry count
-    */
+     * total entry count
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CardinalityEstimatorEstimateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CardinalityEstimatorEstimateCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Estimates the cardinality of the aggregation so far.
  * If it was previously estimated and never invalidated, then the cached version is used.
  */
-@Generated("2c4fc50c542e7ef87251db01a022fd20")
+@Generated("56f184a65cfc53850db5165214e53d15")
 public final class CardinalityEstimatorEstimateCodec {
     //hex: 0x190200
     public static final int REQUEST_MESSAGE_TYPE = 1638912;
@@ -49,12 +49,6 @@ public final class CardinalityEstimatorEstimateCodec {
 
     private CardinalityEstimatorEstimateCodec() {
     }
-
-    /**
-     * The name of CardinalityEstimator
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class CardinalityEstimatorEstimateCodec {
         return clientMessage;
     }
 
+    /**
+     * The name of CardinalityEstimator
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class CardinalityEstimatorEstimateCodec {
     }
 
     /**
-    * the previous cached estimation or the newly computed one.
-    */
+     * the previous cached estimation or the newly computed one.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddClusterViewListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddClusterViewListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a cluster view listener to a connection.
  */
-@Generated("b2dcebf34ce8c8658822904791116d8d")
+@Generated("a3333b736aa74439445fc6215b6ab7aa")
 public final class ClientAddClusterViewListenerCodec {
     //hex: 0x000300
     public static final int REQUEST_MESSAGE_TYPE = 768;
@@ -56,7 +56,6 @@ public final class ClientAddClusterViewListenerCodec {
 
     private ClientAddClusterViewListenerCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -131,13 +130,13 @@ public final class ClientAddClusterViewListenerCodec {
          * @param version Incremental member list version
          * @param memberInfos List of member infos  at the cluster associated with the given version
          *                    params:
-        */
+         */
         public abstract void handleMembersViewEvent(int version, java.util.Collection<com.hazelcast.internal.cluster.MemberInfo> memberInfos);
 
         /**
          * @param version Incremental state version of the partition table
          * @param partitions The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
-        */
+         */
         public abstract void handlePartitionsViewEvent(int version, java.util.Collection<java.util.Map.Entry<java.util.UUID, java.util.List<java.lang.Integer>>> partitions);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddDistributedObjectListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddDistributedObjectListenerCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a distributed object listener to the cluster. This listener will be notified
  * when a distributed object is created or destroyed.
  */
-@Generated("494cd23af1b74c9a0f24877c314a4e98")
+@Generated("c62b84a3e663dddbe4d44db05291506b")
 public final class ClientAddDistributedObjectListenerCodec {
     //hex: 0x000900
     public static final int REQUEST_MESSAGE_TYPE = 2304;
@@ -56,13 +56,6 @@ public final class ClientAddDistributedObjectListenerCodec {
     private ClientAddDistributedObjectListenerCodec() {
     }
 
-    /**
-     * If set to true, the server adds the listener only to itself, otherwise the listener is is added for all
-     * members in the cluster.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public boolean localOnly;
-
     public static ClientMessage encodeRequest(boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
@@ -75,6 +68,10 @@ public final class ClientAddDistributedObjectListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * If set to true, the server adds the listener only to itself, otherwise the listener is is added for all
+     * members in the cluster.
+     */
     public static boolean decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -92,8 +89,8 @@ public final class ClientAddDistributedObjectListenerCodec {
     }
 
     /**
-    * The registration id for the distributed object listener.
-    */
+     * The registration id for the distributed object listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -137,7 +134,7 @@ public final class ClientAddDistributedObjectListenerCodec {
          * @param serviceName Service name of the distributed object.
          * @param eventType Type of the event. It is either CREATED or DESTROYED.
          * @param source The UUID (client or member) of the source of this proxy event.
-        */
+         */
         public abstract void handleDistributedObjectEvent(java.lang.String name, java.lang.String serviceName, java.lang.String eventType, java.util.UUID source);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddPartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAddPartitionLostListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a partition lost listener to the cluster.
  */
-@Generated("76a490d327a14fb2b849ace32651ab0e")
+@Generated("e5760469d73555b30348b270070505e1")
 public final class ClientAddPartitionLostListenerCodec {
     //hex: 0x000600
     public static final int REQUEST_MESSAGE_TYPE = 1536;
@@ -57,13 +57,6 @@ public final class ClientAddPartitionLostListenerCodec {
     private ClientAddPartitionLostListenerCodec() {
     }
 
-    /**
-     * if true only node that has the partition sends the request, if false
-     * sends all partition lost events.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public boolean localOnly;
-
     public static ClientMessage encodeRequest(boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
@@ -76,6 +69,10 @@ public final class ClientAddPartitionLostListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * if true only node that has the partition sends the request, if false
+     * sends all partition lost events.
+     */
     public static boolean decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -93,8 +90,8 @@ public final class ClientAddPartitionLostListenerCodec {
     }
 
     /**
-    * The listener registration id.
-    */
+     * The listener registration id.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -135,7 +132,7 @@ public final class ClientAddPartitionLostListenerCodec {
          * @param partitionId Id of the lost partition.
          * @param lostBackupCount The number of lost backups for the partition. 0: the owner, 1: first backup, 2: second backup...
          * @param source UUID of the node that dispatches the event
-        */
+         */
         public abstract void handlePartitionLostEvent(int partitionId, int lostBackupCount, @Nullable java.util.UUID source);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Makes an authentication request to the cluster.
  */
-@Generated("6a04ae2059ca7049a86502d33db8d157")
+@Generated("f2eb2a8e135a3a2716727745fa3a747c")
 public final class ClientAuthenticationCodec {
     //hex: 0x000100
     public static final int REQUEST_MESSAGE_TYPE = 256;
@@ -145,35 +145,43 @@ public final class ClientAuthenticationCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * A byte that represents the authentication status. It can be AUTHENTICATED(0), CREDENTIALS_FAILED(1),
          * SERIALIZATION_VERSION_MISMATCH(2) or NOT_ALLOWED_IN_CLUSTER(3).
          */
         public byte status;
+
         /**
          * Address of the Hazelcast member which sends the authentication response.
          */
         public @Nullable com.hazelcast.cluster.Address address;
+
         /**
          * UUID of the Hazelcast member which sends the authentication response.
          */
         public @Nullable java.util.UUID memberUuid;
+
         /**
          * client side supported version to inform server side
          */
         public byte serializationVersion;
+
         /**
          * Version of the Hazelcast member which sends the authentication response.
          */
         public java.lang.String serverHazelcastVersion;
+
         /**
          * Partition count of the cluster.
          */
         public int partitionCount;
+
         /**
          * UUID of the cluster that the client authenticated.
          */
         public java.util.UUID clusterId;
+
         /**
          * Returns true if server supports clients with failover feature.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientAuthenticationCustomCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Makes an authentication request to the cluster using custom credentials.
  */
-@Generated("3a1cdd0d69c5938a88df881bf6c227d6")
+@Generated("de965bce612c882bde51c22614ae8a19")
 public final class ClientAuthenticationCustomCodec {
     //hex: 0x000200
     public static final int REQUEST_MESSAGE_TYPE = 512;
@@ -136,35 +136,43 @@ public final class ClientAuthenticationCustomCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * A byte that represents the authentication status. It can be AUTHENTICATED(0), CREDENTIALS_FAILED(1),
          * SERIALIZATION_VERSION_MISMATCH(2) or NOT_ALLOWED_IN_CLUSTER(3).
          */
         public byte status;
+
         /**
          * Address of the Hazelcast member which sends the authentication response.
          */
         public @Nullable com.hazelcast.cluster.Address address;
+
         /**
          * UUID of the Hazelcast member which sends the authentication response.
          */
         public @Nullable java.util.UUID memberUuid;
+
         /**
          * client side supported version to inform server side
          */
         public byte serializationVersion;
+
         /**
          * Version of the Hazelcast member which sends the authentication response.
          */
         public java.lang.String serverHazelcastVersion;
+
         /**
          * Partition count of the cluster.
          */
         public int partitionCount;
+
         /**
          * The cluster id of the cluster.
          */
         public java.util.UUID clusterId;
+
         /**
          * Returns true if server supports clients with failover feature.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientCreateProxiesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientCreateProxiesCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Exceptions related to a proxy creation failure is not send to the client.
  * A proxy creation failure does not cancel this operation, all proxies will be attempted to be created.
  */
-@Generated("9331299827cc08394b46595eb111f277")
+@Generated("7668aa662ad0d3179efdab9a3d27b24c")
 public final class ClientCreateProxiesCodec {
     //hex: 0x000E00
     public static final int REQUEST_MESSAGE_TYPE = 3584;
@@ -51,15 +51,6 @@ public final class ClientCreateProxiesCodec {
 
     private ClientCreateProxiesCodec() {
     }
-
-    /**
-     * proxies that will be created
-     * Each entry's key is distributed object name.
-     * Each entry's value is service name.
-     * For possible service names see createProxy message.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.List<java.util.Map.Entry<java.lang.String, java.lang.String>> proxies;
 
     public static ClientMessage encodeRequest(java.util.Collection<java.util.Map.Entry<java.lang.String, java.lang.String>> proxies) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -73,6 +64,12 @@ public final class ClientCreateProxiesCodec {
         return clientMessage;
     }
 
+    /**
+     * proxies that will be created
+     * Each entry's key is distributed object name.
+     * Each entry's value is service name.
+     * For possible service names see createProxy message.
+     */
     public static java.util.List<java.util.Map.Entry<java.lang.String, java.lang.String>> decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientDeployClassesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientDeployClassesCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Each item is a Map.Entry<String, byte[]> in the list.
  * key of entry is full class name, and byte[] is the class definition.
  */
-@Generated("a90f7a338188dec6bbbda5f884b0d181")
+@Generated("5d92c7c74978297d378eccd15ca0050f")
 public final class ClientDeployClassesCodec {
     //hex: 0x000D00
     public static final int REQUEST_MESSAGE_TYPE = 3328;
@@ -49,12 +49,6 @@ public final class ClientDeployClassesCodec {
 
     private ClientDeployClassesCodec() {
     }
-
-    /**
-     * list of class definitions
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.List<java.util.Map.Entry<java.lang.String, byte[]>> classDefinitions;
 
     public static ClientMessage encodeRequest(java.util.Collection<java.util.Map.Entry<java.lang.String, byte[]>> classDefinitions) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class ClientDeployClassesCodec {
         return clientMessage;
     }
 
+    /**
+     * list of class definitions
+     */
     public static java.util.List<java.util.Map.Entry<java.lang.String, byte[]>> decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientGetDistributedObjectsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientGetDistributedObjectsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the list of distributed objects in the cluster.
  */
-@Generated("f921737ff0d33af2372e34b323197a54")
+@Generated("d48c0343e6ece308410465b33b5ef5a5")
 public final class ClientGetDistributedObjectsCodec {
     //hex: 0x000800
     public static final int REQUEST_MESSAGE_TYPE = 2048;
@@ -47,7 +47,6 @@ public final class ClientGetDistributedObjectsCodec {
 
     private ClientGetDistributedObjectsCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,8 +71,8 @@ public final class ClientGetDistributedObjectsCodec {
     }
 
     /**
-    * An array of distributed object info in the cluster.
-    */
+     * An array of distributed object info in the cluster.
+     */
     public static java.util.List<com.hazelcast.client.impl.client.DistributedObjectInfo> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientLocalBackupListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientLocalBackupListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds listener for backup acks
  */
-@Generated("d8500c6600e37904906c7c6f292da356")
+@Generated("7534fdd03b39c6163e7cde02ef0dbae5")
 public final class ClientLocalBackupListenerCodec {
     //hex: 0x000F00
     public static final int REQUEST_MESSAGE_TYPE = 3840;
@@ -53,7 +53,6 @@ public final class ClientLocalBackupListenerCodec {
 
     private ClientLocalBackupListenerCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -78,8 +77,8 @@ public final class ClientLocalBackupListenerCodec {
     }
 
     /**
-    * Returns the registration id for the listener.
-    */
+     * Returns the registration id for the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -114,7 +113,7 @@ public final class ClientLocalBackupListenerCodec {
 
         /**
          * @param sourceInvocationCorrelationId correlation id of the invocation that backup acks belong to
-        */
+         */
         public abstract void handleBackupEvent(long sourceInvocationCorrelationId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientPingCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientPingCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Sends a ping to the given connection.
  */
-@Generated("a4672984603df3c1cc3a5ebaf6e2bb08")
+@Generated("28509cb3b2949d1b1da6c04caa0a5725")
 public final class ClientPingCodec {
     //hex: 0x000B00
     public static final int REQUEST_MESSAGE_TYPE = 2816;
@@ -47,7 +47,6 @@ public final class ClientPingCodec {
 
     private ClientPingCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemoveDistributedObjectListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemoveDistributedObjectListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified distributed object listener. If there is no such listener added before, this call does no
  * change in the cluster and returns false.
  */
-@Generated("9928ba01391fb73ca96122b18a13423f")
+@Generated("aa20bb2ad24ad4018d4d3d946f3d949b")
 public final class ClientRemoveDistributedObjectListenerCodec {
     //hex: 0x000A00
     public static final int REQUEST_MESSAGE_TYPE = 2560;
@@ -51,12 +51,6 @@ public final class ClientRemoveDistributedObjectListenerCodec {
     private ClientRemoveDistributedObjectListenerCodec() {
     }
 
-    /**
-     * The id assigned during the registration.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID registrationId;
-
     public static ClientMessage encodeRequest(java.util.UUID registrationId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -69,6 +63,9 @@ public final class ClientRemoveDistributedObjectListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * The id assigned during the registration.
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -86,8 +83,8 @@ public final class ClientRemoveDistributedObjectListenerCodec {
     }
 
     /**
-    * true if the listener existed and removed, false otherwise.
-    */
+     * true if the listener existed and removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemovePartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientRemovePartitionLostListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified partition lost listener. If there is no such listener added before, this call does no change
  * in the cluster and returns false.
  */
-@Generated("6dc759b61a5b8beefc8e8ecf627f2b6a")
+@Generated("2336c4b188c4f37a82a8b757f687dd35")
 public final class ClientRemovePartitionLostListenerCodec {
     //hex: 0x000700
     public static final int REQUEST_MESSAGE_TYPE = 1792;
@@ -51,12 +51,6 @@ public final class ClientRemovePartitionLostListenerCodec {
     private ClientRemovePartitionLostListenerCodec() {
     }
 
-    /**
-     * The id assigned during the listener registration.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID registrationId;
-
     public static ClientMessage encodeRequest(java.util.UUID registrationId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -69,6 +63,9 @@ public final class ClientRemovePartitionLostListenerCodec {
         return clientMessage;
     }
 
+    /**
+     * The id assigned during the listener registration.
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -86,8 +83,8 @@ public final class ClientRemovePartitionLostListenerCodec {
     }
 
     /**
-    * true if the listener existed and removed, false otherwise.
-    */
+     * true if the listener existed and removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientTriggerPartitionAssignmentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ClientTriggerPartitionAssignmentCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Triggers partition assignment manually on the cluster.
  * Note that Partition based operations triggers this automatically
  */
-@Generated("53fdd2c2256a37e3a96180dbbec8eba1")
+@Generated("ee0e4071dfc495c04869e74a1d0f96bf")
 public final class ClientTriggerPartitionAssignmentCodec {
     //hex: 0x001000
     public static final int REQUEST_MESSAGE_TYPE = 4096;
@@ -48,7 +48,6 @@ public final class ClientTriggerPartitionAssignmentCodec {
 
     private ClientTriggerPartitionAssignmentCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryAddListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryAddListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a listener to be notified for the events fired on the underlying map on all nodes.
  */
-@Generated("2226fd37fe41989b522c13556352580c")
+@Generated("74eddcfaccd3c6457663999598f1ee19")
 public final class ContinuousQueryAddListenerCodec {
     //hex: 0x160400
     public static final int REQUEST_MESSAGE_TYPE = 1442816;
@@ -105,8 +105,8 @@ public final class ContinuousQueryAddListenerCodec {
     }
 
     /**
-    * Registration id for the listener.
-    */
+     * Registration id for the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -163,7 +163,7 @@ public final class ContinuousQueryAddListenerCodec {
 
         /**
          * @param data Data that holds the details of the event such as key, value, old value, new value and creation time.
-        */
+         */
         public abstract void handleQueryCacheSingleEvent(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data);
 
         /**
@@ -171,7 +171,7 @@ public final class ContinuousQueryAddListenerCodec {
          *               new value and creation time.
          * @param source Source that dispathces this batch event.
          * @param partitionId Id of the partition that holds the keys of the batch event.
-        */
+         */
         public abstract void handleQueryCacheBatchEvent(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryDestroyCacheCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryDestroyCacheCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Destroys the query cache with the given name for a specific map.
  */
-@Generated("d5df1cf97d0180286e89aab3406f23bf")
+@Generated("fd9c443d12a5500dcc0bde11feac9d4e")
 public final class ContinuousQueryDestroyCacheCodec {
     //hex: 0x160600
     public static final int REQUEST_MESSAGE_TYPE = 1443328;
@@ -97,8 +97,8 @@ public final class ContinuousQueryDestroyCacheCodec {
     }
 
     /**
-    * True if all cache is destroyed, false otherwise.
-    */
+     * True if all cache is destroyed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryMadePublishableCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryMadePublishableCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Makes the query cache with the given name for a specific map publishable.
  */
-@Generated("0c32280ae3454dfddb2bd160e9d65487")
+@Generated("acd8d72d3239e127223e0e3a3d022a72")
 public final class ContinuousQueryMadePublishableCodec {
     //hex: 0x160300
     public static final int REQUEST_MESSAGE_TYPE = 1442560;
@@ -97,8 +97,8 @@ public final class ContinuousQueryMadePublishableCodec {
     }
 
     /**
-    * True if successfully set as publishable, false otherwise.
-    */
+     * True if successfully set as publishable, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a publisher that does not include value for the cache events it sends.
  */
-@Generated("587cabf82b59b06e640c763def06036f")
+@Generated("3ccaa740772ac5f08ab32b4e942d9a38")
 public final class ContinuousQueryPublisherCreateCodec {
     //hex: 0x160200
     public static final int REQUEST_MESSAGE_TYPE = 1442304;
@@ -143,8 +143,8 @@ public final class ContinuousQueryPublisherCreateCodec {
     }
 
     /**
-    * Array of keys.
-    */
+     * Array of keys.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a publisher that includes value for the cache events it sends.
  */
-@Generated("a3172b8a2ac652c35af7d95d91c44755")
+@Generated("cf50cb45c8d0a9065a83279a243355ac")
 public final class ContinuousQueryPublisherCreateWithValueCodec {
     //hex: 0x160100
     public static final int REQUEST_MESSAGE_TYPE = 1442048;
@@ -143,8 +143,8 @@ public final class ContinuousQueryPublisherCreateWithValueCodec {
     }
 
     /**
-    * Array of key-value pairs.
-    */
+     * Array of key-value pairs.
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQuerySetReadCursorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQuerySetReadCursorCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns `false` if the event is not in the buffer of event publisher side. That means recovery is not
  * possible.
  */
-@Generated("c821ec8965ffc06282bb4664fe704c71")
+@Generated("62f977f60d3b995a01aa409bbf250fef")
 public final class ContinuousQuerySetReadCursorCodec {
     //hex: 0x160500
     public static final int REQUEST_MESSAGE_TYPE = 1443072;
@@ -109,8 +109,8 @@ public final class ContinuousQuerySetReadCursorCodec {
     }
 
     /**
-    * True if the cursor position could be set, false otherwise.
-    */
+     * True if the cursor position could be set, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchAwaitCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchAwaitCodec.java
@@ -51,7 +51,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * waiting time elapses then the value false is returned.  If the time is
  * less than or equal to zero, the method will not wait at all.
  */
-@Generated("9f4433392910229dd72a86fc713379f4")
+@Generated("280d1321fa057713ef0dee3a898bd446")
 public final class CountDownLatchAwaitCodec {
     //hex: 0x0B0200
     public static final int REQUEST_MESSAGE_TYPE = 721408;
@@ -127,9 +127,9 @@ public final class CountDownLatchAwaitCodec {
     }
 
     /**
-    * true if the count reached zero, false if
-    * the waiting time elapsed before the count reached 0
-    */
+     * true if the count reached zero, false if
+     * the waiting time elapsed before the count reached 0
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetCountCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the current count.
  */
-@Generated("aeb101fabad895cde17a2752afbc0a43")
+@Generated("79f6c9128d7ff95e91fe02219b31601b")
 public final class CountDownLatchGetCountCodec {
     //hex: 0x0B0400
     public static final int REQUEST_MESSAGE_TYPE = 721920;
@@ -97,8 +97,8 @@ public final class CountDownLatchGetCountCodec {
     }
 
     /**
-    * The current count of this CountDownLatch instance
-    */
+     * The current count of this CountDownLatch instance
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetRoundCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchGetRoundCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the current round. A round completes when the count value
  * reaches to 0 and a new round starts afterwards.
  */
-@Generated("39143e0efc103ecb741cc867efbf4cb7")
+@Generated("8e8a2318aeafc9e119fb90d46876c0f9")
 public final class CountDownLatchGetRoundCodec {
     //hex: 0x0B0500
     public static final int REQUEST_MESSAGE_TYPE = 722176;
@@ -98,8 +98,8 @@ public final class CountDownLatchGetRoundCodec {
     }
 
     /**
-    * The current round of this CountDownLatch instance
-    */
+     * The current round of this CountDownLatch instance
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchTrySetCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CountDownLatchTrySetCountCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the count is not zero, then this method does nothing
  * and returns false
  */
-@Generated("1b79e108da3eb25e5f536ca3de37f420")
+@Generated("078f79e78cdef1847940f54e8eb654bf")
 public final class CountDownLatchTrySetCountCodec {
     //hex: 0x0B0100
     public static final int REQUEST_MESSAGE_TYPE = 721152;
@@ -107,9 +107,9 @@ public final class CountDownLatchTrySetCountCodec {
     }
 
     /**
-    * true if the new count was set,
-    * false if the current count is not zero.
-    */
+     * true if the new count was set,
+     * false if the current count is not zero.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorIsShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorIsShutdownCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this executor has been shut down.
  */
-@Generated("976e9721c8286b79d10bda2d8a0487c2")
+@Generated("828d5130afa6aa410ba47c0978dc2a62")
 public final class DurableExecutorIsShutdownCodec {
     //hex: 0x180200
     public static final int REQUEST_MESSAGE_TYPE = 1573376;
@@ -48,12 +48,6 @@ public final class DurableExecutorIsShutdownCodec {
 
     private DurableExecutorIsShutdownCodec() {
     }
-
-    /**
-     * Name of the executor.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class DurableExecutorIsShutdownCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the executor.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class DurableExecutorIsShutdownCodec {
     }
 
     /**
-    * true if this executor has been shut down
-    */
+     * true if this executor has been shut down
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveAndDisposeResultCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveAndDisposeResultCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves and disposes the result of the execution with the given sequence
  */
-@Generated("a448d3a3a4ac391b112c82190ffa21b0")
+@Generated("3395c6978f770c0f10e1b3ef4cf6cf59")
 public final class DurableExecutorRetrieveAndDisposeResultCodec {
     //hex: 0x180600
     public static final int REQUEST_MESSAGE_TYPE = 1574400;
@@ -96,8 +96,8 @@ public final class DurableExecutorRetrieveAndDisposeResultCodec {
     }
 
     /**
-    * The result of the callable execution with the given sequence.
-    */
+     * The result of the callable execution with the given sequence.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveResultCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorRetrieveResultCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves the result of the execution with the given sequence
  */
-@Generated("91a38293c8185f556f43b022cb8df753")
+@Generated("a0bf800c03794eac23982a6058293cd1")
 public final class DurableExecutorRetrieveResultCodec {
     //hex: 0x180400
     public static final int REQUEST_MESSAGE_TYPE = 1573888;
@@ -96,8 +96,8 @@ public final class DurableExecutorRetrieveResultCodec {
     }
 
     /**
-    * The result of the callable execution with the given sequence.
-    */
+     * The result of the callable execution with the given sequence.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorShutdownCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
  * Invocation has no additional effect if already shut down.
  */
-@Generated("65131a5966c1c68fad8e4a091964a551")
+@Generated("38ec34c5628c949393dba76dbf86acfc")
 public final class DurableExecutorShutdownCodec {
     //hex: 0x180100
     public static final int REQUEST_MESSAGE_TYPE = 1573120;
@@ -48,12 +48,6 @@ public final class DurableExecutorShutdownCodec {
 
     private DurableExecutorShutdownCodec() {
     }
-
-    /**
-     * Name of the executor.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class DurableExecutorShutdownCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the executor.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorSubmitToPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to partition for execution
  */
-@Generated("82ac5159cc0217fee2b170895785182c")
+@Generated("738d02c686fddaa8bad986cfb6db7c85")
 public final class DurableExecutorSubmitToPartitionCodec {
     //hex: 0x180300
     public static final int REQUEST_MESSAGE_TYPE = 1573632;
@@ -97,8 +97,8 @@ public final class DurableExecutorSubmitToPartitionCodec {
     }
 
     /**
-    * the sequence for the submitted execution.
-    */
+     * the sequence for the submitted execution.
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddDurableExecutorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddDurableExecutorConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a durable executor configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("26df3ccb0152053eda1d8d384a8699e8")
+@Generated("ab44138a9a02e22bfc22da925227b55b")
 public final class DynamicConfigAddDurableExecutorConfigCodec {
     //hex: 0x1B0900
     public static final int REQUEST_MESSAGE_TYPE = 1771776;
@@ -92,7 +92,7 @@ public final class DynamicConfigAddDurableExecutorConfigCodec {
         /**
          * True if the statisticsEnabled is received from the client, false otherwise.
          * If this is false, statisticsEnabled has the default value for its type.
-        */
+         */
         public boolean isStatisticsEnabledExists;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddQueueConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddQueueConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a queue configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("faed08d78771f41333205db25009f47e")
+@Generated("45926341df86d1f298812ca675a01e1d")
 public final class DynamicConfigAddQueueConfigCodec {
     //hex: 0x1B0B00
     public static final int REQUEST_MESSAGE_TYPE = 1772288;
@@ -124,7 +124,7 @@ public final class DynamicConfigAddQueueConfigCodec {
         /**
          * True if the priorityComparatorClassName is received from the client, false otherwise.
          * If this is false, priorityComparatorClassName has the default value for its type.
-        */
+         */
         public boolean isPriorityComparatorClassNameExists;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddScheduledExecutorConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddScheduledExecutorConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a scheduled executor configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("5911ad8e41569ca43d6bd4f355f09ecd")
+@Generated("b3d0f4de697c454a207b3d5d5032a2f0")
 public final class DynamicConfigAddScheduledExecutorConfigCodec {
     //hex: 0x1B0A00
     public static final int REQUEST_MESSAGE_TYPE = 1772032;
@@ -104,7 +104,7 @@ public final class DynamicConfigAddScheduledExecutorConfigCodec {
         /**
          * True if the statisticsEnabled is received from the client, false otherwise.
          * If this is false, statisticsEnabled has the default value for its type.
-        */
+         */
         public boolean isStatisticsEnabledExists;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Cancels the task running on the member with the given address.
  */
-@Generated("3f5289af22eeac6149d64f9a5d5b8cad")
+@Generated("390edc56ad076eda9f6f7292c4f3baf2")
 public final class ExecutorServiceCancelOnMemberCodec {
     //hex: 0x080400
     public static final int REQUEST_MESSAGE_TYPE = 525312;
@@ -106,8 +106,8 @@ public final class ExecutorServiceCancelOnMemberCodec {
     }
 
     /**
-    * True if cancelled successfully, false otherwise.
-    */
+     * True if cancelled successfully, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceCancelOnPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Cancels the task running on the member that owns the partition with the given id.
  */
-@Generated("211a5b67ae88699c09e7c633883ff60f")
+@Generated("b6a7c8cb1d489cc2ae6d422b34371615")
 public final class ExecutorServiceCancelOnPartitionCodec {
     //hex: 0x080300
     public static final int REQUEST_MESSAGE_TYPE = 525056;
@@ -98,8 +98,8 @@ public final class ExecutorServiceCancelOnPartitionCodec {
     }
 
     /**
-    * True if cancelled successfully, false otherwise.
-    */
+     * True if cancelled successfully, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceIsShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceIsShutdownCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this executor has been shut down.
  */
-@Generated("48e19531d2ef098d4a004a1f85997a01")
+@Generated("9c432994380f41937131fb454e1b0f7a")
 public final class ExecutorServiceIsShutdownCodec {
     //hex: 0x080200
     public static final int REQUEST_MESSAGE_TYPE = 524800;
@@ -48,12 +48,6 @@ public final class ExecutorServiceIsShutdownCodec {
 
     private ExecutorServiceIsShutdownCodec() {
     }
-
-    /**
-     * Name of the executor.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class ExecutorServiceIsShutdownCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the executor.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class ExecutorServiceIsShutdownCodec {
     }
 
     /**
-    * true if this executor has been shut down
-    */
+     * true if this executor has been shut down
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceShutdownCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceShutdownCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
  * Invocation has no additional effect if already shut down.
  */
-@Generated("09b223950e04c5750b977fc8d3816e8e")
+@Generated("8fc8f4607db8f528c20aa44a45b8c3b6")
 public final class ExecutorServiceShutdownCodec {
     //hex: 0x080100
     public static final int REQUEST_MESSAGE_TYPE = 524544;
@@ -48,12 +48,6 @@ public final class ExecutorServiceShutdownCodec {
 
     private ExecutorServiceShutdownCodec() {
     }
-
-    /**
-     * Name of the executor.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class ExecutorServiceShutdownCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the executor.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to member specified by the address.
  */
-@Generated("c7bf713a2449100de74ab08d6ce64dc0")
+@Generated("b80d5cbce48ae992f3eb62cdfbd0f4d6")
 public final class ExecutorServiceSubmitToMemberCodec {
     //hex: 0x080600
     public static final int REQUEST_MESSAGE_TYPE = 525824;
@@ -111,8 +111,8 @@ public final class ExecutorServiceSubmitToMemberCodec {
     }
 
     /**
-    * The result of the callable execution.
-    */
+     * The result of the callable execution.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to the member that owns the partition with the given id.
  */
-@Generated("d46b68115d365820e70660777a10522a")
+@Generated("c039f99877b18e30fbdbfe6dde5249e9")
 public final class ExecutorServiceSubmitToPartitionCodec {
     //hex: 0x080500
     public static final int REQUEST_MESSAGE_TYPE = 525568;
@@ -103,8 +103,8 @@ public final class ExecutorServiceSubmitToPartitionCodec {
     }
 
     /**
-    * The result of the callable execution.
-    */
+     * The result of the callable execution.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockGetLockOwnershipCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockGetLockOwnershipCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns current lock ownership status of the given FencedLock instance.
  */
-@Generated("7ed8df6d7fde0863b6adec61ca6d4a55")
+@Generated("c6f82bebef2e507aa38f5524fb5c36fc")
 public final class FencedLockGetLockOwnershipCodec {
     //hex: 0x070400
     public static final int REQUEST_MESSAGE_TYPE = 459776;
@@ -91,18 +91,22 @@ public final class FencedLockGetLockOwnershipCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Fence token of the lock
          */
         public long fence;
+
         /**
          * Reenterant lock count
          */
         public int lockCount;
+
         /**
          * Id of the session that holds the lock
          */
         public long sessionId;
+
         /**
          * Id of the thread that holds the lock
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockLockCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * is closed between reentrant acquires, the call fails with
  * {@code LockOwnershipLostException}.
  */
-@Generated("e97dc2ef85216fa0945c9cc89eb0e81d")
+@Generated("133a9cddfd01a156aac3e312853452a7")
 public final class FencedLockLockCodec {
     //hex: 0x070100
     public static final int REQUEST_MESSAGE_TYPE = 459008;
@@ -126,9 +126,9 @@ public final class FencedLockLockCodec {
     }
 
     /**
-    * a valid fencing token (positive number) if the lock
-    * is acquired, otherwise -1.
-    */
+     * a valid fencing token (positive number) if the lock
+     * is acquired, otherwise -1.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockTryLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockTryLockCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * duration passes. If the session is closed between reentrant acquires,
  * the call fails with {@code LockOwnershipLostException}.
  */
-@Generated("56398b651612c28870cb2a58ef14368f")
+@Generated("ae8f19f05cd9202b93b6fe57e6cabd46")
 public final class FencedLockTryLockCodec {
     //hex: 0x070200
     public static final int REQUEST_MESSAGE_TYPE = 459264;
@@ -135,9 +135,9 @@ public final class FencedLockTryLockCodec {
     }
 
     /**
-    * a valid fencing token (positive number) if the lock
-    * is acquired, otherwise -1.
-    */
+     * a valid fencing token (positive number) if the lock
+     * is acquired, otherwise -1.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockUnlockCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * {@code LockOwnershipLostException}. Returns true if the lock is still
  * held by the caller after a successful unlock() call, false otherwise.
  */
-@Generated("3ebd2e79fcbdd68a65a987bae0dfbe5b")
+@Generated("20153112cd701d8092d6ab9601738a65")
 public final class FencedLockUnlockCodec {
     //hex: 0x070300
     public static final int REQUEST_MESSAGE_TYPE = 459520;
@@ -124,9 +124,9 @@ public final class FencedLockUnlockCodec {
     }
 
     /**
-    * true if the lock is still held by the caller after
-    * a successful unlock() call, false otherwise.
-    */
+     * true if the lock is still held by the caller after
+     * a successful unlock() call, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FlakeIdGeneratorNewIdBatchCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FlakeIdGeneratorNewIdBatchCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches a new batch of ids for the given flake id generator.
  */
-@Generated("ad54942668b03c43675e91e113352da9")
+@Generated("972d4a1ab23cce3b29084b271ff45ace")
 public final class FlakeIdGeneratorNewIdBatchCodec {
     //hex: 0x1C0100
     public static final int REQUEST_MESSAGE_TYPE = 1835264;
@@ -90,14 +90,17 @@ public final class FlakeIdGeneratorNewIdBatchCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * First id in the batch.
          */
         public long base;
+
         /**
          * Increment for the next id in the batch.
          */
         public long increment;
+
         /**
          * Number of ids in the batch.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
  * (Note that this will occur if the specified collection is this list, and it's nonempty.)
  */
-@Generated("37486e118c9394f0d545e03cef3cb323")
+@Generated("39e36e5dd1ee19e74fb4ff04c6b40bfa")
 public final class ListAddAllCodec {
     //hex: 0x050600
     public static final int REQUEST_MESSAGE_TYPE = 329216;
@@ -100,8 +100,8 @@ public final class ListAddAllCodec {
     }
 
     /**
-    * True if this list changed as a result of the call, false otherwise
-    */
+     * True if this list changed as a result of the call, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllWithIndexCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllWithIndexCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
  * (Note that this will occur if the specified collection is this list, and it's nonempty.)
  */
-@Generated("32ba923a2bbcb342460cfce60202b9f7")
+@Generated("66791e5008e52a068905bb0289d3dd18")
 public final class ListAddAllWithIndexCodec {
     //hex: 0x050E00
     public static final int REQUEST_MESSAGE_TYPE = 331264;
@@ -108,8 +108,8 @@ public final class ListAddAllWithIndexCodec {
     }
 
     /**
-    * True if this list changed as a result of the call, false otherwise.
-    */
+     * True if this list changed as a result of the call, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * elements, and others will impose restrictions on the type of elements that may be added. List classes should
  * clearly specify in their documentation any restrictions on what elements may be added.
  */
-@Generated("2506acf4c186e7eb253fd85e6f88ea5d")
+@Generated("9983424b4fe21f53fd234e164358e29d")
 public final class ListAddCodec {
     //hex: 0x050400
     public static final int REQUEST_MESSAGE_TYPE = 328704;
@@ -100,8 +100,8 @@ public final class ListAddCodec {
     }
 
     /**
-    * true if this list changed as a result of the call, false otherwise
-    */
+     * true if this list changed as a result of the call, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
  */
-@Generated("4036e1c28bce207d2779410519d89b67")
+@Generated("eb78907c65dee93de75cae6b8e9a9fc1")
 public final class ListAddListenerCodec {
     //hex: 0x050B00
     public static final int REQUEST_MESSAGE_TYPE = 330496;
@@ -111,8 +111,8 @@ public final class ListAddListenerCodec {
     }
 
     /**
-    * Registration id for the listener.
-    */
+     * Registration id for the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -153,7 +153,7 @@ public final class ListAddListenerCodec {
          * @param item Item that the event is fired for.
          * @param uuid UUID of the member that dispatches this event.
          * @param eventType Type of the event. It is either ADDED(1) or REMOVED(2).
-        */
+         */
         public abstract void handleItemEvent(@Nullable com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListClearCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all of the elements from this list (optional operation). The list will be empty after this call returns.
  */
-@Generated("735b1606fb196e0233d26cb23410af6b")
+@Generated("78c288bcc16fde97aa09f84ca614fb7b")
 public final class ListClearCodec {
     //hex: 0x050900
     public static final int REQUEST_MESSAGE_TYPE = 329984;
@@ -47,12 +47,6 @@ public final class ListClearCodec {
 
     private ListClearCodec() {
     }
-
-    /**
-     * Name of the List
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class ListClearCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the List
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRemoveAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes from this list all of its elements that are contained in the specified collection (optional operation).
  */
-@Generated("c6ae3e84f81d9d309b6be086434cb508")
+@Generated("897959883be5bdbd566645f2e96b6cb7")
 public final class ListCompareAndRemoveAllCodec {
     //hex: 0x050700
     public static final int REQUEST_MESSAGE_TYPE = 329472;
@@ -97,8 +97,8 @@ public final class ListCompareAndRemoveAllCodec {
     }
 
     /**
-    * True if removed at least one of the items, false otherwise.
-    */
+     * True if removed at least one of the items, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRetainAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRetainAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retains only the elements in this list that are contained in the specified collection (optional operation).
  * In other words, removes from this list all of its elements that are not contained in the specified collection.
  */
-@Generated("494d1733a6622468c2e6d1239b87a84b")
+@Generated("69328659f59024ea5ba5f8dcd634a38d")
 public final class ListCompareAndRetainAllCodec {
     //hex: 0x050800
     public static final int REQUEST_MESSAGE_TYPE = 329728;
@@ -98,8 +98,8 @@ public final class ListCompareAndRetainAllCodec {
     }
 
     /**
-    * True if this list changed as a result of the call, false otherwise.
-    */
+     * True if this list changed as a result of the call, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this list contains all of the elements of the specified collection.
  */
-@Generated("8cfcf18d7d58e08d5e52312f4a5df7bb")
+@Generated("45fffa278cc453b113104f1262fe822f")
 public final class ListContainsAllCodec {
     //hex: 0x050300
     public static final int REQUEST_MESSAGE_TYPE = 328448;
@@ -97,9 +97,9 @@ public final class ListContainsAllCodec {
     }
 
     /**
-    * True if this list contains all of the elements of the
-    * specified collection
-    */
+     * True if this list contains all of the elements of the
+     * specified collection
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this list contains the specified element.
  */
-@Generated("d0ddb673a6d3d6a6659542794fec7dff")
+@Generated("d0307ba77177a7a50e52bf0a100833d0")
 public final class ListContainsCodec {
     //hex: 0x050200
     public static final int REQUEST_MESSAGE_TYPE = 328192;
@@ -97,8 +97,8 @@ public final class ListContainsCodec {
     }
 
     /**
-    * True if this list contains the specified element, false otherwise
-    */
+     * True if this list contains the specified element, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListGetAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return the all elements of this collection
  */
-@Generated("3d29524a9b1d91724275d003058a23fc")
+@Generated("1061950676d512c1c98c40ede35de15e")
 public final class ListGetAllCodec {
     //hex: 0x050A00
     public static final int REQUEST_MESSAGE_TYPE = 330240;
@@ -47,12 +47,6 @@ public final class ListGetAllCodec {
 
     private ListGetAllCodec() {
     }
-
-    /**
-     * Name of the List
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class ListGetAllCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the List
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class ListGetAllCodec {
     }
 
     /**
-    * An array of all item values in the list.
-    */
+     * An array of all item values in the list.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the element at the specified position in this list
  */
-@Generated("a08c0dfd8fdd29d21bee1574c382ce4d")
+@Generated("5297f41a49ecfc34f4a997179c0e8cb6")
 public final class ListGetCodec {
     //hex: 0x050F00
     public static final int REQUEST_MESSAGE_TYPE = 331520;
@@ -96,8 +96,8 @@ public final class ListGetCodec {
     }
 
     /**
-    * The element at the specified position in this list
-    */
+     * The element at the specified position in this list
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIndexOfCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIndexOfCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
  * contain the element.
  */
-@Generated("07749f835db3528c9dcdc5a3d9866e98")
+@Generated("b42136ee9971ff6bced3463e132eaf08")
 public final class ListIndexOfCodec {
     //hex: 0x051400
     public static final int REQUEST_MESSAGE_TYPE = 332800;
@@ -98,9 +98,9 @@ public final class ListIndexOfCodec {
     }
 
     /**
-    * The index of the first occurrence of the specified element in
-    * this list, or -1 if this list does not contain the element
-    */
+     * The index of the first occurrence of the specified element in
+     * this list, or -1 if this list does not contain the element
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIsEmptyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this list contains no elements
  */
-@Generated("98e22069ee0bcd369eb55acc367d13e1")
+@Generated("1e5ac984b28e0f82a3d6d2e6cc3b5455")
 public final class ListIsEmptyCodec {
     //hex: 0x050D00
     public static final int REQUEST_MESSAGE_TYPE = 331008;
@@ -48,12 +48,6 @@ public final class ListIsEmptyCodec {
 
     private ListIsEmptyCodec() {
     }
-
-    /**
-     * Name of the List
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class ListIsEmptyCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the List
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class ListIsEmptyCodec {
     }
 
     /**
-    * True if this list contains no elements
-    */
+     * True if this list contains no elements
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIteratorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIteratorCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns an iterator over the elements in this list in proper sequence.
  */
-@Generated("3ab94686cb117a799ce8b1c8053d6425")
+@Generated("8beb0d798089c0990399cb3988cbaf33")
 public final class ListIteratorCodec {
     //hex: 0x051600
     public static final int REQUEST_MESSAGE_TYPE = 333312;
@@ -47,12 +47,6 @@ public final class ListIteratorCodec {
 
     private ListIteratorCodec() {
     }
-
-    /**
-     * Name of the List
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class ListIteratorCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the List
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class ListIteratorCodec {
     }
 
     /**
-    * An iterator over the elements in this list in proper sequence
-    */
+     * An iterator over the elements in this list in proper sequence
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListLastIndexOfCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListLastIndexOfCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
  * contain the element.
  */
-@Generated("af6f3b6441fa7c7c4a06e3b0d751828c")
+@Generated("1ee8e1eb4154ad4767bb0e932fae2517")
 public final class ListLastIndexOfCodec {
     //hex: 0x051300
     public static final int REQUEST_MESSAGE_TYPE = 332544;
@@ -98,9 +98,9 @@ public final class ListLastIndexOfCodec {
     }
 
     /**
-    * the index of the last occurrence of the specified element in
-    * this list, or -1 if this list does not contain the element
-    */
+     * the index of the last occurrence of the specified element in
+     * this list, or -1 if this list does not contain the element
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListListIteratorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListListIteratorCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * ListIterator#next next. An initial call to ListIterator#previous previous would return the element with the
  * specified index minus one.
  */
-@Generated("64e8d5ec72a2d90c675f81b46391cb52")
+@Generated("d18c16246a2e66c760d3eb6d938d31b2")
 public final class ListListIteratorCodec {
     //hex: 0x051700
     public static final int REQUEST_MESSAGE_TYPE = 333568;
@@ -99,9 +99,9 @@ public final class ListListIteratorCodec {
     }
 
     /**
-    * a list iterator over the elements in this list (in proper
-    * sequence), starting at the specified position in the list
-    */
+     * a list iterator over the elements in this list (in proper
+     * sequence), starting at the specified position in the list
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If this list does not contain the element, it is unchanged.
  * Returns true if this list contained the specified element (or equivalently, if this list changed as a result of the call).
  */
-@Generated("72117a0d0932e5faa6afc820f2be0d3b")
+@Generated("bbfe5e97de2b7ad185bc82c3f8a1ad64")
 public final class ListRemoveCodec {
     //hex: 0x050500
     public static final int REQUEST_MESSAGE_TYPE = 328960;
@@ -99,8 +99,8 @@ public final class ListRemoveCodec {
     }
 
     /**
-    * True if this list contained the specified element, false otherwise
-    */
+     * True if this list contained the specified element, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("e6788e19fa0aa589c527ecd9eeb4599f")
+@Generated("e7c914a48abe18219ddf85cfdbf93f54")
 public final class ListRemoveListenerCodec {
     //hex: 0x050C00
     public static final int REQUEST_MESSAGE_TYPE = 330752;
@@ -98,8 +98,8 @@ public final class ListRemoveListenerCodec {
     }
 
     /**
-    * True if unregistered, false otherwise.
-    */
+     * True if unregistered, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveWithIndexCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveWithIndexCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the element at the specified position in this list (optional operation). Shifts any subsequent elements
  * to the left (subtracts one from their indices). Returns the element that was removed from the list.
  */
-@Generated("417732db1e5ca3b6e888e6c8fddeff06")
+@Generated("d26ff46a4d7c518d1f0dc29099c4a80b")
 public final class ListRemoveWithIndexCodec {
     //hex: 0x051200
     public static final int REQUEST_MESSAGE_TYPE = 332288;
@@ -97,8 +97,8 @@ public final class ListRemoveWithIndexCodec {
     }
 
     /**
-    * The element previously at the specified position
-    */
+     * The element previously at the specified position
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * The element previously at the specified position
  */
-@Generated("ec1ee88d148266b34ca5f8a61328f64e")
+@Generated("6b1abb32efc42f9774efa1bac2c0c8e0")
 public final class ListSetCodec {
     //hex: 0x051000
     public static final int REQUEST_MESSAGE_TYPE = 331776;
@@ -103,8 +103,8 @@ public final class ListSetCodec {
     }
 
     /**
-    * The element previously at the specified position
-    */
+     * The element previously at the specified position
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
  * Integer.MAX_VALUE.
  */
-@Generated("6562a3c9a3480ead3d16c5cc5372421f")
+@Generated("1df8589657aa322a33d25dc719717292")
 public final class ListSizeCodec {
     //hex: 0x050100
     public static final int REQUEST_MESSAGE_TYPE = 327936;
@@ -49,12 +49,6 @@ public final class ListSizeCodec {
 
     private ListSizeCodec() {
     }
-
-    /**
-     * Name of List
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class ListSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of List
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class ListSizeCodec {
     }
 
     /**
-    * The number of elements in this list
-    */
+     * The number of elements in this list
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSubCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSubCodec.java
@@ -46,7 +46,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * structurally modified in any way other than via the returned list.(Structural modifications are those that change
  * the size of this list, or otherwise perturb it in such a fashion that iterations in progress may yield incorrect results.)
  */
-@Generated("afc3aa3bc4a4285221c0cd9210584cb6")
+@Generated("7d456e02908b76e0aaccebeef61be3eb")
 public final class ListSubCodec {
     //hex: 0x051500
     public static final int REQUEST_MESSAGE_TYPE = 333056;
@@ -114,8 +114,8 @@ public final class ListSubCodec {
     }
 
     /**
-    * A view of the specified range within this list
-    */
+     * A view of the specified range within this list
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCAddWanBatchPublisherConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCAddWanBatchPublisherConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Add a new WAN batch publisher configuration
  */
-@Generated("73ca2bc2716e81b146ada9694101ded4")
+@Generated("ad64dbf4eb12e78cf40ae4777e4e86b8")
 public final class MCAddWanBatchPublisherConfigCodec {
     //hex: 0x201500
     public static final int REQUEST_MESSAGE_TYPE = 2102528;
@@ -158,10 +158,12 @@ public final class MCAddWanBatchPublisherConfigCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Returns the IDs for the WAN publishers which were added to the configuration
          */
         public java.util.List<java.lang.String> addedPublisherIds;
+
         /**
          * Returns the IDs for the WAN publishers which were ignored and not added to
          * the configuration.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCChangeClusterStateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCChangeClusterStateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Changes the state of a cluster.
  */
-@Generated("757b60b93af3d9e65614d63913ec386e")
+@Generated("891dd9ee41c7352005f7a556fbb97d80")
 public final class MCChangeClusterStateCodec {
     //hex: 0x200200
     public static final int REQUEST_MESSAGE_TYPE = 2097664;
@@ -48,17 +48,6 @@ public final class MCChangeClusterStateCodec {
 
     private MCChangeClusterStateCodec() {
     }
-
-    /**
-     * New state of the cluster:
-     * 0 - ACTIVE
-     * 1 - NO_MIGRATION
-     * 2 - FROZEN
-     * 3 - PASSIVE
-     * 4 - IN_TRANSITION (not allowed)
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public int newState;
 
     public static ClientMessage encodeRequest(int newState) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,6 +61,14 @@ public final class MCChangeClusterStateCodec {
         return clientMessage;
     }
 
+    /**
+     * New state of the cluster:
+     * 0 - ACTIVE
+     * 1 - NO_MIGRATION
+     * 2 - FROZEN
+     * 3 - PASSIVE
+     * 4 - IN_TRANSITION (not allowed)
+     */
     public static int decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCCheckWanConsistencyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCCheckWanConsistencyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Initiate WAN consistency check for a specific map
  */
-@Generated("57a9700193357b17b3567c3df6eb5d39")
+@Generated("5f0b019408273eb1e8e18dff7f97d119")
 public final class MCCheckWanConsistencyCodec {
     //hex: 0x201700
     public static final int REQUEST_MESSAGE_TYPE = 2103040;
@@ -104,9 +104,9 @@ public final class MCCheckWanConsistencyCodec {
     }
 
     /**
-    * UUID of the consistency check request or null if consistency
-    * check is ignored because of the configuration
-    */
+     * UUID of the consistency check request or null if consistency
+     * check is ignored because of the configuration
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetCPMembersCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetCPMembersCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the current list of CP members.
  */
-@Generated("a5b78d0ac11e118316c820ddf011ab6f")
+@Generated("527b8f76b3d1cc355fd906c1851f8a0c")
 public final class MCGetCPMembersCodec {
     //hex: 0x201900
     public static final int REQUEST_MESSAGE_TYPE = 2103552;
@@ -47,7 +47,6 @@ public final class MCGetCPMembersCodec {
 
     private MCGetCPMembersCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,9 +71,9 @@ public final class MCGetCPMembersCodec {
     }
 
     /**
-    * List of CP member UUIDs. The mapping is from the UUID of the CP member to UUID of that member on the
-    * member list of the cluster service.
-    */
+     * List of CP member UUIDs. The mapping is from the UUID of the CP member to UUID of that member on the
+     * member list of the cluster service.
+     */
     public static java.util.List<java.util.Map.Entry<java.util.UUID, java.util.UUID>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetClusterMetadataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetClusterMetadataCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the current metadata of a cluster.
  */
-@Generated("449215b6571720704a1879192fe72bf3")
+@Generated("59bce08e0a960b01c77f92312a79f617")
 public final class MCGetClusterMetadataCodec {
     //hex: 0x200E00
     public static final int REQUEST_MESSAGE_TYPE = 2100736;
@@ -49,7 +49,6 @@ public final class MCGetClusterMetadataCodec {
 
     private MCGetClusterMetadataCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -65,6 +64,7 @@ public final class MCGetClusterMetadataCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Current state of the cluster:
          * 0 - ACTIVE
@@ -74,14 +74,17 @@ public final class MCGetClusterMetadataCodec {
          * 4 - IN_TRANSITION (not allowed)
          */
         public byte currentState;
+
         /**
          * Current version of the member.
          */
         public java.lang.String memberVersion;
+
         /**
          * Current Jet version of the member.
          */
         public @Nullable java.lang.String jetVersion;
+
         /**
          * Cluster-wide time in milliseconds.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMapConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the config of a map on the member it's called on.
  */
-@Generated("2d430613080554784f077df4ba79bd58")
+@Generated("ff9e3238ae4b1420bbba59356f68307b")
 public final class MCGetMapConfigCodec {
     //hex: 0x200300
     public static final int REQUEST_MESSAGE_TYPE = 2097920;
@@ -57,12 +57,6 @@ public final class MCGetMapConfigCodec {
     private MCGetMapConfigCodec() {
     }
 
-    /**
-     * Name of the map.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String mapName;
-
     public static ClientMessage encodeRequest(java.lang.String mapName) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -75,6 +69,9 @@ public final class MCGetMapConfigCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the map.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,6 +81,7 @@ public final class MCGetMapConfigCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * The in memory storage format of the map:
          * 0 - Binary
@@ -91,26 +89,32 @@ public final class MCGetMapConfigCodec {
          * 2 - Native
          */
         public int inMemoryFormat;
+
         /**
          * Backup count of the map.
          */
         public int backupCount;
+
         /**
          * Async backup count of the map.
          */
         public int asyncBackupCount;
+
         /**
          * Time to live seconds for the map entries.
          */
         public int timeToLiveSeconds;
+
         /**
          * Maximum idle seconds for the map entries.
          */
         public int maxIdleSeconds;
+
         /**
          * Maximum size of the map.
          */
         public int maxSize;
+
         /**
          * The maximum size policy of the map:
          * 0 - PER_NODE
@@ -125,10 +129,12 @@ public final class MCGetMapConfigCodec {
          * 9 - FREE_NATIVE_MEMORY_PERCENTAGE
          */
         public int maxSizePolicy;
+
         /**
          * Whether reading from backup data is allowed.
          */
         public boolean readBackupData;
+
         /**
          * The eviction policy of the map:
          * 0 - LRU
@@ -137,6 +143,7 @@ public final class MCGetMapConfigCodec {
          * 3 - RANDOM
          */
         public int evictionPolicy;
+
         /**
          * Classname of the SplitBrainMergePolicy for the map.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMemberConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMemberConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the effective config of a member rendered as XML.
  */
-@Generated("a21ad0545aeaed17c65918ac941677ec")
+@Generated("45bfe55c1f2a1019170d97242eba2de4")
 public final class MCGetMemberConfigCodec {
     //hex: 0x200500
     public static final int REQUEST_MESSAGE_TYPE = 2098432;
@@ -47,7 +47,6 @@ public final class MCGetMemberConfigCodec {
 
     private MCGetMemberConfigCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,8 +71,8 @@ public final class MCGetMemberConfigCodec {
     }
 
     /**
-    * Effective config of a member rendered as XML.
-    */
+     * Effective config of a member rendered as XML.
+     */
     public static java.lang.String decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetSystemPropertiesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetSystemPropertiesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the system properties of the member it's called on.
  */
-@Generated("66700404d830fba5021ba8e352ac9134")
+@Generated("ac7d4a9d1f04bbf22f20e4b07ee81567")
 public final class MCGetSystemPropertiesCodec {
     //hex: 0x200A00
     public static final int REQUEST_MESSAGE_TYPE = 2099712;
@@ -47,7 +47,6 @@ public final class MCGetSystemPropertiesCodec {
 
     private MCGetSystemPropertiesCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,8 +71,8 @@ public final class MCGetSystemPropertiesCodec {
     }
 
     /**
-    * System properties of the member.
-    */
+     * System properties of the member.
+     */
     public static java.util.List<java.util.Map.Entry<java.lang.String, java.lang.String>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetThreadDumpCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetThreadDumpCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Takes a thread dump of the member it's called on.
  */
-@Generated("2d6c146397a654b429dffe483be83694")
+@Generated("696a38f62f0ff694183e8d186f2ad369")
 public final class MCGetThreadDumpCodec {
     //hex: 0x200700
     public static final int REQUEST_MESSAGE_TYPE = 2098944;
@@ -48,12 +48,6 @@ public final class MCGetThreadDumpCodec {
 
     private MCGetThreadDumpCodec() {
     }
-
-    /**
-     * Whether only dead-locked threads or all threads should be dumped.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public boolean dumpDeadLocks;
 
     public static ClientMessage encodeRequest(boolean dumpDeadLocks) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MCGetThreadDumpCodec {
         return clientMessage;
     }
 
+    /**
+     * Whether only dead-locked threads or all threads should be dumped.
+     */
     public static boolean decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -84,8 +81,8 @@ public final class MCGetThreadDumpCodec {
     }
 
     /**
-    * Thread dump of the member's JVM.
-    */
+     * Thread dump of the member's JVM.
+     */
     public static java.lang.String decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetTimedMemberStateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetTimedMemberStateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the latest TimedMemberState of the member it's called on.
  */
-@Generated("7745d6f1692b0447a7616d31540b5cb2")
+@Generated("287fb47ed74d4b8ac374cc69916589a6")
 public final class MCGetTimedMemberStateCodec {
     //hex: 0x200B00
     public static final int REQUEST_MESSAGE_TYPE = 2099968;
@@ -47,7 +47,6 @@ public final class MCGetTimedMemberStateCodec {
 
     private MCGetTimedMemberStateCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,8 +71,8 @@ public final class MCGetTimedMemberStateCodec {
     }
 
     /**
-    * Latest TimedMemberState of the member, serialized as JSON.
-    */
+     * Latest TimedMemberState of the member, serialized as JSON.
+     */
     public static java.lang.String decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCInterruptHotRestartBackupCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCInterruptHotRestartBackupCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Interrupts hot restart backup
  */
-@Generated("527272b85f2299e22c245ed6a7f0da71")
+@Generated("d84ec818d75bbfe4f5cd4c38a54a9ddd")
 public final class MCInterruptHotRestartBackupCodec {
     //hex: 0x202000
     public static final int REQUEST_MESSAGE_TYPE = 2105344;
@@ -47,7 +47,6 @@ public final class MCInterruptHotRestartBackupCodec {
 
     private MCInterruptHotRestartBackupCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCMatchMCConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCMatchMCConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks if local MC config (client filter list) has the same ETag as provided.
  */
-@Generated("8d6db7b52109b4461eb5572e14117e56")
+@Generated("ed2cc3465cdab57283694a6ae6bcf184")
 public final class MCMatchMCConfigCodec {
     //hex: 0x200C00
     public static final int REQUEST_MESSAGE_TYPE = 2100224;
@@ -48,12 +48,6 @@ public final class MCMatchMCConfigCodec {
 
     private MCMatchMCConfigCodec() {
     }
-
-    /**
-     * ETag value of current MC config.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String eTag;
 
     public static ClientMessage encodeRequest(java.lang.String eTag) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MCMatchMCConfigCodec {
         return clientMessage;
     }
 
+    /**
+     * ETag value of current MC config.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class MCMatchMCConfigCodec {
     }
 
     /**
-    * true if ETag values are equal; or false otherwise.
-    */
+     * true if ETag values are equal; or false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCPollMCEventsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCPollMCEventsCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Polls events available on member. Once read, events are removed from
  * member's internal queue.
  */
-@Generated("c445377c8afc20640b1bdf76dbb5816b")
+@Generated("bb0c91773d2bde1be8abe015c26e5fc5")
 public final class MCPollMCEventsCodec {
     //hex: 0x201800
     public static final int REQUEST_MESSAGE_TYPE = 2103296;
@@ -48,7 +48,6 @@ public final class MCPollMCEventsCodec {
 
     private MCPollMCEventsCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -73,8 +72,8 @@ public final class MCPollMCEventsCodec {
     }
 
     /**
-    * List of events.
-    */
+     * List of events.
+     */
     public static java.util.List<com.hazelcast.internal.management.dto.MCEventDTO> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCPromoteLiteMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCPromoteLiteMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Promotes the lite member it's called on to a data member.
  */
-@Generated("90b189c29b77a64cbb030363af69c644")
+@Generated("fa84adfdb4d2eff56f266676f0f9b94a")
 public final class MCPromoteLiteMemberCodec {
     //hex: 0x200900
     public static final int REQUEST_MESSAGE_TYPE = 2099456;
@@ -47,7 +47,6 @@ public final class MCPromoteLiteMemberCodec {
 
     private MCPromoteLiteMemberCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCPromoteToCPMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCPromoteToCPMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Promotes the local member to the CP role.
  */
-@Generated("b8e99e4db3948cadb6982125fb9596dc")
+@Generated("b96a15891898b7e86233db7a8b31122e")
 public final class MCPromoteToCPMemberCodec {
     //hex: 0x201A00
     public static final int REQUEST_MESSAGE_TYPE = 2103808;
@@ -47,7 +47,6 @@ public final class MCPromoteToCPMemberCodec {
 
     private MCPromoteToCPMemberCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCReadMetricsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCReadMetricsCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Reads the recorded metrics starting with the smallest sequence number
  * greater or equals to the sequence number set in fromSequence.
  */
-@Generated("bbd89f32976e245156787978f7e74b2c")
+@Generated("cccdf91e24c7a4dfce67d8d02ff99787")
 public final class MCReadMetricsCodec {
     //hex: 0x200100
     public static final int REQUEST_MESSAGE_TYPE = 2097408;
@@ -90,10 +90,12 @@ public final class MCReadMetricsCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * The map of timestamp and compressed metrics data
          */
         public java.util.List<java.util.Map.Entry<java.lang.Long, byte[]>> elements;
+
         /**
          * The sequence number that the next task should start with
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRemoveCPMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRemoveCPMemberCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the given unreachable CP member from the active CP members
  * list and all CP groups it belongs to.
  */
-@Generated("13957ebb7e2f6d9f62e5ae135c79e4f8")
+@Generated("37db2cdcc171a11add3897b06e80c7b7")
 public final class MCRemoveCPMemberCodec {
     //hex: 0x201B00
     public static final int REQUEST_MESSAGE_TYPE = 2104064;
@@ -49,12 +49,6 @@ public final class MCRemoveCPMemberCodec {
 
     private MCRemoveCPMemberCodec() {
     }
-
-    /**
-     * UUID of the unreachable CP member
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID cpMemberUuid;
 
     public static ClientMessage encodeRequest(java.util.UUID cpMemberUuid) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class MCRemoveCPMemberCodec {
         return clientMessage;
     }
 
+    /**
+     * UUID of the unreachable CP member
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCResetCPSubsystemCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCResetCPSubsystemCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Wipes and resets the whole CP Subsystem state and initializes it
  * as if the Hazelcast cluster is starting up initially.
  */
-@Generated("fa1da70c433f783eed69842fd56e89da")
+@Generated("52bb2a24bbea359c92e3ae60dc0c6761")
 public final class MCResetCPSubsystemCodec {
     //hex: 0x201C00
     public static final int REQUEST_MESSAGE_TYPE = 2104320;
@@ -48,7 +48,6 @@ public final class MCResetCPSubsystemCodec {
 
     private MCResetCPSubsystemCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRunConsoleCommandCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRunConsoleCommandCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Runs given console command on the member it's called on.
  */
-@Generated("6af3250f170a0ab9c375ef9d0491cd7a")
+@Generated("bc876909bbea01d89721181a741d46d9")
 public final class MCRunConsoleCommandCodec {
     //hex: 0x201200
     public static final int REQUEST_MESSAGE_TYPE = 2101760;
@@ -96,8 +96,8 @@ public final class MCRunConsoleCommandCodec {
     }
 
     /**
-    * Execution result: console command output.
-    */
+     * Execution result: console command output.
+     */
     public static java.lang.String decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRunGcCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRunGcCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Requests garbage collection to be performed on the member it's called on.
  */
-@Generated("8fa374c96b4f71573f09faae908d9429")
+@Generated("4209a4daadc781632e48b296bf71d8e2")
 public final class MCRunGcCodec {
     //hex: 0x200600
     public static final int REQUEST_MESSAGE_TYPE = 2098688;
@@ -47,7 +47,6 @@ public final class MCRunGcCodec {
 
     private MCRunGcCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRunScriptCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCRunScriptCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Runs given script on the member it's called on.
  */
-@Generated("e9adee453a3d16dfe50c495c68a02ed5")
+@Generated("ffa907b02bf47347431c4ef5659e5939")
 public final class MCRunScriptCodec {
     //hex: 0x201100
     public static final int REQUEST_MESSAGE_TYPE = 2101504;
@@ -96,8 +96,8 @@ public final class MCRunScriptCodec {
     }
 
     /**
-    * Execution result: script output.
-    */
+     * Execution result: script output.
+     */
     public static java.lang.String decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCShutdownClusterCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCShutdownClusterCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Shuts down the cluster.
  */
-@Generated("3f1cabd7ca9997b825ee49261dff49f1")
+@Generated("b1c3db76b5786426ec0abd5c6de64dc7")
 public final class MCShutdownClusterCodec {
     //hex: 0x200F00
     public static final int REQUEST_MESSAGE_TYPE = 2100992;
@@ -47,7 +47,6 @@ public final class MCShutdownClusterCodec {
 
     private MCShutdownClusterCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCShutdownMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCShutdownMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Shuts down the member it's called on.
  */
-@Generated("ea4f5a6f5434bf99f8a374cfff280ade")
+@Generated("c4d2cea9e5bbcc4a8c05be13dce5791b")
 public final class MCShutdownMemberCodec {
     //hex: 0x200800
     public static final int REQUEST_MESSAGE_TYPE = 2099200;
@@ -47,7 +47,6 @@ public final class MCShutdownMemberCodec {
 
     private MCShutdownMemberCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCTriggerForceStartCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCTriggerForceStartCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Triggers force start
  */
-@Generated("a494beab70416da5299d629582484fed")
+@Generated("c21f272190266b7d74545ca9d297a11d")
 public final class MCTriggerForceStartCodec {
     //hex: 0x201E00
     public static final int REQUEST_MESSAGE_TYPE = 2104832;
@@ -48,7 +48,6 @@ public final class MCTriggerForceStartCodec {
 
     private MCTriggerForceStartCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -73,8 +72,8 @@ public final class MCTriggerForceStartCodec {
     }
 
     /**
-    * True if the forced start was successfully initiated, false otherwise
-    */
+     * True if the forced start was successfully initiated, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCTriggerHotRestartBackupCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCTriggerHotRestartBackupCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Triggers hot restart backup
  */
-@Generated("eb6fc14c8c08461aca4d5228d65a20c5")
+@Generated("44c730bb9e5e0a9d104848095b2ab50c")
 public final class MCTriggerHotRestartBackupCodec {
     //hex: 0x201F00
     public static final int REQUEST_MESSAGE_TYPE = 2105088;
@@ -47,7 +47,6 @@ public final class MCTriggerHotRestartBackupCodec {
 
     private MCTriggerHotRestartBackupCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCTriggerPartialStartCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCTriggerPartialStartCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Triggers partial start
  */
-@Generated("34a3c9af0f6b45db942ec4d5b59f64a0")
+@Generated("d59a7f2ac2c8a30140929feb6b1e8795")
 public final class MCTriggerPartialStartCodec {
     //hex: 0x201D00
     public static final int REQUEST_MESSAGE_TYPE = 2104576;
@@ -48,7 +48,6 @@ public final class MCTriggerPartialStartCodec {
 
     private MCTriggerPartialStartCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -73,8 +72,8 @@ public final class MCTriggerPartialStartCodec {
     }
 
     /**
-    * True if the partial restart was successfully initiated, false otherwise
-    */
+     * True if the partial restart was successfully initiated, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCWanSyncMapCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCWanSyncMapCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Initiate WAN sync for a specific map or all maps
  */
-@Generated("0938d5f7d7908bae83719c30ff3ecefe")
+@Generated("96ee0180ede91646deb33318ad9a957e")
 public final class MCWanSyncMapCodec {
     //hex: 0x201600
     public static final int REQUEST_MESSAGE_TYPE = 2102784;
@@ -113,8 +113,8 @@ public final class MCWanSyncMapCodec {
     }
 
     /**
-    * UUID of the synchronization
-    */
+     * UUID of the synchronization
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("5c0c5beaa10d4758dd6cf559fa727a6e")
+@Generated("2c03e0d57beb8c223c66545d39a5e1e7")
 public final class MapAddEntryListenerCodec {
     //hex: 0x011900
     public static final int REQUEST_MESSAGE_TYPE = 71936;
@@ -121,8 +121,8 @@ public final class MapAddEntryListenerCodec {
     }
 
     /**
-    * A unique string which is used as a key to remove the listener.
-    */
+     * A unique string which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -185,7 +185,7 @@ public final class MapAddEntryListenerCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("958ab24a6236232349e045c6a06868bd")
+@Generated("287d183cab5dce11c7f979f50209141c")
 public final class MapAddEntryListenerToKeyCodec {
     //hex: 0x011800
     public static final int REQUEST_MESSAGE_TYPE = 71680;
@@ -128,8 +128,8 @@ public final class MapAddEntryListenerToKeyCodec {
     }
 
     /**
-    * A unique string which is used as a key to remove the listener.
-    */
+     * A unique string which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -192,7 +192,7 @@ public final class MapAddEntryListenerToKeyCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("6297a02761feff2ab0aeb49ddbd71e2f")
+@Generated("8369f3a6807da6ccfeec543fcdeb03ef")
 public final class MapAddEntryListenerToKeyWithPredicateCodec {
     //hex: 0x011600
     public static final int REQUEST_MESSAGE_TYPE = 71168;
@@ -136,8 +136,8 @@ public final class MapAddEntryListenerToKeyWithPredicateCodec {
     }
 
     /**
-    * A unique string which is used as a key to remove the listener.
-    */
+     * A unique string which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -200,7 +200,7 @@ public final class MapAddEntryListenerToKeyWithPredicateCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
  * filtered by the given predicate.
  */
-@Generated("a25f731ef3e2d083f07c13e7ddf90770")
+@Generated("25b77ea7e55d7af952125a0870668ddc")
 public final class MapAddEntryListenerWithPredicateCodec {
     //hex: 0x011700
     public static final int REQUEST_MESSAGE_TYPE = 71424;
@@ -129,8 +129,8 @@ public final class MapAddEntryListenerWithPredicateCodec {
     }
 
     /**
-    * A unique string which is used as a key to remove the listener.
-    */
+     * A unique string which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -193,7 +193,7 @@ public final class MapAddEntryListenerWithPredicateCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddInterceptorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddInterceptorCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an interceptor for this map. Added interceptor will intercept operations
  * and execute user defined methods and will cancel operations if user defined method throw exception.
  */
-@Generated("24930ed4d28dbbf7fee2ec2db3940b5e")
+@Generated("4cf1bbaeff14fdd2500416061a0d2b58")
 public final class MapAddInterceptorCodec {
     //hex: 0x011400
     public static final int REQUEST_MESSAGE_TYPE = 70656;
@@ -97,8 +97,8 @@ public final class MapAddInterceptorCodec {
     }
 
     /**
-    * id of registered interceptor.
-    */
+     * id of registered interceptor.
+     */
     public static java.lang.String decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddNearCacheInvalidationListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddNearCacheInvalidationListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds listener to map. This listener will be used to listen near cache invalidation events.
  */
-@Generated("f85840699ab54b7918e874b63a98163b")
+@Generated("1a64b08cd96e0f139ce7f83d4c38ec0d")
 public final class MapAddNearCacheInvalidationListenerCodec {
     //hex: 0x013F00
     public static final int REQUEST_MESSAGE_TYPE = 81664;
@@ -115,8 +115,8 @@ public final class MapAddNearCacheInvalidationListenerCodec {
     }
 
     /**
-    * A unique string which is used as a key to remove the listener.
-    */
+     * A unique string which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -184,7 +184,7 @@ public final class MapAddNearCacheInvalidationListenerCodec {
          * @param sourceUuid UUID of the member who fired this event.
          * @param partitionUuid UUID of the source partition that invalidated entry belongs to.
          * @param sequence Sequence number of the invalidation event.
-        */
+         */
         public abstract void handleIMapInvalidationEvent(@Nullable com.hazelcast.internal.serialization.Data key, java.util.UUID sourceUuid, java.util.UUID partitionUuid, long sequence);
 
         /**
@@ -192,7 +192,7 @@ public final class MapAddNearCacheInvalidationListenerCodec {
          * @param sourceUuids List of UUIDs of the members who fired these events.
          * @param partitionUuids List of UUIDs of the source partitions that invalidated entries belong to.
          * @param sequences List of sequence numbers of the invalidation events.
-        */
+         */
         public abstract void handleIMapBatchInvalidationEvent(java.util.Collection<com.hazelcast.internal.serialization.Data> keys, java.util.Collection<java.util.UUID> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddPartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddPartitionLostListenerCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * IMPORTANT: Listeners registered from HazelcastClient may miss some of the map partition lost events due
  * to design limitations.
  */
-@Generated("cfec5b15e219adafe6fec3486918d0c2")
+@Generated("885cb522c62e14f9fb97c78acace1a76")
 public final class MapAddPartitionLostListenerCodec {
     //hex: 0x011B00
     public static final int REQUEST_MESSAGE_TYPE = 72448;
@@ -108,8 +108,8 @@ public final class MapAddPartitionLostListenerCodec {
     }
 
     /**
-    * returns the registration id for the MapPartitionLostListener.
-    */
+     * returns the registration id for the MapPartitionLostListener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -147,7 +147,7 @@ public final class MapAddPartitionLostListenerCodec {
         /**
          * @param partitionId Id of the lost partition.
          * @param uuid UUID of the member that owns the lost partition.
-        */
+         */
         public abstract void handleMapPartitionLostEvent(int partitionId, java.util.UUID uuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the aggregation logic on all map entries and returns the result
  */
-@Generated("8ab8341a5bdf9295ea075d3cff7df01a")
+@Generated("2ae2bb73e7c01e5665892b761dd8f795")
 public final class MapAggregateCodec {
     //hex: 0x013900
     public static final int REQUEST_MESSAGE_TYPE = 80128;
@@ -96,8 +96,8 @@ public final class MapAggregateCodec {
     }
 
     /**
-    * the aggregation result
-    */
+     * the aggregation result
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateWithPredicateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the aggregation logic on map entries filtered with the Predicate and returns the result
  */
-@Generated("dbc94c7f3d64a43426978e2070e9b392")
+@Generated("616cc0781fd78d75285418141b117e92")
 public final class MapAggregateWithPredicateCodec {
     //hex: 0x013A00
     public static final int REQUEST_MESSAGE_TYPE = 80384;
@@ -103,8 +103,8 @@ public final class MapAggregateWithPredicateCodec {
     }
 
     /**
-    * the aggregation result
-    */
+     * the aggregation result
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapClearCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * will delete the records from that database. The MAP_CLEARED event is fired for any registered listeners.
  * To clear a map without calling MapStore#deleteAll, use #evictAll.
  */
-@Generated("f6942c1f6ef2ca84ec4c299514567a1c")
+@Generated("cd3a62754ed2cc69ec9e8a9a6a5ccd5f")
 public final class MapClearCodec {
     //hex: 0x012D00
     public static final int REQUEST_MESSAGE_TYPE = 77056;
@@ -49,12 +49,6 @@ public final class MapClearCodec {
 
     private MapClearCodec() {
     }
-
-    /**
-     * of map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class MapClearCodec {
         return clientMessage;
     }
 
+    /**
+     * of map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains a mapping for the specified key.
  */
-@Generated("843a1ef26b5358c78bd82ab6976d346f")
+@Generated("a2f35768bf06d8eef5ead5267d1a537b")
 public final class MapContainsKeyCodec {
     //hex: 0x010600
     public static final int REQUEST_MESSAGE_TYPE = 67072;
@@ -104,8 +104,8 @@ public final class MapContainsKeyCodec {
     }
 
     /**
-    * Returns true if the key exists, otherwise returns false.
-    */
+     * Returns true if the key exists, otherwise returns false.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsValueCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this map maps one or more keys to the specified value.This operation will probably require time
  * linear in the map size for most implementations of the Map interface.
  */
-@Generated("88e096f93252bd8751bf5c0caf3237f6")
+@Generated("61aacf62b55e8cf42ab957af7c640b5b")
 public final class MapContainsValueCodec {
     //hex: 0x010700
     public static final int REQUEST_MESSAGE_TYPE = 67328;
@@ -98,8 +98,8 @@ public final class MapContainsValueCodec {
     }
 
     /**
-    * Returns true if the value exists, otherwise returns false.
-    */
+     * Returns true if the value exists, otherwise returns false.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("6895c42db725a987502be3e95bf0bb33")
+@Generated("acd4c66e0f4f25e7562db0fd5283dcd4")
 public final class MapEntriesWithPagingPredicateCodec {
     //hex: 0x013600
     public static final int REQUEST_MESSAGE_TYPE = 79360;
@@ -90,10 +90,12 @@ public final class MapEntriesWithPagingPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * key-value pairs for the query.
          */
         public java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> response;
+
         /**
          * The updated anchor list.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("243cfa331a0b7450a22af143c88accbf")
+@Generated("6538ec348ec7d9970ee04fc90fc55824")
 public final class MapEntriesWithPredicateCodec {
     //hex: 0x012800
     public static final int REQUEST_MESSAGE_TYPE = 75776;
@@ -99,8 +99,8 @@ public final class MapEntriesWithPredicateCodec {
     }
 
     /**
-    * result key-value entry collection of the query.
-    */
+     * result key-value entry collection of the query.
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntrySetCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
  * if query result size limit is configured.
  */
-@Generated("1c55b031e4998894f5d025aba39bf1ca")
+@Generated("8248ad204526687646d2888272f0295d")
 public final class MapEntrySetCodec {
     //hex: 0x012500
     public static final int REQUEST_MESSAGE_TYPE = 75008;
@@ -50,12 +50,6 @@ public final class MapEntrySetCodec {
 
     private MapEntrySetCodec() {
     }
-
-    /**
-     * name of map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -69,6 +63,9 @@ public final class MapEntrySetCodec {
         return clientMessage;
     }
 
+    /**
+     * name of map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -87,8 +84,8 @@ public final class MapEntrySetCodec {
     }
 
     /**
-    * a set clone of the keys mappings in this map
-    */
+     * a set clone of the keys mappings in this map
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("589f0493b83d6899e07d62105ae6d76f")
+@Generated("e2863cdc4a6c658f758e5c8679e0cb15")
 public final class MapEventJournalReadCodec {
     //hex: 0x014200
     public static final int REQUEST_MESSAGE_TYPE = 82432;
@@ -126,18 +126,22 @@ public final class MapEventJournalReadCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Number of items that have been read.
          */
         public int readCount;
+
         /**
          * List of items that have been read.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> items;
+
         /**
          * Sequence numbers of items in the event journal.
          */
         public @Nullable long[] itemSeqs;
+
         /**
          * Sequence number of the item following the last read item.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalSubscribeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalSubscribeCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This includes retrieving the event journal sequences of the
  * oldest and newest event in the journal.
  */
-@Generated("7871a2d12b28714430e4589346a658bd")
+@Generated("54b05820e0f1ac3151793887b0f5b913")
 public final class MapEventJournalSubscribeCodec {
     //hex: 0x014100
     public static final int REQUEST_MESSAGE_TYPE = 82176;
@@ -52,12 +52,6 @@ public final class MapEventJournalSubscribeCodec {
     private MapEventJournalSubscribeCodec() {
     }
 
-    /**
-     * name of the map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
-
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(true);
@@ -70,6 +64,9 @@ public final class MapEventJournalSubscribeCodec {
         return clientMessage;
     }
 
+    /**
+     * name of the map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -79,10 +76,12 @@ public final class MapEventJournalSubscribeCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Sequence id of the oldest event in the event journal.
          */
         public long oldestSequence;
+
         /**
          * Sequence id of the newest event in the event journal.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictAllCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * called by this method. If you do want to deleteAll to be called use the clear method. The EVICT_ALL event is
  * fired for any registered listeners.
  */
-@Generated("3caa17965c7c3d426df7f10f1f3dbe9e")
+@Generated("91ac8992097ed084bac6f1c65d81bae3")
 public final class MapEvictAllCodec {
     //hex: 0x011F00
     public static final int REQUEST_MESSAGE_TYPE = 73472;
@@ -49,12 +49,6 @@ public final class MapEvictAllCodec {
 
     private MapEvictAllCodec() {
     }
-
-    /**
-     * name of map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class MapEvictAllCodec {
         return clientMessage;
     }
 
+    /**
+     * name of map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
  * from the underlying MapStore, evict only removes the entry from the memory.
  */
-@Generated("445b3f0f7c91d94510597fe350b86a3b")
+@Generated("d91e9ee8d9b4ab7f3fbbfab6d5d76342")
 public final class MapEvictCodec {
     //hex: 0x011E00
     public static final int REQUEST_MESSAGE_TYPE = 73216;
@@ -105,8 +105,8 @@ public final class MapEvictCodec {
     }
 
     /**
-    * true if the key is evicted, false otherwise.
-    */
+     * true if the key is evicted, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
  */
-@Generated("2e2ef76212a274c01f7adbca13d2d6a5")
+@Generated("8f0e42e7ca7f72546512df6aa6cc1cc4")
 public final class MapExecuteOnAllKeysCodec {
     //hex: 0x013000
     public static final int REQUEST_MESSAGE_TYPE = 77824;
@@ -96,8 +96,8 @@ public final class MapExecuteOnAllKeysCodec {
     }
 
     /**
-    * results of entry process on the entries
-    */
+     * results of entry process on the entries
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeyCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
  * the process() method of EntryProcessor.
  */
-@Generated("c034c4bbf4fc058b278538f2cf10af06")
+@Generated("465b354737889ae5a56a242c1b53882f")
 public final class MapExecuteOnKeyCodec {
     //hex: 0x012E00
     public static final int REQUEST_MESSAGE_TYPE = 77312;
@@ -111,8 +111,8 @@ public final class MapExecuteOnKeyCodec {
     }
 
     /**
-    * result of entry process.
-    */
+     * result of entry process.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
  * each key in the collection.
  */
-@Generated("cc74ae60ed0cda9dadab625a788f81a6")
+@Generated("a6370ef67202334b32b14c862e22254b")
 public final class MapExecuteOnKeysCodec {
     //hex: 0x013200
     public static final int REQUEST_MESSAGE_TYPE = 78336;
@@ -104,8 +104,8 @@ public final class MapExecuteOnKeysCodec {
     }
 
     /**
-    * results of entry process on the entries with the provided keys
-    */
+     * results of entry process on the entries with the provided keys
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
  * Returns the results mapped by each key in the map.
  */
-@Generated("8ada90459632509644272660424766af")
+@Generated("4b444d19b14a79c9936571b44c148ef9")
 public final class MapExecuteWithPredicateCodec {
     //hex: 0x013100
     public static final int REQUEST_MESSAGE_TYPE = 78080;
@@ -104,8 +104,8 @@ public final class MapExecuteWithPredicateCodec {
     }
 
     /**
-    * results of entry process on the entries matching the query criteria
-    */
+     * results of entry process on the entries matching the query criteria
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchEntriesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchEntriesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of entries from the specified partition starting from specified table index.
  */
-@Generated("7ec30a8d8f1b2c260f0ce0e1370ca679")
+@Generated("31a8f0820ff9f3c042b0be16cdc8b59e")
 public final class MapFetchEntriesCodec {
     //hex: 0x013800
     public static final int REQUEST_MESSAGE_TYPE = 79872;
@@ -94,10 +94,12 @@ public final class MapFetchEntriesCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * The index-size pairs that define the state of iteration
          */
         public java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Integer>> iterationPointers;
+
         /**
          * List of entries.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchKeysCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches specified number of keys from the specified partition starting from specified table index.
  */
-@Generated("277a685993eee2f90e68927f3b58a29e")
+@Generated("2866514178d94e907e90acc44b9b5235")
 public final class MapFetchKeysCodec {
     //hex: 0x013700
     public static final int REQUEST_MESSAGE_TYPE = 79616;
@@ -94,10 +94,12 @@ public final class MapFetchKeysCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * The index-size pairs that define the state of iteration
          */
         public java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Integer>> iterationPointers;
+
         /**
          * List of keys.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchNearCacheInvalidationMetadataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchNearCacheInvalidationMetadataCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches invalidation metadata from partitions of map.
  */
-@Generated("de8f263b9b6623a58614021527f186ed")
+@Generated("f765161d9ce005320c8c096883ce530f")
 public final class MapFetchNearCacheInvalidationMetadataCodec {
     //hex: 0x013D00
     public static final int REQUEST_MESSAGE_TYPE = 81152;
@@ -87,10 +87,12 @@ public final class MapFetchNearCacheInvalidationMetadataCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Map of partition ids and sequence number of invalidations mapped by the map name.
          */
         public java.util.List<java.util.Map.Entry<java.lang.String, java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Long>>>> namePartitionSequenceList;
+
         /**
          * Map of member UUIDs mapped by the partition ids of invalidations.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchWithQueryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchWithQueryCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the specified number of entries from the specified partition starting from specified table index
  * that match the predicate and applies the projection logic on them.
  */
-@Generated("7ca3e934935fc522f7cd21e6b27429d7")
+@Generated("44bfed9b675bf48572750c3b63800cc0")
 public final class MapFetchWithQueryCodec {
     //hex: 0x014000
     public static final int REQUEST_MESSAGE_TYPE = 81920;
@@ -109,10 +109,12 @@ public final class MapFetchWithQueryCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * List of fetched entries.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> results;
+
         /**
          * The index-size pairs that define the state of iteration
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFlushCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFlushCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If this map has a MapStore, this method flushes all the local dirty entries by calling MapStore.storeAll()
  * and/or MapStore.deleteAll().
  */
-@Generated("21ba7bb33dfbc0c07c94c6142304d076")
+@Generated("3d6f96982df31292e9c0c6dcf9ed317b")
 public final class MapFlushCodec {
     //hex: 0x010A00
     public static final int REQUEST_MESSAGE_TYPE = 68096;
@@ -48,12 +48,6 @@ public final class MapFlushCodec {
 
     private MapFlushCodec() {
     }
-
-    /**
-     * Name of the map.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MapFlushCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the map.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("389c69ff19f309ba22df448c190a7c0d")
+@Generated("b735e58406dabd08ba1c8bfbb7685628")
 public final class MapGetAllCodec {
     //hex: 0x012300
     public static final int REQUEST_MESSAGE_TYPE = 74496;
@@ -100,8 +100,8 @@ public final class MapGetAllCodec {
     }
 
     /**
-    * values for the provided keys.
-    */
+     * values for the provided keys.
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns a clone of the original value, so modifying the returned value does not change the actual
  * value in the map. You should put the modified value back to make changes visible to all nodes.
  */
-@Generated("c28ac29328266690006c259858d25c0c")
+@Generated("bef3c34c87295bba7a54ffd0f5b91672")
 public final class MapGetCodec {
     //hex: 0x010200
     public static final int REQUEST_MESSAGE_TYPE = 66048;
@@ -104,8 +104,8 @@ public final class MapGetCodec {
     }
 
     /**
-    * The value for the key if exists
-    */
+     * The value for the key if exists
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetEntryViewCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetEntryViewCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns a clone of original mapping, modifying the returned value does not change the actual value
  * in the map. One should put modified value back to make changes visible to all nodes.
  */
-@Generated("1c3db8bd0b0e822dd69a98d66aa7b4f6")
+@Generated("facc6ff0a63c2db75263152b35c82e6f")
 public final class MapGetEntryViewCodec {
     //hex: 0x011D00
     public static final int REQUEST_MESSAGE_TYPE = 72960;
@@ -97,10 +97,12 @@ public final class MapGetEntryViewCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Entry view of the specified key.
          */
         public @Nullable com.hazelcast.map.impl.SimpleEntryView<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data> response;
+
         /**
          * Last set max idle in millis.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsEmptyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains no key-value mappings.
  */
-@Generated("3381b4e3066b1eb50b035a5d07226146")
+@Generated("b43607eeb9ae2089309214ad074acfbc")
 public final class MapIsEmptyCodec {
     //hex: 0x012B00
     public static final int REQUEST_MESSAGE_TYPE = 76544;
@@ -48,12 +48,6 @@ public final class MapIsEmptyCodec {
 
     private MapIsEmptyCodec() {
     }
-
-    /**
-     * name of map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MapIsEmptyCodec {
         return clientMessage;
     }
 
+    /**
+     * name of map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class MapIsEmptyCodec {
     }
 
     /**
-    * true if this map contains no key-value mappings
-    */
+     * true if this map contains no key-value mappings
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsLockedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsLockedCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
  */
-@Generated("cc59b674304d5cdaf820c9a0821cf874")
+@Generated("cd19d425ce93fc01b6c755c70971c3b5")
 public final class MapIsLockedCodec {
     //hex: 0x011200
     public static final int REQUEST_MESSAGE_TYPE = 70144;
@@ -97,8 +97,8 @@ public final class MapIsLockedCodec {
     }
 
     /**
-    * Returns true if the entry is locked, otherwise returns false
-    */
+     * Returns true if the entry is locked, otherwise returns false
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
  * throw a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("e6fdeb3740d7ef86bf68f9bc6986b77f")
+@Generated("e1e75808f0f0a0e0be67daebe2a19d03")
 public final class MapKeySetCodec {
     //hex: 0x012200
     public static final int REQUEST_MESSAGE_TYPE = 74240;
@@ -49,12 +49,6 @@ public final class MapKeySetCodec {
 
     private MapKeySetCodec() {
     }
-
-    /**
-     * name of the map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class MapKeySetCodec {
         return clientMessage;
     }
 
+    /**
+     * name of the map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class MapKeySetCodec {
     }
 
     /**
-    * a set clone of the keys contained in this map.
-    */
+     * a set clone of the keys contained in this map.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("d532bd46dfd1a8db5f1ee07d735261b6")
+@Generated("b95fae564d10de98423c4302f9a65037")
 public final class MapKeySetWithPagingPredicateCodec {
     //hex: 0x013400
     public static final int REQUEST_MESSAGE_TYPE = 78848;
@@ -90,10 +90,12 @@ public final class MapKeySetWithPagingPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * result keys for the query.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> response;
+
         /**
          * The updated anchor list.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("6e8124f9e8a3d888d29a9ef523a8a520")
+@Generated("b5ff12abcafabb3cf519c3c0a727cb9a")
 public final class MapKeySetWithPredicateCodec {
     //hex: 0x012600
     public static final int REQUEST_MESSAGE_TYPE = 75264;
@@ -99,8 +99,8 @@ public final class MapKeySetWithPredicateCodec {
     }
 
     /**
-    * result key set for the query.
-    */
+     * result key set for the query.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the projection logic on all map entries and returns the result
  */
-@Generated("f172edc678181bde407f3b5b2457a50c")
+@Generated("3d4d01ca0c28526907ef12e5dc8ec597")
 public final class MapProjectCodec {
     //hex: 0x013B00
     public static final int REQUEST_MESSAGE_TYPE = 80640;
@@ -96,8 +96,8 @@ public final class MapProjectCodec {
     }
 
     /**
-    * the resulted collection upon transformation to the type of the projection
-    */
+     * the resulted collection upon transformation to the type of the projection
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectWithPredicateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the projection logic on map entries filtered with the Predicate and returns the result
  */
-@Generated("fe55c43b2db1cc3492f3340d24b70b98")
+@Generated("3605905e1344b03c426861d3ee6bc03e")
 public final class MapProjectWithPredicateCodec {
     //hex: 0x013C00
     public static final int REQUEST_MESSAGE_TYPE = 80896;
@@ -103,8 +103,8 @@ public final class MapProjectWithPredicateCodec {
     }
 
     /**
-    * the resulted collection upon transformation to the type of the projection
-    */
+     * the resulted collection upon transformation to the type of the projection
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutAllCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("e1dbf7aca4974894ebf5ac181eb01ae7")
+@Generated("3c5e981af6cf2af26218823d588e9e63")
 public final class MapPutAllCodec {
     //hex: 0x012C00
     public static final int REQUEST_MESSAGE_TYPE = 76800;
@@ -76,7 +76,7 @@ public final class MapPutAllCodec {
         /**
          * True if the triggerMapLoader is received from the client, false otherwise.
          * If this is false, triggerMapLoader has the default value for its type.
-        */
+         */
         public boolean isTriggerMapLoaderExists;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
  * rounded to the next closest second value.
  */
-@Generated("c4f37cbd6c82baf12bac4a55da96d9d4")
+@Generated("3c0ded4b6c49afdf8f3bd4ac0e549033")
 public final class MapPutCodec {
     //hex: 0x010100
     public static final int REQUEST_MESSAGE_TYPE = 65792;
@@ -121,8 +121,8 @@ public final class MapPutCodec {
     }
 
     /**
-    * old value of the entry
-    */
+     * old value of the entry
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
  * with a value. Entry will expire and get evicted after the ttl.
  */
-@Generated("e5e95b8a0dade94163f8d77d33bcb9d4")
+@Generated("be316d81c62110a300868bad785e9f36")
 public final class MapPutIfAbsentCodec {
     //hex: 0x010E00
     public static final int REQUEST_MESSAGE_TYPE = 69120;
@@ -119,8 +119,8 @@ public final class MapPutIfAbsentCodec {
     }
 
     /**
-    * returns a clone of the previous value, not the original (identically equal) value previously put into the map.
-    */
+     * returns a clone of the previous value, not the original (identically equal) value previously put into the map.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentWithMaxIdleCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
  * with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
  */
-@Generated("66f30fff9a762f8eb02782166c841985")
+@Generated("5d13d0d742b6b299fbeb34c0c9c4559b")
 public final class MapPutIfAbsentWithMaxIdleCodec {
     //hex: 0x014600
     public static final int REQUEST_MESSAGE_TYPE = 83456;
@@ -128,8 +128,8 @@ public final class MapPutIfAbsentWithMaxIdleCodec {
     }
 
     /**
-    * old value of the entry
-    */
+     * old value of the entry
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientWithMaxIdleCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
  * If ttl and maxIdle are 0, then the entry lives forever.
  */
-@Generated("ecacc9d1898123d4652ee72c45ad0a02")
+@Generated("c1bf174479fcc47e225406fb67e11719")
 public final class MapPutTransientWithMaxIdleCodec {
     //hex: 0x014500
     public static final int REQUEST_MESSAGE_TYPE = 83200;
@@ -128,8 +128,8 @@ public final class MapPutTransientWithMaxIdleCodec {
     }
 
     /**
-    * old value of the entry
-    */
+     * old value of the entry
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutWithMaxIdleCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
  * rounded to the next closest second value.
  */
-@Generated("b226348fae36bbd274ca6c131bfb90b0")
+@Generated("e31cb521b2cb530979d9cfdb9a5aeb2a")
 public final class MapPutWithMaxIdleCodec {
     //hex: 0x014400
     public static final int REQUEST_MESSAGE_TYPE = 82944;
@@ -130,8 +130,8 @@ public final class MapPutWithMaxIdleCodec {
     }
 
     /**
-    * old value of the entry
-    */
+     * old value of the entry
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * possible that the map explicitly mapped the key to null. The map will not contain a mapping for the specified key once the
  * call returns.
  */
-@Generated("4e9fce3ad6fa6fcbab664b902bad3a24")
+@Generated("e1340610cead4ede83e3997b7d134b40")
 public final class MapRemoveCodec {
     //hex: 0x010300
     public static final int REQUEST_MESSAGE_TYPE = 66304;
@@ -107,8 +107,8 @@ public final class MapRemoveCodec {
     }
 
     /**
-    * Clone of the removed value, not the original (identically equal) value previously put into the map.
-    */
+     * Clone of the removed value, not the original (identically equal) value previously put into the map.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("9204edeeb3b76ac44c86795d7c4ebc11")
+@Generated("edb8347e19e96406d7410435b9758bc6")
 public final class MapRemoveEntryListenerCodec {
     //hex: 0x011A00
     public static final int REQUEST_MESSAGE_TYPE = 72192;
@@ -98,8 +98,8 @@ public final class MapRemoveEntryListenerCodec {
     }
 
     /**
-    * true if registration is removed, false otherwise.
-    */
+     * true if registration is removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveIfSameCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the mapping for a key from this map if existing value equal to the this value
  */
-@Generated("9f143c847371e498434d547d50743d9f")
+@Generated("83c31fee20a7ad9d9b1d73ad50039c65")
 public final class MapRemoveIfSameCodec {
     //hex: 0x010800
     public static final int REQUEST_MESSAGE_TYPE = 67584;
@@ -111,8 +111,8 @@ public final class MapRemoveIfSameCodec {
     }
 
     /**
-    * Returns true if the key exists and removed, otherwise returns false.
-    */
+     * Returns true if the key exists and removed, otherwise returns false.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveInterceptorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveInterceptorCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given interceptor for this map so it will not intercept operations anymore.
  */
-@Generated("c509bb796fffe73f867f36097b05880f")
+@Generated("e16c419a65b19f3097e8a6ce6d9c59a4")
 public final class MapRemoveInterceptorCodec {
     //hex: 0x011500
     public static final int REQUEST_MESSAGE_TYPE = 70912;
@@ -97,8 +97,8 @@ public final class MapRemoveInterceptorCodec {
     }
 
     /**
-    * Returns true if successful, otherwise returns false
-    */
+     * Returns true if successful, otherwise returns false
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemovePartitionLostListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemovePartitionLostListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified map partition lost listener. If there is no such listener added before, this call does no
  * change in the cluster and returns false.
  */
-@Generated("7b113c66bf08167a8d8614d4424a931f")
+@Generated("3c68729558ef83af87f6890b1ad7c5ae")
 public final class MapRemovePartitionLostListenerCodec {
     //hex: 0x011C00
     public static final int REQUEST_MESSAGE_TYPE = 72704;
@@ -98,8 +98,8 @@ public final class MapRemovePartitionLostListenerCodec {
     }
 
     /**
-    * true if registration is removed, false otherwise.
-    */
+     * true if registration is removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Replaces the entry for a key only if currently mapped to a given value.
  */
-@Generated("25e899458b0b6ae7143349b20b19ee32")
+@Generated("87fa4d72ae62f74e95eadcdaf40bf2e9")
 public final class MapReplaceCodec {
     //hex: 0x010400
     public static final int REQUEST_MESSAGE_TYPE = 66560;
@@ -110,8 +110,8 @@ public final class MapReplaceCodec {
     }
 
     /**
-    * Clone of the previous value, not the original (identically equal) value previously put into the map.
-    */
+     * Clone of the previous value, not the original (identically equal) value previously put into the map.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceIfSameCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Replaces the the entry for a key only if existing values equal to the testValue
  */
-@Generated("f44483e64a3ed4b76237e610f8728f7a")
+@Generated("1848a501dc912ab86f3e025eea013829")
 public final class MapReplaceIfSameCodec {
     //hex: 0x010500
     public static final int REQUEST_MESSAGE_TYPE = 66816;
@@ -118,8 +118,8 @@ public final class MapReplaceIfSameCodec {
     }
 
     /**
-    * true if value is replaced with new one, false otherwise
-    */
+     * true if value is replaced with new one, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetTtlCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetTtlCodec.java
@@ -48,7 +48,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * <p>
  * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
  */
-@Generated("9f5050511031a20b72612a8187d14ca7")
+@Generated("5b714c330f532d89981ed1b3c68dacf5")
 public final class MapSetTtlCodec {
     //hex: 0x014300
     public static final int REQUEST_MESSAGE_TYPE = 82688;
@@ -116,8 +116,8 @@ public final class MapSetTtlCodec {
     }
 
     /**
-    * 'true' if the entry is affected, 'false' otherwise
-    */
+     * 'true' if the entry is affected, 'false' otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetWithMaxIdleCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * 
  * Similar to the put operation except that set doesn't return the old value, which is more efficient.
  */
-@Generated("470afc94130a01f01d64bdf620b2779a")
+@Generated("54cb471a4def2bfc082104123e8cdd5d")
 public final class MapSetWithMaxIdleCodec {
     //hex: 0x014700
     public static final int REQUEST_MESSAGE_TYPE = 83712;
@@ -131,8 +131,8 @@ public final class MapSetWithMaxIdleCodec {
     }
 
     /**
-    * old value of the entry
-    */
+     * old value of the entry
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
  * returns Integer.MAX_VALUE
  */
-@Generated("dc87a4fc172cbc8bd67e24805c4a9327")
+@Generated("78103401cd479f5df06513f8392c404a")
 public final class MapSizeCodec {
     //hex: 0x012A00
     public static final int REQUEST_MESSAGE_TYPE = 76288;
@@ -49,12 +49,6 @@ public final class MapSizeCodec {
 
     private MapSizeCodec() {
     }
-
-    /**
-     * of map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class MapSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * of map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class MapSizeCodec {
     }
 
     /**
-    * the number of key-value mappings in this map
-    */
+     * the number of key-value mappings in this map
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSubmitToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSubmitToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
  * operation of EntryProcessor.
  */
-@Generated("60acec193f7d3d5f437997e39539ce15")
+@Generated("5774940d376999065be4609412799edf")
 public final class MapSubmitToKeyCodec {
     //hex: 0x012F00
     public static final int REQUEST_MESSAGE_TYPE = 77568;
@@ -112,8 +112,8 @@ public final class MapSubmitToKeyCodec {
     }
 
     /**
-    * result of entry process.
-    */
+     * result of entry process.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryLockCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * purposes and lies dormant until one of two things happens the lock is acquired by the current thread, or
  * the specified waiting time elapses.
  */
-@Generated("f59d24b1b6e6589e544ce1d6693d853b")
+@Generated("6adbca402c86d80c8440bef4bf94f3e5")
 public final class MapTryLockCodec {
     //hex: 0x011100
     public static final int REQUEST_MESSAGE_TYPE = 69888;
@@ -131,8 +131,8 @@ public final class MapTryLockCodec {
     }
 
     /**
-    * Returns true if successful, otherwise returns false
-    */
+     * Returns true if successful, otherwise returns false
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryPutCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * it means that the caller thread could not acquire the lock for the key within the timeout duration,
  * thus the put operation is not successful.
  */
-@Generated("663186eb962944f806f786db6b918f1d")
+@Generated("fa9600fd8c08f58a9fc4df46b51f14e0")
 public final class MapTryPutCodec {
     //hex: 0x010C00
     public static final int REQUEST_MESSAGE_TYPE = 68608;
@@ -121,8 +121,8 @@ public final class MapTryPutCodec {
     }
 
     /**
-    * Returns true if successful, otherwise returns false
-    */
+     * Returns true if successful, otherwise returns false
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the key is already locked by another thread and/or member, then this operation will wait the timeout
  * amount for acquiring the lock.
  */
-@Generated("c238ba531eeb5fa9aca8a66bfef0a7a0")
+@Generated("7cb434b16773d42c48e3ce4df9e6d050")
 public final class MapTryRemoveCodec {
     //hex: 0x010B00
     public static final int REQUEST_MESSAGE_TYPE = 68352;
@@ -114,8 +114,8 @@ public final class MapTryRemoveCodec {
     }
 
     /**
-    * Returns true if successful, otherwise returns false
-    */
+     * Returns true if successful, otherwise returns false
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
  * if query result size limit is configured.
  */
-@Generated("e1064b256c20fce1779a6297704e7bfc")
+@Generated("8668f4477cab803476d58fa7f0032789")
 public final class MapValuesCodec {
     //hex: 0x012400
     public static final int REQUEST_MESSAGE_TYPE = 74752;
@@ -50,12 +50,6 @@ public final class MapValuesCodec {
 
     private MapValuesCodec() {
     }
-
-    /**
-     * name of map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -69,6 +63,9 @@ public final class MapValuesCodec {
         return clientMessage;
     }
 
+    /**
+     * name of map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -87,8 +84,8 @@ public final class MapValuesCodec {
     }
 
     /**
-    * All values in the map
-    */
+     * All values in the map
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("7d722d4d24caf2c3dc7657418ca1afb7")
+@Generated("bba0311281de1179c2f47b9b76b0a6fa")
 public final class MapValuesWithPagingPredicateCodec {
     //hex: 0x013500
     public static final int REQUEST_MESSAGE_TYPE = 79104;
@@ -90,10 +90,12 @@ public final class MapValuesWithPagingPredicateCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * values for the query.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> response;
+
         /**
          * The updated anchor list.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("548d5d1a71095dca8c4f6edaab7d9368")
+@Generated("3b1320c86e4bfa115ce7aeb335b8a49c")
 public final class MapValuesWithPredicateCodec {
     //hex: 0x012700
     public static final int REQUEST_MESSAGE_TYPE = 75520;
@@ -99,8 +99,8 @@ public final class MapValuesWithPredicateCodec {
     }
 
     /**
-    * result value collection of the query.
-    */
+     * result value collection of the query.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapAddEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
  */
-@Generated("3126644d8d23b727c9b258e1a4c61912")
+@Generated("6bbc3776393f59c68f41eeee6582003a")
 public final class MultiMapAddEntryListenerCodec {
     //hex: 0x020E00
     public static final int REQUEST_MESSAGE_TYPE = 134656;
@@ -112,8 +112,8 @@ public final class MultiMapAddEntryListenerCodec {
     }
 
     /**
-    * Returns registration id for the entry listener
-    */
+     * Returns registration id for the entry listener
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -176,7 +176,7 @@ public final class MultiMapAddEntryListenerCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapAddEntryListenerToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds the specified entry listener for the specified key.The listener will be notified for all
  * add/remove/update/evict events for the specified key only.
  */
-@Generated("bd1a2a5db054fc0961beb9ffb645313a")
+@Generated("7bb1e78d6d524924f31ff5a9993166c8")
 public final class MultiMapAddEntryListenerToKeyCodec {
     //hex: 0x020D00
     public static final int REQUEST_MESSAGE_TYPE = 134400;
@@ -120,8 +120,8 @@ public final class MultiMapAddEntryListenerToKeyCodec {
     }
 
     /**
-    * Returns registration id for the entry listener
-    */
+     * Returns registration id for the entry listener
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -184,7 +184,7 @@ public final class MultiMapAddEntryListenerToKeyCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapClearCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Clears the multimap. Removes all key-value pairs.
  */
-@Generated("285ff012f077f35c8d9771e8a8289455")
+@Generated("1263d32dfe7bd17dad11cc43259b104f")
 public final class MultiMapClearCodec {
     //hex: 0x020B00
     public static final int REQUEST_MESSAGE_TYPE = 133888;
@@ -47,12 +47,6 @@ public final class MultiMapClearCodec {
 
     private MultiMapClearCodec() {
     }
-
-    /**
-     * Name of the MultiMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class MultiMapClearCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the MultiMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsEntryCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns whether the multimap contains the given key-value pair.
  */
-@Generated("5ad64307d6537e09fad368a38f8c1890")
+@Generated("3133b3b5376e5f848b8910f232169d1b")
 public final class MultiMapContainsEntryCodec {
     //hex: 0x020900
     public static final int REQUEST_MESSAGE_TYPE = 133376;
@@ -111,8 +111,8 @@ public final class MultiMapContainsEntryCodec {
     }
 
     /**
-    * True if the multimap contains the key-value pair, false otherwise.
-    */
+     * True if the multimap contains the key-value pair, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns whether the multimap contains an entry with the key.
  */
-@Generated("b75405fef8637b8c303b1eb9b7b48538")
+@Generated("631cea34ee86dad9b18157718e7c4cc5")
 public final class MultiMapContainsKeyCodec {
     //hex: 0x020700
     public static final int REQUEST_MESSAGE_TYPE = 132864;
@@ -104,8 +104,8 @@ public final class MultiMapContainsKeyCodec {
     }
 
     /**
-    * True if the multimap contains an entry with the key, false otherwise.
-    */
+     * True if the multimap contains an entry with the key, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns whether the multimap contains an entry with the value.
  */
-@Generated("2863a3739bbdf0ce38cec1c0d37c3009")
+@Generated("87639328627db82279bb62b55aa45ae6")
 public final class MultiMapContainsValueCodec {
     //hex: 0x020800
     public static final int REQUEST_MESSAGE_TYPE = 133120;
@@ -97,8 +97,8 @@ public final class MultiMapContainsValueCodec {
     }
 
     /**
-    * True if the multimap contains an entry with the value, false otherwise.
-    */
+     * True if the multimap contains an entry with the value, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapEntrySetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the set of key-value pairs in the multimap.The collection is NOT backed by the map, so changes to the map
  * are NOT reflected in the collection, and vice-versa
  */
-@Generated("9e5f92b23ad27abc6e0d539728906c8e")
+@Generated("46c507f4effa37e145dd9beefa77669d")
 public final class MultiMapEntrySetCodec {
     //hex: 0x020600
     public static final int REQUEST_MESSAGE_TYPE = 132608;
@@ -48,12 +48,6 @@ public final class MultiMapEntrySetCodec {
 
     private MultiMapEntrySetCodec() {
     }
-
-    /**
-     * Name of the MultiMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MultiMapEntrySetCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the MultiMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class MultiMapEntrySetCodec {
     }
 
     /**
-    * The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
-    */
+     * The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapGetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
  * the map are NOT reflected in the collection, and vice-versa.
  */
-@Generated("ca64695c685ac95d1bba1fcf2a0595b0")
+@Generated("8dece0c7bd23fa57dc7bf471ec6fc824")
 public final class MultiMapGetCodec {
     //hex: 0x020200
     public static final int REQUEST_MESSAGE_TYPE = 131584;
@@ -104,8 +104,8 @@ public final class MultiMapGetCodec {
     }
 
     /**
-    * The collection of the values associated with the key.
-    */
+     * The collection of the values associated with the key.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapIsLockedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapIsLockedCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
  */
-@Generated("3f0a9fd23f81c11d6dcb83911a2fb424")
+@Generated("cdbfe0e7ffb41a6fb94ece49c4528d12")
 public final class MultiMapIsLockedCodec {
     //hex: 0x021200
     public static final int REQUEST_MESSAGE_TYPE = 135680;
@@ -97,8 +97,8 @@ public final class MultiMapIsLockedCodec {
     }
 
     /**
-    * True if the lock acquired,false otherwise
-    */
+     * True if the lock acquired,false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapKeySetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the set of keys in the multimap.The collection is NOT backed by the map, so changes to the map are NOT
  * reflected in the collection, and vice-versa.
  */
-@Generated("120b34722307c819e986623fe4ff0aed")
+@Generated("a5548ee2cc781d7ef3e0df8073ed08a5")
 public final class MultiMapKeySetCodec {
     //hex: 0x020400
     public static final int REQUEST_MESSAGE_TYPE = 132096;
@@ -48,12 +48,6 @@ public final class MultiMapKeySetCodec {
 
     private MultiMapKeySetCodec() {
     }
-
-    /**
-     * Name of the MultiMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MultiMapKeySetCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the MultiMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class MultiMapKeySetCodec {
     }
 
     /**
-    * The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
-    */
+     * The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapPutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Stores a key-value pair in the multimap.
  */
-@Generated("53b8be8ff98ae8d7b01d9ba5e59dbef5")
+@Generated("caf7ebd3ce0c81c555674570a3cef02f")
 public final class MultiMapPutCodec {
     //hex: 0x020100
     public static final int REQUEST_MESSAGE_TYPE = 131328;
@@ -111,8 +111,8 @@ public final class MultiMapPutCodec {
     }
 
     /**
-    * True if size of the multimap is increased, false if the multimap already contains the key-value pair.
-    */
+     * True if size of the multimap is increased, false if the multimap already contains the key-value pair.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("800123fa4d154379e12f85d34ad31482")
+@Generated("9305147fa774659601fedbc68ed78900")
 public final class MultiMapRemoveCodec {
     //hex: 0x020300
     public static final int REQUEST_MESSAGE_TYPE = 131840;
@@ -103,8 +103,8 @@ public final class MultiMapRemoveCodec {
     }
 
     /**
-    * True if the size of the multimap changed after the remove operation, false otherwise.
-    */
+     * True if the size of the multimap changed after the remove operation, false otherwise.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveEntryCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
  * NOT reflected in the collection, and vice-versa.
  */
-@Generated("5b3d43282f24a80130d971f2922002f1")
+@Generated("be2a8942fba9a0462b0040c27b9a1c0d")
 public final class MultiMapRemoveEntryCodec {
     //hex: 0x021500
     public static final int REQUEST_MESSAGE_TYPE = 136448;
@@ -112,8 +112,8 @@ public final class MultiMapRemoveEntryCodec {
     }
 
     /**
-    * True if the size of the multimap changed after the remove operation, false otherwise.
-    */
+     * True if the size of the multimap changed after the remove operation, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("6d03567631ff9b92a52a14dee597e105")
+@Generated("2682eea0f7ea857e1ba047209ae938cf")
 public final class MultiMapRemoveEntryListenerCodec {
     //hex: 0x020F00
     public static final int REQUEST_MESSAGE_TYPE = 134912;
@@ -98,8 +98,8 @@ public final class MultiMapRemoveEntryListenerCodec {
     }
 
     /**
-    * True if registration is removed, false otherwise
-    */
+     * True if registration is removed, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapSizeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of key-value pairs in the multimap.
  */
-@Generated("f7ee345aebbdea2f073151fd60e4ad6d")
+@Generated("e01b7b44e91897f89f91dc5775f7fded")
 public final class MultiMapSizeCodec {
     //hex: 0x020A00
     public static final int REQUEST_MESSAGE_TYPE = 133632;
@@ -48,12 +48,6 @@ public final class MultiMapSizeCodec {
 
     private MultiMapSizeCodec() {
     }
-
-    /**
-     * Name of the MultiMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MultiMapSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the MultiMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class MultiMapSizeCodec {
     }
 
     /**
-    * The number of key-value pairs in the multimap.
-    */
+     * The number of key-value pairs in the multimap.
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapTryLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapTryLockCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * and lies dormant until one of two things happens:the lock is acquired by the current thread, or the specified
  * waiting time elapses.
  */
-@Generated("14a6a36394ed2a84706fb784680835c4")
+@Generated("a60fc7a3b8ed52caa05472b6c8186b92")
 public final class MultiMapTryLockCodec {
     //hex: 0x021100
     public static final int REQUEST_MESSAGE_TYPE = 135424;
@@ -131,8 +131,8 @@ public final class MultiMapTryLockCodec {
     }
 
     /**
-    * True if the lock was acquired and false if the waiting time elapsed before the lock acquired
-    */
+     * True if the lock was acquired and false if the waiting time elapsed before the lock acquired
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValueCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValueCountCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of values that match the given key in the multimap.
  */
-@Generated("995d2d8705d3132c7732fab2f891fd0d")
+@Generated("af2ce43fe9ba8942d0dfd68dbfb3bf51")
 public final class MultiMapValueCountCodec {
     //hex: 0x020C00
     public static final int REQUEST_MESSAGE_TYPE = 134144;
@@ -104,8 +104,8 @@ public final class MultiMapValueCountCodec {
     }
 
     /**
-    * The number of values that match the given key in the multimap
-    */
+     * The number of values that match the given key in the multimap
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValuesCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the collection of values in the multimap.The collection is NOT backed by the map, so changes to the map
  * are NOT reflected in the collection, and vice-versa.
  */
-@Generated("a62f9ca704e815cd7c726b8777d6996d")
+@Generated("2cf429cd9f9606b2a19f6f0ef7d0d98c")
 public final class MultiMapValuesCodec {
     //hex: 0x020500
     public static final int REQUEST_MESSAGE_TYPE = 132352;
@@ -48,12 +48,6 @@ public final class MultiMapValuesCodec {
 
     private MultiMapValuesCodec() {
     }
-
-    /**
-     * Name of the MultiMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class MultiMapValuesCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the MultiMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class MultiMapValuesCodec {
     }
 
     /**
-    * The collection of values in the multimap. the returned collection might be modifiable but it has no effect on the multimap.
-    */
+     * The collection of values in the multimap. the returned collection might be modifiable but it has no effect on the multimap.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterAddCodec.java
@@ -44,7 +44,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If smart routing is disabled, the actual member processing the client
  * message may act as a proxy.
  */
-@Generated("22931c8cf294a20989caabd574c05f1b")
+@Generated("55c1306102f6982fe4f603bfef63f477")
 public final class PNCounterAddCodec {
     //hex: 0x1D0200
     public static final int REQUEST_MESSAGE_TYPE = 1901056;
@@ -122,14 +122,17 @@ public final class PNCounterAddCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Value of the counter.
          */
         public long value;
+
         /**
          * last observed replica timestamps (vector clock)
          */
         public java.util.List<java.util.Map.Entry<java.util.UUID, java.lang.Long>> replicaTimestamps;
+
         /**
          * Number of replicas that keep the state of this counter.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If smart routing is disabled, the actual member processing the client
  * message may act as a proxy.
  */
-@Generated("d8a7082ae860982cf4e64577b96d87de")
+@Generated("9e352756ec73c210bc75b048b70fb52a")
 public final class PNCounterGetCodec {
     //hex: 0x1D0100
     public static final int REQUEST_MESSAGE_TYPE = 1900800;
@@ -103,14 +103,17 @@ public final class PNCounterGetCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Value of the counter.
          */
         public long value;
+
         /**
          * last observed replica timestamps (vector clock)
          */
         public java.util.List<java.util.Map.Entry<java.util.UUID, java.lang.Long>> replicaTimestamps;
+
         /**
          * Number of replicas that keep the state of this counter.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetConfiguredReplicaCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/PNCounterGetConfiguredReplicaCountCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The actual replica count may be less, depending on the number of data
  * members in the cluster (members that own data).
  */
-@Generated("702724bffbe0a7e6ad410d5ac0022f7b")
+@Generated("789501105b009c03dbce5ec37a955090")
 public final class PNCounterGetConfiguredReplicaCountCodec {
     //hex: 0x1D0300
     public static final int REQUEST_MESSAGE_TYPE = 1901312;
@@ -51,12 +51,6 @@ public final class PNCounterGetConfiguredReplicaCountCodec {
 
     private PNCounterGetConfiguredReplicaCountCodec() {
     }
-
-    /**
-     * the name of the PNCounter
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -70,6 +64,9 @@ public final class PNCounterGetConfiguredReplicaCountCodec {
         return clientMessage;
     }
 
+    /**
+     * the name of the PNCounter
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -88,8 +85,8 @@ public final class PNCounterGetConfiguredReplicaCountCodec {
     }
 
     /**
-    * the configured replica count
-    */
+     * the configured replica count
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueAddAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (This implies that the behavior of this call is undefined if the specified collection is this collection,
  * and this collection is nonempty.)
  */
-@Generated("2950ff077cd645adeb1e941be94b1c8c")
+@Generated("10cf009709f4fe69b9d00c166b17228e")
 public final class QueueAddAllCodec {
     //hex: 0x031000
     public static final int REQUEST_MESSAGE_TYPE = 200704;
@@ -100,8 +100,8 @@ public final class QueueAddAllCodec {
     }
 
     /**
-    * <tt>true</tt> if this collection changed as a result of the call
-    */
+     * <tt>true</tt> if this collection changed as a result of the call
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueAddListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueAddListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an listener for this collection. Listener will be notified or all collection add/remove events.
  */
-@Generated("6346dde1780fc76a0b4d9462e889bdb3")
+@Generated("2bdada9e84d1f71fbdb5526d44fee101")
 public final class QueueAddListenerCodec {
     //hex: 0x031100
     public static final int REQUEST_MESSAGE_TYPE = 200960;
@@ -111,8 +111,8 @@ public final class QueueAddListenerCodec {
     }
 
     /**
-    * The registration id
-    */
+     * The registration id
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -153,7 +153,7 @@ public final class QueueAddListenerCodec {
          * @param item Item that the event is fired for.
          * @param uuid UUID of the member that dispatches this event.
          * @param eventType Type of the event. It is either ADDED(1) or REMOVED(2).
-        */
+         */
         public abstract void handleItemEvent(@Nullable com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueClearCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes all of the elements from this collection (optional operation). The collection will be empty after this
  * method returns.
  */
-@Generated("bd7872317b7b63a290f96e65ed38436f")
+@Generated("51bedf5d6efaa81145d131b519e22184")
 public final class QueueClearCodec {
     //hex: 0x030F00
     public static final int REQUEST_MESSAGE_TYPE = 200448;
@@ -48,12 +48,6 @@ public final class QueueClearCodec {
 
     private QueueClearCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class QueueClearCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRemoveAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes all of this collection's elements that are also contained in the specified collection (optional operation).
  * After this call returns, this collection will contain no elements in common with the specified collection.
  */
-@Generated("bbe2d52552f7b0e4d0b339fe4399470f")
+@Generated("39618e0c7d30f95fcfef1f09404524ec")
 public final class QueueCompareAndRemoveAllCodec {
     //hex: 0x030D00
     public static final int REQUEST_MESSAGE_TYPE = 199936;
@@ -98,8 +98,8 @@ public final class QueueCompareAndRemoveAllCodec {
     }
 
     /**
-    * <tt>true</tt> if this collection changed as a result of the call
-    */
+     * <tt>true</tt> if this collection changed as a result of the call
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRetainAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRetainAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retains only the elements in this collection that are contained in the specified collection (optional operation).
  * In other words, removes from this collection all of its elements that are not contained in the specified collection.
  */
-@Generated("d401f4c86c7c5bb41ba2e69752e23016")
+@Generated("be1733a4523b9115713b38122e4554bd")
 public final class QueueCompareAndRetainAllCodec {
     //hex: 0x030E00
     public static final int REQUEST_MESSAGE_TYPE = 200192;
@@ -98,8 +98,8 @@ public final class QueueCompareAndRetainAllCodec {
     }
 
     /**
-    * <tt>true</tt> if this collection changed as a result of the call
-    */
+     * <tt>true</tt> if this collection changed as a result of the call
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return true if this collection contains all of the elements in the specified collection.
  */
-@Generated("eb5b00e50d1e34f7060660f805c00fef")
+@Generated("dd1031d259eb5c903b7aa7c190666bf5")
 public final class QueueContainsAllCodec {
     //hex: 0x030C00
     public static final int REQUEST_MESSAGE_TYPE = 199680;
@@ -97,8 +97,8 @@ public final class QueueContainsAllCodec {
     }
 
     /**
-    * <tt>true</tt> if this collection contains all of the elements in the specified collection
-    */
+     * <tt>true</tt> if this collection contains all of the elements in the specified collection
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
  * contains at least one element e such that value.equals(e)
  */
-@Generated("387b0bf6802b706e3c7085072f55565e")
+@Generated("eb14ffed87653ebced8b34a2ae1d4349")
 public final class QueueContainsCodec {
     //hex: 0x030B00
     public static final int REQUEST_MESSAGE_TYPE = 199424;
@@ -98,8 +98,8 @@ public final class QueueContainsCodec {
     }
 
     /**
-    * <tt>true</tt> if this collection contains the specified element
-    */
+     * <tt>true</tt> if this collection contains the specified element
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * thrown. Attempts to drain a queue to itself result in ILLEGAL_ARGUMENT. Further, the behavior of
  * this operation is undefined if the specified collection is modified while the operation is in progress.
  */
-@Generated("5c35e45290e42cc92b579d51129a2ff9")
+@Generated("26dbb6a444391c5c50d25e1aae13ac84")
 public final class QueueDrainToCodec {
     //hex: 0x030900
     public static final int REQUEST_MESSAGE_TYPE = 198912;
@@ -51,12 +51,6 @@ public final class QueueDrainToCodec {
 
     private QueueDrainToCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -70,6 +64,9 @@ public final class QueueDrainToCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -88,8 +85,8 @@ public final class QueueDrainToCodec {
     }
 
     /**
-    * list of all removed data in queue
-    */
+     * list of all removed data in queue
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToMaxSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueDrainToMaxSizeCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * ILLEGAL_ARGUMENT. Further, the behavior of this operation is undefined if the specified collection is
  * modified while the operation is in progress.
  */
-@Generated("f154bc6c7c6a40d20b612536c91bdb33")
+@Generated("a670dba3fe81ee318495bcb886234357")
 public final class QueueDrainToMaxSizeCodec {
     //hex: 0x030A00
     public static final int REQUEST_MESSAGE_TYPE = 199168;
@@ -100,8 +100,8 @@ public final class QueueDrainToMaxSizeCodec {
     }
 
     /**
-    * list of all removed data in result of this method
-    */
+     * list of all removed data in result of this method
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueIsEmptyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this collection contains no elements.
  */
-@Generated("9ae6451ea8f3debbbeb0d5690ff13251")
+@Generated("27b38ec621d7d5414e735c96cb97b5fc")
 public final class QueueIsEmptyCodec {
     //hex: 0x031400
     public static final int REQUEST_MESSAGE_TYPE = 201728;
@@ -48,12 +48,6 @@ public final class QueueIsEmptyCodec {
 
     private QueueIsEmptyCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class QueueIsEmptyCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class QueueIsEmptyCodec {
     }
 
     /**
-    * <tt>True</tt> if this collection contains no elements
-    */
+     * <tt>True</tt> if this collection contains no elements
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueIteratorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueIteratorCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns an iterator over the elements in this collection.  There are no guarantees concerning the order in which
  * the elements are returned (unless this collection is an instance of some class that provides a guarantee).
  */
-@Generated("4bed490d9c924e507e0de339632673d0")
+@Generated("1bad6fc34376a98907a45b52ae9ca3c8")
 public final class QueueIteratorCodec {
     //hex: 0x030800
     public static final int REQUEST_MESSAGE_TYPE = 198656;
@@ -48,12 +48,6 @@ public final class QueueIteratorCodec {
 
     private QueueIteratorCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class QueueIteratorCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class QueueIteratorCodec {
     }
 
     /**
-    * list of all data in queue
-    */
+     * list of all data in queue
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueOfferCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueOfferCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
  * become available.
  */
-@Generated("7d972d4d34010a5b7336b8b76e5d551e")
+@Generated("d671c22c0be07ee1c7665a87e01d1b66")
 public final class QueueOfferCodec {
     //hex: 0x030100
     public static final int REQUEST_MESSAGE_TYPE = 196864;
@@ -105,8 +105,8 @@ public final class QueueOfferCodec {
     }
 
     /**
-    * <tt>True</tt> if the element was added to this queue, else <tt>false</tt>
-    */
+     * <tt>True</tt> if the element was added to this queue, else <tt>false</tt>
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueuePeekCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueuePeekCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
  */
-@Generated("efafea63f4f42e085df845f855530f63")
+@Generated("244ba277330aa0fc0b545e5b0912cf94")
 public final class QueuePeekCodec {
     //hex: 0x030700
     public static final int REQUEST_MESSAGE_TYPE = 198400;
@@ -47,12 +47,6 @@ public final class QueuePeekCodec {
 
     private QueuePeekCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class QueuePeekCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class QueuePeekCodec {
     }
 
     /**
-    * The head of this queue, or <tt>null</tt> if this queue is empty
-    */
+     * The head of this queue, or <tt>null</tt> if this queue is empty
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueuePollCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueuePollCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
  * to become available.
  */
-@Generated("2590f1cb1f38b21eacf62d6931bed007")
+@Generated("a49b5029ca211b187da80c59e6823de7")
 public final class QueuePollCodec {
     //hex: 0x030500
     public static final int REQUEST_MESSAGE_TYPE = 197888;
@@ -97,8 +97,8 @@ public final class QueuePollCodec {
     }
 
     /**
-    * The head of this queue, or <tt>null</tt> if this queue is empty
-    */
+     * The head of this queue, or <tt>null</tt> if this queue is empty
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemainingCapacityCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemainingCapacityCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * always tell if an attempt to insert an element will succeed by inspecting remainingCapacity because it may be
  * the case that another thread is about to insert or remove an element.
  */
-@Generated("d62c89dcd19fa8777e59f68022577e31")
+@Generated("e49891614f9d751832669b3ef84f8156")
 public final class QueueRemainingCapacityCodec {
     //hex: 0x031300
     public static final int REQUEST_MESSAGE_TYPE = 201472;
@@ -51,12 +51,6 @@ public final class QueueRemainingCapacityCodec {
 
     private QueueRemainingCapacityCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -70,6 +64,9 @@ public final class QueueRemainingCapacityCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -88,8 +85,8 @@ public final class QueueRemainingCapacityCodec {
     }
 
     /**
-    * The remaining capacity
-    */
+     * The remaining capacity
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemoveCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
  * if this queue is empty.
  */
-@Generated("a6d00adac8a9e35c540ecc440aada868")
+@Generated("d8d35df480dffedfc648621b25055e58")
 public final class QueueRemoveCodec {
     //hex: 0x030400
     public static final int REQUEST_MESSAGE_TYPE = 197632;
@@ -98,8 +98,8 @@ public final class QueueRemoveCodec {
     }
 
     /**
-    * <tt>true</tt> if this queue changed as a result of the call
-    */
+     * <tt>true</tt> if this queue changed as a result of the call
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemoveListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemoveListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("77a6f79791779bf34dde66b1ec73ab04")
+@Generated("041d09e22c825d36ffb8850029576143")
 public final class QueueRemoveListenerCodec {
     //hex: 0x031200
     public static final int REQUEST_MESSAGE_TYPE = 201216;
@@ -98,8 +98,8 @@ public final class QueueRemoveListenerCodec {
     }
 
     /**
-    * True if the item listener is removed, false otherwise
-    */
+     * True if the item listener is removed, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of elements in this collection.  If this collection contains more than Integer.MAX_VALUE
  * elements, returns Integer.MAX_VALUE
  */
-@Generated("bcf20c4ea44113fe6eaa9b178e3c3e48")
+@Generated("2f04f5c8a3897222141474c7d15488c4")
 public final class QueueSizeCodec {
     //hex: 0x030300
     public static final int REQUEST_MESSAGE_TYPE = 197376;
@@ -49,12 +49,6 @@ public final class QueueSizeCodec {
 
     private QueueSizeCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class QueueSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class QueueSizeCodec {
     }
 
     /**
-    * The number of elements in this collection
-    */
+     * The number of elements in this collection
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueTakeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueTakeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
  */
-@Generated("c88dd0936761be89f073f3c9b40002fd")
+@Generated("09978346d93d8319468cad5dc2fcb9f4")
 public final class QueueTakeCodec {
     //hex: 0x030600
     public static final int REQUEST_MESSAGE_TYPE = 198144;
@@ -47,12 +47,6 @@ public final class QueueTakeCodec {
 
     private QueueTakeCodec() {
     }
-
-    /**
-     * Name of the Queue
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class QueueTakeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Queue
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class QueueTakeCodec {
     }
 
     /**
-    * The head of this queue
-    */
+     * The head of this queue
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
  */
-@Generated("a4da54cc2b90b31978bcc42335112c7a")
+@Generated("ecb903e05962de3da060485f0b0daacc")
 public final class ReplicatedMapAddEntryListenerCodec {
     //hex: 0x0D0D00
     public static final int REQUEST_MESSAGE_TYPE = 855296;
@@ -104,8 +104,8 @@ public final class ReplicatedMapAddEntryListenerCodec {
     }
 
     /**
-    * A unique string  which is used as a key to remove the listener.
-    */
+     * A unique string  which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -168,7 +168,7 @@ public final class ReplicatedMapAddEntryListenerCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds the specified entry listener for the specified key. The listener will be notified for all
  * add/remove/update/evict events of the specified key only.
  */
-@Generated("dce3fbb57d2ff223ac59ec3b26b6ead5")
+@Generated("3ed6de156f12608e865a5862d903b083")
 public final class ReplicatedMapAddEntryListenerToKeyCodec {
     //hex: 0x0D0C00
     public static final int REQUEST_MESSAGE_TYPE = 855040;
@@ -112,8 +112,8 @@ public final class ReplicatedMapAddEntryListenerToKeyCodec {
     }
 
     /**
-    * A unique string  which is used as a key to remove the listener.
-    */
+     * A unique string  which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -176,7 +176,7 @@ public final class ReplicatedMapAddEntryListenerToKeyCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
  * events filtered by the given predicate.
  */
-@Generated("21ccd0cef983edab7bf93472ac2cd772")
+@Generated("544345d9586f703066f1dab3837f9dc9")
 public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
     //hex: 0x0D0A00
     public static final int REQUEST_MESSAGE_TYPE = 854528;
@@ -119,8 +119,8 @@ public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
     }
 
     /**
-    * A unique string  which is used as a key to remove the listener.
-    */
+     * A unique string  which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -183,7 +183,7 @@ public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
  * events filtered by the given predicate.
  */
-@Generated("a76a56377485cdcc35cad81ef80d5dec")
+@Generated("8c1b2c4637d33185c76513706c29f37f")
 public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
     //hex: 0x0D0B00
     public static final int REQUEST_MESSAGE_TYPE = 854784;
@@ -112,8 +112,8 @@ public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
     }
 
     /**
-    * A unique string  which is used as a key to remove the listener.
-    */
+     * A unique string  which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -176,7 +176,7 @@ public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddNearCacheEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddNearCacheEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a near cache entry listener for this map. This listener will be notified when an entry is added/removed/updated/evicted/expired etc. so that the near cache entries can be invalidated.
  */
-@Generated("cdc28645ac50e64163604e8486ee2244")
+@Generated("533c44836693a09341186ea0c18bc681")
 public final class ReplicatedMapAddNearCacheEntryListenerCodec {
     //hex: 0x0D1200
     public static final int REQUEST_MESSAGE_TYPE = 856576;
@@ -112,8 +112,8 @@ public final class ReplicatedMapAddNearCacheEntryListenerCodec {
     }
 
     /**
-    * A unique string  which is used as a key to remove the listener.
-    */
+     * A unique string  which is used as a key to remove the listener.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -176,7 +176,7 @@ public final class ReplicatedMapAddNearCacheEntryListenerCodec {
          *                  LOADED(512)
          * @param uuid UUID of the member that dispatches the event.
          * @param numberOfAffectedEntries Number of entries affected by this event.
-        */
+         */
         public abstract void handleEntryEvent(@Nullable com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data mergingValue, int eventType, java.util.UUID uuid, int numberOfAffectedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapClearCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * it is retried for at most 3 times (on the failing nodes only). If it does not work after the third time, this
  * method throws a OPERATION_TIMEOUT back to the caller.
  */
-@Generated("351dfb129f6a14a51d932afc4c4e8068")
+@Generated("f14a05b6b7998dde30d30dc175266aac")
 public final class ReplicatedMapClearCodec {
     //hex: 0x0D0900
     public static final int REQUEST_MESSAGE_TYPE = 854272;
@@ -50,12 +50,6 @@ public final class ReplicatedMapClearCodec {
 
     private ReplicatedMapClearCodec() {
     }
-
-    /**
-     * Name of the Replicated Map
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -69,6 +63,9 @@ public final class ReplicatedMapClearCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Replicated Map
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains a mapping for the specified key.
  */
-@Generated("dda68b75ee68db26259e1027dacaa6c2")
+@Generated("f8f437b701987f492d394461206ee74c")
 public final class ReplicatedMapContainsKeyCodec {
     //hex: 0x0D0400
     public static final int REQUEST_MESSAGE_TYPE = 852992;
@@ -97,8 +97,8 @@ public final class ReplicatedMapContainsKeyCodec {
     }
 
     /**
-    * <tt>True</tt> if this map contains a mapping for the specified key
-    */
+     * <tt>True</tt> if this map contains a mapping for the specified key
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsValueCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this map maps one or more keys to the specified value.
  * This operation will probably require time linear in the map size for most implementations of the Map interface.
  */
-@Generated("b05dbe9f61e41127cdef6b6b39f069cb")
+@Generated("9ed66393c25abcd600380ccf79eb2d4e")
 public final class ReplicatedMapContainsValueCodec {
     //hex: 0x0D0500
     public static final int REQUEST_MESSAGE_TYPE = 853248;
@@ -98,8 +98,8 @@ public final class ReplicatedMapContainsValueCodec {
     }
 
     /**
-    * <tt>true</tt> if this map maps one or more keys to the specified value
-    */
+     * <tt>true</tt> if this map maps one or more keys to the specified value
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapEntrySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapEntrySetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets a lazy set view of the mappings contained in this map.
  */
-@Generated("6163173f4a23e2abed525518fddf3ca2")
+@Generated("243992e7a3045d83abc3ddd6d0751855")
 public final class ReplicatedMapEntrySetCodec {
     //hex: 0x0D1100
     public static final int REQUEST_MESSAGE_TYPE = 856320;
@@ -47,12 +47,6 @@ public final class ReplicatedMapEntrySetCodec {
 
     private ReplicatedMapEntrySetCodec() {
     }
-
-    /**
-     * Name of the ReplicatedMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class ReplicatedMapEntrySetCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the ReplicatedMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class ReplicatedMapEntrySetCodec {
     }
 
     /**
-    * A lazy set view of the mappings contained in this map.
-    */
+     * A lazy set view of the mappings contained in this map.
+     */
     public static java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapGetCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * necessarily indicate that the map contains no mapping for the key; it's also possible that the map
  * explicitly maps the key to null.  The #containsKey operation may be used to distinguish these two cases.
  */
-@Generated("2ef151616440a2b591e67b93baee434c")
+@Generated("7f94e851a658ccd3e92537eaad0372ce")
 public final class ReplicatedMapGetCodec {
     //hex: 0x0D0600
     public static final int REQUEST_MESSAGE_TYPE = 853504;
@@ -99,8 +99,8 @@ public final class ReplicatedMapGetCodec {
     }
 
     /**
-    * The value to which the specified key is mapped, or null if this map contains no mapping for the key
-    */
+     * The value to which the specified key is mapped, or null if this map contains no mapping for the key
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapIsEmptyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return true if this map contains no key-value mappings
  */
-@Generated("0046d632c43c62cac8f0e5184427c008")
+@Generated("985ef45fb7740d5cb2229d13f74561b8")
 public final class ReplicatedMapIsEmptyCodec {
     //hex: 0x0D0300
     public static final int REQUEST_MESSAGE_TYPE = 852736;
@@ -48,12 +48,6 @@ public final class ReplicatedMapIsEmptyCodec {
 
     private ReplicatedMapIsEmptyCodec() {
     }
-
-    /**
-     * Name of the ReplicatedMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class ReplicatedMapIsEmptyCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the ReplicatedMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class ReplicatedMapIsEmptyCodec {
     }
 
     /**
-    * <tt>True</tt> if this map contains no key-value mappings
-    */
+     * <tt>True</tt> if this map contains no key-value mappings
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapKeySetCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * very poor performance if called repeatedly (for example, in a loop). If the use case is different from querying
  * the data, please copy the resulting set into a new java.util.HashSet.
  */
-@Generated("0a04f2a14b9a8d2150b8853eff87186c")
+@Generated("2e51d582492bbbcb1c2a6f2c025d30b4")
 public final class ReplicatedMapKeySetCodec {
     //hex: 0x0D0F00
     public static final int REQUEST_MESSAGE_TYPE = 855808;
@@ -52,12 +52,6 @@ public final class ReplicatedMapKeySetCodec {
 
     private ReplicatedMapKeySetCodec() {
     }
-
-    /**
-     * Name of the ReplicatedMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -71,6 +65,9 @@ public final class ReplicatedMapKeySetCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the ReplicatedMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -89,8 +86,8 @@ public final class ReplicatedMapKeySetCodec {
     }
 
     /**
-    * A lazy set view of the keys contained in this map.
-    */
+     * A lazy set view of the keys contained in this map.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
  * to define when the value is outdated and thus should be removed from the replicated map.
  */
-@Generated("a607cef5a103976cc3e7fa1d1fecc86f")
+@Generated("a73e02911255d5f31017db092258c52e")
 public final class ReplicatedMapPutCodec {
     //hex: 0x0D0100
     public static final int REQUEST_MESSAGE_TYPE = 852224;
@@ -112,8 +112,8 @@ public final class ReplicatedMapPutCodec {
     }
 
     /**
-    * The old value if existed for the key.
-    */
+     * The old value if existed for the key.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * null does not necessarily indicate that the map contained no mapping for the key; it's also possible that the map
  * explicitly mapped the key to null. The map will not contain a mapping for the specified key once the call returns.
  */
-@Generated("4345525d5b0a2ba1a87128af86e3dcbc")
+@Generated("49ebc2963d577fac1d81b615de21670f")
 public final class ReplicatedMapRemoveCodec {
     //hex: 0x0D0700
     public static final int REQUEST_MESSAGE_TYPE = 853760;
@@ -99,8 +99,8 @@ public final class ReplicatedMapRemoveCodec {
     }
 
     /**
-    * the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>.
-    */
+     * the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveEntryListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveEntryListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("a739bd7a06a910475200a29e0c980634")
+@Generated("4cc664073781d1d133581943a214b6f5")
 public final class ReplicatedMapRemoveEntryListenerCodec {
     //hex: 0x0D0E00
     public static final int REQUEST_MESSAGE_TYPE = 855552;
@@ -98,8 +98,8 @@ public final class ReplicatedMapRemoveEntryListenerCodec {
     }
 
     /**
-    * True if registration is removed, false otherwise.
-    */
+     * True if registration is removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of key-value mappings in this map. If the map contains more than Integer.MAX_VALUE elements,
  * returns Integer.MAX_VALUE.
  */
-@Generated("053eee63c6e2af8f66d32b0d17e52cd9")
+@Generated("da4377c2faeba81d2267709e391ba3ce")
 public final class ReplicatedMapSizeCodec {
     //hex: 0x0D0200
     public static final int REQUEST_MESSAGE_TYPE = 852480;
@@ -49,12 +49,6 @@ public final class ReplicatedMapSizeCodec {
 
     private ReplicatedMapSizeCodec() {
     }
-
-    /**
-     * Name of the ReplicatedMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class ReplicatedMapSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the ReplicatedMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class ReplicatedMapSizeCodec {
     }
 
     /**
-    * the number of key-value mappings in this map.
-    */
+     * the number of key-value mappings in this map.
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapValuesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns a lazy collection view of the values contained in this map.
  */
-@Generated("ab990d9c4d06fa3ac498d0aca6d6a02b")
+@Generated("cdb04efc2cbe92f878a2e873f386908b")
 public final class ReplicatedMapValuesCodec {
     //hex: 0x0D1000
     public static final int REQUEST_MESSAGE_TYPE = 856064;
@@ -47,12 +47,6 @@ public final class ReplicatedMapValuesCodec {
 
     private ReplicatedMapValuesCodec() {
     }
-
-    /**
-     * Name of the ReplicatedMap
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class ReplicatedMapValuesCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the ReplicatedMap
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class ReplicatedMapValuesCodec {
     }
 
     /**
-    * A collection view of the values contained in this map.
-    */
+     * A collection view of the values contained in this map.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddAllCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
  * The result of the future contains the sequenceId of the last written item
  */
-@Generated("84665da7d0de269ea82d91bfe91eb3d9")
+@Generated("08bd2df6c17485bd58ed34f0d315e630")
 public final class RingbufferAddAllCodec {
     //hex: 0x170800
     public static final int REQUEST_MESSAGE_TYPE = 1509376;
@@ -111,8 +111,8 @@ public final class RingbufferAddAllCodec {
     }
 
     /**
-    * the CompletionStage to synchronize on completion.
-    */
+     * the CompletionStage to synchronize on completion.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddCodec.java
@@ -46,7 +46,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
  * to find that item.
  */
-@Generated("ecf7839c5ebbaa3129771704462bbbbf")
+@Generated("15af1ee0dcdb469933d75f1a65c380d3")
 public final class RingbufferAddCodec {
     //hex: 0x170600
     public static final int REQUEST_MESSAGE_TYPE = 1508864;
@@ -114,8 +114,8 @@ public final class RingbufferAddCodec {
     }
 
     /**
-    * the sequence of the added item, or -1 if the add failed.
-    */
+     * the sequence of the added item, or -1 if the add failed.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferCapacityCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferCapacityCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the capacity of this Ringbuffer.
  */
-@Generated("bca68eddfa8a0db1eadfe09c3436531d")
+@Generated("171faf774475facbb89c0d70d16560d5")
 public final class RingbufferCapacityCodec {
     //hex: 0x170400
     public static final int REQUEST_MESSAGE_TYPE = 1508352;
@@ -48,12 +48,6 @@ public final class RingbufferCapacityCodec {
 
     private RingbufferCapacityCodec() {
     }
-
-    /**
-     * Name of the Ringbuffer
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class RingbufferCapacityCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Ringbuffer
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class RingbufferCapacityCodec {
     }
 
     /**
-    * the capacity
-    */
+     * the capacity
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferHeadSequenceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferHeadSequenceCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are found. If the RingBuffer is empty, the head will be one more than the tail.
  * The initial value of the head is 0 (1 more than tail).
  */
-@Generated("12195e1f18a986c7efb2d6e6bd6d88d9")
+@Generated("44af78e673dab4db9cad0e107eb8a87b")
 public final class RingbufferHeadSequenceCodec {
     //hex: 0x170300
     public static final int REQUEST_MESSAGE_TYPE = 1508096;
@@ -50,12 +50,6 @@ public final class RingbufferHeadSequenceCodec {
 
     private RingbufferHeadSequenceCodec() {
     }
-
-    /**
-     * Name of the Ringbuffer
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -69,6 +63,9 @@ public final class RingbufferHeadSequenceCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Ringbuffer
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -87,8 +84,8 @@ public final class RingbufferHeadSequenceCodec {
     }
 
     /**
-    * the sequence of the head
-    */
+     * the sequence of the head
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
  * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
  */
-@Generated("68b6bdcf934053207c1d61b5d75c802b")
+@Generated("b600422fbbaffe0b6d5c4f6937ebfd71")
 public final class RingbufferReadManyCodec {
     //hex: 0x170900
     public static final int REQUEST_MESSAGE_TYPE = 1509632;
@@ -118,18 +118,22 @@ public final class RingbufferReadManyCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Number of items that have been read before filtering.
          */
         public int readCount;
+
         /**
          * List of items that have beee read.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> items;
+
         /**
          * List of sequence numbers for the items that have been read.
          */
         public @Nullable long[] itemSeqs;
+
         /**
          * Sequence number of the item following the last read item.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadOneCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadOneCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * readers or it can be read multiple times by the same reader. Currently it isn't possible to control how long this
  * call is going to block. In the future we could add e.g. tryReadOne(long sequence, long timeout, TimeUnit unit).
  */
-@Generated("4b7baa9a2cc07e8aefddce605a11a7e4")
+@Generated("9932c0d895cbfb6543a5c62f06fbd9d0")
 public final class RingbufferReadOneCodec {
     //hex: 0x170700
     public static final int REQUEST_MESSAGE_TYPE = 1509120;
@@ -99,8 +99,8 @@ public final class RingbufferReadOneCodec {
     }
 
     /**
-    * the read item
-    */
+     * the read item
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferRemainingCapacityCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferRemainingCapacityCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the remaining capacity of the ringbuffer. The returned value could be stale as soon as it is returned.
  * If ttl is not set, the remaining capacity will always be the capacity.
  */
-@Generated("631f7c04484d188464a0b94df27660a5")
+@Generated("ae02525731153cc88bb692fdfa84d5be")
 public final class RingbufferRemainingCapacityCodec {
     //hex: 0x170500
     public static final int REQUEST_MESSAGE_TYPE = 1508608;
@@ -49,12 +49,6 @@ public final class RingbufferRemainingCapacityCodec {
 
     private RingbufferRemainingCapacityCodec() {
     }
-
-    /**
-     * Name of the Ringbuffer
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class RingbufferRemainingCapacityCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Ringbuffer
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class RingbufferRemainingCapacityCodec {
     }
 
     /**
-    * the remaining capacity
-    */
+     * the remaining capacity
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
  * head completed the first looparound the ring. This is because no items are getting retired.
  */
-@Generated("7c8575c88ba88a8b4dd360699ee775cc")
+@Generated("b13169842e53b8f6bf7f9ee5de846e7e")
 public final class RingbufferSizeCodec {
     //hex: 0x170100
     public static final int REQUEST_MESSAGE_TYPE = 1507584;
@@ -49,12 +49,6 @@ public final class RingbufferSizeCodec {
 
     private RingbufferSizeCodec() {
     }
-
-    /**
-     * Name of the Ringbuffer
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class RingbufferSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Ringbuffer
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class RingbufferSizeCodec {
     }
 
     /**
-    * the size
-    */
+     * the size
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferTailSequenceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferTailSequenceCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
  * The initial value of the tail is -1.
  */
-@Generated("a1a5bd572743a26c27d6e75f7fff31b3")
+@Generated("d11066d229a0934e0d3035177246ebab")
 public final class RingbufferTailSequenceCodec {
     //hex: 0x170200
     public static final int REQUEST_MESSAGE_TYPE = 1507840;
@@ -49,12 +49,6 @@ public final class RingbufferTailSequenceCodec {
 
     private RingbufferTailSequenceCodec() {
     }
-
-    /**
-     * Name of the Ringbuffer
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class RingbufferTailSequenceCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Ringbuffer
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class RingbufferTailSequenceCodec {
     }
 
     /**
-    * the sequence of the tail
-    */
+     * the sequence of the tail
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Cancels further execution and scheduling of the task
  */
-@Generated("1efe4d4733e2583bdf3af06872e1b9b3")
+@Generated("25d140926bc48960417e6f568d3fb681")
 public final class ScheduledExecutorCancelFromMemberCodec {
     //hex: 0x1A0A00
     public static final int REQUEST_MESSAGE_TYPE = 1706496;
@@ -112,8 +112,8 @@ public final class ScheduledExecutorCancelFromMemberCodec {
     }
 
     /**
-    * True if the task was cancelled
-    */
+     * True if the task was cancelled
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorCancelFromPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Cancels further execution and scheduling of the task
  */
-@Generated("b3ada0ccb9a56d6c6e2b0c6af6740054")
+@Generated("e0b3565a0f314ebc9dab6439d003dd9d")
 public final class ScheduledExecutorCancelFromPartitionCodec {
     //hex: 0x1A0900
     public static final int REQUEST_MESSAGE_TYPE = 1706240;
@@ -104,8 +104,8 @@ public final class ScheduledExecutorCancelFromPartitionCodec {
     }
 
     /**
-    * True if the task was cancelled
-    */
+     * True if the task was cancelled
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetAllScheduledFuturesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetAllScheduledFuturesCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns all scheduled tasks in for a given scheduler in the given member.
  */
-@Generated("b06bda1a65bad6eb8f24633dad046547")
+@Generated("0e48e3b0be77c380427c250849dce2ce")
 public final class ScheduledExecutorGetAllScheduledFuturesCodec {
     //hex: 0x1A0400
     public static final int REQUEST_MESSAGE_TYPE = 1704960;
@@ -47,12 +47,6 @@ public final class ScheduledExecutorGetAllScheduledFuturesCodec {
 
     private ScheduledExecutorGetAllScheduledFuturesCodec() {
     }
-
-    /**
-     * The name of the scheduler.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String schedulerName;
 
     public static ClientMessage encodeRequest(java.lang.String schedulerName) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class ScheduledExecutorGetAllScheduledFuturesCodec {
         return clientMessage;
     }
 
+    /**
+     * The name of the scheduler.
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class ScheduledExecutorGetAllScheduledFuturesCodec {
     }
 
     /**
-    * A list of scheduled task handlers used to construct the future proxies.
-    */
+     * A list of scheduled task handlers used to construct the future proxies.
+     */
     public static java.util.Collection<com.hazelcast.scheduledexecutor.ScheduledTaskHandler> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
  */
-@Generated("a1f2a073e9bab5b6ee86494e38d85058")
+@Generated("ade3756d7f3cc69c2976b546f133d649")
 public final class ScheduledExecutorGetDelayFromMemberCodec {
     //hex: 0x1A0800
     public static final int REQUEST_MESSAGE_TYPE = 1705984;
@@ -104,8 +104,8 @@ public final class ScheduledExecutorGetDelayFromMemberCodec {
     }
 
     /**
-    * The remaining delay of the task formatted in nanoseconds.
-    */
+     * The remaining delay of the task formatted in nanoseconds.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetDelayFromPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
  */
-@Generated("52defe833af388308c8cde0b36b70e6c")
+@Generated("e1998dc81771ba44263fdf8ee621f46a")
 public final class ScheduledExecutorGetDelayFromPartitionCodec {
     //hex: 0x1A0700
     public static final int REQUEST_MESSAGE_TYPE = 1705728;
@@ -97,8 +97,8 @@ public final class ScheduledExecutorGetDelayFromPartitionCodec {
     }
 
     /**
-    * The remaining delay of the task formatted in nanoseconds.
-    */
+     * The remaining delay of the task formatted in nanoseconds.
+     */
     public static long decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromMemberCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the result of the task ({@link java.util.concurrent.Callable})
  * The call will blocking until the result is ready.
  */
-@Generated("a8c72a5bcf77932c37772e4abb635029")
+@Generated("e1af7a5aa43d9a1df1091745417e2781")
 public final class ScheduledExecutorGetResultFromMemberCodec {
     //hex: 0x1A1000
     public static final int REQUEST_MESSAGE_TYPE = 1708032;
@@ -104,8 +104,8 @@ public final class ScheduledExecutorGetResultFromMemberCodec {
     }
 
     /**
-    * The result of the completed task, in serialized form ({
-    */
+     * The result of the completed task, in serialized form ({
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetResultFromPartitionCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the result of the task ({@link java.util.concurrent.Callable})
  * The call will blocking until the result is ready.
  */
-@Generated("98dcdb14b0b3a2cd95f0346564345af3")
+@Generated("dd1b13ff1afac3af2ca3407627d5222a")
 public final class ScheduledExecutorGetResultFromPartitionCodec {
     //hex: 0x1A0F00
     public static final int REQUEST_MESSAGE_TYPE = 1707776;
@@ -97,8 +97,8 @@ public final class ScheduledExecutorGetResultFromPartitionCodec {
     }
 
     /**
-    * The result of the completed task, in serialized form ({
-    */
+     * The result of the completed task, in serialized form ({
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns statistics of the task
  */
-@Generated("1e530da47ff10d71d4698a4db236032c")
+@Generated("b4497b70e9020322ca8890eff252074f")
 public final class ScheduledExecutorGetStatsFromMemberCodec {
     //hex: 0x1A0600
     public static final int REQUEST_MESSAGE_TYPE = 1705472;
@@ -99,22 +99,27 @@ public final class ScheduledExecutorGetStatsFromMemberCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Last period of time the task was idle, waiting to get scheduled.
          */
         public long lastIdleTimeNanos;
+
         /**
          * Total amount of time the task was idle, waiting to get scheduled in.
          */
         public long totalIdleTimeNanos;
+
         /**
          * How many times the task was ran/called.
          */
         public long totalRuns;
+
         /**
          * The total amount of time the task spent while scheduled in.
          */
         public long totalRunTimeNanos;
+
         /**
          * The duration of the task's last execution.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorGetStatsFromPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns statistics of the task
  */
-@Generated("1c322eaf3dc97a3e2db018b2fa9c5c58")
+@Generated("acbb1a1461057fc1b489f174c36bbb86")
 public final class ScheduledExecutorGetStatsFromPartitionCodec {
     //hex: 0x1A0500
     public static final int REQUEST_MESSAGE_TYPE = 1705216;
@@ -92,22 +92,27 @@ public final class ScheduledExecutorGetStatsFromPartitionCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Last period of time the task was idle, waiting to get scheduled.
          */
         public long lastIdleTimeNanos;
+
         /**
          * Total amount of time the task was idle, waiting to get scheduled in.
          */
         public long totalIdleTimeNanos;
+
         /**
          * How many times the task was ran/called.
          */
         public long totalRuns;
+
         /**
          * The total amount of time the task spent while scheduled in.
          */
         public long totalRunTimeNanos;
+
         /**
          * The duration of the task's last execution.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks whether a task as identified from the given handler is already cancelled.
  */
-@Generated("a92225f76f63e5d8cbd238bca39533ae")
+@Generated("6795322ab6b563ccda61be27f4da4166")
 public final class ScheduledExecutorIsCancelledFromMemberCodec {
     //hex: 0x1A0C00
     public static final int REQUEST_MESSAGE_TYPE = 1707008;
@@ -104,8 +104,8 @@ public final class ScheduledExecutorIsCancelledFromMemberCodec {
     }
 
     /**
-    * True if the task is cancelled
-    */
+     * True if the task is cancelled
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsCancelledFromPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks whether a task as identified from the given handler is already cancelled.
  */
-@Generated("2b7a3fb8e2b05880285b02d2715141e8")
+@Generated("b9160c2eea67c032d5730649450c9e77")
 public final class ScheduledExecutorIsCancelledFromPartitionCodec {
     //hex: 0x1A0B00
     public static final int REQUEST_MESSAGE_TYPE = 1706752;
@@ -97,8 +97,8 @@ public final class ScheduledExecutorIsCancelledFromPartitionCodec {
     }
 
     /**
-    * True if the task is cancelled
-    */
+     * True if the task is cancelled
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromMemberCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Checks whether a task is done.
  * @see {@link java.util.concurrent.Future#cancel(boolean)}
  */
-@Generated("ae858bed94007d87a4be355d5f2aeb16")
+@Generated("bfac3b3943b139b9e2e516a623441ddd")
 public final class ScheduledExecutorIsDoneFromMemberCodec {
     //hex: 0x1A0E00
     public static final int REQUEST_MESSAGE_TYPE = 1707520;
@@ -105,8 +105,8 @@ public final class ScheduledExecutorIsDoneFromMemberCodec {
     }
 
     /**
-    * True if the task is done
-    */
+     * True if the task is done
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorIsDoneFromPartitionCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Checks whether a task is done.
  * @see {@link java.util.concurrent.Future#cancel(boolean)}
  */
-@Generated("d50b677dc51355e433e20cf937f2717c")
+@Generated("2df73bbd480a9e3300279fccd0c24067")
 public final class ScheduledExecutorIsDoneFromPartitionCodec {
     //hex: 0x1A0D00
     public static final int REQUEST_MESSAGE_TYPE = 1707264;
@@ -98,8 +98,8 @@ public final class ScheduledExecutorIsDoneFromPartitionCodec {
     }
 
     /**
-    * True if the task is done
-    */
+     * True if the task is done
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to a member for execution. Member is provided with its uuid.
  */
-@Generated("3a3d6458aba40a886baf0b1eb0d28c42")
+@Generated("3c912c8462728e11e0094c39caa7411a")
 public final class ScheduledExecutorSubmitToMemberCodec {
     //hex: 0x1A0300
     public static final int REQUEST_MESSAGE_TYPE = 1704704;
@@ -99,7 +99,7 @@ public final class ScheduledExecutorSubmitToMemberCodec {
         /**
          * True if the autoDisposable is received from the client, false otherwise.
          * If this is false, autoDisposable has the default value for its type.
-        */
+         */
         public boolean isAutoDisposableExists;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
  */
-@Generated("97cd798c27e5bb41faa3c075bda867e9")
+@Generated("5e4c87c9513513c6169801ea0f6fb37b")
 public final class ScheduledExecutorSubmitToPartitionCodec {
     //hex: 0x1A0200
     public static final int REQUEST_MESSAGE_TYPE = 1704448;
@@ -93,7 +93,7 @@ public final class ScheduledExecutorSubmitToPartitionCodec {
         /**
          * True if the autoDisposable is received from the client, false otherwise.
          * If this is false, autoDisposable has the default value for its type.
-        */
+         */
         public boolean isAutoDisposableExists;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAcquireCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAcquireCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * then the current thread becomes disabled for thread scheduling purposes
  * and lies dormant until other threads release enough permits.
  */
-@Generated("59f628125a8b862520c8441edd9d0244")
+@Generated("9c5da2c869a35cf7f74d5d753b14d949")
 public final class SemaphoreAcquireCodec {
     //hex: 0x0C0200
     public static final int REQUEST_MESSAGE_TYPE = 786944;
@@ -139,9 +139,9 @@ public final class SemaphoreAcquireCodec {
     }
 
     /**
-    * true if requested permits are acquired,
-    * false otherwise
-    */
+     * true if requested permits are acquired,
+     * false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAvailablePermitsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreAvailablePermitsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of available permits.
  */
-@Generated("76eec9ecf8de60561621b1f1cc89308b")
+@Generated("e1da265da7684751a6423872eac8fbe8")
 public final class SemaphoreAvailablePermitsCodec {
     //hex: 0x0C0600
     public static final int REQUEST_MESSAGE_TYPE = 787968;
@@ -97,8 +97,8 @@ public final class SemaphoreAvailablePermitsCodec {
     }
 
     /**
-    * number of available permits
-    */
+     * number of available permits
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreChangeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreChangeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Increases or decreases the number of permits by the given value.
  */
-@Generated("a0889cea13a760bce340476f3e500341")
+@Generated("cb3e6aace049d9b0481b231421d11b18")
 public final class SemaphoreChangeCodec {
     //hex: 0x0C0500
     public static final int REQUEST_MESSAGE_TYPE = 787712;
@@ -128,8 +128,8 @@ public final class SemaphoreChangeCodec {
     }
 
     /**
-    * true
-    */
+     * true
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreDrainCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreDrainCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Acquires all available permits at once and returns immediately.
  */
-@Generated("b3ea04ff8c99b1320ef4068dc909e5e7")
+@Generated("cc66a531cbe344b2cfb67ff1948ad3ac")
 public final class SemaphoreDrainCodec {
     //hex: 0x0C0400
     public static final int REQUEST_MESSAGE_TYPE = 787456;
@@ -120,8 +120,8 @@ public final class SemaphoreDrainCodec {
     }
 
     /**
-    * number of acquired permits
-    */
+     * number of acquired permits
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreGetSemaphoreTypeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreGetSemaphoreTypeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if the semaphore is JDK compatible
  */
-@Generated("beb788daa01b0347beb5fd84c1fb59de")
+@Generated("90b7c55edca33814a676305f1518b42c")
 public final class SemaphoreGetSemaphoreTypeCodec {
     //hex: 0x0C0700
     public static final int REQUEST_MESSAGE_TYPE = 788224;
@@ -48,12 +48,6 @@ public final class SemaphoreGetSemaphoreTypeCodec {
 
     private SemaphoreGetSemaphoreTypeCodec() {
     }
-
-    /**
-     * Name of the ISemaphore proxy
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String proxyName;
 
     public static ClientMessage encodeRequest(java.lang.String proxyName) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class SemaphoreGetSemaphoreTypeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the ISemaphore proxy
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class SemaphoreGetSemaphoreTypeCodec {
     }
 
     /**
-    * true if the semaphore is JDK compatible
-    */
+     * true if the semaphore is JDK compatible
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreInitCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreInitCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Initializes the ISemaphore instance with the given permit number, if not
  * initialized before.
  */
-@Generated("64597030b7c2e4e693cb7686fb862005")
+@Generated("fabfab46c4f1578d4482ee37e6a18030")
 public final class SemaphoreInitCodec {
     //hex: 0x0C0100
     public static final int REQUEST_MESSAGE_TYPE = 786688;
@@ -105,8 +105,8 @@ public final class SemaphoreInitCodec {
     }
 
     /**
-    * true if the ISemaphore is initialized with this call
-    */
+     * true if the ISemaphore is initialized with this call
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreReleaseCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SemaphoreReleaseCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Releases the given number of permits and increases the number of
  * available permits by that amount.
  */
-@Generated("92baa3bef6b87b25ae6a7ea30635e487")
+@Generated("cef815d0d0541a99a94626efbfe72cbe")
 public final class SemaphoreReleaseCodec {
     //hex: 0x0C0300
     public static final int REQUEST_MESSAGE_TYPE = 787200;
@@ -129,8 +129,8 @@ public final class SemaphoreReleaseCodec {
     }
 
     /**
-    * true
-    */
+     * true
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set so that its value is the union of the two sets. The behavior of this operation is undefined if the specified
  * collection is modified while the operation is in progress.
  */
-@Generated("0b104359583427279eaa877b56c389d6")
+@Generated("f79c8f26a0fd40537abb2c04bdee3ada")
 public final class SetAddAllCodec {
     //hex: 0x060600
     public static final int REQUEST_MESSAGE_TYPE = 394752;
@@ -100,8 +100,8 @@ public final class SetAddAllCodec {
     }
 
     /**
-    * True if this set changed as a result of the call
-    */
+     * True if this set changed as a result of the call
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * element, including null, and throw an exception, as described in the specification for Collection
  * Individual set implementations should clearly document any restrictions on the elements that they may contain.
  */
-@Generated("9c85900eecfd45aea25c8af9fbe507fc")
+@Generated("d19618a1bc24abb781f8320e7b17d77a")
 public final class SetAddCodec {
     //hex: 0x060400
     public static final int REQUEST_MESSAGE_TYPE = 394240;
@@ -102,9 +102,9 @@ public final class SetAddCodec {
     }
 
     /**
-    * True if this set did not already contain the specified
-    * element and the element is added, returns false otherwise.
-    */
+     * True if this set did not already contain the specified
+     * element and the element is added, returns false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
  */
-@Generated("8c7221db8ff52d4b9a5a17ea7e492b6c")
+@Generated("aa44fc910a469dfee683d39edf01bf95")
 public final class SetAddListenerCodec {
     //hex: 0x060B00
     public static final int REQUEST_MESSAGE_TYPE = 396032;
@@ -111,8 +111,8 @@ public final class SetAddListenerCodec {
     }
 
     /**
-    * The registration id.
-    */
+     * The registration id.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -153,7 +153,7 @@ public final class SetAddListenerCodec {
          * @param item Item that the event is fired for.
          * @param uuid UUID of the member that dispatches this event.
          * @param eventType Type of the event. It is either ADDED(1) or REMOVED(2).
-        */
+         */
         public abstract void handleItemEvent(@Nullable com.hazelcast.internal.serialization.Data item, java.util.UUID uuid, int eventType);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetClearCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetClearCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all of the elements from this set (optional operation). The set will be empty after this call returns.
  */
-@Generated("baec32172c11aee81886555dd5e1a183")
+@Generated("0f0d0e37953e2ed975ee6da145b5d6ea")
 public final class SetClearCodec {
     //hex: 0x060900
     public static final int REQUEST_MESSAGE_TYPE = 395520;
@@ -47,12 +47,6 @@ public final class SetClearCodec {
 
     private SetClearCodec() {
     }
-
-    /**
-     * Name of the Set
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class SetClearCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Set
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRemoveAllCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
  * asymmetric set difference of the two sets.
  */
-@Generated("24b2a670c4abc32e3bba57211c70ffb8")
+@Generated("392687c1ae6396a402064ac2c1cde2f9")
 public final class SetCompareAndRemoveAllCodec {
     //hex: 0x060700
     public static final int REQUEST_MESSAGE_TYPE = 395008;
@@ -99,8 +99,8 @@ public final class SetCompareAndRemoveAllCodec {
     }
 
     /**
-    * true if at least one item in values existed and removed, false otherwise.
-    */
+     * true if at least one item in values existed and removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRetainAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRetainAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
  * intersection of the two sets.
  */
-@Generated("d1938d90c4246b367e4d958a185f956d")
+@Generated("7fc0b8b41f554b798d12d25bb475e832")
 public final class SetCompareAndRetainAllCodec {
     //hex: 0x060800
     public static final int REQUEST_MESSAGE_TYPE = 395264;
@@ -100,9 +100,9 @@ public final class SetCompareAndRetainAllCodec {
     }
 
     /**
-    * true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
-    * in the Set are removed.
-    */
+     * true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
+     * in the Set are removed.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this set contains all of the elements of the specified collection. If the specified collection is
  * also a set, this method returns true if it is a subset of this set.
  */
-@Generated("099d93899623cc14be0e48dbd1489e93")
+@Generated("90ea867af30e1d99150dc6ee987b55e1")
 public final class SetContainsAllCodec {
     //hex: 0x060300
     public static final int REQUEST_MESSAGE_TYPE = 393984;
@@ -98,9 +98,9 @@ public final class SetContainsAllCodec {
     }
 
     /**
-    * true if this set contains all of the elements of the
-    * specified collection
-    */
+     * true if this set contains all of the elements of the
+     * specified collection
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this set contains the specified element.
  */
-@Generated("971ace01aa909366698ad6f33fc6e6ee")
+@Generated("bd0cd04ae5127f779c9185408ebab5cf")
 public final class SetContainsCodec {
     //hex: 0x060200
     public static final int REQUEST_MESSAGE_TYPE = 393728;
@@ -97,8 +97,8 @@ public final class SetContainsCodec {
     }
 
     /**
-    * True if this set contains the specified element, false otherwise
-    */
+     * True if this set contains the specified element, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetGetAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return the all elements of this collection
  */
-@Generated("7118e8ccaad12bf7aaab125d2fbcb0e2")
+@Generated("2077ab477bc4bd38f72a76eb89404d2b")
 public final class SetGetAllCodec {
     //hex: 0x060A00
     public static final int REQUEST_MESSAGE_TYPE = 395776;
@@ -47,12 +47,6 @@ public final class SetGetAllCodec {
 
     private SetGetAllCodec() {
     }
-
-    /**
-     * Name of the Set
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class SetGetAllCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Set
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -84,8 +81,8 @@ public final class SetGetAllCodec {
     }
 
     /**
-    * Array of all values in the Set
-    */
+     * Array of all values in the Set
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetIsEmptyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this set contains no elements.
  */
-@Generated("6434f75fe7345cc2abb27ffc8ae86f31")
+@Generated("2c1eee74faf8e02dd39021abfaa3bd28")
 public final class SetIsEmptyCodec {
     //hex: 0x060D00
     public static final int REQUEST_MESSAGE_TYPE = 396544;
@@ -48,12 +48,6 @@ public final class SetIsEmptyCodec {
 
     private SetIsEmptyCodec() {
     }
-
-    /**
-     * Name of the Set
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class SetIsEmptyCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Set
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -85,8 +82,8 @@ public final class SetIsEmptyCodec {
     }
 
     /**
-    * True if this set contains no elements
-    */
+     * True if this set contains no elements
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
  * (This set will not contain the element once the call returns.)
  */
-@Generated("f55daaf4d3c15627e96f381b1ac7dacd")
+@Generated("87ee5c92f920d502e8a8694362b8b996")
 public final class SetRemoveCodec {
     //hex: 0x060500
     public static final int REQUEST_MESSAGE_TYPE = 394496;
@@ -99,8 +99,8 @@ public final class SetRemoveCodec {
     }
 
     /**
-    * True if this set contained the specified element and it is removed successfully
-    */
+     * True if this set contained the specified element and it is removed successfully
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetRemoveListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetRemoveListenerCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
  * cluster and returns false.
  */
-@Generated("635037ccf2d80838b82a3a6d1c17a13c")
+@Generated("0e7fdf084f9c6826e8423cb91e532712")
 public final class SetRemoveListenerCodec {
     //hex: 0x060C00
     public static final int REQUEST_MESSAGE_TYPE = 396288;
@@ -98,8 +98,8 @@ public final class SetRemoveListenerCodec {
     }
 
     /**
-    * true if the listener with the provided id existed and removed, false otherwise.
-    */
+     * true if the listener with the provided id existed and removed, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of elements in this set (its cardinality). If this set contains more than Integer.MAX_VALUE
  * elements, returns Integer.MAX_VALUE.
  */
-@Generated("8d31dabefb0f6a42e1a69b84d3205755")
+@Generated("6b72f984c691f0770c218977c47f1acb")
 public final class SetSizeCodec {
     //hex: 0x060100
     public static final int REQUEST_MESSAGE_TYPE = 393472;
@@ -49,12 +49,6 @@ public final class SetSizeCodec {
 
     private SetSizeCodec() {
     }
-
-    /**
-     * Name of the Set
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.lang.String name;
 
     public static ClientMessage encodeRequest(java.lang.String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -68,6 +62,9 @@ public final class SetSizeCodec {
         return clientMessage;
     }
 
+    /**
+     * Name of the Set
+     */
     public static java.lang.String decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
@@ -86,8 +83,8 @@ public final class SetSizeCodec {
     }
 
     /**
-    * The number of elements in this set (its cardinality)
-    */
+     * The number of elements in this set (its cardinality)
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlCloseCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlCloseCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Closes server-side query cursor.
  */
-@Generated("91a9e9d686272dfa2caf8a619168693e")
+@Generated("7c496263da6091c8172595d56b69c90f")
 public final class SqlCloseCodec {
     //hex: 0x210300
     public static final int REQUEST_MESSAGE_TYPE = 2163456;
@@ -47,12 +47,6 @@ public final class SqlCloseCodec {
 
     private SqlCloseCodec() {
     }
-
-    /**
-     * Query ID.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public com.hazelcast.sql.impl.QueryId queryId;
 
     public static ClientMessage encodeRequest(com.hazelcast.sql.impl.QueryId queryId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class SqlCloseCodec {
         return clientMessage;
     }
 
+    /**
+     * Query ID.
+     */
     public static com.hazelcast.sql.impl.QueryId decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecuteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecuteCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Starts execution of an SQL query.
  */
-@Generated("95508cca638171fab71c5c06d87241af")
+@Generated("48b0f740d0f5747358df04c1c08d38db")
 public final class SqlExecuteCodec {
     //hex: 0x210100
     public static final int REQUEST_MESSAGE_TYPE = 2162944;
@@ -104,26 +104,32 @@ public final class SqlExecuteCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Query ID.
          */
         public @Nullable com.hazelcast.sql.impl.QueryId queryId;
+
         /**
          * Row metadata.
          */
         public @Nullable java.util.List<com.hazelcast.sql.SqlColumnMetadata> rowMetadata;
+
         /**
          * Row page.
          */
         public @Nullable java.util.List<java.util.List<com.hazelcast.internal.serialization.Data>> rowPage;
+
         /**
          * Whether the row page is the last.
          */
         public boolean rowPageLast;
+
         /**
          * The number of updated rows.
          */
         public long updateCount;
+
         /**
          * Error object.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlFetchCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlFetchCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Fetches the next row page.
  */
-@Generated("5cb985b672f036c8ba849a9ed635effd")
+@Generated("dc46385cebf6254b28edab4d47aecfeb")
 public final class SqlFetchCodec {
     //hex: 0x210200
     public static final int REQUEST_MESSAGE_TYPE = 2163200;
@@ -88,14 +88,17 @@ public final class SqlFetchCodec {
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
+
         /**
          * Row page.
          */
         public @Nullable java.util.List<java.util.List<com.hazelcast.internal.serialization.Data>> rowPage;
+
         /**
          * Whether the row page is the last.
          */
         public boolean rowPageLast;
+
         /**
          * Error object.
          */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicAddMessageListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicAddMessageListenerCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Subscribes to this topic. When someone publishes a message on this topic. onMessage() function of the given
  * MessageListener is called. More than one message listener can be added on one instance.
  */
-@Generated("f01e5da1a05024d58c02ba8748bfd690")
+@Generated("8a95bf1f1999015e9036caa2f74fdd0c")
 public final class TopicAddMessageListenerCodec {
     //hex: 0x040200
     public static final int REQUEST_MESSAGE_TYPE = 262656;
@@ -104,8 +104,8 @@ public final class TopicAddMessageListenerCodec {
     }
 
     /**
-    * returns the registration id
-    */
+     * returns the registration id
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();
@@ -146,7 +146,7 @@ public final class TopicAddMessageListenerCodec {
          * @param item Item that the event is fired for.
          * @param publishTime Time that the item is published to the topic.
          * @param uuid UUID of the member that dispatches this event.
-        */
+         */
         public abstract void handleTopicEvent(com.hazelcast.internal.serialization.Data item, long publishTime, java.util.UUID uuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicRemoveMessageListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicRemoveMessageListenerCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Stops receiving messages for the given message listener.If the given listener already removed, this method does nothing.
  */
-@Generated("2703eb1372ab9a41bd563712a0cdea49")
+@Generated("170a20d3d0fd933adbfe62679a46bbb7")
 public final class TopicRemoveMessageListenerCodec {
     //hex: 0x040300
     public static final int REQUEST_MESSAGE_TYPE = 262912;
@@ -97,8 +97,8 @@ public final class TopicRemoveMessageListenerCodec {
     }
 
     /**
-    * True if registration is removed, false otherwise
-    */
+     * True if registration is removed, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionCreateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a transaction with the given parameters.
  */
-@Generated("58654edd3e58f972d3fbbf7dbd36cf38")
+@Generated("95229146bb615cb34f92663d7bd52778")
 public final class TransactionCreateCodec {
     //hex: 0x150200
     public static final int REQUEST_MESSAGE_TYPE = 1376768;
@@ -120,8 +120,8 @@ public final class TransactionCreateCodec {
     }
 
     /**
-    * The transaction id for the created transaction.
-    */
+     * The transaction id for the created transaction.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListAddCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a new item to the transactional list.
  */
-@Generated("8fe90241bd323cf3243725e8f7a237ab")
+@Generated("54b9c9a7a372c753f817ca49416c5ed3")
 public final class TransactionalListAddCodec {
     //hex: 0x110100
     public static final int REQUEST_MESSAGE_TYPE = 1114368;
@@ -112,8 +112,8 @@ public final class TransactionalListAddCodec {
     }
 
     /**
-    * True if the item is added successfully, false otherwise
-    */
+     * True if the item is added successfully, false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Remove item from the transactional list
  */
-@Generated("9b9c7b0b731ef6a1a5bf2a95c0b5b5c5")
+@Generated("1ee27000b0c988f661f077a7e7b36c07")
 public final class TransactionalListRemoveCodec {
     //hex: 0x110200
     public static final int REQUEST_MESSAGE_TYPE = 1114624;
@@ -112,8 +112,8 @@ public final class TransactionalListRemoveCodec {
     }
 
     /**
-    * True if the removed successfully,false otherwise
-    */
+     * True if the removed successfully,false otherwise
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListSizeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the size of the list
  */
-@Generated("6acf77cb5c07768a13240a685e870a9f")
+@Generated("7b9d1fee1ae51d3620e5621ba72a2085")
 public final class TransactionalListSizeCodec {
     //hex: 0x110300
     public static final int REQUEST_MESSAGE_TYPE = 1114880;
@@ -105,8 +105,8 @@ public final class TransactionalListSizeCodec {
     }
 
     /**
-    * The size of the list
-    */
+     * The size of the list
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains an entry for the specified key.
  */
-@Generated("426dd58b259c51df8e0e504f53865805")
+@Generated("bda36300ea1aa8286e91f65d6cb12c9e")
 public final class TransactionalMapContainsKeyCodec {
     //hex: 0x0E0100
     public static final int REQUEST_MESSAGE_TYPE = 917760;
@@ -112,8 +112,8 @@ public final class TransactionalMapContainsKeyCodec {
     }
 
     /**
-    * True if this map contains an entry for the specified key.
-    */
+     * True if this map contains an entry for the specified key.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains an entry for the specified value.
  */
-@Generated("72763646b585a86de341c61d085b4b85")
+@Generated("e6e7b15a25f1117db517a004c2c3f595")
 public final class TransactionalMapContainsValueCodec {
     //hex: 0x0E1200
     public static final int REQUEST_MESSAGE_TYPE = 922112;
@@ -112,8 +112,8 @@ public final class TransactionalMapContainsValueCodec {
     }
 
     /**
-    * True if this map contains an entry for the specified key.
-    */
+     * True if this map contains an entry for the specified key.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the value for the specified key, or null if this map does not contain this key.
  */
-@Generated("e7b5f37a838cfee1dc2e083345660349")
+@Generated("23d154c3e3840cea4a14ab25688f3b4f")
 public final class TransactionalMapGetCodec {
     //hex: 0x0E0200
     public static final int REQUEST_MESSAGE_TYPE = 918016;
@@ -111,8 +111,8 @@ public final class TransactionalMapGetCodec {
     }
 
     /**
-    * The value for the specified key
-    */
+     * The value for the specified key
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetForUpdateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetForUpdateCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
  * the end of the transaction (either commit or rollback).
  */
-@Generated("6160585e2748af5de71c7c4e01937e4e")
+@Generated("c15ed74db8d9c275153032fb58fe5bfd")
 public final class TransactionalMapGetForUpdateCodec {
     //hex: 0x0E0300
     public static final int REQUEST_MESSAGE_TYPE = 918272;
@@ -112,8 +112,8 @@ public final class TransactionalMapGetForUpdateCodec {
     }
 
     /**
-    * The value for the specified key
-    */
+     * The value for the specified key
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapIsEmptyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapIsEmptyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains no entries.
  */
-@Generated("828ecd7c7fdb8add4fa92cc3b0839565")
+@Generated("e307b87ba76a5c60a87ff38ff704d10e")
 public final class TransactionalMapIsEmptyCodec {
     //hex: 0x0E0500
     public static final int REQUEST_MESSAGE_TYPE = 918784;
@@ -105,8 +105,8 @@ public final class TransactionalMapIsEmptyCodec {
     }
 
     /**
-    * <tt>true</tt> if this map contains no entries.
-    */
+     * <tt>true</tt> if this map contains no entries.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("0a28dc718cbf139bb749e0919d42e266")
+@Generated("e9bfe47a0ed00873ba390f8fd03f1d4e")
 public final class TransactionalMapKeySetCodec {
     //hex: 0x0E0E00
     public static final int REQUEST_MESSAGE_TYPE = 921088;
@@ -106,8 +106,8 @@ public final class TransactionalMapKeySetCodec {
     }
 
     /**
-    * A set clone of the keys contained in this map.
-    */
+     * A set clone of the keys contained in this map.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("b7181987125b048065519312e07469d1")
+@Generated("857f361f5c7586003239c201cb50bc75")
 public final class TransactionalMapKeySetWithPredicateCodec {
     //hex: 0x0E0F00
     public static final int REQUEST_MESSAGE_TYPE = 921344;
@@ -114,8 +114,8 @@ public final class TransactionalMapKeySetWithPredicateCodec {
     }
 
     /**
-    * Result key set for the query.
-    */
+     * Result key set for the query.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
  * current transaction context till transaction is committed.
  */
-@Generated("0ce6ccaffffe975553d9752429f3dd38")
+@Generated("13adb58ca57caf88654ff36166637848")
 public final class TransactionalMapPutCodec {
     //hex: 0x0E0600
     public static final int REQUEST_MESSAGE_TYPE = 919040;
@@ -128,8 +128,8 @@ public final class TransactionalMapPutCodec {
     }
 
     /**
-    * Previous value associated with key or  null if there was no mapping for key
-    */
+     * Previous value associated with key or  null if there was no mapping for key
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutIfAbsentCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified key is not already associated with a value, associate it with the given value.
  * The object to be put will be accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("1110a814d9038310c347c39c0da3904b")
+@Generated("dd121f5ca77d75f3c015c76f2d3927ae")
 public final class TransactionalMapPutIfAbsentCodec {
     //hex: 0x0E0800
     public static final int REQUEST_MESSAGE_TYPE = 919552;
@@ -119,8 +119,8 @@ public final class TransactionalMapPutIfAbsentCodec {
     }
 
     /**
-    * The previous value associated with key, or null if there was no mapping for key.
-    */
+     * The previous value associated with key, or null if there was no mapping for key.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * specified key once the call returns. The object to be removed will be accessible only in the current transaction
  * context until the transaction is committed.
  */
-@Generated("0b0c9d680c55c116fbf27fda9e8f4dd5")
+@Generated("ee4b42377329edb6e25971b7a189b269")
 public final class TransactionalMapRemoveCodec {
     //hex: 0x0E0B00
     public static final int REQUEST_MESSAGE_TYPE = 920320;
@@ -113,8 +113,8 @@ public final class TransactionalMapRemoveCodec {
     }
 
     /**
-    * The previous value associated with key, or null if there was no mapping for key
-    */
+     * The previous value associated with key, or null if there was no mapping for key
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveIfSameCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
  * from only the current transaction context until the transaction is committed.
  */
-@Generated("dd0555ae32ba4ca21a9fc07ec61f7b32")
+@Generated("a376ec077314e78a01ef0ad8f4289474")
 public final class TransactionalMapRemoveIfSameCodec {
     //hex: 0x0E0D00
     public static final int REQUEST_MESSAGE_TYPE = 920832;
@@ -120,8 +120,8 @@ public final class TransactionalMapRemoveIfSameCodec {
     }
 
     /**
-    * True if the value was removed
-    */
+     * True if the value was removed
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
  * accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("0616f142ab1a9fa4791438048e57fb4b")
+@Generated("955f41e21394aff6e0446944afcd92bf")
 public final class TransactionalMapReplaceCodec {
     //hex: 0x0E0900
     public static final int REQUEST_MESSAGE_TYPE = 919808;
@@ -119,8 +119,8 @@ public final class TransactionalMapReplaceCodec {
     }
 
     /**
-    * The previous value associated with key, or null if there was no mapping for key.
-    */
+     * The previous value associated with key, or null if there was no mapping for key.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceIfSameCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
  * accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("f71df26065956be0a398e57048b42f00")
+@Generated("2fd62686c9159a5284775a3668a29835")
 public final class TransactionalMapReplaceIfSameCodec {
     //hex: 0x0E0A00
     public static final int REQUEST_MESSAGE_TYPE = 920064;
@@ -127,8 +127,8 @@ public final class TransactionalMapReplaceIfSameCodec {
     }
 
     /**
-    * true if the value was replaced.
-    */
+     * true if the value was replaced.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSizeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of entries in this map.
  */
-@Generated("92c03c1318b227b53f7ef7dccf0382b3")
+@Generated("c81157d4437d3bfa115978ae0a6b2250")
 public final class TransactionalMapSizeCodec {
     //hex: 0x0E0400
     public static final int REQUEST_MESSAGE_TYPE = 918528;
@@ -105,8 +105,8 @@ public final class TransactionalMapSizeCodec {
     }
 
     /**
-    * The number of entries in this map.
-    */
+     * The number of entries in this map.
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
  * distributed query, so it may throw a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("73c70861f518f680de766d1e384afaaa")
+@Generated("430dd7bfad4b90aa531aaf2eff81eac8")
 public final class TransactionalMapValuesCodec {
     //hex: 0x0E1000
     public static final int REQUEST_MESSAGE_TYPE = 921600;
@@ -106,8 +106,8 @@ public final class TransactionalMapValuesCodec {
     }
 
     /**
-    * All values in the map
-    */
+     * All values in the map
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("52f11fd15ac9bbc545f80df779a04667")
+@Generated("b953ccc22c9cbf3654d8fcb2d581efe2")
 public final class TransactionalMapValuesWithPredicateCodec {
     //hex: 0x0E1100
     public static final int REQUEST_MESSAGE_TYPE = 921856;
@@ -114,8 +114,8 @@ public final class TransactionalMapValuesWithPredicateCodec {
     }
 
     /**
-    * Result value collection of the query.
-    */
+     * Result value collection of the query.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the collection of values associated with the key.
  */
-@Generated("2d600e5f6a9b96d7db5d6ec909be86ad")
+@Generated("deefb21fec075fc3aca97d9f344f57c6")
 public final class TransactionalMultiMapGetCodec {
     //hex: 0x0F0200
     public static final int REQUEST_MESSAGE_TYPE = 983552;
@@ -111,8 +111,8 @@ public final class TransactionalMultiMapGetCodec {
     }
 
     /**
-    * The collection of the values associated with the key
-    */
+     * The collection of the values associated with the key
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapPutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Stores a key-value pair in the multimap.
  */
-@Generated("7a1ac5242da2bf918ba878b9148d3225")
+@Generated("a6f3bf15dc0ca6286ee6314f0eee22e0")
 public final class TransactionalMultiMapPutCodec {
     //hex: 0x0F0100
     public static final int REQUEST_MESSAGE_TYPE = 983296;
@@ -119,8 +119,8 @@ public final class TransactionalMultiMapPutCodec {
     }
 
     /**
-    * True if the size of the multimap is increased, false if the multimap already contains the key-value pair.
-    */
+     * True if the size of the multimap is increased, false if the multimap already contains the key-value pair.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("ca183e3d2ae235bc4fa6054ea24dbb18")
+@Generated("4a47caff86118aa80a73d63ad423dd01")
 public final class TransactionalMultiMapRemoveCodec {
     //hex: 0x0F0300
     public static final int REQUEST_MESSAGE_TYPE = 983808;
@@ -111,8 +111,8 @@ public final class TransactionalMultiMapRemoveCodec {
     }
 
     /**
-    * True if the size of the multimap changed after the remove operation, false otherwise.
-    */
+     * True if the size of the multimap changed after the remove operation, false otherwise.
+     */
     public static java.util.List<com.hazelcast.internal.serialization.Data> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveEntryCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all the entries associated with the given key.
  */
-@Generated("f615e45f0295b2e88899e6db70a8459f")
+@Generated("8a070d32c7e84da5550ef764f8580540")
 public final class TransactionalMultiMapRemoveEntryCodec {
     //hex: 0x0F0400
     public static final int REQUEST_MESSAGE_TYPE = 984064;
@@ -119,8 +119,8 @@ public final class TransactionalMultiMapRemoveEntryCodec {
     }
 
     /**
-    * True if the size of the multimap changed after the remove operation, false otherwise.
-    */
+     * True if the size of the multimap changed after the remove operation, false otherwise.
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapSizeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of key-value pairs in the multimap.
  */
-@Generated("352adbd4a6b0c0cf45e3d5abd9c48582")
+@Generated("0f738c842546e8dc674c9c81d0c82ae1")
 public final class TransactionalMultiMapSizeCodec {
     //hex: 0x0F0600
     public static final int REQUEST_MESSAGE_TYPE = 984576;
@@ -105,8 +105,8 @@ public final class TransactionalMultiMapSizeCodec {
     }
 
     /**
-    * The number of key-value pairs in the multimap
-    */
+     * The number of key-value pairs in the multimap
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapValueCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapValueCountCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of values matching the given key in the multimap.
  */
-@Generated("0883b08e7f9becf106b70597c8136d30")
+@Generated("fbe91f49f2e9d129fb8e455a5227da1a")
 public final class TransactionalMultiMapValueCountCodec {
     //hex: 0x0F0500
     public static final int REQUEST_MESSAGE_TYPE = 984320;
@@ -112,8 +112,8 @@ public final class TransactionalMultiMapValueCountCodec {
     }
 
     /**
-    * The number of values matching the given key in the multimap
-    */
+     * The number of values matching the given key in the multimap
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
  * become available.
  */
-@Generated("cd80b03b8954a730849cbd31d1527be3")
+@Generated("cd5ec9cb62b07261e3da92f622245cc1")
 public final class TransactionalQueueOfferCodec {
     //hex: 0x120100
     public static final int REQUEST_MESSAGE_TYPE = 1179904;
@@ -121,8 +121,8 @@ public final class TransactionalQueueOfferCodec {
     }
 
     /**
-    * <tt>true</tt> if successful, or <tt>false</tt> if the specified waiting time elapses before space is available
-    */
+     * <tt>true</tt> if successful, or <tt>false</tt> if the specified waiting time elapses before space is available
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePeekCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePeekCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
  */
-@Generated("c0890a28b74bc669961f9355462804ed")
+@Generated("4570738506214ddee8b726e576318237")
 public final class TransactionalQueuePeekCodec {
     //hex: 0x120400
     public static final int REQUEST_MESSAGE_TYPE = 1180672;
@@ -112,8 +112,8 @@ public final class TransactionalQueuePeekCodec {
     }
 
     /**
-    * The value at the head of the queue.
-    */
+     * The value at the head of the queue.
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePollCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueuePollCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
  * to become available.
  */
-@Generated("20086aef805d735d38cf5c89b6f1a587")
+@Generated("7d1549ffae5eb0104c25eff64412f06a")
 public final class TransactionalQueuePollCodec {
     //hex: 0x120300
     public static final int REQUEST_MESSAGE_TYPE = 1180416;
@@ -113,8 +113,8 @@ public final class TransactionalQueuePollCodec {
     }
 
     /**
-    * The head of this queue, or <tt>null</tt> if the specified waiting time elapses before an element is available
-    */
+     * The head of this queue, or <tt>null</tt> if the specified waiting time elapses before an element is available
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueSizeCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
  * elements, returns Integer.MAX_VALUE.
  */
-@Generated("182bf99e7a79f6a3f12a4bb05eff268d")
+@Generated("eed6a85edbfeffc478c44eed18b60b97")
 public final class TransactionalQueueSizeCodec {
     //hex: 0x120500
     public static final int REQUEST_MESSAGE_TYPE = 1180928;
@@ -106,8 +106,8 @@ public final class TransactionalQueueSizeCodec {
     }
 
     /**
-    * The number of elements in this collection
-    */
+     * The number of elements in this collection
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueTakeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueTakeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
  */
-@Generated("3e4d517105f5f187c01ffd1c8e84d936")
+@Generated("d312a36c3d7e102a8f3db8396025cad5")
 public final class TransactionalQueueTakeCodec {
     //hex: 0x120200
     public static final int REQUEST_MESSAGE_TYPE = 1180160;
@@ -104,8 +104,8 @@ public final class TransactionalQueueTakeCodec {
     }
 
     /**
-    * The head of this queue
-    */
+     * The head of this queue
+     */
     public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetAddCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Add new item to transactional set.
  */
-@Generated("d2ca7399bfa90ef798c2ad482422ecb5")
+@Generated("1fa67f865ed631436e8cc6449533493c")
 public final class TransactionalSetAddCodec {
     //hex: 0x100100
     public static final int REQUEST_MESSAGE_TYPE = 1048832;
@@ -112,8 +112,8 @@ public final class TransactionalSetAddCodec {
     }
 
     /**
-    * True if item is added successfully
-    */
+     * True if item is added successfully
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Remove item from transactional set.
  */
-@Generated("ba1ae8922d0cd34a309cb7574cd8b714")
+@Generated("de1db019582fba5bba042915b8cc91a2")
 public final class TransactionalSetRemoveCodec {
     //hex: 0x100200
     public static final int REQUEST_MESSAGE_TYPE = 1049088;
@@ -112,8 +112,8 @@ public final class TransactionalSetRemoveCodec {
     }
 
     /**
-    * True if item is remove successfully
-    */
+     * True if item is remove successfully
+     */
     public static boolean decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetSizeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetSizeCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the size of the set.
  */
-@Generated("cd3a7639db4f994bd8e80f7f964e3249")
+@Generated("c5e230ea337d9461004c1a1d6916c07d")
 public final class TransactionalSetSizeCodec {
     //hex: 0x100300
     public static final int REQUEST_MESSAGE_TYPE = 1049344;
@@ -105,8 +105,8 @@ public final class TransactionalSetSizeCodec {
     }
 
     /**
-    * The size of the set
-    */
+     * The size of the set
+     */
     public static int decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionClearRemoteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionClearRemoteCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Clears the XA transaction with the given xid from remote member.
  */
-@Generated("803d2dec34203c594d22c43273cd8b3b")
+@Generated("33c80140e7d9a74a56a52bdf30830fd8")
 public final class XATransactionClearRemoteCodec {
     //hex: 0x140100
     public static final int REQUEST_MESSAGE_TYPE = 1310976;
@@ -47,12 +47,6 @@ public final class XATransactionClearRemoteCodec {
 
     private XATransactionClearRemoteCodec() {
     }
-
-    /**
-     * Java XA transaction id as defined in interface javax.transaction.xa.Xid.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public com.hazelcast.transaction.impl.xa.SerializableXID xid;
 
     public static ClientMessage encodeRequest(javax.transaction.xa.Xid xid) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -66,6 +60,9 @@ public final class XATransactionClearRemoteCodec {
         return clientMessage;
     }
 
+    /**
+     * Java XA transaction id as defined in interface javax.transaction.xa.Xid.
+     */
     public static com.hazelcast.transaction.impl.xa.SerializableXID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCollectTransactionsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCollectTransactionsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Obtains a list of prepared transaction from the cluster.
  */
-@Generated("99e777dc5ce62bfa12d0c00f21066b9b")
+@Generated("0c2d80a3df53ca7504b2e0a0ce93e4da")
 public final class XATransactionCollectTransactionsCodec {
     //hex: 0x140200
     public static final int REQUEST_MESSAGE_TYPE = 1311232;
@@ -47,7 +47,6 @@ public final class XATransactionCollectTransactionsCodec {
 
     private XATransactionCollectTransactionsCodec() {
     }
-
 
     public static ClientMessage encodeRequest() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -72,8 +71,8 @@ public final class XATransactionCollectTransactionsCodec {
     }
 
     /**
-    * Array of Xids.
-    */
+     * Array of Xids.
+     */
     public static java.util.List<javax.transaction.xa.Xid> decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionCreateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates an XA transaction with the given parameters.
  */
-@Generated("70278ae8ef7f760acbc1566756b4f443")
+@Generated("f72a30698c197ae5e91800b75b704259")
 public final class XATransactionCreateCodec {
     //hex: 0x140500
     public static final int REQUEST_MESSAGE_TYPE = 1312000;
@@ -97,8 +97,8 @@ public final class XATransactionCreateCodec {
     }
 
     /**
-    * The transaction unique identifier.
-    */
+     * The transaction unique identifier.
+     */
     public static java.util.UUID decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionPrepareCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionPrepareCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Ask a member to prepare for a transaction commit of the transaction specified in xid.
  */
-@Generated("439608f1957af7a9f9de317f35ac3058")
+@Generated("1f1f8afb54a9a659efad555f87cbbb95")
 public final class XATransactionPrepareCodec {
     //hex: 0x140600
     public static final int REQUEST_MESSAGE_TYPE = 1312256;
@@ -48,12 +48,6 @@ public final class XATransactionPrepareCodec {
 
     private XATransactionPrepareCodec() {
     }
-
-    /**
-     * The id of the transaction to prepare.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID transactionId;
 
     public static ClientMessage encodeRequest(java.util.UUID transactionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class XATransactionPrepareCodec {
         return clientMessage;
     }
 
+    /**
+     * The id of the transaction to prepare.
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionRollbackCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/XATransactionRollbackCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Informs the member to roll back work done on behalf of a transaction.
  */
-@Generated("dc9c7e9ff5553adaa612ea43b18e48ee")
+@Generated("1d7f90d4767bb3ed80c1795c01173fd8")
 public final class XATransactionRollbackCodec {
     //hex: 0x140700
     public static final int REQUEST_MESSAGE_TYPE = 1312512;
@@ -48,12 +48,6 @@ public final class XATransactionRollbackCodec {
 
     private XATransactionRollbackCodec() {
     }
-
-    /**
-     * The id of the transaction to rollback.
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public java.util.UUID transactionId;
 
     public static ClientMessage encodeRequest(java.util.UUID transactionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -67,6 +61,9 @@ public final class XATransactionRollbackCodec {
         return clientMessage;
     }
 
+    /**
+     * The id of the transaction to rollback.
+     */
     public static java.util.UUID decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ClientMessage.Frame initialFrame = iterator.next();


### PR DESCRIPTION
…equest params

There were couple of problems with the Javadocs in the codecs.

- There were no blank lines for fields of the ResponseParameters classes.
  This was making it harder to read.
- Javadocs of the decodeResponse methods for single parameter responses
  were not correctly aligned.
- Javadocs for the handleXXEvent methods were not correctly aligned.
- Javadocs of the extended parameters were not correctly aligned.

Apart from the Javadocs, for request parameters that have a single parameter,
we were defining an unused field. This was removed and the documentation of
it is moved to the decodeRequest method. (like what we did for decodeResponse)