### PR TITLE
Introduce parallel-parametrized runner

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -93,8 +93,13 @@ public final class ThreadLeakTestUtils {
     private static Set<Thread> getNonSystemAndNonCommonPoolThreads(Map<Thread, StackTraceElement[]> stackTraces) {
         Set<Thread> nonSystemThreads = new HashSet<>();
         for (Thread thread : stackTraces.keySet()) {
+            if (thread.getName().contains("hz.test")) {
+                continue;
+            }
+
             ThreadGroup threadGroup = thread.getThreadGroup();
-            if (threadGroup != null && threadGroup.getParent() != null && !thread.getName().contains("ForkJoinPool.commonPool")) {
+            if (threadGroup != null && threadGroup.getParent() != null
+                    && !thread.getName().contains("ForkJoinPool.commonPool")) {
                 // non-system alive thread
                 nonSystemThreads.add(thread);
             }

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -22,7 +22,8 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -60,8 +61,8 @@ import static com.hazelcast.test.backup.TestBackupUtils.assertBackupSizeEventual
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CacheExpirationTest extends CacheTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBasicDistributedTest.java
@@ -18,15 +18,16 @@ package com.hazelcast.cardinality;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CardinalityEstimatorBasicDistributedTest extends CardinalityEstimatorAbstractTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorSplitBrainTest.java
@@ -24,13 +24,13 @@ import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -42,8 +42,8 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.client.listeners;
 
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.topic.Message;
-import com.hazelcast.topic.MessageListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import com.hazelcast.topic.impl.TopicService;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
@@ -60,7 +60,7 @@ public class ClientExpirationListenerTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationListener_notified_afterExpirationOfEntries() throws Exception {
-        int numberOfPutOperations = 1000;
+        int numberOfPutOperations = 10;
         CountDownLatch expirationEventArrivalCount = new CountDownLatch(numberOfPutOperations);
 
         map.addEntryListener(new ExpirationListener(expirationEventArrivalCount), true);
@@ -99,7 +99,7 @@ public class ClientExpirationListenerTest extends HazelcastTestSupport {
      */
     @Test
     public void expiration_and_eviction_listener_are_not_both_notified_after_expiration() {
-        int numberOfPutOperations = 1000;
+        int numberOfPutOperations = 10;
 
         ExpirationAndEvictionListener listener = new ExpirationAndEvictionListener();
         map.addEntryListener(listener, true);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -16,23 +16,23 @@
 
 package com.hazelcast.collection.impl.queue;
 
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.QueueStore;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.QueueStore;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -61,8 +61,8 @@ import static org.junit.Assert.fail;
  * <p>
  * The number and content of backup items are tested for all merge policies.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class QueueSplitBrainTest extends SplitBrainTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -133,21 +133,21 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         CPMemberInfo removedEndpoint = new CPMemberInfo(member);
         instances[1].getCPSubsystem().getCPSubsystemManagementService().removeCPMember(removedEndpoint.getUuid())
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPGroup metadataGroup = instances[1].getCPSubsystem()
-                                            .getCPSubsystemManagementService()
-                                            .getCPGroup(METADATA_CP_GROUP_NAME)
-                                            .toCompletableFuture()
-                                            .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup(METADATA_CP_GROUP_NAME)
+                .toCompletableFuture()
+                .get();
         assertEquals(2, metadataGroup.members().size());
         assertFalse(metadataGroup.members().contains(removedEndpoint));
 
         CPGroup testGroup = instances[1].getCPSubsystem()
-                                        .getCPSubsystemManagementService()
-                                        .getCPGroup("test")
-                                        .toCompletableFuture()
-                                        .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("test")
+                .toCompletableFuture()
+                .get();
         assertNotNull(testGroup);
         assertEquals(2, testGroup.members().size());
         assertFalse(testGroup.members().contains(removedEndpoint));
@@ -161,7 +161,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         CPGroupId groupId = getRaftInvocationManager(instances[0]).createRaftGroup("test", 2).get();
         CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup(groupId.getName())
-                                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPMember crashedMember = group.members().iterator().next();
 
@@ -170,14 +170,14 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         factory.getInstance(crashedMember.getAddress()).getLifecycleService().terminate();
 
         CPSubsystemManagementService cpSubsystemManagementService = runningInstance.getCPSubsystem()
-                                                                                   .getCPSubsystemManagementService();
+                .getCPSubsystemManagementService();
         cpSubsystemManagementService.forceDestroyCPGroup(groupId.getName())
-                                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
         cpSubsystemManagementService.removeCPMember(crashedMember.getUuid())
-                                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         Collection<CPMember> activeMembers = cpSubsystemManagementService.getCPMembers()
-                                                                         .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertFalse(activeMembers.contains(crashedMember));
     }
 
@@ -193,7 +193,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         RaftNodeImpl groupLeaderRaftNode = getLeaderNode(instances, groupId);
         CPGroup group = instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup(groupId.getName())
-                                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPMember[] groupMembers = group.members().toArray(new CPMember[0]);
         CPMember crashedMember = groupMembers[0].getUuid().equals(groupLeaderRaftNode.getLocalMember().getUuid())
@@ -209,9 +209,9 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         // we triggered removal of the crashed member but we won't be able to commit to the "test" group
         CompletableFuture<Void> f = runningInstance.getCPSubsystem()
-                                                   .getCPSubsystemManagementService()
-                                                   .removeCPMember(crashedMember.getUuid())
-                                                   .toCompletableFuture();
+                .getCPSubsystemManagementService()
+                .removeCPMember(crashedMember.getUuid())
+                .toCompletableFuture();
 
         // wait until RaftCleanupHandler kicks in and appends ApplyRaftGroupMembersCmd to the leader of the "test" group
         assertTrueEventually(
@@ -220,7 +220,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         // force-destroy the raft group.
         // Now, the pending membership change in the "test" group will fail and we will fix it in the metadata group.
         runningInstance.getCPSubsystem().getCPSubsystemManagementService().forceDestroyCPGroup(groupId.getName())
-                       .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         f.get();
 
@@ -242,7 +242,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         promoted.getLifecycleService().terminate();
 
         master.getCPSubsystem().getCPSubsystemManagementService().removeCPMember(promotedMember.getUuid())
-              .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         MembershipChangeSchedule schedule = getRaftInvocationManager(master).<MembershipChangeSchedule>query(getMetadataGroupId(master),
                 new GetMembershipChangeScheduleOp(), LINEARIZABLE).get();
@@ -405,11 +405,11 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         instances[0].shutdown();
 
         instances[3].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get(30, TimeUnit.SECONDS);
+                .toCompletableFuture().get(30, TimeUnit.SECONDS);
 
         CPGroupId metadataGroupId = getMetadataGroupId(instances[1]);
         CPGroup group = instances[1].getCPSubsystem().getCPSubsystemManagementService().getCPGroup(METADATA_CP_GROUP_NAME)
-                                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertEquals(3, group.members().size());
         Collection<CPMember> members = group.members();
         assertTrue(members.contains(instances[3].getCPSubsystem().getLocalCPMember()));
@@ -431,34 +431,34 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         CPSubsystemManagementService managementService = instances[3].getCPSubsystem().getCPSubsystemManagementService();
         CPGroup group = managementService.getCPGroup(metadataGroupId.getName())
-                                         .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertEquals(2, group.members().size());
 
         instances[5].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         group = managementService.getCPGroup(metadataGroupId.getName())
-                                 .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertEquals(3, group.members().size());
         Collection<CPMember> members = group.members();
         assertTrue(members.contains(instances[5].getCPSubsystem().getLocalCPMember()));
         assertTrueEventually(() -> assertNotNull(getRaftNode(instances[5], metadataGroupId)));
 
         instances[6].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         group = managementService.getCPGroup(metadataGroupId.getName())
-                                 .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertEquals(4, group.members().size());
         members = group.members();
         assertTrue(members.contains(instances[6].getCPSubsystem().getLocalCPMember()));
         assertTrueEventually(() -> assertNotNull(getRaftNode(instances[5], metadataGroupId)));
 
         instances[7].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         group = managementService.getCPGroup(metadataGroupId.getName())
-                                 .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertEquals(5, group.members().size());
         members = group.members();
         assertTrue(members.contains(instances[7].getCPSubsystem().getLocalCPMember()));
@@ -493,7 +493,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         String groupName = "group1";
         instances[0].getCPSubsystem().getAtomicLong("long1@" + groupName).set(5);
         CPGroup otherGroup = managementService.getCPGroup(groupName)
-                                              .toCompletableFuture().get();
+                .toCompletableFuture().get();
         CPGroupId groupId = otherGroup.id();
 
         waitAllForLeaderElection(Arrays.copyOf(instances, 5), groupId);
@@ -502,7 +502,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         List<Address> shutdownAddresses = asList(otherGroupMembers[0].getAddress(), otherGroupMembers[1].getAddress());
 
         instances[5].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get(30, TimeUnit.SECONDS);
+                .toCompletableFuture().get(30, TimeUnit.SECONDS);
 
         HazelcastInstance[] runningInstances = new HazelcastInstance[instances.length - shutdownAddresses.size()];
         for (int i = 0, j = 0; i < instances.length; i++) {
@@ -515,7 +515,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         }
 
         CPGroup metadataGroup = managementService.getCPGroup(metadataGroupId.getName())
-                                                 .toCompletableFuture().get();
+                .toCompletableFuture().get();
         otherGroup = managementService.getCPGroup(groupName).toCompletableFuture().get();
         assertEquals(4, metadataGroup.members().size());
         assertEquals(4, otherGroup.members().size());
@@ -526,10 +526,10 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         });
 
         instances[6].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get(30, TimeUnit.SECONDS);
+                .toCompletableFuture().get(30, TimeUnit.SECONDS);
 
         metadataGroup = managementService.getCPGroup(metadataGroupId.getName())
-                                         .toCompletableFuture().get();
+                .toCompletableFuture().get();
         otherGroup = managementService.getCPGroup(groupName).toCompletableFuture().get();
         assertEquals(5, metadataGroup.members().size());
         assertEquals(5, otherGroup.members().size());
@@ -642,7 +642,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         assertClusterSizeEventually(2, instances[1]);
 
         instances[1].getCPSubsystem().getCPSubsystemManagementService().removeCPMember(localCpMember.getUuid())
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         instances[0] = newHazelcastInstance(initOrCreateConfig(createConfig(3, 3)), randomString(),
                 new StaticMemberNodeContext(factory, localMember));
@@ -651,7 +651,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         assertTrueAllTheTime(() -> assertNull(instances[0].getCPSubsystem().getLocalCPMember()), 5);
 
         instances[0].getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
         assertNotNull(instances[0].getCPSubsystem().getLocalCPMember());
         assertNotEquals(localCpMember, instances[0].getCPSubsystem().getLocalCPMember());
     }
@@ -662,8 +662,8 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         int commitIndexAdvanceCountToSnapshot = 50;
         Config config = createConfig(nodeCount, nodeCount);
         config.getCPSubsystemConfig()
-              .getRaftAlgorithmConfig()
-              .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+                .getRaftAlgorithmConfig()
+                .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
 
         HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
         for (int i = 0; i < nodeCount; i++) {
@@ -685,35 +685,35 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         for (int i = 0; i < 5; i++) {
             instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup(METADATA_CP_GROUP_NAME)
-                        .toCompletableFuture().get();
+                    .toCompletableFuture().get();
         }
 
         instances[0].shutdown();
 
         HazelcastInstance newInstance = factory.newHazelcastInstance(config);
         newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                   .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPGroup metadataGroup = newInstance.getCPSubsystem()
-                                           .getCPSubsystemManagementService()
-                                           .getCPGroup(METADATA_CP_GROUP_NAME)
-                                           .toCompletableFuture()
-                                           .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup(METADATA_CP_GROUP_NAME)
+                .toCompletableFuture()
+                .get();
 
         CPGroup group1 = newInstance.getCPSubsystem()
-                                    .getCPSubsystemManagementService()
-                                    .getCPGroup("group1")
-                                    .toCompletableFuture()
-                                    .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("group1")
+                .toCompletableFuture()
+                .get();
 
         CPGroup group2 = newInstance.getCPSubsystem()
-                                    .getCPSubsystemManagementService()
-                                    .getCPGroup("group2")
-                                    .toCompletableFuture()
-                                    .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("group2")
+                .toCompletableFuture()
+                .get();
 
         List<CPMember> cpMembers = new ArrayList<>(newInstance.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
-                                                              .toCompletableFuture().get());
+                .toCompletableFuture().get());
 
         assertTrueEventually(() -> {
             long commitIndex = getCommitIndex(getLeaderNode(new HazelcastInstance[]{instances[1], instances[2], newInstance},
@@ -746,7 +746,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         int commitIndexAdvanceCountToSnapshot = 50;
         Config config = createConfig(nodeCount, nodeCount);
         config.getCPSubsystemConfig().getRaftAlgorithmConfig()
-              .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+                .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
 
         HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
         for (int i = 0; i < nodeCount; i++) {
@@ -770,9 +770,9 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().toCompletableFuture().join();
 
         List<CPMember> cpMembers = new ArrayList<>(newInstance.getCPSubsystem()
-                                                              .getCPSubsystemManagementService()
-                                                              .getCPMembers()
-                                                              .toCompletableFuture().join());
+                .getCPSubsystemManagementService()
+                .getCPMembers()
+                .toCompletableFuture().join());
 
         assertTrueEventually(() -> {
             RaftService service = getRaftService(newInstance);
@@ -837,7 +837,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         waitUntilCPDiscoveryCompleted(instances);
 
         instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup(METADATA_CP_GROUP_NAME)
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         instances[1].getLifecycleService().terminate();
         instances[2].getLifecycleService().terminate();
@@ -861,29 +861,29 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         HazelcastInstance newInstance3 = factory.newHazelcastInstance(config);
         newInstance3.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPGroup metadataGroup = newInstance1.getCPSubsystem()
-                                            .getCPSubsystemManagementService()
-                                            .getCPGroup(METADATA_CP_GROUP_NAME)
-                                            .toCompletableFuture()
-                                            .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup(METADATA_CP_GROUP_NAME)
+                .toCompletableFuture()
+                .get();
 
         CPGroup group1 = newInstance1.getCPSubsystem()
-                                     .getCPSubsystemManagementService()
-                                     .getCPGroup("group1")
-                                     .toCompletableFuture()
-                                     .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("group1")
+                .toCompletableFuture()
+                .get();
 
         CPGroup group2 = newInstance1.getCPSubsystem()
-                                     .getCPSubsystemManagementService()
-                                     .getCPGroup("group2")
-                                     .toCompletableFuture()
-                                     .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("group2")
+                .toCompletableFuture()
+                .get();
 
         List<CPMember> cpMembers =
                 new ArrayList<>(newInstance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
-                                            .toCompletableFuture().get());
+                        .toCompletableFuture().get());
 
         HazelcastInstance[] newInstances = new HazelcastInstance[]{newInstance1, newInstance2, newInstance3};
 
@@ -920,8 +920,8 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         int commitIndexAdvanceCountToSnapshot = 50;
         Config config = createConfig(nodeCount, nodeCount);
         config.getCPSubsystemConfig()
-              .getRaftAlgorithmConfig()
-              .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+                .getRaftAlgorithmConfig()
+                .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
 
         HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
         for (int i = 0; i < nodeCount; i++) {
@@ -934,7 +934,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         RaftGroupId initialMetadataGroupId = getMetadataGroupId(instances[0]);
 
         instances[0].getCPSubsystem().getCPSubsystemManagementService().getCPGroup(METADATA_CP_GROUP_NAME)
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         instances[1].getLifecycleService().terminate();
         instances[2].getLifecycleService().terminate();
@@ -968,29 +968,29 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         HazelcastInstance newInstance3 = factory.newHazelcastInstance(config);
         newInstance3.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                    .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPGroup metadataGroup = newInstance1.getCPSubsystem()
-                                            .getCPSubsystemManagementService()
-                                            .getCPGroup(METADATA_CP_GROUP_NAME)
-                                            .toCompletableFuture()
-                                            .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup(METADATA_CP_GROUP_NAME)
+                .toCompletableFuture()
+                .get();
 
         CPGroup group1 = newInstance1.getCPSubsystem()
-                                     .getCPSubsystemManagementService()
-                                     .getCPGroup("group1")
-                                     .toCompletableFuture()
-                                     .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("group1")
+                .toCompletableFuture()
+                .get();
 
         CPGroup group2 = newInstance1.getCPSubsystem()
-                                     .getCPSubsystemManagementService()
-                                     .getCPGroup("group2")
-                                     .toCompletableFuture()
-                                     .get();
+                .getCPSubsystemManagementService()
+                .getCPGroup("group2")
+                .toCompletableFuture()
+                .get();
 
         List<CPMember> cpMembers =
                 new ArrayList<>(newInstance1.getCPSubsystem().getCPSubsystemManagementService().getCPMembers()
-                                            .toCompletableFuture().get());
+                        .toCompletableFuture().get());
 
         HazelcastInstance[] newInstances = new HazelcastInstance[]{newInstance1, newInstance2, newInstance3};
 
@@ -1088,7 +1088,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         HazelcastInstance instance4 = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
         instance4.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                 .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         CPMember cpMember3 = instances[2].getCPSubsystem().getLocalCPMember();
         instances[2].getLifecycleService().terminate();
@@ -1096,10 +1096,10 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         assertTrueEventually(() -> {
             CPGroup metadataGroup = instances[0].getCPSubsystem()
-                                                .getCPSubsystemManagementService()
-                                                .getCPGroup(CPGroup.METADATA_CP_GROUP_NAME)
-                                                .toCompletableFuture()
-                                                .get();
+                    .getCPSubsystemManagementService()
+                    .getCPGroup(CPGroup.METADATA_CP_GROUP_NAME)
+                    .toCompletableFuture()
+                    .get();
             assertTrue(metadataGroup.members().contains(instance4.getCPSubsystem().getLocalCPMember()));
             assertEquals(cpMemberCount, metadataGroup.members().size());
         });
@@ -1118,24 +1118,24 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
         assertTrueEventually(() -> {
             CPGroup metadataGroup = instances[0].getCPSubsystem()
-                                                .getCPSubsystemManagementService()
-                                                .getCPGroup(CPGroup.METADATA_CP_GROUP_NAME)
-                                                .toCompletableFuture()
-                                                .get();
+                    .getCPSubsystemManagementService()
+                    .getCPGroup(CPGroup.METADATA_CP_GROUP_NAME)
+                    .toCompletableFuture()
+                    .get();
             assertEquals(cpMemberCount - 1, metadataGroup.members().size());
             assertFalse(metadataGroup.members().contains(cpMember3));
         });
 
         HazelcastInstance instance4 = factory.newHazelcastInstance(createConfig(cpMemberCount, cpMemberCount));
         instance4.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                 .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             CPGroup metadataGroup = instances[0].getCPSubsystem()
-                                                .getCPSubsystemManagementService()
-                                                .getCPGroup(CPGroup.METADATA_CP_GROUP_NAME)
-                                                .toCompletableFuture()
-                                                .get();
+                    .getCPSubsystemManagementService()
+                    .getCPGroup(CPGroup.METADATA_CP_GROUP_NAME)
+                    .toCompletableFuture()
+                    .get();
             assertTrue(metadataGroup.members().contains(instance4.getCPSubsystem().getLocalCPMember()));
             assertEquals(cpMemberCount, metadataGroup.members().size());
         });

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
@@ -19,10 +19,10 @@ package com.hazelcast.cp.internal.datastructures.lock;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
 import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.internal.util.RandomPicker;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.RandomPicker;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -90,10 +90,10 @@ public class FencedLockBasicTest extends AbstractFencedLockBasicTest {
     @Test
     public void test_lockFailsAfterCPGroupDestroyed() throws ExecutionException, InterruptedException {
         instances[0].getCPSubsystem()
-                    .getCPSubsystemManagementService()
-                    .forceDestroyCPGroup(lock.getGroupId().getName())
-                    .toCompletableFuture()
-                    .get();
+                .getCPSubsystemManagementService()
+                .forceDestroyCPGroup(lock.getGroupId().getName())
+                .toCompletableFuture()
+                .get();
 
         try {
             lock.lock();

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreAdvancedTest.java
@@ -119,7 +119,7 @@ public class SemaphoreAdvancedTest extends AbstractSemaphoreAdvancedTest {
 
         HazelcastInstance newInstance = factory.newHazelcastInstance(createConfig(groupSize, groupSize));
         newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
-                   .toCompletableFuture().get();
+                .toCompletableFuture().get();
 
         assertTrueEventually(() -> {
             SemaphoreService service = getNodeEngineImpl(newInstance).getService(SemaphoreService.SERVICE_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreBasicTest.java
@@ -21,11 +21,11 @@ import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.cp.internal.RaftOp;
+import com.hazelcast.internal.util.RandomPicker;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.RandomPicker;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
@@ -812,7 +812,7 @@ public class LocalRaftTest extends HazelcastTestSupport {
 
         group.split(leader.getLocalMember());
 
-        assertTrueEventually(() -> assertEquals(RaftRole.FOLLOWER,  getRole(leader)));
+        assertTrueEventually(() -> assertEquals(RaftRole.FOLLOWER, getRole(leader)));
 
         assertEquals(leader.getLocalMember(), getVotedFor(leader));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -25,11 +25,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -76,8 +76,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category(SlowTest.class)
 public class MembershipFailureTest extends HazelcastTestSupport {
 
@@ -650,9 +650,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void test_twoSlavesDisconnected() {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);
@@ -674,9 +674,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void test_twoSlavesDisconnectedFromOneSlave() {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);
@@ -703,9 +703,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void test_oneSlaveDisconnectedFromTwoSlaves() {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);
@@ -731,9 +731,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void test_threeSlavesDisconnectedFromTwoSlaves() {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);
@@ -762,9 +762,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void test_twoSlavesDisconnectedFromThreeSlaves() {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);
@@ -792,9 +792,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void test_multipleDisconnections() {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);
@@ -832,9 +832,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
     private void test_twoSlavesDisconnectedFromOneSlave(ClusterState clusterState) {
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
-                                             .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
-                                             .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
-                                             .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+                .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT.getName(), "5")
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance instance1 = newHazelcastInstance(config);
         HazelcastInstance instance2 = newHazelcastInstance(config);
         HazelcastInstance instance3 = newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/HttpRestEndpointGroupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/HttpRestEndpointGroupsTest.java
@@ -18,12 +18,12 @@ package com.hazelcast.internal.nio.ascii;
 
 import com.hazelcast.config.RestEndpointGroup;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -31,9 +31,9 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 /**
  * Tests if HTTP REST URLs are protected by the correct REST endpoint groups.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category(SlowTest.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category(QuickTest.class)
 public class HttpRestEndpointGroupsTest extends RestApiConfigTestBase {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownSlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownSlowTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/*
+ * When executed with HazelcastParallelClassRunner, this test creates
+ * a massive amount of threads (peaks of 1000 threads and 800 daemon
+ * threads). As comparison the BasicMapTest creates about 700 threads
+ * and 25 daemon threads. This regularly results in test failures when
+ * multiple PR builders run in parallel due to a resource starvation.
+ *
+ * Countermeasures are to remove the ParallelJVMTest
+ * annotation or to use the HazelcastSerialClassRunner.
+ *
+ * Without ParallelJVMTest we'll add the whole test duration
+ * to the PR builder time (about 25 seconds) and still create
+ * the resource usage peak, which may have a negative impact
+ * on parallel PR builder runs on the same host machine.
+ *
+ * With HazelcastSerialClassRunner the test takes over 3 minutes, but
+ * with a maximum of 200 threads and 160 daemon threads. This should
+ * have less impact on other tests and the total duration of the PR
+ * build (since the test will still be executed in parallel to others).
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class GracefulShutdownSlowTest extends GracefulShutdownTest {
+
+    @Override
+    protected Config getConfig() {
+        return regularInstanceConfig();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
@@ -18,13 +18,13 @@ package com.hazelcast.internal.partition;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.test.ChangeLoggingRule;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
@@ -32,8 +32,8 @@ import java.util.Collection;
 
 import static java.util.Arrays.asList;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 // related issue https://github.com/hazelcast/hazelcast/issues/5444
 public class MigrationCorrectnessTest extends AbstractMigrationCorrectnessTest {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.internal.partition.impl.MigrationManager;
 import com.hazelcast.internal.partition.service.TestMigrationAwareService;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/json/MapAggregationJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapAggregationJsonTest.java
@@ -26,12 +26,14 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,16 +48,16 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MapAggregationJsonTest extends HazelcastTestSupport {
 
     public static final int OBJECT_COUNT = 1000;
     private static final String STRING_PREFIX = "s";
 
-    TestHazelcastInstanceFactory factory;
-    HazelcastInstance instance;
+    static TestHazelcastInstanceFactory factory;
+    static HazelcastInstance instance;
 
     @Parameter(0)
     public InMemoryFormat inMemoryFormat;
@@ -73,16 +75,22 @@ public class MapAggregationJsonTest extends HazelcastTestSupport {
         });
     }
 
-    @Before
-    public void setup() {
-        factory = createHazelcastInstanceFactory(3);
-        factory.newInstances(getConfig(), 3);
+    @BeforeClass
+    public static void setup() {
+        factory = new TestHazelcastInstanceFactory(3);
+        factory.newInstances(smallInstanceConfig());
+
         instance = factory.getAllHazelcastInstances().iterator().next();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        factory.terminateAll();
     }
 
     @Override
     protected Config getConfig() {
-        Config config = super.getConfig();
+        Config config = smallInstanceConfig();
         config.getMapConfig("default")
                 .setInMemoryFormat(inMemoryFormat)
                 .setMetadataPolicy(metadataPolicy);

--- a/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
@@ -95,9 +95,9 @@ public class MapIndexJsonTest extends HazelcastTestSupport {
 
     @Override
     protected Config getConfig() {
-        Config config = super.getConfig();
-        MapConfig mapConfig = new MapConfig("default")
-                .setInMemoryFormat(inMemoryFormat)
+        Config config = smallInstanceConfig();
+        MapConfig mapConfig = config.getMapConfig("default");
+        mapConfig.setInMemoryFormat(inMemoryFormat)
                 .setMetadataPolicy(metadataPolicy)
                 .addIndexConfig(sortedIndexConfig("longValue"))
                 .addIndexConfig(sortedIndexConfig("doubleValue"))

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
@@ -27,12 +27,14 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.map.IMap;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -47,13 +49,13 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MapPredicateJsonTest extends HazelcastTestSupport {
 
-    TestHazelcastInstanceFactory factory;
-    HazelcastInstance instance;
+    static TestHazelcastInstanceFactory factory;
+    static HazelcastInstance instance;
 
     @Parameter(0)
     public InMemoryFormat inMemoryFormat;
@@ -71,16 +73,22 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
         });
     }
 
-    @Before
-    public void setup() {
-        factory = createHazelcastInstanceFactory(3);
-        factory.newInstances(getConfig(), 3);
+    @BeforeClass
+    public static void setup() {
+        factory = new TestHazelcastInstanceFactory(3);
+        factory.newInstances(smallInstanceConfig());
+
         instance = factory.getAllHazelcastInstances().iterator().next();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        factory.terminateAll();
     }
 
     @Override
     protected Config getConfig() {
-        Config config = super.getConfig();
+        Config config = smallInstanceConfig();
         config.getMapConfig("default")
                 .setInMemoryFormat(inMemoryFormat)
                 .setMetadataPolicy(metadataPolicy);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapBackupTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.EntryView;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MapBackupTest extends HazelcastTestSupport {
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
+    @Test
+    public void testPutAllBackup() {
+        int size = 100;
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(getConfig());
+        HazelcastInstance instance2 = factory.newHazelcastInstance(getConfig());
+
+        IMap<Integer, Integer> map1 = instance1.getMap("testPutAllBackup");
+        IMap<Integer, Integer> map2 = instance2.getMap("testPutAllBackup");
+        warmUpPartitions(factory.getAllHazelcastInstances());
+
+        Map<Integer, Integer> mm = new HashMap<Integer, Integer>();
+        for (int i = 0; i < size; i++) {
+            mm.put(i, i);
+        }
+
+        map2.putAll(mm);
+        assertEquals(size, map2.size());
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, map2.get(i).intValue());
+        }
+
+        instance2.shutdown();
+        assertEquals(size, map1.size());
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, map1.get(i).intValue());
+        }
+    }
+
+    @Test
+    public void testPutAllTooManyEntriesWithBackup() {
+        int size = 10000;
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(getConfig());
+        HazelcastInstance instance2 = factory.newHazelcastInstance(getConfig());
+
+        IMap<Integer, Integer> map1 = instance1.getMap("testPutAllTooManyEntries");
+        IMap<Integer, Integer> map2 = instance2.getMap("testPutAllTooManyEntries");
+        warmUpPartitions(factory.getAllHazelcastInstances());
+
+        Map<Integer, Integer> mm = new HashMap<Integer, Integer>();
+        for (int i = 0; i < size; i++) {
+            mm.put(i, i);
+        }
+
+        map2.putAll(mm);
+        assertEquals(size, map2.size());
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, map2.get(i).intValue());
+        }
+
+        instance2.shutdown();
+        assertEquals(size, map1.size());
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, map1.get(i).intValue());
+        }
+    }
+
+    @Test
+    public void testIfWeCarryRecordVersionInfoToReplicas() {
+        String mapName = randomMapName();
+        int mapSize = 1000;
+        int expectedRecordVersion = 3;
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance node1 = factory.newHazelcastInstance(getConfig());
+        HazelcastInstance node2 = factory.newHazelcastInstance(getConfig());
+
+        IMap<Integer, Integer> map1 = node1.getMap(mapName);
+        for (int i = 0; i < mapSize; i++) {
+            map1.put(i, 0); // version 0
+            map1.put(i, 1); // version 1
+            map1.put(i, 2); // version 2
+            map1.put(i, 3); // version 3
+        }
+
+        node1.shutdown();
+
+        IMap<Integer, Integer> map3 = node2.getMap(mapName);
+
+        for (int i = 0; i < mapSize; i++) {
+            EntryView<Integer, Integer> entryView = map3.getEntryView(i);
+            assertEquals(expectedRecordVersion, entryView.getVersion());
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderDistributedTest.java
@@ -17,15 +17,16 @@
 package com.hazelcast.map.impl.mapstore;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class EntryLoaderDistributedTest extends EntryLoaderSimpleTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -36,7 +36,8 @@ import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -44,7 +45,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -66,8 +66,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({ParallelJVMTest.class, QuickTest.class})
 public class EntryLoaderSimpleTest extends HazelcastTestSupport {
 
@@ -111,9 +111,9 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
 
     @Test
     public void testEntryWithExpirationTime_expires() {
-        testEntryLoader.putExternally("key", "val", System.currentTimeMillis() + 10000);
+        testEntryLoader.putExternally("key", "val", System.currentTimeMillis() + 3000);
         assertEquals("val", map.get("key"));
-        sleepAtLeastMillis(10000);
+        sleepAtLeastMillis(3000);
         assertNull(map.get("key"));
     }
 
@@ -133,7 +133,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     public void testLoadAllWithExpirationTimes() {
         final int entryCount = 100;
         for (int i = 0; i < entryCount; i++) {
-            testEntryLoader.putExternally("key" + i, "val" + i, System.currentTimeMillis() + 10000);
+            testEntryLoader.putExternally("key" + i, "val" + i, System.currentTimeMillis() + 6000);
         }
         map.loadAll(false);
 
@@ -267,7 +267,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testKeySet() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 3000, 0, entryCount);
         Set<String> entries = map.keySet();
         for (int i = 0; i < entryCount; i++) {
             assertContains(entries, "key" + i);
@@ -278,7 +278,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testKeySet_withPredicate() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 3000, 0, entryCount);
         Set<String> entries = map.keySet(Predicates.greaterEqual("__key", "key90"));
         for (int i = 90; i < entryCount; i++) {
             assertContains(entries, "key" + i);
@@ -289,7 +289,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testValues() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 3000, 0, entryCount);
         Collection<String> entries = map.values();
         for (int i = 0; i < entryCount; i++) {
             assertContains(entries, "val" + i);
@@ -300,7 +300,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testValues_withPredicate() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 3000, 0, entryCount);
         Collection<String> entries = map.values(Predicates.greaterEqual("this", "val90"));
         for (int i = 90; i < entryCount; i++) {
             assertContains(entries, "val" + i);
@@ -311,7 +311,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testEntrySet() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 3000, 0, entryCount);
         Set<Map.Entry<String, String>> entries = map.entrySet();
         for (int i = 0; i < entryCount; i++) {
             assertContains(entries, new AbstractMap.SimpleEntry<>("key" + i, "val" + i));
@@ -322,7 +322,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     @Test
     public void testEntrySet_withPredicate() {
         final int entryCount = 100;
-        putEntriesExternally(testEntryLoader, "key", "val", 10000, 0, entryCount);
+        putEntriesExternally(testEntryLoader, "key", "val", 3000, 0, entryCount);
         Set<Map.Entry<String, String>> entries = map.entrySet(Predicates.greaterEqual("__key", "key90"));
         for (int i = 90; i < entryCount; i++) {
             assertContains(entries, new AbstractMap.SimpleEntry<>("key" + i, "val" + i));

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -31,13 +31,13 @@ import com.hazelcast.spi.merge.LatestUpdateMergePolicy;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -64,8 +64,8 @@ import static org.junit.Assert.fail;
  * The {@link DiscardMergePolicy}, {@link PassThroughMergePolicy} and {@link PutIfAbsentMergePolicy} are also
  * tested with a data structure, which is only created in the smaller cluster.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -147,7 +147,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         MigrationEventsPack secondEventsPack = eventsPackList.get(1);
 
         if (secondEventsPack.migrationProcessCompleted.getCompletedMigrations() == 1
-            && !secondEventsPack.migrationsCompleted.get(0).isSuccess()) {
+                && !secondEventsPack.migrationsCompleted.get(0).isSuccess()) {
             // There is a failed migration process
             // because migrations restarted before 3rd member is ready.
             // This migration process is failed immediately

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
@@ -30,13 +30,13 @@ import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.ParallelParameterized;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -59,8 +59,8 @@ import static org.junit.Assert.fail;
  * The {@link DiscardMergePolicy}, {@link PassThroughMergePolicy} and {@link PutIfAbsentMergePolicy} are also
  * tested with a data structure, which is only created in the smaller cluster.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(ParallelParameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/list/TransactionalListSplitBrainProtectionReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/list/TransactionalListSplitBrainProtectionReadTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.splitbrainprotection.list;
 
 import com.hazelcast.splitbrainprotection.AbstractSplitBrainProtectionTest;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
+import com.hazelcast.test.ParallelParameterized;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -32,7 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
@@ -42,11 +42,10 @@ import java.util.Collection;
 
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ_WRITE;
-import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
-@RunWith(Parameterized.class)
+@RunWith(ParallelParameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class TransactionalListSplitBrainProtectionReadTest extends AbstractSplitBrainProtectionTest {

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/queue/TransactionalQueueSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/queue/TransactionalQueueSplitBrainProtectionWriteTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.READ_WRITE;
 import static com.hazelcast.splitbrainprotection.SplitBrainProtectionOn.WRITE;
-import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
@@ -22,11 +22,14 @@ import org.junit.runners.model.TestTimedOutException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class FailOnTimeoutStatement extends Statement {
+
+    static final String PARALLEL_PREFIX = "Parallel::";
 
     private final Statement originalStatement;
     private final TimeUnit timeUnit;
@@ -62,11 +65,10 @@ public class FailOnTimeoutStatement extends Statement {
     }
 
     Thread newThread(FutureTask<Throwable> task, String name) {
-        if (Thread.currentThread() instanceof MultithreadedTestRunnerThread) {
-            return new MultithreadedTestRunnerThread(task, name);
-        } else {
-            return new Thread(task, name);
+        if (Thread.currentThread() instanceof ForkJoinWorkerThread) {
+            name += PARALLEL_PREFIX;
         }
+        return new Thread(task, name);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -21,22 +21,8 @@ import com.hazelcast.test.annotation.ConfigureParallelRunnerWith;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.Statement;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.io.Reader;
-import java.io.Writer;
 import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -59,7 +45,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
         }
     }
 
-    private static int getDefaultMaxThreads() {
+    static int getDefaultMaxThreads() {
         int cpuWorkers = max(getRuntime().availableProcessors(), 8);
         //the parallel profile can spawn multiple JVMs
         boolean multipleJVM = Boolean.getBoolean("multipleJVM");
@@ -72,20 +58,17 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
         return cpuWorkers;
     }
 
-    private final AtomicInteger numThreads = new AtomicInteger(0);
-    private final int maxThreads;
-
     public HazelcastParallelClassRunner(Class<?> clazz) throws InitializationError {
         super(clazz);
-        maxThreads = getMaxThreads(clazz);
+        setScheduler(new HzRunnerScheduler());
     }
 
     public HazelcastParallelClassRunner(Class<?> clazz, Object[] parameters, String name) throws InitializationError {
         super(clazz, parameters, name);
-        maxThreads = getMaxThreads(clazz);
+        setScheduler(new HzRunnerScheduler());
     }
 
-    private int getMaxThreads(Class<?> clazz) throws InitializationError {
+    public static int getMaxThreads(Class<?> clazz) throws InitializationError {
         if (!SPAWN_MULTIPLE_THREADS) {
             return 1;
         }
@@ -107,39 +90,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
 
     @Override
     protected void runChild(final FrameworkMethod method, final RunNotifier notifier) {
-        while (numThreads.get() >= maxThreads) {
-            try {
-                Thread.sleep(25);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
-            }
-        }
-        numThreads.incrementAndGet();
-        new MultithreadedTestRunnerThread(new TestRunner(method, notifier)).start();
-    }
-
-    @Override
-    protected Statement childrenInvoker(final RunNotifier notifier) {
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                // save the current system properties
-                Properties currentSystemProperties = System.getProperties();
-                try {
-                    // use thread-local based system properties so parallel tests don't effect each other
-                    System.setProperties(new ThreadLocalProperties(currentSystemProperties));
-                    HazelcastParallelClassRunner.super.childrenInvoker(notifier).evaluate();
-                    // wait for all child threads (tests) to complete
-                    while (numThreads.get() > 0) {
-                        Thread.sleep(25);
-                    }
-                } finally {
-                    // restore the system properties
-                    System.setProperties(currentSystemProperties);
-                }
-            }
-        };
+        new TestRunner(method, notifier).run();
     }
 
     private class TestRunner implements Runnable {
@@ -160,190 +111,11 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
                 long start = System.currentTimeMillis();
                 System.out.println("Started Running Test: " + testName);
                 HazelcastParallelClassRunner.super.runChild(method, notifier);
-                numThreads.decrementAndGet();
                 float took = (float) (System.currentTimeMillis() - start) / 1000;
                 System.out.println(format("Finished Running Test: %s in %.3f seconds.", testName, took));
             } finally {
                 removeThreadLocalTestMethodName();
             }
-        }
-    }
-
-    @SuppressWarnings({"deprecation"})
-    private static final class ThreadLocalProperties extends Properties {
-
-        private final Properties globalProperties;
-
-        private final ThreadLocal<Properties> localProperties = new InheritableThreadLocal<Properties>();
-
-        private ThreadLocalProperties(Properties properties) {
-            this.globalProperties = properties;
-        }
-
-        private Properties init(Properties properties) {
-            for (Map.Entry entry : globalProperties.entrySet()) {
-                properties.put(entry.getKey(), entry.getValue());
-            }
-            return properties;
-        }
-
-        private Properties getThreadLocal() {
-            Properties properties = localProperties.get();
-            if (properties == null) {
-                properties = init(new Properties());
-                localProperties.set(properties);
-            }
-            return properties;
-        }
-
-        @Override
-        public String getProperty(String key) {
-            return getThreadLocal().getProperty(key);
-        }
-
-        @Override
-        public Object setProperty(String key, String value) {
-            return getThreadLocal().setProperty(key, value);
-        }
-
-        @Override
-        public Enumeration<?> propertyNames() {
-            return getThreadLocal().propertyNames();
-        }
-
-        @Override
-        public Set<String> stringPropertyNames() {
-            return getThreadLocal().stringPropertyNames();
-        }
-
-        @Override
-        public int size() {
-            return getThreadLocal().size();
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return getThreadLocal().isEmpty();
-        }
-
-        @Override
-        public Enumeration<Object> keys() {
-            return getThreadLocal().keys();
-        }
-
-        @Override
-        public Enumeration<Object> elements() {
-            return getThreadLocal().elements();
-        }
-
-        @Override
-        public boolean contains(Object value) {
-            return getThreadLocal().contains(value);
-        }
-
-        @Override
-        public boolean containsValue(Object value) {
-            return getThreadLocal().containsValue(value);
-        }
-
-        @Override
-        public boolean containsKey(Object key) {
-            return getThreadLocal().containsKey(key);
-        }
-
-        @Override
-        public Object get(Object key) {
-            return getThreadLocal().get(key);
-        }
-
-        @Override
-        public Object put(Object key, Object value) {
-            return getThreadLocal().put(key, value);
-        }
-
-        @Override
-        public Object remove(Object key) {
-            return getThreadLocal().remove(key);
-        }
-
-        @Override
-        public void putAll(Map<?, ?> t) {
-            getThreadLocal().putAll(t);
-        }
-
-        @Override
-        public void clear() {
-            getThreadLocal().clear();
-        }
-
-        @Override
-        public Set<Object> keySet() {
-            return getThreadLocal().keySet();
-        }
-
-        @Override
-        public Set<Map.Entry<Object, Object>> entrySet() {
-            return getThreadLocal().entrySet();
-        }
-
-        @Override
-        public Collection<Object> values() {
-            return getThreadLocal().values();
-        }
-
-        @Override
-        public void load(Reader reader) throws IOException {
-            getThreadLocal().load(reader);
-        }
-
-        @Override
-        public void load(InputStream inStream) throws IOException {
-            getThreadLocal().load(inStream);
-        }
-
-        @Override
-        public void save(OutputStream out, String comments) {
-            getThreadLocal().save(out, comments);
-        }
-
-        @Override
-        public void store(Writer writer, String comments) throws IOException {
-            getThreadLocal().store(writer, comments);
-        }
-
-        @Override
-        public void store(OutputStream out, String comments) throws IOException {
-            getThreadLocal().store(out, comments);
-        }
-
-        @Override
-        public void loadFromXML(InputStream in) throws IOException {
-            getThreadLocal().loadFromXML(in);
-        }
-
-        @Override
-        public void storeToXML(OutputStream os, String comment) throws IOException {
-            getThreadLocal().storeToXML(os, comment);
-        }
-
-        @Override
-        public void storeToXML(OutputStream os, String comment, String encoding) throws IOException {
-            getThreadLocal().storeToXML(os, comment, encoding);
-        }
-
-        @Override
-        public String getProperty(String key, String defaultValue) {
-            return getThreadLocal().getProperty(key, defaultValue);
-        }
-
-        @Override
-        public void list(PrintStream out) {
-            getThreadLocal().list(out);
-        }
-
-        @Override
-        public void list(PrintWriter out) {
-            getThreadLocal().list(out);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -88,6 +88,7 @@ import java.util.function.BiConsumer;
 import static com.hazelcast.internal.partition.TestPartitionUtils.getPartitionServiceState;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.OsHelper.isLinux;
+import static com.hazelcast.test.FailOnTimeoutStatement.PARALLEL_PREFIX;
 import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
 import static java.lang.Integer.getInteger;
 import static java.lang.String.format;
@@ -1456,7 +1457,8 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void assertThatIsNotMultithreadedTest() {
-        assertFalse("Test cannot run with parallel runner", Thread.currentThread() instanceof MultithreadedTestRunnerThread);
+        assertFalse("Test cannot run with parallel runner",
+                Thread.currentThread().getName().contains(PARALLEL_PREFIX));
     }
 
     // ###################################

--- a/hazelcast/src/test/java/com/hazelcast/test/HzRunnerScheduler.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HzRunnerScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HzRunnerScheduler.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HzRunnerScheduler.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import org.junit.runners.model.RunnerScheduler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.test.HazelcastParallelClassRunner.getDefaultMaxThreads;
+
+/**
+ * Runner scheduler to run tests in parallel.
+ */
+public class HzRunnerScheduler implements RunnerScheduler {
+
+    private static final ExecutorService POOL
+            = Executors.newWorkStealingPool(getDefaultMaxThreads());
+
+    private final List<Future<?>> tests = new LinkedList<>();
+    private Properties currentSystemProperties;
+
+    @Override
+    public void schedule(Runnable test) {
+        currentSystemProperties = System.getProperties();
+        System.setProperties(new ThreadLocalProperties(currentSystemProperties));
+
+        tests.add(POOL.submit(test));
+    }
+
+    @Override
+    public void finished() {
+        try {
+            List<Throwable> throwables = new ArrayList<>();
+
+            for (Future<?> test : tests) {
+                try {
+                    test.get();
+                } catch (Throwable t) {
+                    throwables.add(t);
+                }
+            }
+
+            if (!throwables.isEmpty()) {
+                throw createRuntimeException(throwables);
+            }
+        } finally {
+            System.setProperties(currentSystemProperties);
+        }
+    }
+
+    private static RuntimeException createRuntimeException(List<Throwable> throwables) {
+        return new RuntimeException() {
+            @Override
+            public String getMessage() {
+                StringBuilder msg = new StringBuilder();
+                for (Throwable throwable : throwables) {
+                    msg.append("\n\t-------exception-separator--------\n\n\t");
+                    StringWriter sw = new StringWriter();
+                    throwable.printStackTrace(new PrintWriter(sw));
+                    msg.append(sw.toString());
+                    msg.append("\n\t-------exception-separator--------\n");
+                }
+                return msg.toString();
+            }
+        };
+    }
+
+    @SuppressWarnings({"deprecation"})
+    private static final class ThreadLocalProperties extends Properties {
+
+        private final Properties globalProperties;
+
+        private final ThreadLocal<Properties> localProperties = new InheritableThreadLocal<Properties>();
+
+        private ThreadLocalProperties(Properties properties) {
+            this.globalProperties = properties;
+        }
+
+        private Properties init(Properties properties) {
+            for (Map.Entry entry : globalProperties.entrySet()) {
+                properties.put(entry.getKey(), entry.getValue());
+            }
+            return properties;
+        }
+
+        private Properties getThreadLocal() {
+            Properties properties = localProperties.get();
+            if (properties == null) {
+                properties = init(new Properties());
+                localProperties.set(properties);
+            }
+            return properties;
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return getThreadLocal().getProperty(key);
+        }
+
+        @Override
+        public Object setProperty(String key, String value) {
+            return getThreadLocal().setProperty(key, value);
+        }
+
+        @Override
+        public Enumeration<?> propertyNames() {
+            return getThreadLocal().propertyNames();
+        }
+
+        @Override
+        public Set<String> stringPropertyNames() {
+            return getThreadLocal().stringPropertyNames();
+        }
+
+        @Override
+        public int size() {
+            return getThreadLocal().size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return getThreadLocal().isEmpty();
+        }
+
+        @Override
+        public Enumeration<Object> keys() {
+            return getThreadLocal().keys();
+        }
+
+        @Override
+        public Enumeration<Object> elements() {
+            return getThreadLocal().elements();
+        }
+
+        @Override
+        public boolean contains(Object value) {
+            return getThreadLocal().contains(value);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return getThreadLocal().containsValue(value);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return getThreadLocal().containsKey(key);
+        }
+
+        @Override
+        public Object get(Object key) {
+            return getThreadLocal().get(key);
+        }
+
+        @Override
+        public Object put(Object key, Object value) {
+            return getThreadLocal().put(key, value);
+        }
+
+        @Override
+        public Object remove(Object key) {
+            return getThreadLocal().remove(key);
+        }
+
+        @Override
+        public void putAll(Map<?, ?> t) {
+            getThreadLocal().putAll(t);
+        }
+
+        @Override
+        public void clear() {
+            getThreadLocal().clear();
+        }
+
+        @Override
+        public Set<Object> keySet() {
+            return getThreadLocal().keySet();
+        }
+
+        @Override
+        public Set<Map.Entry<Object, Object>> entrySet() {
+            return getThreadLocal().entrySet();
+        }
+
+        @Override
+        public Collection<Object> values() {
+            return getThreadLocal().values();
+        }
+
+        @Override
+        public void load(Reader reader) throws IOException {
+            getThreadLocal().load(reader);
+        }
+
+        @Override
+        public void load(InputStream inStream) throws IOException {
+            getThreadLocal().load(inStream);
+        }
+
+        @Override
+        public void save(OutputStream out, String comments) {
+            getThreadLocal().save(out, comments);
+        }
+
+        @Override
+        public void store(Writer writer, String comments) throws IOException {
+            getThreadLocal().store(writer, comments);
+        }
+
+        @Override
+        public void store(OutputStream out, String comments) throws IOException {
+            getThreadLocal().store(out, comments);
+        }
+
+        @Override
+        public void loadFromXML(InputStream in) throws IOException {
+            getThreadLocal().loadFromXML(in);
+        }
+
+        @Override
+        public void storeToXML(OutputStream os, String comment) throws IOException {
+            getThreadLocal().storeToXML(os, comment);
+        }
+
+        @Override
+        public void storeToXML(OutputStream os, String comment, String encoding) throws IOException {
+            getThreadLocal().storeToXML(os, comment, encoding);
+        }
+
+        @Override
+        public String getProperty(String key, String defaultValue) {
+            return getThreadLocal().getProperty(key, defaultValue);
+        }
+
+        @Override
+        public void list(PrintStream out) {
+            getThreadLocal().list(out);
+        }
+
+        @Override
+        public void list(PrintWriter out) {
+            getThreadLocal().list(out);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/ParallelParameterized.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ParallelParameterized.java
@@ -16,16 +16,13 @@
 
 package com.hazelcast.test;
 
-/**
- * Marker thread subclass for threads created by {@link HazelcastParallelClassRunner}.
- */
-class MultithreadedTestRunnerThread extends Thread {
+import org.junit.runners.Parameterized;
 
-    MultithreadedTestRunnerThread(Runnable target) {
-        super(target);
-    }
+public class ParallelParameterized extends Parameterized {
 
-    MultithreadedTestRunnerThread(Runnable target, String name) {
-        super(target, name);
+    public ParallelParameterized(Class<?> klass) throws Throwable {
+        super(klass);
+
+        setScheduler(new HzRunnerScheduler());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
         <!-- Additional JVM system arguments -->
         <extraVmArgs/>
-        <vmHeapSettings>-Xms512m -Xmx2G</vmHeapSettings>
+        <vmHeapSettings>-Xms2G -Xmx2G</vmHeapSettings>
         <!-- Java 9+ module system args to be appended during surefire/failsafe executions. -->
         <javaModuleArgs/>
     </properties>


### PR DESCRIPTION
- Introduced new `org.junit.runner.Runner` implementation for parallel tests, this runner has no sleep between runs.
- Some tests are re-organized, like separating one test class into two as slow and quick.
- Some tests are refactored to sleep less, like expiration tests
