### PR TITLE
SQL: Do not clear query handles during split brain recovery

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlInternalService.java
@@ -111,16 +111,12 @@ public class SqlInternalService {
         stateRegistryUpdater.start();
     }
 
-    public void reset() {
-        stateRegistry.reset();
-        clientStateRegistry.reset();
-    }
-
     public void shutdown() {
-        stateRegistryUpdater.stop();
-        operationHandler.stop();
+        stateRegistryUpdater.shutdown();
+        operationHandler.shutdown();
 
-        reset();
+        stateRegistry.shutdown();
+        clientStateRegistry.shutdown();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -151,9 +151,6 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
         if (jetSqlCoreBackend != null) {
             jetSqlCoreBackend.reset();
         }
-        if (internalService != null) {
-            internalService.reset();
-        }
     }
 
     public void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryOperationHandlerImpl.java
@@ -89,7 +89,7 @@ public class QueryOperationHandlerImpl implements QueryOperationHandler, QuerySt
         );
     }
 
-    public void stop() {
+    public void shutdown() {
         fragmentPool.stop();
         operationPool.stop();
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
@@ -160,7 +160,7 @@ public class QueryClientStateRegistry {
         }
     }
 
-    public void reset() {
+    public void shutdown() {
         clientCursors.clear();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateRegistry.java
@@ -130,14 +130,7 @@ public class QueryStateRegistry {
         states.remove(queryId);
     }
 
-    /**
-     * Clears the registry. The method is called in case of recovery from the split brain.
-     * <p>
-     *  No additional precautions (such as forceful completion of already running queries) are needed, because a new ID
-     *  is assigned to the local member, and a member with the previous ID is declared dead. As a result,
-     *  {@link QueryStateRegistryUpdater} will detect that old queries have missing members, and will cancel them.
-     */
-    public void reset() {
+    public void shutdown() {
         states.clear();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateRegistryUpdater.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryStateRegistryUpdater.java
@@ -74,7 +74,7 @@ public class QueryStateRegistryUpdater {
         worker.start();
     }
 
-    public void stop() {
+    public void shutdown() {
         worker.stop();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationChannelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/operation/QueryOperationChannelTest.java
@@ -54,7 +54,7 @@ public class QueryOperationChannelTest extends SqlTestSupport {
     @After
     public void after() {
         if (operationHandler != null) {
-            operationHandler.stop();
+            operationHandler.shutdown();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/state/QueryStateRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/state/QueryStateRegistryTest.java
@@ -104,39 +104,6 @@ public class QueryStateRegistryTest extends SqlTestSupport {
         assertFalse(state.isInitiator());
     }
 
-    @Test
-    public void testClear() {
-        QueryStateRegistry registry = new QueryStateRegistry(TestClockProvider.createDefault());
-
-        QueryStateCompletionCallback completionCallback = new TestQueryStateCompletionCallback();
-
-        QueryId queryId = QueryId.create(UUID.randomUUID());
-
-        // Test clear on completion.
-        QueryState state = registry.onDistributedQueryStarted(UUID.randomUUID(), queryId, completionCallback);
-
-        assertEquals(1, registry.getStates().size());
-        assertSame(state, registry.getStates().iterator().next());
-        assertSame(state, registry.getState(state.getQueryId()));
-
-        registry.onQueryCompleted(queryId);
-
-        assertNull(registry.getState(queryId));
-        assertTrue(registry.getStates().isEmpty());
-
-        // Test clear on reset.
-        state = registry.onDistributedQueryStarted(UUID.randomUUID(), queryId, completionCallback);
-
-        assertEquals(1, registry.getStates().size());
-        assertSame(state, registry.getStates().iterator().next());
-        assertSame(state, registry.getState(state.getQueryId()));
-
-        registry.reset();
-
-        assertNull(registry.getState(queryId));
-        assertTrue(registry.getStates().isEmpty());
-    }
-
     private static class TestQueryStateCompletionCallback implements QueryStateCompletionCallback {
         @Override
         public void onCompleted(QueryId queryId) {


### PR DESCRIPTION
This PR fixes the hang observed during the split-brain testing in #17706. Before the fix, we had an incorrect implementation of the `reset` routine invoked during cluster merge: we cleared existing query handles without invoking cancellation on them. As a result, the user ended up with an unregistered handle that can never complete.

After the fix, we do not clear query handles on `reset`. Instead, we rely on the `QueryStateRegistryUpdater` to eventually detect that some members have new IDs, and cancel affected handles properly. Basically, the fix is to remove the `reset` routine completely, because it was implemented incorrectly, and the existing mechanisms are sufficient to ensure that problematic queries are canceled.

Note that the same hang could occur during member shutdown. It will be fixed separately in #17714

Closes #17706 