### PR TITLE
[BACPORT] Fixed PartitionIndexingTest (#17738)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -234,7 +234,10 @@ public class MigrationManager {
                 } else {
                     operationService.execute(op);
                 }
-                removeActiveMigration(partitionId);
+
+                // We remove active migration in the end of the FinalizeMigrationOperation to make sure
+                // the cluster comes to a SAFE state only when indexes on partitions being populated
+                // completely.
             } else {
                 PartitionReplica partitionOwner = partitionStateManager.getPartitionImpl(partitionId).getOwnerReplicaOrNull();
                 if (localReplica.equals(partitionOwner)) {
@@ -324,7 +327,7 @@ public class MigrationManager {
      * removed.
      * Acquires the partition service lock.
      */
-    private boolean removeActiveMigration(int partitionId) {
+    public boolean removeActiveMigration(int partitionId) {
         partitionServiceLock.lock();
         try {
             if (activeMigrationInfo != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -97,6 +97,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
         }
 
         partitionStateManager.clearMigratingFlag(partitionId);
+        partitionService.getMigrationManager().removeActiveMigration(partitionId);
         if (success) {
             nodeEngine.onPartitionMigrate(migrationInfo);
         }


### PR DESCRIPTION
Make sure the indexes are being populated properly before a cluster
comes to the SAFE state.
To achieve this we remove active migration only in the end of the FinalizeMigrationOperation
instead of just right after submission of the FinalizeMigrationOperation

Closes https://github.com/hazelcast/hazelcast/issues/17724