### PR TITLE
Extract FieldsUtil from sample resolver

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/FieldsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/FieldsUtil.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl;
+
+import com.hazelcast.nio.serialization.ClassDefinition;
+import com.hazelcast.nio.serialization.FieldType;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Utilities to extract a list of properties from a {@link Class} object
+ * using reflection or from {@link ClassDefinition} of a Portable.
+ */
+public class FieldsUtil {
+
+    private static final String METHOD_PREFIX_GET = "get";
+    private static final String METHOD_PREFIX_IS = "is";
+    private static final String METHOD_GET_FACTORY_ID = "getFactoryId";
+    private static final String METHOD_GET_CLASS_ID = "getClassId";
+
+    /**
+     * Return a list of fields and their types from a {@link Class}.
+     */
+    @Nonnull
+    public static SortedMap<String, Class<?>> resolveClass(@Nonnull Class<?> clazz) {
+        SortedMap<String, Class<?>> fields = new TreeMap<>();
+
+        // Add public getters.
+        for (Method method : clazz.getMethods()) {
+            String attributeName = extractAttributeNameFromMethod(clazz, method);
+
+            if (attributeName == null) {
+                continue;
+            }
+
+            fields.putIfAbsent(attributeName, method.getReturnType());
+        }
+
+        // Add public fields.
+        Class<?> currentClass = clazz;
+
+        while (currentClass != Object.class) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                if (!Modifier.isPublic(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+
+                fields.putIfAbsent(field.getName(), field.getType());
+            }
+
+            currentClass = currentClass.getSuperclass();
+        }
+
+        return fields;
+    }
+
+    @Nullable
+    private static String extractAttributeNameFromMethod(@Nonnull Class<?> clazz, @Nonnull Method method) {
+        if (skipMethod(clazz, method)) {
+            return null;
+        }
+
+        String methodName = method.getName();
+
+        String fieldNameWithWrongCase;
+
+        if (methodName.startsWith(METHOD_PREFIX_GET) && methodName.length() > METHOD_PREFIX_GET.length()) {
+            fieldNameWithWrongCase = methodName.substring(METHOD_PREFIX_GET.length());
+        } else if (methodName.startsWith(METHOD_PREFIX_IS) && methodName.length() > METHOD_PREFIX_IS.length()) {
+            // Skip getters that do not return primitive boolean.
+            if (method.getReturnType() != boolean.class) {
+                return null;
+            }
+
+            fieldNameWithWrongCase = methodName.substring(METHOD_PREFIX_IS.length());
+        } else {
+            return null;
+        }
+
+        return Character.toLowerCase(fieldNameWithWrongCase.charAt(0)) + fieldNameWithWrongCase.substring(1);
+    }
+
+    @SuppressWarnings("RedundantIfStatement")
+    private static boolean skipMethod(@Nonnull Class<?> clazz, @Nonnull Method method) {
+        // Exclude non-public getters.
+        if (!Modifier.isPublic(method.getModifiers())) {
+            return true;
+        }
+
+        // Exclude static getters.
+        if (Modifier.isStatic(method.getModifiers())) {
+            return true;
+        }
+
+        // Exclude void return type.
+        Class<?> returnType = method.getReturnType();
+        if (returnType == void.class || returnType == Void.class) {
+            return true;
+        }
+
+        // Skip methods with parameters.
+        if (method.getParameterCount() != 0) {
+            return true;
+        }
+
+        // Skip "getClass"
+        if (method.getDeclaringClass() == Object.class) {
+            return true;
+        }
+
+        // Skip getFactoryId() and getClassId() from Portable and IdentifiedDataSerializable.
+        String methodName = method.getName();
+        if (methodName.equals(METHOD_GET_FACTORY_ID) || methodName.equals(METHOD_GET_CLASS_ID)) {
+            if (IdentifiedDataSerializable.class.isAssignableFrom(clazz) || Portable.class.isAssignableFrom(clazz)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve the list of fields from a portable {@link ClassDefinition},
+     * along with their {@link QueryDataType}.
+     */
+    @Nonnull
+    public static SortedMap<String, QueryDataType> resolvePortable(@Nonnull ClassDefinition clazz) {
+        SortedMap<String, QueryDataType> fields = new TreeMap<>();
+
+        // Add regular fields.
+        for (String name : clazz.getFieldNames()) {
+            FieldType portableType = clazz.getFieldType(name);
+
+            QueryDataType type = resolvePortableType(portableType);
+
+            fields.putIfAbsent(name, type);
+        }
+
+        return fields;
+    }
+
+    @SuppressWarnings("checkstyle:ReturnCount")
+    @Nonnull
+    private static QueryDataType resolvePortableType(@Nonnull FieldType portableType) {
+        switch (portableType) {
+            case BOOLEAN:
+                return QueryDataType.BOOLEAN;
+
+            case BYTE:
+                return QueryDataType.TINYINT;
+
+            case SHORT:
+                return QueryDataType.SMALLINT;
+
+            case CHAR:
+                return QueryDataType.VARCHAR_CHARACTER;
+
+            case UTF:
+                return QueryDataType.VARCHAR;
+
+            case INT:
+                return QueryDataType.INT;
+
+            case LONG:
+                return QueryDataType.BIGINT;
+
+            case FLOAT:
+                return QueryDataType.REAL;
+
+            case DOUBLE:
+                return QueryDataType.DOUBLE;
+
+            default:
+                return QueryDataType.OBJECT;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/FieldsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/FieldsUtil.java
@@ -34,12 +34,14 @@ import java.util.TreeMap;
  * Utilities to extract a list of properties from a {@link Class} object
  * using reflection or from {@link ClassDefinition} of a Portable.
  */
-public class FieldsUtil {
+public final class FieldsUtil {
 
     private static final String METHOD_PREFIX_GET = "get";
     private static final String METHOD_PREFIX_IS = "is";
     private static final String METHOD_GET_FACTORY_ID = "getFactoryId";
     private static final String METHOD_GET_CLASS_ID = "getClassId";
+
+    private FieldsUtil() { }
 
     /**
      * Return a list of fields and their types from a {@link Class}.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/QueryPath.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/QueryPath.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static com.hazelcast.query.QueryConstants.KEY_ATTRIBUTE_NAME;
@@ -53,6 +54,11 @@ public final class QueryPath implements IdentifiedDataSerializable {
         this.key = key;
     }
 
+    /**
+     * Return the field path or {@code null}, if this object represents the
+     * whole value (the whole key or the whole entry value).
+     */
+    @Nullable
     public String getPath() {
         return path;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableField.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/TableField.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.schema;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
 /**
- * Base class for all table field. Different backends may have additional
+ * Base class for all table fields. Different backends may have additional
  * metadata associated with the field.
  */
 public class TableField {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
@@ -108,7 +108,8 @@ public final class MapSampleMetadataResolver {
         // Add top-level object.
         String topName = isKey ? QueryPath.KEY : QueryPath.VALUE;
         QueryPath topPath = isKey ? QueryPath.KEY_PATH : QueryPath.VALUE_PATH;
-        fields.remove(topName); // explicitly remove to have the newly-inserted topName at the end
+        // explicitly remove to have the newly-inserted topName at the end
+        fields.remove(topName);
         fields.put(topName, new MapTableField(topName, QueryDataType.OBJECT, !fields.isEmpty(), topPath));
 
         return new MapSampleMetadata(
@@ -143,7 +144,8 @@ public final class MapSampleMetadataResolver {
         // Add top-level object.
         String topName = isKey ? QueryPath.KEY : QueryPath.VALUE;
         QueryPath topPath = isKey ? QueryPath.KEY_PATH : QueryPath.VALUE_PATH;
-        fields.remove(topName); // explicitly remove to have the newly-inserted topName at the end
+        // explicitly remove to have the newly-inserted topName at the end
+        fields.remove(topName);
         fields.put(topName, new MapTableField(topName, topType, !fields.isEmpty(), topPath));
 
         return new MapSampleMetadata(

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolverTest.java
@@ -220,9 +220,9 @@ public class PartitionedMapTableResolverTest extends MapSchemaTestSupport {
 
         // Check serializable maps. They all should have the same schema.
         MapTableField[] expectedFields = new MapTableField[] {
-            hiddenField(KEY, QueryDataType.OBJECT, true),
             field("field1", QueryDataType.INT, true),
             field("field2", QueryDataType.INT, true),
+            hiddenField(KEY, QueryDataType.OBJECT, true),
             field("field3", QueryDataType.INT, false),
             hiddenField(VALUE, QueryDataType.OBJECT, false)
         };
@@ -234,9 +234,9 @@ public class PartitionedMapTableResolverTest extends MapSchemaTestSupport {
         // Check portable in the OBJECT mode.
         checkFields(
             getExistingTable(tables, MAP_PORTABLE_OBJECT),
-            hiddenField(KEY, QueryDataType.OBJECT, true),
             field("portableField1", QueryDataType.INT, true),
             field("portableField2", QueryDataType.INT, true),
+            hiddenField(KEY, QueryDataType.OBJECT, true),
             field("portableField3", QueryDataType.INT, false),
             hiddenField(VALUE, QueryDataType.OBJECT, false)
         );
@@ -244,9 +244,9 @@ public class PartitionedMapTableResolverTest extends MapSchemaTestSupport {
         // Check portable in the BINARY mode.
         checkFields(
             getExistingTable(tables, MAP_PORTABLE_BINARY),
-            hiddenField(KEY, QueryDataType.OBJECT, true),
             field("portableField1", QueryDataType.INT, true),
             field("portableField2", QueryDataType.INT, true),
+            hiddenField(KEY, QueryDataType.OBJECT, true),
             field("portableField3", QueryDataType.INT, false),
             hiddenField(VALUE, QueryDataType.OBJECT, false)
         );
@@ -264,14 +264,7 @@ public class PartitionedMapTableResolverTest extends MapSchemaTestSupport {
             expectedFields = new MapTableField[0];
         }
 
-        assertEquals(expectedFields.length, table.getFieldCount());
-
-        for (int i = 0; i < expectedFields.length; i++) {
-            MapTableField field = table.getField(i);
-            MapTableField expectedField = expectedFields[i];
-
-            assertEquals(expectedField, field);
-        }
+        assertEquals(Arrays.asList(expectedFields), table.getFields());
     }
 
     @Test


### PR DESCRIPTION
The FieldsUtil will be also used by Jet. So far Jet contained analogous
code with subtle differences.

Also fix the issue when top-level field name clashes with a nested
field, then the top-level field would override the nested field, but be
hidden, even if it's the only field.
