### PR TITLE
[BACKPORT-3.12.z] - Release acquired FencedLock sessions before throwing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractRaftFencedLockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractRaftFencedLockProxy.java
@@ -100,6 +100,7 @@ public abstract class AbstractRaftFencedLockProxy extends SessionAwareProxy impl
                 releaseSession(sessionId);
                 throw new IllegalMonitorStateException("Lock[" + proxyName + "] not acquired because its wait is cancelled!");
             } catch (Throwable t) {
+                releaseSession(sessionId);
                 if (t instanceof InterruptedException) {
                     throw (InterruptedException) t;
                 } else {
@@ -132,6 +133,9 @@ public abstract class AbstractRaftFencedLockProxy extends SessionAwareProxy impl
             } catch (WaitKeyCancelledException e) {
                 releaseSession(sessionId);
                 throw new IllegalMonitorStateException("Lock[" + proxyName + "] not acquired because its wait is cancelled!");
+            } catch (Throwable t) {
+                releaseSession(sessionId);
+                throw rethrow(t);
             }
         }
     }
@@ -186,6 +190,9 @@ public abstract class AbstractRaftFencedLockProxy extends SessionAwareProxy impl
                 if (timeoutMillis <= 0) {
                     return INVALID_FENCE;
                 }
+            } catch (Throwable t) {
+                releaseSession(sessionId);
+                throw rethrow(t);
             }
         }
     }


### PR DESCRIPTION
Even if the calls to the lock, lockInterruptibly or tryLock
(or other variants of these methods) fail for some reason other than
SessionExpiredException or WaitKeyCancelledException, we were not
releasing the sessions we acquired in the beginning, before throwing
the exception. This fix aims to solve this problem by catching all
kinds of exceptions (other than the two mentioned above), releasing
the session and then rethrowing the catched exception.