### PR TITLE
Insert empty schemas into SqlCatalog

### DIFF
--- a/hazelcast-sql/src/main/java/org/apache/calcite/jdbc/HazelcastRootCalciteSchema.java
+++ b/hazelcast-sql/src/main/java/org/apache/calcite/jdbc/HazelcastRootCalciteSchema.java
@@ -23,7 +23,7 @@ import org.apache.calcite.schema.SchemaVersion;
  * Root Calcite schema.
  * <p>
  * Calcite uses {@link org.apache.calcite.schema.Schema} to store actual objects, and
- * {@link org.apache.calcite.jdbc.CalciteSchema} as a wrapper. This class is a straightforward implementation of the latter.
+ * {@link org.apache.calcite.jdbc.CalciteSchema} as a wrapper. This class is a straightforward implementation of the former.
  * <p>
  * Located in the Calcite package because the required super constructor is package-private.
  */

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/JetSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/JetSqlTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 
 import static com.hazelcast.instance.impl.HazelcastInstanceFactory.newHazelcastInstance;
 import static com.hazelcast.sql.impl.QueryUtils.CATALOG;
+import static com.hazelcast.sql.impl.QueryUtils.SCHEMA_NAME_PARTITIONED;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -143,7 +144,10 @@ public class JetSqlTest extends SqlTestSupport {
             assertContains(task.getSearchPaths(), asList(CATALOG, JET_NAMESPACE));
             assertEquals(
                     task.getSchema().getSchemas(),
-                    ImmutableMap.of(JET_NAMESPACE, ImmutableMap.of(JET_TABLE, TEST_TABLE))
+                    ImmutableMap.of(
+                            JET_NAMESPACE, ImmutableMap.of(JET_TABLE, TEST_TABLE),
+                            SCHEMA_NAME_PARTITIONED, ImmutableMap.of()
+                    )
             );
 
             return mock(SqlPlan.class);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/TestTableResolver.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/TestTableResolver.java
@@ -49,7 +49,7 @@ public class TestTableResolver implements TableResolver {
     @Override
     public List<List<String>> getDefaultSearchPaths() {
         if (searchPath == null) {
-            return null;
+            return Collections.emptyList();
         } else {
             return Collections.singletonList(Arrays.asList(QueryUtils.CATALOG, searchPath));
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/SqlCatalog.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/SqlCatalog.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql.impl.schema;
 
+import com.hazelcast.sql.impl.QueryUtils;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -24,7 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Schema that is used for the duration of query.
+ * Schema that is used for the duration of a query.
  */
 public class SqlCatalog {
 
@@ -38,6 +40,12 @@ public class SqlCatalog {
 
         for (TableResolver tableResolver : tableResolvers) {
             Collection<Table> tables = tableResolver.getTables();
+
+            for (List<String> searchPath : tableResolver.getDefaultSearchPaths()) {
+                assert searchPath.size() == 2 && searchPath.get(0).equals(QueryUtils.CATALOG) : searchPath;
+
+                schemas.putIfAbsent(searchPath.get(1), new HashMap<>());
+            }
 
             for (Table table : tables) {
                 String schemaName = table.getSchemaName();

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableResolver.java
@@ -40,6 +40,7 @@ public interface TableResolver {
      *
      * @return The list of search paths for object resolution.
      */
+    @Nonnull
     List<List<String>> getDefaultSearchPaths();
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/SqlCatalogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/SqlCatalogTest.java
@@ -96,7 +96,7 @@ public class SqlCatalogTest {
 
         @Override
         public List<List<String>> getDefaultSearchPaths() {
-            throw new UnsupportedOperationException();
+            return emptyList();
         }
 
         @Nonnull


### PR DESCRIPTION
Previously, the schemas were added only if some table existed in that
schema. This caused that the "public" schema used for objects created
using DDL appeared to not exist if no table was in it. For example, the
query:

    SELECT * FROM public.my_map

failed with:
    object 'public' doesn't exist in 'hazelcast'

After this change it will fail with:
    object 'my_map' doesn't exist in 'hazelcast.public'

The error will be the same regardless other tables exist in the public
schema or not.