### PR TITLE
Remove assert for unlisted exceptions in the protocol

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -339,7 +339,6 @@ public class ClientExceptionFactory {
         Throwable throwable = null;
         if (exceptionFactory == null) {
             String className = errorHolder.getClassName();
-            assert checkClassNameForValidity(className) : "Exception must be defined in the protocol : " + className;
             try {
                 Class<? extends Throwable> exceptionClass =
                         (Class<? extends Throwable>) ClassLoaderUtil.loadClass(classLoader, className);


### PR DESCRIPTION
The assertion is removed because we don't want to rely on the
users disabling exceptions. A user if enable exceptions
could get asserts.