### PR TITLE
[BACKPORT-4.0.z] Camelcase eureka properties must be configurable via XML/YAML

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DomConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DomConfigHelper.java
@@ -92,11 +92,15 @@ public final class DomConfigHelper {
     }
 
     public static String cleanNodeName(final Node node) {
+        return cleanNodeName(node, true);
+    }
+
+    public static String cleanNodeName(final Node node, final boolean shouldLowercase) {
         final String nodeName = node.getLocalName();
         if (nodeName == null) {
             throw new HazelcastException("Local node name is null for " + node);
         }
-        return StringUtil.lowerCaseInternal(nodeName);
+        return shouldLowercase ? StringUtil.lowerCaseInternal(nodeName) : nodeName;
     }
 
     public static String getTextContent(final Node node, boolean domLevel3) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1341,7 +1341,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             }
         }
         for (Node n : childElements(node)) {
-            String key = cleanNodeName(n);
+            String key = cleanNodeName(n, !"eureka".equals(n.getParentNode().getLocalName()));
             String value = getTextContent(n).trim();
             config.setProperty(key, value);
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -407,6 +407,8 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "            <eureka enabled=\"true\">\n"
                 + "                <use-public-ip>true</use-public-ip>\n"
                 + "                <namespace>hazelcast</namespace>\n"
+                + "                <shouldUseDns>false</shouldUseDns>\n"
+                + "                <serviceUrl.default>http://localhost:8082/eureka</serviceUrl.default>\n"
                 + "            </eureka>\n"
                 + "        </join>\n"
                 + "    </network>"
@@ -419,6 +421,8 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertTrue(eurekaConfig.isEnabled());
         assertTrue(eurekaConfig.isUsePublicIp());
         assertEquals("hazelcast", eurekaConfig.getProperty("namespace"));
+        assertEquals("false", eurekaConfig.getProperty("shouldUseDns"));
+        assertEquals("http://localhost:8082/eureka", eurekaConfig.getProperty("serviceUrl.default"));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -369,7 +369,9 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "      eureka:\n"
                 + "        enabled: true\n"
                 + "        use-public-ip: true\n"
-                + "        namespace: hazelcast\n";
+                + "        namespace: hazelcast\n"
+                + "        shouldUseDns: false\n"
+                + "        serviceUrl.default: http://localhost:8082/eureka\n";
 
         Config config = buildConfig(yaml);
 
@@ -378,6 +380,8 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertTrue(eurekaConfig.isEnabled());
         assertTrue(eurekaConfig.isUsePublicIp());
         assertEquals("hazelcast", eurekaConfig.getProperty("namespace"));
+        assertEquals("false", eurekaConfig.getProperty("shouldUseDns"));
+        assertEquals("http://localhost:8082/eureka", eurekaConfig.getProperty("serviceUrl.default"));
     }
 
     @Override


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/16679

At PCF(Tanzu), we are using the eureka-plugin to discover members from multiple PAS(TAS) setup. We have only option there to pass Eureka properties to the members which is a YAML/JSON based configuration.