### PR TITLE
Add getAndDecrement method to IAtomicLong

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/atomiclong/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/atomiclong/AtomicLongProxy.java
@@ -72,6 +72,11 @@ public class AtomicLongProxy extends ClientProxy implements IAtomicLong {
     }
 
     @Override
+    public long getAndDecrement() {
+        return getAndDecrementAsync().joinInternal();
+    }
+
+    @Override
     public long get() {
         return getAsync().joinInternal();
     }
@@ -138,6 +143,11 @@ public class AtomicLongProxy extends ClientProxy implements IAtomicLong {
     @Override
     public InternalCompletableFuture<Long> decrementAndGetAsync() {
         return addAndGetAsync(-1);
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndDecrementAsync() {
+        return getAndAddAsync(-1);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/IAtomicLong.java
@@ -98,6 +98,13 @@ public interface IAtomicLong extends DistributedObject {
     long decrementAndGet();
 
     /**
+     * Atomically decrements the current value by one.
+     *
+     * @return the old value
+     */
+    long getAndDecrement();
+
+    /**
      * Gets the current value.
      *
      * @return the current value
@@ -241,6 +248,17 @@ public interface IAtomicLong extends DistributedObject {
      * @since 3.7
      */
     CompletionStage<Long> decrementAndGetAsync();
+
+    /**
+     * Atomically decrements the current value by one.
+     * <p>
+     * This method will dispatch a request and return immediately a
+     * {@link CompletionStage}.
+     *
+     * @return a {@link CompletionStage} with the old value
+     * @since 4.1
+     */
+    CompletionStage<Long> getAndDecrementAsync();
 
     /**
      * Gets the current value. This method will dispatch a request and return

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/proxy/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/proxy/AtomicLongProxy.java
@@ -98,6 +98,11 @@ public class AtomicLongProxy implements IAtomicLong {
     }
 
     @Override
+    public long getAndDecrement() {
+        return getAndAdd(-1);
+    }
+
+    @Override
     public long getAndSet(long newValue) {
         return getAndSetAsync(newValue).joinInternal();
     }
@@ -142,6 +147,11 @@ public class AtomicLongProxy implements IAtomicLong {
     @Override
     public InternalCompletableFuture<Long> getAndIncrementAsync() {
         return getAndAddAsync(1);
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndDecrementAsync() {
+        return getAndAddAsync(-1);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/LongRegisterProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/LongRegisterProxy.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
 /**
  * Partially implements {@link IAtomicLong}.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class LongRegisterProxy extends AbstractDistributedObject<LongRegisterService> implements IAtomicLong {
 
     private final String name;
@@ -120,8 +121,18 @@ public class LongRegisterProxy extends AbstractDistributedObject<LongRegisterSer
     }
 
     @Override
+    public long getAndDecrement() {
+        return getAndDecrementAsync().joinInternal();
+    }
+
+    @Override
     public InternalCompletableFuture<Long> decrementAndGetAsync() {
         return addAndGetAsync(-1);
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndDecrementAsync() {
+        return getAndAddAsync(-1);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/ClientLongRegisterProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/ClientLongRegisterProxy.java
@@ -92,6 +92,11 @@ public class ClientLongRegisterProxy extends ClientProxy implements IAtomicLong 
     }
 
     @Override
+    public long getAndDecrement() {
+        return getAndDecrementAsync().join();
+    }
+
+    @Override
     public long get() {
         return getAsync().join();
     }
@@ -124,7 +129,7 @@ public class ClientLongRegisterProxy extends ClientProxy implements IAtomicLong 
     @Override
     public InternalCompletableFuture<Long> addAndGetAsync(long delta) {
         ClientMessage request = LongRegisterAddAndGetCodec.encodeRequest(name, delta);
-        return invokeOnPartitionAsync(request, message -> LongRegisterAddAndGetCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterAddAndGetCodec::decodeResponse);
     }
 
     @Override
@@ -135,37 +140,42 @@ public class ClientLongRegisterProxy extends ClientProxy implements IAtomicLong 
     @Override
     public InternalCompletableFuture<Long> decrementAndGetAsync() {
         ClientMessage request = LongRegisterDecrementAndGetCodec.encodeRequest(name);
-        return invokeOnPartitionAsync(request, message -> LongRegisterDecrementAndGetCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterDecrementAndGetCodec::decodeResponse);
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndDecrementAsync() {
+        return getAndAddAsync(-1);
     }
 
     @Override
     public InternalCompletableFuture<Long> getAsync() {
         ClientMessage request = LongRegisterGetCodec.encodeRequest(name);
-        return invokeOnPartitionAsync(request, message -> LongRegisterGetCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterGetCodec::decodeResponse);
     }
 
     @Override
     public InternalCompletableFuture<Long> getAndAddAsync(long delta) {
         ClientMessage request = LongRegisterGetAndAddCodec.encodeRequest(name, delta);
-        return invokeOnPartitionAsync(request, message -> LongRegisterGetAndAddCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterGetAndAddCodec::decodeResponse);
     }
 
     @Override
     public InternalCompletableFuture<Long> getAndSetAsync(long newValue) {
         ClientMessage request = LongRegisterGetAndSetCodec.encodeRequest(name, newValue);
-        return invokeOnPartitionAsync(request, message -> LongRegisterGetAndSetCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterGetAndSetCodec::decodeResponse);
     }
 
     @Override
     public InternalCompletableFuture<Long> incrementAndGetAsync() {
         ClientMessage request = LongRegisterIncrementAndGetCodec.encodeRequest(name);
-        return invokeOnPartitionAsync(request, message -> LongRegisterIncrementAndGetCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterIncrementAndGetCodec::decodeResponse);
     }
 
     @Override
     public InternalCompletableFuture<Long> getAndIncrementAsync() {
         ClientMessage request = LongRegisterGetAndIncrementCodec.encodeRequest(name);
-        return invokeOnPartitionAsync(request, message -> LongRegisterGetAndIncrementCodec.decodeResponse(message).response);
+        return invokeOnPartitionAsync(request, LongRegisterGetAndIncrementCodec::decodeResponse);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterAddAndGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterAddAndGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically adds the given value to the current value.
  */
-@Generated("63ee4c490a92b62aa7097ac021166042")
+@Generated("65ee3f6c4bf38c3a36a556b802c8b818")
 public final class LongRegisterAddAndGetCodec {
     //hex: 0xFF0100
     public static final int REQUEST_MESSAGE_TYPE = 16711936;
@@ -70,6 +70,7 @@ public final class LongRegisterAddAndGetCodec {
         clientMessage.setOperationName("LongRegister.AddAndGet");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         encodeLong(initialFrame.content, REQUEST_DELTA_FIELD_OFFSET, delta);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
@@ -85,15 +86,6 @@ public final class LongRegisterAddAndGetCodec {
         return request;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * the updated value, the given value added to the current value
-         */
-        public long response;
-    }
-
     public static ClientMessage encodeResponse(long response) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         Frame initialFrame = new Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
@@ -104,12 +96,13 @@ public final class LongRegisterAddAndGetCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * the updated value, the given value added to the current value
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterDecrementAndGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterDecrementAndGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically decrements the current value by one.
  */
-@Generated("06b1e25505f5eacacafd507a42aef6a7")
+@Generated("6c0bf7488b13c5e0dd4b4965dee02044")
 public final class LongRegisterDecrementAndGetCodec {
     //hex: 0xFF0200
     public static final int REQUEST_MESSAGE_TYPE = 16712192;
@@ -49,42 +49,26 @@ public final class LongRegisterDecrementAndGetCodec {
     private LongRegisterDecrementAndGetCodec() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class RequestParameters {
-
-        /**
-         * The name of this IAtomicLong instance.
-         */
-        public String name;
-    }
-
     public static ClientMessage encodeRequest(String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("LongRegister.DecrementAndGet");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
         return clientMessage;
     }
 
-    public static RequestParameters decodeRequest(ClientMessage clientMessage) {
+    /**
+     * The name of this IAtomicLong instance.
+     */
+    public static String decodeRequest(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        RequestParameters request = new RequestParameters();
         //empty initial frame
         iterator.next();
-        request.name = StringCodec.decode(iterator);
-        return request;
-    }
-
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * the updated value, the current value decremented by one
-         */
-        public long response;
+        return StringCodec.decode(iterator);
     }
 
     public static ClientMessage encodeResponse(long response) {
@@ -97,12 +81,13 @@ public final class LongRegisterDecrementAndGetCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * the updated value, the current value decremented by one
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetAndAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetAndAddCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically adds the given value to the current value.
  */
-@Generated("a69747a6bca0280c517d30cd0806d3db")
+@Generated("0c3bf5e90896133c417017c37bc08918")
 public final class LongRegisterGetAndAddCodec {
     //hex: 0xFF0400
     public static final int REQUEST_MESSAGE_TYPE = 16712704;
@@ -70,6 +70,7 @@ public final class LongRegisterGetAndAddCodec {
         clientMessage.setOperationName("LongRegister.GetAndAdd");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         encodeLong(initialFrame.content, REQUEST_DELTA_FIELD_OFFSET, delta);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
@@ -85,15 +86,6 @@ public final class LongRegisterGetAndAddCodec {
         return request;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * the old value before the add
-         */
-        public long response;
-    }
-
     public static ClientMessage encodeResponse(long response) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         Frame initialFrame = new Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
@@ -104,12 +96,13 @@ public final class LongRegisterGetAndAddCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * the old value before the add
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetAndIncrementCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetAndIncrementCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically increments the current value by one.
  */
-@Generated("5c2d18c80266a065c81468df2669822c")
+@Generated("86fb25d4be75a2ef92e1720f1fff3f43")
 public final class LongRegisterGetAndIncrementCodec {
     //hex: 0xFF0700
     public static final int REQUEST_MESSAGE_TYPE = 16713472;
@@ -49,42 +49,26 @@ public final class LongRegisterGetAndIncrementCodec {
     private LongRegisterGetAndIncrementCodec() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class RequestParameters {
-
-        /**
-         * The name of this IAtomicLong instance.
-         */
-        public String name;
-    }
-
     public static ClientMessage encodeRequest(String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("LongRegister.GetAndIncrement");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
         return clientMessage;
     }
 
-    public static RequestParameters decodeRequest(ClientMessage clientMessage) {
+    /**
+     * The name of this IAtomicLong instance.
+     */
+    public static String decodeRequest(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        RequestParameters request = new RequestParameters();
         //empty initial frame
         iterator.next();
-        request.name = StringCodec.decode(iterator);
-        return request;
-    }
-
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * the old value
-         */
-        public long response;
+        return StringCodec.decode(iterator);
     }
 
     public static ClientMessage encodeResponse(long response) {
@@ -97,12 +81,13 @@ public final class LongRegisterGetAndIncrementCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * the old value
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetAndSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value and returns the old value.
  */
-@Generated("5657e74606bdb08f6f16d420e66c5617")
+@Generated("c2546a8c104310f2093f20dc2fc54743")
 public final class LongRegisterGetAndSetCodec {
     //hex: 0xFF0500
     public static final int REQUEST_MESSAGE_TYPE = 16712960;
@@ -70,6 +70,7 @@ public final class LongRegisterGetAndSetCodec {
         clientMessage.setOperationName("LongRegister.GetAndSet");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         encodeLong(initialFrame.content, REQUEST_NEW_VALUE_FIELD_OFFSET, newValue);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
@@ -85,15 +86,6 @@ public final class LongRegisterGetAndSetCodec {
         return request;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * the old value
-         */
-        public long response;
-    }
-
     public static ClientMessage encodeResponse(long response) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         Frame initialFrame = new Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
@@ -104,12 +96,13 @@ public final class LongRegisterGetAndSetCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * the old value
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Gets the current value.
  */
-@Generated("e012ce352f54e23f8d9f5763b284e82f")
+@Generated("d53796c3d0c3f13fc3da807d388ba2a8")
 public final class LongRegisterGetCodec {
     //hex: 0xFF0300
     public static final int REQUEST_MESSAGE_TYPE = 16712448;
@@ -49,42 +49,26 @@ public final class LongRegisterGetCodec {
     private LongRegisterGetCodec() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class RequestParameters {
-
-        /**
-         * The name of this IAtomicLong instance.
-         */
-        public String name;
-    }
-
     public static ClientMessage encodeRequest(String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("LongRegister.Get");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
         return clientMessage;
     }
 
-    public static RequestParameters decodeRequest(ClientMessage clientMessage) {
+    /**
+     * The name of this IAtomicLong instance.
+     */
+    public static String decodeRequest(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        RequestParameters request = new RequestParameters();
         //empty initial frame
         iterator.next();
-        request.name = StringCodec.decode(iterator);
-        return request;
-    }
-
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * the current value
-         */
-        public long response;
+        return StringCodec.decode(iterator);
     }
 
     public static ClientMessage encodeResponse(long response) {
@@ -97,12 +81,13 @@ public final class LongRegisterGetCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * the current value
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterIncrementAndGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterIncrementAndGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically increments the current value by one.
  */
-@Generated("8d4aa7d0a89a750a3481a9a8607f874b")
+@Generated("cfe7398bb6c9695b6bd92c0b126ddebc")
 public final class LongRegisterIncrementAndGetCodec {
     //hex: 0xFF0600
     public static final int REQUEST_MESSAGE_TYPE = 16713216;
@@ -49,42 +49,26 @@ public final class LongRegisterIncrementAndGetCodec {
     private LongRegisterIncrementAndGetCodec() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class RequestParameters {
-
-        /**
-         * The name of this IAtomicLong instance.
-         */
-        public String name;
-    }
-
     public static ClientMessage encodeRequest(String name) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("LongRegister.IncrementAndGet");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
         return clientMessage;
     }
 
-    public static RequestParameters decodeRequest(ClientMessage clientMessage) {
+    /**
+     * The name of this IAtomicLong instance.
+     */
+    public static String decodeRequest(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        RequestParameters request = new RequestParameters();
         //empty initial frame
         iterator.next();
-        request.name = StringCodec.decode(iterator);
-        return request;
-    }
-
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-
-        /**
-         * The updated value, the current value incremented by one
-         */
-        public long response;
+        return StringCodec.decode(iterator);
     }
 
     public static ClientMessage encodeResponse(long response) {
@@ -97,12 +81,13 @@ public final class LongRegisterIncrementAndGetCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
+    /**
+     * The updated value, the current value incremented by one
+     */
+    public static long decodeResponse(ClientMessage clientMessage) {
         ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
         Frame initialFrame = iterator.next();
-        response.response = decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
-        return response;
+        return decodeLong(initialFrame.content, RESPONSE_RESPONSE_FIELD_OFFSET);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/codec/LongRegisterSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value.
  */
-@Generated("7b2f85ec4327845874fb1002f23aa63e")
+@Generated("2df89e075f17f86b529aeb6402e8adcc")
 public final class LongRegisterSetCodec {
     //hex: 0xFF0800
     public static final int REQUEST_MESSAGE_TYPE = 16713728;
@@ -69,6 +69,7 @@ public final class LongRegisterSetCodec {
         clientMessage.setOperationName("LongRegister.Set");
         Frame initialFrame = new Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
+        encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
         encodeLong(initialFrame.content, REQUEST_NEW_VALUE_FIELD_OFFSET, newValue);
         clientMessage.add(initialFrame);
         StringCodec.encode(clientMessage, name);
@@ -84,10 +85,6 @@ public final class LongRegisterSetCodec {
         return request;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-    public static class ResponseParameters {
-    }
-
     public static ClientMessage encodeResponse() {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         Frame initialFrame = new Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
@@ -97,12 +94,5 @@ public final class LongRegisterSetCodec {
         return clientMessage;
     }
 
-    public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
-        ForwardFrameIterator iterator = clientMessage.frameIterator();
-        ResponseParameters response = new ResponseParameters();
-        //empty initial frame
-        iterator.next();
-        return response;
-    }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterDecrementAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterDecrementAndGetMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.security.Permission;
 
 public class LongRegisterDecrementAndGetMessageTask
-        extends AbstractPartitionMessageTask<LongRegisterDecrementAndGetCodec.RequestParameters> {
+        extends AbstractPartitionMessageTask<String> {
 
     public LongRegisterDecrementAndGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -38,11 +38,11 @@ public class LongRegisterDecrementAndGetMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new AddAndGetOperation(parameters.name, -1);
+        return new AddAndGetOperation(parameters, -1);
     }
 
     @Override
-    protected LongRegisterDecrementAndGetCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+    protected String decodeClientMessage(ClientMessage clientMessage) {
         return LongRegisterDecrementAndGetCodec.decodeRequest(clientMessage);
     }
 
@@ -58,12 +58,12 @@ public class LongRegisterDecrementAndGetMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return new AtomicLongPermission(parameters.name, ActionConstants.ACTION_MODIFY);
+        return new AtomicLongPermission(parameters, ActionConstants.ACTION_MODIFY);
     }
 
     @Override
     public String getDistributedObjectName() {
-        return parameters.name;
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterGetAndIncrementMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterGetAndIncrementMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.security.Permission;
 
 public class LongRegisterGetAndIncrementMessageTask
-        extends AbstractPartitionMessageTask<LongRegisterGetAndIncrementCodec.RequestParameters> {
+        extends AbstractPartitionMessageTask<String> {
 
     public LongRegisterGetAndIncrementMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -38,11 +38,11 @@ public class LongRegisterGetAndIncrementMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new GetAndAddOperation(parameters.name, 1);
+        return new GetAndAddOperation(parameters, 1);
     }
 
     @Override
-    protected LongRegisterGetAndIncrementCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+    protected String decodeClientMessage(ClientMessage clientMessage) {
         return LongRegisterGetAndIncrementCodec.decodeRequest(clientMessage);
     }
 
@@ -58,12 +58,12 @@ public class LongRegisterGetAndIncrementMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return new AtomicLongPermission(parameters.name, ActionConstants.ACTION_MODIFY);
+        return new AtomicLongPermission(parameters, ActionConstants.ACTION_MODIFY);
     }
 
     @Override
     public String getDistributedObjectName() {
-        return parameters.name;
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterGetMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.security.Permission;
 
 public class LongRegisterGetMessageTask
-        extends AbstractPartitionMessageTask<LongRegisterGetCodec.RequestParameters> {
+        extends AbstractPartitionMessageTask<String> {
 
     public LongRegisterGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -38,11 +38,11 @@ public class LongRegisterGetMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new GetOperation(parameters.name);
+        return new GetOperation(parameters);
     }
 
     @Override
-    protected LongRegisterGetCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+    protected String decodeClientMessage(ClientMessage clientMessage) {
         return LongRegisterGetCodec.decodeRequest(clientMessage);
     }
 
@@ -58,12 +58,12 @@ public class LongRegisterGetMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return new AtomicLongPermission(parameters.name, ActionConstants.ACTION_READ);
+        return new AtomicLongPermission(parameters, ActionConstants.ACTION_READ);
     }
 
     @Override
     public String getDistributedObjectName() {
-        return parameters.name;
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterIncrementAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/client/task/LongRegisterIncrementAndGetMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.security.Permission;
 
 public class LongRegisterIncrementAndGetMessageTask
-        extends AbstractPartitionMessageTask<LongRegisterIncrementAndGetCodec.RequestParameters> {
+        extends AbstractPartitionMessageTask<String> {
 
     public LongRegisterIncrementAndGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -38,11 +38,11 @@ public class LongRegisterIncrementAndGetMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new AddAndGetOperation(parameters.name, 1);
+        return new AddAndGetOperation(parameters, 1);
     }
 
     @Override
-    protected LongRegisterIncrementAndGetCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+    protected String decodeClientMessage(ClientMessage clientMessage) {
         return LongRegisterIncrementAndGetCodec.decodeRequest(clientMessage);
     }
 
@@ -58,12 +58,12 @@ public class LongRegisterIncrementAndGetMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return new AtomicLongPermission(parameters.name, ActionConstants.ACTION_MODIFY);
+        return new AtomicLongPermission(parameters, ActionConstants.ACTION_MODIFY);
     }
 
     @Override
     public String getDistributedObjectName() {
-        return parameters.name;
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomiclong/AbstractAtomicLongBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomiclong/AbstractAtomicLongBasicTest.java
@@ -78,9 +78,21 @@ public abstract class AbstractAtomicLongBasicTest extends HazelcastRaftTestSuppo
     }
 
     @Test
+    public void testGetAndDecrement() {
+        assertEquals(0, atomicLong.getAndDecrement());
+        assertEquals(-1, atomicLong.getAndDecrement());
+    }
+
+    @Test
     public void testIncrementAndGet() {
         assertEquals(1, atomicLong.incrementAndGet());
         assertEquals(2, atomicLong.incrementAndGet());
+    }
+
+    @Test
+    public void testGetAndIncrement() {
+        assertEquals(0, atomicLong.getAndIncrement());
+        assertEquals(1, atomicLong.getAndIncrement());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/longregister/LongRegisterAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/longregister/LongRegisterAbstractTest.java
@@ -58,9 +58,21 @@ public abstract class LongRegisterAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testGetAndDecrement() {
+        assertEquals(0, longRegister.getAndDecrement());
+        assertEquals(-1, longRegister.getAndDecrement());
+    }
+
+    @Test
     public void testIncrementAndGet() {
         assertEquals(1, longRegister.incrementAndGet());
         assertEquals(2, longRegister.incrementAndGet());
+    }
+
+    @Test
+    public void testGetAndIncrement() {
+        assertEquals(0, longRegister.getAndIncrement());
+        assertEquals(1, longRegister.getAndIncrement());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/longregister/client/ClientLongRegisterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/longregister/client/ClientLongRegisterTest.java
@@ -64,7 +64,8 @@ public class ClientLongRegisterTest extends HazelcastTestSupport {
         assertEquals(7, longRegister.decrementAndGet());
         assertEquals(7, longRegister.getAndIncrement());
         assertEquals(8, longRegister.getAndSet(9));
-        assertEquals(10, longRegister.incrementAndGet());
+        assertEquals(9, longRegister.getAndDecrement());
+        assertEquals(9, longRegister.incrementAndGet());
     }
 
     @Test


### PR DESCRIPTION
There were getAndDoX and doXAndGet method pairs for the IAtomicLong
but there were just the decrementAndGet, getAndDecrement was missing.
One may do getAndAdd(-1) to get the desired behaviour, so there were
no missing functionality but the getAndDecrement method is added to
make the API more consistent.

Also, updated the codecs and message tasks of the LongRegister with
the recent changes.