### PR TITLE
[BACKPORT-4.0.z] - Release acquired FencedLock sessions before throwing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractFencedLockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractFencedLockProxy.java
@@ -101,6 +101,7 @@ public abstract class AbstractFencedLockProxy extends SessionAwareProxy implemen
                 throw new IllegalMonitorStateException("Lock[" + objectName + "] not acquired because the lock call "
                         + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
             } catch (Throwable t) {
+                releaseSession(sessionId);
                 if (t instanceof InterruptedException) {
                     throw (InterruptedException) t;
                 } else {
@@ -134,6 +135,9 @@ public abstract class AbstractFencedLockProxy extends SessionAwareProxy implemen
                 releaseSession(sessionId);
                 throw new IllegalMonitorStateException("Lock[" + objectName + "] not acquired because the lock call "
                         + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
+            } catch (Throwable t) {
+                releaseSession(sessionId);
+                throw rethrow(t);
             }
         }
     }
@@ -188,6 +192,9 @@ public abstract class AbstractFencedLockProxy extends SessionAwareProxy implemen
                 if (timeoutMillis <= 0) {
                     return INVALID_FENCE;
                 }
+            } catch (Throwable t) {
+                releaseSession(sessionId);
+                throw rethrow(t);
             }
         }
     }


### PR DESCRIPTION
Even if the calls to the lock, lockInterruptibly or tryLock
(or other variants of these methods) fail for some reason other than
SessionExpiredException or WaitKeyCancelledException, we were not
releasing the sessions we acquired in the beginning, before throwing
the exception. This fix aims to solve this problem by catching all
kinds of exceptions (other than the two mentioned above), releasing
the session and then rethrowing the catched exception.