### PR TITLE
Move long-running SQL tests into separate classes

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -33,7 +33,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -43,7 +43,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -77,9 +76,8 @@ import static org.junit.Assert.assertNotNull;
  * Test that covers basic column read operations through SQL.
  */
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
-@SuppressWarnings("checkstyle:RedundantModifier")
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class SqlBasicTest extends SqlTestSupport {
 
     private static final int IDS_FACTORY_ID = 1;
@@ -93,8 +91,8 @@ public class SqlBasicTest extends SqlTestSupport {
     private static final String MAP_OBJECT = "map_object";
     private static final String MAP_BINARY = "map_binary";
 
-    private static final int[] PAGE_SIZES = { 1, 16, 256, 4096 };
-    private static final int[] DATA_SET_SIZES = { 1, 256, 4096 };
+    private static final int[] PAGE_SIZES = { 256 };
+    private static final int[] DATA_SET_SIZES = { 4096 };
     private static final SqlTestInstanceFactory FACTORY = SqlTestInstanceFactory.create();
 
     private static HazelcastInstance member1;
@@ -1015,7 +1013,7 @@ public class SqlBasicTest extends SqlTestSupport {
         }
     }
 
-    private enum SerializationMode {
+    protected enum SerializationMode {
         SERIALIZABLE,
         DATA_SERIALIZABLE,
         IDENTIFIED_DATA_SERIALIZABLE,

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -33,7 +33,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -77,7 +77,8 @@ import static org.junit.Assert.assertNotNull;
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category({SlowTest.class, ParallelJVMTest.class})
+@Category({QuickTest.class, ParallelJVMTest.class})
+@SuppressWarnings("checkstyle:RedundantModifier")
 public class SqlBasicTest extends SqlTestSupport {
 
     private static final int IDS_FACTORY_ID = 1;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/index/SqlIndexAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/index/SqlIndexAbstractTest.java
@@ -100,23 +100,6 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
     private Class<? extends ExpressionBiValue> valueClass;
     private int runIdGen;
 
-    @Parameterized.Parameters(name = "indexType:{0}, composite:{1}, field1:{2}, field2:{3}")
-    public static Collection<Object[]> parameters() {
-        List<Object[]> res = new ArrayList<>();
-
-        for (IndexType indexType : Arrays.asList(IndexType.SORTED, IndexType.HASH)) {
-            for (boolean composite : Arrays.asList(true, false)) {
-                for (ExpressionType<?> firstType : allTypes()) {
-                    for (ExpressionType<?> secondType : allTypes()) {
-                        res.add(new Object[] { indexType, composite, firstType, secondType });
-                    }
-                }
-            }
-        }
-
-        return res;
-    }
-
     @BeforeClass
     public static void beforeClass() {
          factory = new TestHazelcastInstanceFactory(2);
@@ -618,6 +601,38 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
 
     protected MapConfig getMapConfig() {
         return new MapConfig().setName(mapName).setBackupCount(0).addIndexConfig(getIndexConfig());
+    }
+
+    public static Collection<Object[]> parametersQuick() {
+        List<Object[]> res = new ArrayList<>();
+
+        for (IndexType indexType : Arrays.asList(IndexType.SORTED, IndexType.HASH)) {
+            for (boolean composite : Arrays.asList(true, false)) {
+                for (ExpressionType<?> firstType : baseTypes()) {
+                    for (ExpressionType<?> secondType : baseTypes()) {
+                        res.add(new Object[] { indexType, composite, firstType, secondType });
+                    }
+                }
+            }
+        }
+
+        return res;
+    }
+
+    public static Collection<Object[]> parametersSlow() {
+        List<Object[]> res = new ArrayList<>();
+
+        for (IndexType indexType : Arrays.asList(IndexType.SORTED, IndexType.HASH)) {
+            for (boolean composite : Arrays.asList(true, false)) {
+                for (ExpressionType<?> firstType : allTypes()) {
+                    for (ExpressionType<?> secondType : allTypes()) {
+                        res.add(new Object[] { indexType, composite, firstType, secondType });
+                    }
+                }
+            }
+        }
+
+        return res;
     }
 
     private static class Query {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/index/SqlIndexTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/index/SqlIndexTest.java
@@ -23,10 +23,17 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.Collection;
+
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SqlIndexTest extends SqlIndexAbstractTest {
+    @Parameterized.Parameters(name = "indexType:{0}, composite:{1}, field1:{2}, field2:{3}")
+    public static Collection<Object[]> parameters() {
+        return parametersQuick();
+    }
+
     @Override
     protected boolean isHd() {
         return false;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/index/SqlIndexTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/index/SqlIndexTestSupport.java
@@ -64,6 +64,14 @@ public class SqlIndexTestSupport extends SqlTestSupport {
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }
 
+    protected static List<ExpressionType<?>> baseTypes() {
+        return Arrays.asList(
+            BOOLEAN,
+            INTEGER,
+            STRING
+        );
+    }
+
     protected static List<ExpressionType<?>> allTypes() {
         return Arrays.asList(
             BOOLEAN,

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/SqlBasicClientSlowTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/SqlBasicClientSlowTest.java
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-package com.hazelcast.sql;
+package com.hazelcast.sql_slow;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-/**
- * Test that covers basic column read operations through SQL executed from a client.
- */
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlBasicClientTest extends SqlBasicTest {
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class SqlBasicClientSlowTest extends SqlBasicSlowTest {
     @Override
     protected HazelcastInstance getTarget() {
         return client;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/SqlBasicSlowTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/SqlBasicSlowTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql_slow;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.sql.SqlBasicTest;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class SqlBasicSlowTest extends SqlBasicTest {
+
+    private static final int[] PAGE_SIZES = { 1, 16, 256, 4096 };
+    private static final int[] DATA_SET_SIZES = { 1, 256, 4096 };
+
+    @Parameterized.Parameters(name = "cursorBufferSize:{0}, dataSetSize:{1}, serializationMode:{2}, inMemoryFormat:{3}")
+    public static Collection<Object[]> parameters() {
+        List<Object[]> res = new ArrayList<>();
+
+        for (int pageSize : PAGE_SIZES) {
+            for (int dataSetSize : DATA_SET_SIZES) {
+                for (SerializationMode serializationMode : SerializationMode.values()) {
+                    for (InMemoryFormat format : new InMemoryFormat[] { InMemoryFormat.OBJECT, InMemoryFormat.BINARY }) {
+                        res.add(new Object[] {
+                            pageSize,
+                            dataSetSize,
+                            serializationMode,
+                            format
+                        });
+                    }
+                }
+            }
+        }
+
+        return res;
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/SqlIndexSlowTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/SqlIndexSlowTest.java
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-package com.hazelcast.sql;
+package com.hazelcast.sql_slow;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.sql.index.SqlIndexTest;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-/**
- * Test that covers basic column read operations through SQL executed from a client.
- */
+import java.util.Collection;
+
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlBasicClientTest extends SqlBasicTest {
-    @Override
-    protected HazelcastInstance getTarget() {
-        return client;
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class SqlIndexSlowTest extends SqlIndexTest {
+    @Parameterized.Parameters(name = "indexType:{0}, composite:{1}, field1:{2}, field2:{3}")
+    public static Collection<Object[]> parameters() {
+        return parametersSlow();
     }
 }


### PR DESCRIPTION
Currently, we have a couple of SQL test classes that take significant time to complete due to a large number of parameters. The goal of this PR is to create base quick tests with few parameters and fully-fledged long-running nightly tests with all required parameters. The affected classes are: `SqlIndexAbstractTest` and `SqlBasicTest` (along with their children classes).

The change decreases the total test run time on my machine as reported by IDEA from 500 seconds to 122 seconds.

Slow tests are moved to the package `com.hazelcast.impl.sql_slow`. While the name might seem strange, the goal is to be able to run tests from `com.hazelcast.impl` from IDE easily.

Related to https://github.com/hazelcast/hazelcast/issues/17472