### PR TITLE
Disable verbose output on some tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.internal.partition;
 
-import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -32,9 +30,6 @@ import java.util.Collection;
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class GracefulShutdownCorrectnessTest extends AbstractGracefulShutdownCorrectnessTest {
-
-    @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 
     @Parameterized.Parameters(name = "backups:{0},nodes:{1},shutdown:{2}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.internal.partition;
 
-import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,9 +34,6 @@ import static java.util.Arrays.asList;
 @Category({QuickTest.class, ParallelJVMTest.class})
 // related issue https://github.com/hazelcast/hazelcast/issues/5444
 public class MigrationCorrectnessTest extends AbstractMigrationCorrectnessTest {
-
-    @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 
     @Parameters(name = "backups:{0},nodes:{1},fragmented:{2}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -25,12 +25,10 @@ import com.hazelcast.internal.partition.impl.MigrationManager;
 import com.hazelcast.internal.partition.service.TestMigrationAwareService;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -68,9 +66,6 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupport {
-
-    @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 
     @Before
     public void setupParams() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionAssignmentsCorrectnessTest.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.internal.partition;
 
-import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,7 +40,4 @@ public class PartitionAssignmentsCorrectnessTest extends AbstractPartitionAssign
                 {3, 4},
         });
     }
-
-    @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentBasicTest.java
@@ -23,12 +23,14 @@ import com.hazelcast.internal.util.FilteringClassLoader;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -52,6 +54,9 @@ import static org.junit.Assert.fail;
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class UserCodeDeploymentBasicTest extends HazelcastTestSupport {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-no-stacktrace.xml");
 
     private TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
     @Parameterized.Parameter

--- a/hazelcast/src/test/resources/log4j2-no-stacktrace.xml
+++ b/hazelcast/src/test/resources/log4j2-no-stacktrace.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%ex{0}%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR disables the verbose output on some test classes. Some output files are pretty fat:
```
 307M com.hazelcast.internal.partition.MigrationCorrectnessTest-output.txt
 100M com.hazelcast.internal.partition.PartitionAssignmentsCorrectnessTest-output.txt
  82M com.hazelcast.internal.partition.GracefulShutdownCorrectnessTest-output.txt
  22M com.hazelcast.internal.usercodedeployment.impl.filter.UserCodeDeploymentBasicTest-output.txt
  11M com.hazelcast.internal.partition.MigrationInvocationsSafetyTest-output.txt
```