### PR TITLE
[FORWARD-PORT] Introduce major version packet flags

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -45,8 +45,6 @@ public final class Packet extends HeapData implements OutboundFrame {
     // 2. Packet type (bits 0, 2, 5)
     // 3. Flags specific to a given packet type (bits 1, 6)
     // 4. 4.x flag (bit 7)
-    // 5. 3.x flag (bit 8)
-
 
     // 1. URGENT flag
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -44,6 +44,8 @@ public final class Packet extends HeapData implements OutboundFrame {
     // 1. URGENT (bit 4)
     // 2. Packet type (bits 0, 2, 5)
     // 3. Flags specific to a given packet type (bits 1, 6)
+    // 4. 4.x flag (bit 7)
+    // 5. 3.x flag (bit 8)
 
 
     // 1. URGENT flag
@@ -96,6 +98,16 @@ public final class Packet extends HeapData implements OutboundFrame {
      */
     public static final int FLAG_JET_FLOW_CONTROL = 1 << 1;
 
+    /**
+     * Marks a packet as sent by a 4.x member
+     */
+    public static final int FLAG_4_0 = 1 << 7;
+
+    /**
+     * Marks a packet as sent by a 3.12 member
+     */
+    public static final int FLAG_3_12 = 1 << 8;
+
 
     //            END OF HEADER FLAG SECTION
 
@@ -107,6 +119,7 @@ public final class Packet extends HeapData implements OutboundFrame {
     private transient ServerConnection conn;
 
     public Packet() {
+        raiseFlags(FLAG_4_0);
     }
 
     public Packet(byte[] payload) {
@@ -116,6 +129,7 @@ public final class Packet extends HeapData implements OutboundFrame {
     public Packet(byte[] payload, int partitionId) {
         super(payload);
         this.partitionId = partitionId;
+        raiseFlags(FLAG_4_0);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Packet.java
@@ -103,12 +103,6 @@ public final class Packet extends HeapData implements OutboundFrame {
      */
     public static final int FLAG_4_0 = 1 << 7;
 
-    /**
-     * Marks a packet as sent by a 3.12 member
-     */
-    public static final int FLAG_3_12 = 1 << 8;
-
-
     //            END OF HEADER FLAG SECTION
 
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PacketTest.java
@@ -17,12 +17,14 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.nio.Packet;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.nio.Packet.FLAG_4_0;
 import static com.hazelcast.internal.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.internal.nio.Packet.FLAG_URGENT;
 import static org.junit.Assert.assertEquals;
@@ -30,16 +32,28 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PacketTest {
+
+    @Test
+    public void isFlag_4_xSet() {
+        byte[] payload = {};
+        Packet packet = new Packet();
+        Packet packet2 = new Packet(payload);
+        Packet packet3 = new Packet(payload, 1);
+
+        assertTrue(packet.isFlagRaised(FLAG_4_0));
+        assertTrue(packet2.isFlagRaised(FLAG_4_0));
+        assertTrue(packet3.isFlagRaised(FLAG_4_0));
+    }
 
     @Test
     public void raiseFlags() {
         Packet packet = new Packet();
         packet.raiseFlags(FLAG_URGENT);
 
-        assertEquals(FLAG_URGENT, packet.getFlags());
+        assertEquals(FLAG_4_0 | FLAG_URGENT, packet.getFlags());
     }
 
     @Test


### PR DESCRIPTION
Introduce major version packet flags

Adds a packet flag on all outgoing packets. This is to support running a
cluster where a member can be connected to other members of the same
major version as well as have a connection to members of different major
versions. To distinguish between the two on a Packet level, we need to
introduce a Packet flag. This flag should be introduced on all versions
which will support migrating between 3.x and 4.x, which at this point
means 3.12.8+, 4.0.2+ and 4.1.x. The flags can be removed in 4.2 which
will not support data migration anymore.

Clean cherry-pick of https://github.com/hazelcast/hazelcast/pull/16993.