### PR TITLE
Downgrade surefire plugin to resolve OOM issues in 3.0.0-M4

### DIFF
--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -36,6 +36,17 @@
         <maven.compiler.source>9</maven.compiler.source>
         <maven.compiler.target>9</maven.compiler.target>
 
+        <javaModuleArgs>
+            --add-exports java.base/jdk.internal.ref=com.hazelcast.core
+            --add-opens java.base/java.nio=com.hazelcast.core
+            --add-opens java.base/sun.nio.ch=com.hazelcast.core
+            --add-opens java.base/java.lang=com.hazelcast.core
+            --add-opens jdk.management/com.sun.management.internal=com.hazelcast.core
+            --add-opens java.management/sun.management=com.hazelcast.core
+            --add-exports java.xml/jdk.xml.internal=com.hazelcast.core
+            --illegal-access=warn
+        </javaModuleArgs>
+
         <!-- needed for CheckStyle -->
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
@@ -48,39 +59,6 @@
                 <version>3.8.0</version>
                 <configuration combine.self="override">
                     <release>9</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration combine.self="override">
-                    <!--
-                    Allow access to Operating system metrics:
-                        open jdk.management/com.sun.management.internal
-
-                    Avoid warnings caused by reflection in
-                    SelectorOptimizer:
-                        open java.base/sun.nio.ch
-                    FilteringClassLoader:
-                        open java.base/java.lang
-                    TimedMemberStateFactoryHelper:
-                        open java.management/sun.management
-
-                    Powermock issue workaround (https://github.com/powermock/powermock/issues/905):
-                        export java.xml/jdk.xml.internal
-                     -->
-                    <argLine>
-                        ${vmHeapSettings}
-                        --add-opens jdk.management/com.sun.management.internal=com.hazelcast.core
-                        --add-opens java.base/sun.nio.ch=com.hazelcast.core
-                        --add-opens java.base/java.lang=com.hazelcast.core
-                        --add-opens java.management/sun.management=com.hazelcast.core
-                        --add-exports java.xml/jdk.xml.internal=com.hazelcast.core
-                        --illegal-access=warn
-                        -Dhazelcast.phone.home.enabled=false
-                        -Dlog4j.skipJansi=true
-                        ${extraVmArgs}
-                    </argLine>
                 </configuration>
             </plugin>
 
@@ -118,4 +96,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>parallelTest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven.animal.sniffer.plugin.version>1.19</maven.animal.sniffer.plugin.version>
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
-        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
         <maven.spotbugs.plugin.version>3.1.12</maven.spotbugs.plugin.version>
         <maven.sonar.plugin.version>3.6.0.1398</maven.sonar.plugin.version>


### PR DESCRIPTION
This PR downgrades the Surefire plugin version and workarounds the `parallelTest` profile problem (on older Surefire plugin).

After the Surefire plugin upgrade in #17728 we experienced OOM errors on several Jenkins jobs which seems to be related.
The tests are not properly filtered when generating test result files. Many result files contain results from methods belonging to another test class.
For instance the result files `TEST-*.xml` in `hazelcast/target/surefire-reports` of investigated failed job have in summary 9.7GB:
http://jenkins.hazelcast.com/view/Official%20Builds/job/Hazelcast-4.master-OracleJDK8/115/console