### PR TITLE
Fixed NPE in SqlErrorAbstractTest (#17727)

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlErrorAbstractTest.java
@@ -345,7 +345,7 @@ public class SqlErrorAbstractTest extends SqlTestSupport {
                 for (Partition partition : partitionService.getPartitions()) {
                     Member owner = partition.getOwner();
 
-                    assertNotNull(partition.getOwner());
+                    assertNotNull(owner);
 
                     assignedMemberIds.add(owner.getUuid());
                 }


### PR DESCRIPTION
This PR fixes the NPE in the `SqlErrorAbstractTest`. The NPE occurred because we did two consecutive calls to `Partition.getOwner` On the first call we asserted that the owner is not null. But after we asserted that, the subsequent call to `Partition.getOwner` may return `null` again. After the fix, we get the owner only once.

It is strange, though, that we may get `null` partition owner after we observed a non-null owner moments before. This could be an indication of an additional bug inside the partitioning service, of an indication of an incorrect implementation of `SqlErrorAbstractTest.newHazelcastInstance` that doesn't take some invariants into count. We fix NPE only for now. If there is really another problem - we will see it later.

Fixed https://github.com/hazelcast/hazelcast/issues/17727