### PR TITLE
Fixed PartitionIndexingTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -252,7 +252,10 @@ public class MigrationManager {
                 } else {
                     operationService.execute(op);
                 }
-                removeActiveMigration(migrationInfo);
+
+                // We remove active migration in the end of the FinalizeMigrationOperation to make sure
+                // the cluster comes to a SAFE state only when indexes on partitions being populated
+                // completely.
             } else {
                 PartitionReplica partitionOwner = partitionStateManager.getPartitionImpl(partitionId).getOwnerReplicaOrNull();
                 if (localReplica.equals(partitionOwner)) {
@@ -304,7 +307,7 @@ public class MigrationManager {
      * and returns {@code true} if removed.
      * @param migration migration
      */
-    private boolean removeActiveMigration(MigrationInfo migration) {
+    public boolean removeActiveMigration(MigrationInfo migration) {
         MigrationInfo activeMigration =
                 activeMigrations.computeIfPresent(migration.getPartitionId(),
                         (k, currentMigration) -> currentMigration.equals(migration) ? null : currentMigration);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -97,6 +97,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
         }
 
         partitionStateManager.clearMigratingFlag(partitionId);
+        partitionService.getMigrationManager().removeActiveMigration(migrationInfo);
         if (success) {
             nodeEngine.onPartitionMigrate(migrationInfo);
         }


### PR DESCRIPTION
Make sure the indexes are being populated properly before a cluster
comes to the SAFE state.
To achieve this we remove active migration only in the end of the FinalizeMigrationOperation
instead of just right after submission of the FinalizeMigrationOperation

Closes https://github.com/hazelcast/hazelcast/issues/17724