### PR TITLE
SQL: Fix memory leak in the client handler

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlClientCursorCleanup.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlClientCursorCleanup.java
@@ -49,7 +49,7 @@ public class SqlClientCursorCleanup extends SqlTestSupport {
     private static final String MAP_NAME = "map";
     private static final int KEY_COUNT = 10000;
 
-    private static volatile boolean FAIL;
+    private static volatile boolean fail;
 
     private final SqlTestInstanceFactory factory = SqlTestInstanceFactory.create();
 
@@ -73,7 +73,7 @@ public class SqlClientCursorCleanup extends SqlTestSupport {
 
     @After
     public void after() {
-        FAIL = false;
+        fail = false;
 
         factory.shutdownAll();
 
@@ -83,7 +83,7 @@ public class SqlClientCursorCleanup extends SqlTestSupport {
 
     @Test
     public void testExceptionOnExecute() {
-        FAIL = true;
+        fail = true;
 
         try {
             SqlResult result = client.getSql().execute("SELECT * FROM " + MAP_NAME);
@@ -103,7 +103,7 @@ public class SqlClientCursorCleanup extends SqlTestSupport {
         try {
             SqlResult result = client.getSql().execute("SELECT * FROM " + MAP_NAME);
 
-            FAIL = true;
+            fail = true;
 
             for (SqlRow ignore : result) {
                 // No-op.
@@ -130,7 +130,7 @@ public class SqlClientCursorCleanup extends SqlTestSupport {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            if (FAIL) {
+            if (fail) {
                 throw new IOException();
             }
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlClientCursorCleanup.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlClientCursorCleanup.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.sql.impl.SqlInternalService;
+import com.hazelcast.sql.impl.SqlServiceImpl;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings("StatementWithEmptyBody")
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlClientCursorCleanup extends SqlTestSupport {
+
+    private static final String MAP_NAME = "map";
+    private static final int KEY_COUNT = 10000;
+
+    private static volatile boolean FAIL;
+
+    private final SqlTestInstanceFactory factory = SqlTestInstanceFactory.create();
+
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance(smallInstanceConfig());
+        client = factory.newHazelcastClient(new ClientConfig());
+
+        IMap<Long, Person> map = member.getMap(MAP_NAME);
+        Map<Long, Person> localMap = new HashMap<>();
+
+        for (long i = 0; i < KEY_COUNT; i++) {
+            localMap.put(i, new Person());
+        }
+
+        map.putAll(localMap);
+    }
+
+    @After
+    public void after() {
+        FAIL = false;
+
+        factory.shutdownAll();
+
+        member = null;
+        client = null;
+    }
+
+    @Test
+    public void testExceptionOnExecute() {
+        FAIL = true;
+
+        try {
+            SqlResult result = client.getSql().execute("SELECT * FROM " + MAP_NAME);
+
+            for (SqlRow ignore : result) {
+                // No-op.
+            }
+
+            fail("Must fail");
+        } catch (Exception e) {
+            assertNoState();
+        }
+    }
+
+    @Test
+    public void testExceptionOnFetch() {
+        try {
+            SqlResult result = client.getSql().execute("SELECT * FROM " + MAP_NAME);
+
+            FAIL = true;
+
+            for (SqlRow ignore : result) {
+                // No-op.
+            }
+
+            fail("Must fail");
+        } catch (Exception e) {
+            assertNoState();
+        }
+    }
+
+    private void assertNoState() {
+        SqlInternalService service = ((SqlServiceImpl) member.getSql()).getInternalService();
+
+        assertEquals(0, service.getStateRegistry().getStates().size());
+        assertEquals(0, service.getClientStateRegistry().getCursorCount());
+    }
+
+    public static class Person implements DataSerializable {
+
+        public Person() {
+            // No-op
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            if (FAIL) {
+                throw new IOException();
+            }
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            // No-op
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/misc/SqlClientCursorCleanupTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/misc/SqlClientCursorCleanupTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.sql;
+package com.hazelcast.sql.misc;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -22,6 +22,9 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.SqlTestInstanceFactory;
 import com.hazelcast.sql.impl.SqlInternalService;
 import com.hazelcast.sql.impl.SqlServiceImpl;
 import com.hazelcast.sql.impl.SqlTestSupport;
@@ -44,7 +47,7 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("StatementWithEmptyBody")
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlClientCursorCleanup extends SqlTestSupport {
+public class SqlClientCursorCleanupTest extends SqlTestSupport {
 
     private static final String MAP_NAME = "map";
     private static final int KEY_COUNT = 10000;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
@@ -113,7 +113,7 @@ public class QueryClientStateRegistry {
             // we may fail to serialize a specific column value to Data. We have to close the cursor in this case.
             AbstractSqlResult result = clientCursor.getSqlResult();
 
-            QueryException error = QueryException.error(e.getMessage(), e);
+            QueryException error = QueryException.error("Failed to prepare the SQL result for the client: " + e.getMessage(), e);
 
             result.close(error);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryClientStateRegistry.java
@@ -108,8 +108,7 @@ public class QueryClientStateRegistry {
             // We use public API to extract results from the cursor. The cursor may throw HazelcastSqlException only. When
             // it happens, the cursor is already closed with the error, so we just re-throw.
             throw e;
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             // Any other exception indicates that something has happened outside of the internal query state. For example,
             // we may fail to serialize a specific column value to Data. We have to close the cursor in this case.
             AbstractSqlResult result = clientCursor.getSqlResult();


### PR DESCRIPTION
This PR fixes the memory leak that may happen in the case of exception during client `execute` and `fetch` operations. 

Before the fix, an exception occurred during the client page processing could lead to orphaned handles in the `QueryStateRegistry` and `QueryClientStateRegistry`. With the fix, we cleanup handles in the case of exception.

A better approach would be to encapsulate client result consumption into the `QueryStateRegistry` and remove the `QueryClientStateRegistry` completely. This way, we would have only one state map that is easier to manage. The problem is that this change would require significant changes to the Jet handler. Therefore, we use a simpler fix.