### PR TITLE
Changed should to must in exception messages

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
@@ -126,7 +126,7 @@ public class HazelcastCacheManager implements CacheManager {
         String key = keyValue[0].trim();
         String value = (keyValue.length == 1) ? null : keyValue[1].trim();
 
-        isTrue(value != null && !value.isEmpty(), String.format("value for %s should not be null or empty", key));
+        isTrue(value != null && !value.isEmpty(), String.format("value for %s must not be null or empty", key));
 
         if ("defaultReadTimeout".equals(key)) {
             defaultReadTimeout = Long.parseLong(value);

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/QueryCacheYamlConfigBuilderHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/QueryCacheYamlConfigBuilderHelper.java
@@ -80,7 +80,7 @@ final class QueryCacheYamlConfigBuilderHelper extends AbstractQueryCacheConfigBu
         }
 
         if (classNameNode == null && sqlNode == null) {
-            throw new InvalidConfigurationException("Either class-name and sql should be defined for the predicate of map "
+            throw new InvalidConfigurationException("Either class-name and sql must be defined for the predicate of map "
                     + childNode.getParentNode().getParentNode().getNodeName());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientFailoverDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientFailoverDomConfigProcessor.java
@@ -49,7 +49,7 @@ public class YamlClientFailoverDomConfigProcessor extends ClientFailoverDomConfi
 
         if (!clientConfigDefined) {
             String path = ((YamlElementAdapter) node).getYamlNode().path();
-            throw new InvalidConfigurationException(String.format("At least one client configuration should be defined "
+            throw new InvalidConfigurationException(String.format("At least one client configuration must be defined "
                     + "under '%s'", path));
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -86,7 +86,7 @@ public final class FailoverClientConfigSupport {
     }
 
     /**
-     * For a client to be valid alternative, all configurations should be equal except
+     * For a client to be valid alternative, all configurations must be equal except
      * Cluster name
      * SecurityConfig
      * Discovery related parts of NetworkConfig
@@ -97,7 +97,7 @@ public final class FailoverClientConfigSupport {
      */
     private static void checkValidAlternative(List<ClientConfig> alternativeClientConfigs) {
         if (alternativeClientConfigs.isEmpty()) {
-            throw new InvalidConfigurationException("ClientFailoverConfig should have at least one client config.");
+            throw new InvalidConfigurationException("ClientFailoverConfig must have at least one client config.");
         }
         ClientConfig mainConfig = alternativeClientConfigs.get(0);
         for (ClientConfig alternativeClientConfig : alternativeClientConfigs.subList(1, alternativeClientConfigs.size())) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -339,7 +339,7 @@ public class ClientExceptionFactory {
         Throwable throwable = null;
         if (exceptionFactory == null) {
             String className = errorHolder.getClassName();
-            assert checkClassNameForValidity(className) : "Exception should be defined in the protocol : " + className;
+            assert checkClassNameForValidity(className) : "Exception must be defined in the protocol : " + className;
             try {
                 Class<? extends Throwable> exceptionClass =
                         (Class<? extends Throwable>) ClassLoaderUtil.loadClass(classLoader, className);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -169,7 +169,7 @@ public class MapStoreConfig implements IdentifiedDataSerializable {
      */
     public MapStoreConfig setWriteBatchSize(int writeBatchSize) {
         if (writeBatchSize < 1) {
-            throw new IllegalArgumentException("Write batch size should be at least 1");
+            throw new IllegalArgumentException("Write batch size must be at least 1");
         }
         this.writeBatchSize = writeBatchSize;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommandProcessor.java
@@ -85,6 +85,6 @@ public class BulkGetCommandProcessor extends MemcacheCommandProcessor<BulkGetCom
 
     @Override
     public void handleRejection(BulkGetCommand request) {
-        throw new UnsupportedOperationException("not used, this method should be removed from the interface");
+        throw new UnsupportedOperationException("not used, remove this method from the interface");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -152,11 +152,11 @@ public class HttpPostCommand extends HttpCommand {
     }
 
     private void readLF(ByteBuffer cb) {
-        assert cb.hasRemaining() : "'\\n' should follow '\\r'";
+        assert cb.hasRemaining() : "'\\n' must follow '\\r'";
 
         byte b = cb.get();
         if (b != LINE_FEED) {
-            throw new IllegalStateException("'\\n' should follow '\\r', but got '" + (char) b + "'");
+            throw new IllegalStateException("'\\n' must follow '\\r', but got '" + (char) b + "'");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -931,7 +931,7 @@ public class ClusterJoinManager {
         String targetAddressStr = "[" + targetAddress.getHost() + "]:" + targetAddress.getPort();
 
         if (thisAddressStr.equals(targetAddressStr)) {
-            throw new IllegalArgumentException("Addresses should be different! This: "
+            throw new IllegalArgumentException("Addresses must be different! This: "
                     + thisAddress + ", Target: " + targetAddress);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -64,7 +64,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         super(node);
         int tryCount = node.getProperties().getInteger(ClusterProperty.TCP_JOIN_PORT_TRY_COUNT);
         if (tryCount <= 0) {
-            throw new IllegalArgumentException(String.format("%s should be greater than zero! Current value: %d",
+            throw new IllegalArgumentException(String.format("%s must be greater than zero! Current value: %d",
                     ClusterProperty.TCP_JOIN_PORT_TRY_COUNT, tryCount));
         }
         maxPortTryCount = tryCount;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -449,7 +449,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
         }
 
         if (classNameNode == null && sqlNode == null) {
-            throw new InvalidConfigurationException("Either class-name and sql should be defined for the predicate of map "
+            throw new InvalidConfigurationException("Either class-name and sql must be defined for the predicate of map "
                     + childNode.getParentNode().getParentNode().getNodeName());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/json/NonTerminalJsonValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/NonTerminalJsonValue.java
@@ -33,6 +33,6 @@ public class NonTerminalJsonValue extends JsonValue {
 
     @Override
     void write(JsonWriter writer) throws IOException {
-        throw new HazelcastException("This object should not be encoded");
+        throw new HazelcastException("This object must not be encoded");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -435,7 +435,7 @@ public final class ClassLoaderUtil {
          */
         @SuppressWarnings("checkstyle:RedundantModifier")
         public IrresolvableConstructor() {
-            throw new UnsupportedOperationException("Irresolvable constructor should never be instantiated.");
+            throw new UnsupportedOperationException("Irresolvable constructor must never be instantiated.");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -146,7 +146,7 @@ public class PartitionServiceProxy implements PartitionService {
     @Override
     public boolean isMemberSafe(Member member) {
         if (member == null) {
-            throw new NullPointerException("Parameter member should not be null");
+            throw new NullPointerException("Parameter member must not be null");
         }
         final Member localMember = nodeEngine.getLocalMember();
         if (localMember.equals(member)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckPartitionReplicaVersionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckPartitionReplicaVersionTask.java
@@ -37,7 +37,7 @@ final class CheckPartitionReplicaVersionTask extends AbstractPartitionPrimaryRep
                                      BiConsumer<Object, Throwable> callback) {
         super(nodeEngine, partitionId);
         if (replicaIndex < 1 || replicaIndex > InternalPartition.MAX_BACKUP_COUNT) {
-            throw new IllegalArgumentException("Replica index should be in range [1-"
+            throw new IllegalArgumentException("Replica index must be in range [1-"
                     + InternalPartition.MAX_BACKUP_COUNT + "]");
         }
         this.replicaIndex = replicaIndex;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1316,7 +1316,7 @@ public class MigrationManager {
                     && migration.getDestinationCurrentReplicaIndex() > 0
                     && migration.getDestinationNewReplicaIndex() == 0) {
 
-                throw new IllegalStateException("Promotion migrations should be handled by "
+                throw new IllegalStateException("Promotion migrations must be handled by "
                         + RepairPartitionTableTask.class.getSimpleName() + " -> " + migration);
             }
 
@@ -1603,7 +1603,7 @@ public class MigrationManager {
                     && migrationInfo.getDestinationCurrentReplicaIndex() > 0
                     && migrationInfo.getDestinationNewReplicaIndex() == 0) {
 
-                throw new AssertionError("Promotion migrations should be handled by "
+                throw new AssertionError("Promotion migrations must be handled by "
                         + RepairPartitionTableTask.class.getSimpleName() + "! -> " + migrationInfo);
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
@@ -280,7 +280,7 @@ public final class Preconditions {
     public static <E> E checkInstanceOf(Class<E> type, Object object) {
         isNotNull(type, "type");
         if (!type.isInstance(object)) {
-            throw new IllegalArgumentException(object + " should be instanceof " + type.getName());
+            throw new IllegalArgumentException(object + " must be instanceof " + type.getName());
         }
         return (E) object;
     }
@@ -369,4 +369,3 @@ public final class Preconditions {
         }
     }
 }
-

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
@@ -76,27 +76,27 @@ public final class MapStoreContextFactory {
 
         @Override
         public SerializationService getSerializationService() {
-            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+            throw new UnsupportedOperationException("This method must not be called. No defined map store exists.");
         }
 
         @Override
         public ILogger getLogger(Class clazz) {
-            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+            throw new UnsupportedOperationException("This method must not be called. No defined map store exists.");
         }
 
         @Override
         public String getMapName() {
-            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+            throw new UnsupportedOperationException("This method must not be called. No defined map store exists.");
         }
 
         @Override
         public MapServiceContext getMapServiceContext() {
-            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+            throw new UnsupportedOperationException("This method must not be called. No defined map store exists.");
         }
 
         @Override
         public MapStoreConfig getMapStoreConfig() {
-            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+            throw new UnsupportedOperationException("This method must not be called. No defined map store exists.");
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
@@ -213,7 +213,7 @@ public final class ConverterCache {
 
         @Override
         public Comparable convert(Comparable value) {
-            throw new UnsupportedOperationException("should never be called");
+            throw new UnsupportedOperationException("must never be called");
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -74,7 +74,7 @@ public class PagingPredicateImpl<K, V>
      */
     public PagingPredicateImpl(int pageSize) {
         if (pageSize <= 0) {
-            throw new IllegalArgumentException("pageSize should be greater than 0!");
+            throw new IllegalArgumentException("pageSize must be greater than 0!");
         }
         this.pageSize = pageSize;
         anchorList = new ArrayList<>();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -348,7 +348,7 @@ public class SqlPredicate
             compoundPredicate.setPredicates(predicates);
             return compoundPredicate;
         } catch (InstantiationException | IllegalAccessException e) {
-            throw new IllegalArgumentException(String.format("%s should have a public default constructor", klass.getName()));
+            throw new IllegalArgumentException(String.format("%s must have a public default constructor", klass.getName()));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -180,7 +180,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     public <T, E> RingbufferContainer<T, E> getOrCreateContainer(int partitionId, ObjectNamespace namespace,
                                                                  RingbufferConfig config) {
         if (config == null) {
-            throw new NullPointerException("Ringbuffer config should not be null when ringbuffer is being created");
+            throw new NullPointerException("Ringbuffer config must not be null when ringbuffer is being created");
         }
         final Map<ObjectNamespace, RingbufferContainer> partitionContainers = getOrCreateRingbufferContainers(partitionId);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -277,7 +277,7 @@ final class OperationBackupHandler {
     private Operation getBackupOperation(BackupAwareOperation backupAwareOp) {
         Operation backupOp = backupAwareOp.getBackupOperation();
         if (backupOp == null) {
-            throw new IllegalArgumentException("Backup operation should not be null! " + backupAwareOp);
+            throw new IllegalArgumentException("Backup operation must not be null! " + backupAwareOp);
         }
         if (ASSERTION_ENABLED) {
             checkServiceNamespaces(backupAwareOp, backupOp);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
@@ -106,7 +106,7 @@ public class DistributedObjectFuture {
 
     void set(DistributedObject o, boolean initialized) {
         if (o == null) {
-            throw new IllegalArgumentException("Proxy should not be null!");
+            throw new IllegalArgumentException("Proxy must not be null!");
         }
         synchronized (this) {
             if (error == null) {
@@ -122,7 +122,7 @@ public class DistributedObjectFuture {
 
     void setError(Throwable t) {
         if (t == null) {
-            throw new IllegalArgumentException("Error should not be null!");
+            throw new IllegalArgumentException("Error must not be null!");
         }
         if (proxy != null) {
             throw new IllegalStateException("Proxy is already set! Proxy: " + proxy + ", error: " + t);

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
@@ -189,7 +189,7 @@ public final class SqlStatement {
     @Nonnull
     public SqlStatement setTimeoutMillis(long timeout) {
         if (timeout < 0 && timeout != TIMEOUT_NOT_SET) {
-            throw new IllegalArgumentException("Timeout should be non-negative or -1: " + timeout);
+            throw new IllegalArgumentException("Timeout must be non-negative or -1: " + timeout);
         }
 
         this.timeout = timeout;
@@ -230,7 +230,7 @@ public final class SqlStatement {
     @Nonnull
     public SqlStatement setCursorBufferSize(int cursorBufferSize) {
         if (cursorBufferSize <= 0) {
-            throw new IllegalArgumentException("Cursor buffer size should be positive: " + cursorBufferSize);
+            throw new IllegalArgumentException("Cursor buffer size must be positive: " + cursorBufferSize);
         }
 
         this.cursorBufferSize = cursorBufferSize;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/NullConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/NullConverter.java
@@ -49,77 +49,77 @@ public final class NullConverter extends Converter {
 
     @Override
     public boolean asBoolean(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public byte asTinyint(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public short asSmallint(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public int asInt(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public long asBigint(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public BigDecimal asDecimal(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public float asReal(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public double asDouble(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public String asVarchar(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public LocalDate asDate(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public LocalTime asTime(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public LocalDateTime asTimestamp(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public OffsetDateTime asTimestampWithTimezone(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public Object asObject(Object val) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
     @Override
     public Object convertToSelf(Converter converter, Object value) {
-        throw new UnsupportedOperationException("should never be called");
+        throw new UnsupportedOperationException("must never be called");
     }
 
 }


### PR DESCRIPTION
Resolves #11723

Replaced the word 'should' with (in most cases) 'must' in exception messages. This is to improve user focus and to indicate obligation rather than advice.