### PR TITLE
Migrate unsecure random provider to ThreadLocalRandom

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandomProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandomProvider.java
@@ -18,16 +18,14 @@ package com.hazelcast.internal.util;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A random number generator isolated to the current thread.
  */
 public final class ThreadLocalRandomProvider {
 
-    private static final Random SEED_GENERATOR = new Random();
-
-    private static final ThreadLocal<Random> THREAD_LOCAL_RANDOM = new ThreadLocal<Random>();
-    private static final ThreadLocal<SecureRandom> THREAD_LOCAL_SECURE_RANDOM = new ThreadLocal<SecureRandom>();
+    private static final ThreadLocal<SecureRandom> THREAD_LOCAL_SECURE_RANDOM = new ThreadLocal<>();
 
     private ThreadLocalRandomProvider() {
     }
@@ -38,13 +36,7 @@ public final class ThreadLocalRandomProvider {
      * @return the current thread's {@link Random}.
      */
     public static Random get() {
-        Random random = THREAD_LOCAL_RANDOM.get();
-        if (random == null) {
-            long seed = SEED_GENERATOR.nextLong();
-            random = new Random(seed);
-            THREAD_LOCAL_RANDOM.set(random);
-        }
-        return random;
+        return ThreadLocalRandom.current();
     }
 
     /**


### PR DESCRIPTION
As the minimal Java version was moved to 8 a while ago, we can start using `ThreadLocalRandom` for as the unsecure random provider. This provider is heavily used for unsecure UUID generation (see `UuidUtil#newUnsecureUUID()` and its usages across the code base).

### Benchmark

I didn't include the benchmark into the PR as it doesn't add a lot of value to the code base, but here it is:
```java
@State(Scope.Benchmark)
public class UuidUtilBenchmark {

    @Benchmark
    public void hzUnsecureUUID(Blackhole blackhole) {
        blackhole.consume(UuidUtil.newUnsecureUUID());
    }

    @Benchmark
    public void threadLocalRandomUnsecureUUID(Blackhole blackhole) {
        blackhole.consume(newThreadLocalRandomUUID());
    }

    public static void main(String[] args) throws RunnerException {
        // @formatter:off
        Options opt = new OptionsBuilder()
                .include(UuidUtilBenchmark.class.getSimpleName())
                .warmupIterations(3)
                .warmupTime(TimeValue.seconds(1))
                .measurementIterations(10)
                .measurementTime(TimeValue.seconds(1))
                .forks(1)
                .threads(1)
                .build();
        // @formatter:on

        new Runner(opt).run();
    }

    public static UUID newThreadLocalRandomUUID() {
        return getUUID(ThreadLocalRandom.current());
    }

    // same implementation as in UuidUtil
    private static UUID getUUID(Random random) {
        byte[] data = new byte[16];
        random.nextBytes(data);

        // clear version
        data[6] &= 0x0f;
        // set to version 4
        data[6] |= 0x40;
        // clear variant
        data[8] &= 0x3f;
        // set to IETF variant
        data[8] |= 0x80;

        long mostSigBits = 0;
        long leastSigBits = 0;
        assert data.length == 16 : "data must be 16 bytes in length";
        for (int i = 0; i < 8; i++) {
            mostSigBits = (mostSigBits << 8) | (data[i] & 0xff);
        }
        for (int i = 8; i < 16; i++) {
            leastSigBits = (leastSigBits << 8) | (data[i] & 0xff);
        }
        return new UUID(mostSigBits, leastSigBits);
    }

}
```

### Benchmark results

Environment: JDK 1.8.0_272, OpenJDK 64-Bit Server VM, 25.272-b10, `uname -a`: Linux apechkurov-laptop 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

Before this PR:
```
Benchmark                                         Mode  Cnt         Score        Error  Units
UuidUtilBenchmark.hzUnsecureUUID                 thrpt   10  22219070.903 ± 289468.900  ops/s
UuidUtilBenchmark.threadLocalRandomUnsecureUUID  thrpt   10  30668308.033 ± 164197.991  ops/s
```

With this PR:
```
Benchmark                                         Mode  Cnt         Score        Error  Units
UuidUtilBenchmark.hzUnsecureUUID                 thrpt   10  30876921.014 ± 110777.956  ops/s
UuidUtilBenchmark.threadLocalRandomUnsecureUUID  thrpt   10  30625661.063 ± 281256.623  ops/s
```