### PR TITLE
Fix access static member via instance reference

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
@@ -174,8 +174,8 @@ public class ClientReplicatedMapListenerTest extends HazelcastTestSupport {
         // wait to get event on client side
         assertOpenEventually(eventReceivedLatch);
 
-        assertEquals(0, key.DESERIALIZATION_COUNT.get());
-        assertEquals(0, value.DESERIALIZATION_COUNT.get());
+        assertEquals(0, DeserializationCounter.DESERIALIZATION_COUNT.get());
+        assertEquals(0, DeserializationCounter.DESERIALIZATION_COUNT.get());
     }
 
     public static class DeserializationCounter implements DataSerializable {

--- a/hazelcast/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
@@ -590,9 +590,9 @@ public class ClientReplicatedMapTest extends HazelcastTestSupport {
 
         replicatedMap.remove(key);
 
-        assertEquals(0, ((Key1) key).COUNTER.get());
+        assertEquals(0, Key1.COUNTER.get());
         // expect only 1 deserialization in ClientReplicatedMapProxy#remove method
-        assertEquals(1, ((Value1) value).COUNTER.get());
+        assertEquals(1, Value1.COUNTER.get());
     }
 
     @Test
@@ -615,9 +615,9 @@ public class ClientReplicatedMapTest extends HazelcastTestSupport {
 
         replicatedMap.get(key);
 
-        assertEquals(0, ((Key2) key).COUNTER.get());
+        assertEquals(0, Key2.COUNTER.get());
         // expect only 1 deserialization in ClientReplicatedMapProxy#remove method
-        assertEquals(1, ((Value2) value).COUNTER.get());
+        assertEquals(1, Value2.COUNTER.get());
     }
 
     public static class Key1 extends DeserializationCounter {

--- a/hazelcast/src/test/java/com/hazelcast/spi/MemberAddressProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/MemberAddressProviderTest.java
@@ -265,7 +265,7 @@ public class MemberAddressProviderTest {
         public static Properties properties;
 
         public MemberAddressProviderWithStaticProperties(Properties properties) {
-            this.properties = properties;
+            MemberAddressProviderWithStaticProperties.properties = properties;
         }
 
         @Override
@@ -293,7 +293,7 @@ public class MemberAddressProviderTest {
         public static ILogger logger;
 
         public MemberAddressProviderWithLogger(ILogger logger) {
-            this.logger = logger;
+            MemberAddressProviderWithLogger.logger = logger;
         }
 
         @Override
@@ -323,8 +323,8 @@ public class MemberAddressProviderTest {
 
 
         public MemberAddressProviderWithLoggerAndProperties(ILogger logger, Properties properties) {
-            this.logger = logger;
-            this.properties = properties;
+            MemberAddressProviderWithLoggerAndProperties.logger = logger;
+            MemberAddressProviderWithLoggerAndProperties.properties = properties;
         }
 
         @Override
@@ -354,8 +354,8 @@ public class MemberAddressProviderTest {
 
 
         public MemberAddressProviderWithPropertiesAndLogger(Properties properties, ILogger logger) {
-            this.logger = logger;
-            this.properties = properties;
+            MemberAddressProviderWithPropertiesAndLogger.logger = logger;
+            MemberAddressProviderWithPropertiesAndLogger.properties = properties;
         }
 
         @Override


### PR DESCRIPTION
It is encouraged not to access static member via instance reference and it causes warnings
This PR includes the fix. 