### PR TITLE
Stamp assertion guarded by a cluster version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -641,10 +641,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             return false;
         }
 
-        assert calculateStamp(partitionState.getPartitions()) == partitionState.getStamp() : "Invalid partition stamp! Expected: "
-                + calculateStamp(partitionState.getPartitions()) + ", Actual: " + partitionState.getStamp();
-
         if (nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V4_1)) {
+            assert calculateStamp(partitionState.getPartitions()) == partitionState.getStamp()
+                    : "Invalid partition stamp! Expected: " + calculateStamp(partitionState.getPartitions())
+                    + ", Actual: " + partitionState.getStamp();
             return applyNewPartitionTable(partitionState.getPartitions(), partitionState.getCompletedMigrations(), sender);
         } else {
             //RU_COMPAT_4_0


### PR DESCRIPTION
Reasoning:
When we are in 4.0 protocol then a partition state does not contain
stamp. It's always set to 0 as 4.0 member do not know about this field at all.

Hence the assertion was failing and 4.1 member was not able to join a 4.0 cluster
when assertions were enabled.