### PR TITLE
Fix racy test cases in ScheduledExecutorServiceBasicTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceBasicTest.java
@@ -1589,12 +1589,14 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
             entry.getValue().get();
         }
 
-        // collect metrics
-        Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
+        assertTrueEventually(() -> {
+            // collect metrics
+            Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
 
-        // check results
-        assertMetricsCollected(metrics, 1000, 0,
+            // check results
+            assertMetricsCollected(metrics, 1000, 0,
                 1, 1, 0, 1, 0);
+        });
     }
 
     @Test
@@ -1612,11 +1614,13 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
             entry.getValue().get();
         }
 
-        // collect metrics
-        Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
+        assertTrueAllTheTime(() -> {
+            // collect metrics
+            Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
 
-        // check results
-        assertTrue("No metrics collection expected but " + metrics, metrics.isEmpty());
+            // check results
+            assertTrue("No metrics collection expected but " + metrics, metrics.isEmpty());
+        }, 5);
     }
 
     @Test
@@ -1635,13 +1639,15 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
 
         assertOpenEventually(progress);
 
-        // collect metrics
-        Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
-
-        // check results
         try {
-            assertMetricsCollected(metrics, 0, 0,
+            assertTrueEventually(() -> {
+                // collect metrics
+                Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
+
+                // check results
+                assertMetricsCollected(metrics, 0, 0,
                     3, 2, 0, now, 0);
+            });
         } finally {
             suspend.release();
         }
@@ -1663,11 +1669,13 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
 
         assertOpenEventually(progress);
 
-        // collect metrics
-        Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
+        assertTrueAllTheTime(() -> {
+            // collect metrics
+            Map<String, List<Long>> metrics = collectMetrics(SCHEDULED_EXECUTOR_PREFIX, instances);
 
-        // check results
-        assertTrue("No metrics collection expected but " + metrics, metrics.isEmpty());
+            // check results
+            assertTrue("No metrics collection expected but " + metrics, metrics.isEmpty());
+        }, 5);
     }
 
 


### PR DESCRIPTION
The affected test cases schedule tasks and assert if the metrics reflect
that the tasks are executed. The logic checking it is racy. The
executors update their statistics synchronously, but the Future the test
uses for synchronization gets completed before the statistics are
updated. If the thread updating the statistics gets suspended for long
enough, the tests fail.

Also updated the test cases checking for the lack of statistics updates
for the same reason as with the original version they may produce false
positives for the mentioned reason.

Fixes #17725