### PR TITLE
[BACKPORT-4.1.z] The replicationmap-permission support added to configuration persistance handlers

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -595,7 +595,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         final Set<PermissionConfig> clientPermissionConfigs = securityConfig.getClientPermissionConfigs();
         assertFalse(securityConfig.getClientBlockUnmappedActions());
         assertTrue(isNotEmpty(clientPermissionConfigs));
-        assertEquals(24, clientPermissionConfigs.size());
+        assertEquals(PermissionType.values().length, clientPermissionConfigs.size());
         final PermissionConfig pnCounterPermission = new PermissionConfig(PermissionType.PN_COUNTER, "pnCounterPermission", "*")
                 .addAction("create")
                 .setEndpoints(Collections.emptySet());

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -867,6 +867,11 @@
                             <hz:action>all</hz:action>
                         </hz:actions>
                     </hz:reliable-topic-permission>
+                    <hz:replicatedmap-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:replicatedmap-permission>
                 </hz:client-permissions>
                 <hz:client-block-unmapped-actions>false</hz:client-block-unmapped-actions>
             </hz:security>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -2866,6 +2866,8 @@
                                     maxOccurs="unbounded"/>
                         <xs:element name="reliable-topic-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
+                        <xs:element name="replicatedmap-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
                     </xs:choice>
                     <xs:attribute name="on-join-operation" type="permission-on-join-operation" use="optional" default="RECEIVE"/>
                 </xs:complexType>

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -160,7 +160,12 @@ public class PermissionConfig implements IdentifiedDataSerializable {
         /**
          * ReliableTopic
          */
-        RELIABLE_TOPIC("reliable-topic-permission");
+        RELIABLE_TOPIC("reliable-topic-permission"),
+        /**
+         * ReplicatedMap
+         */
+        REPLICATEDMAP("replicatedmap-permission")
+        ;
         private final String nodeName;
 
         PermissionType(String nodeName) {

--- a/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.1.xsd
@@ -2686,6 +2686,7 @@
             <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ring-buffer-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="reliable-topic-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="replicatedmap-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
         <xs:attribute name="on-join-operation" type="permission-on-join-operation" use="optional" default="RECEIVE"/>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2490,6 +2490,11 @@
                     <action>all</action>
                 </actions>
             </pn-counter-permission>
+            <replicatedmap-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </replicatedmap-permission>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
         <security-interceptors>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2412,6 +2412,10 @@ hazelcast:
         - name: "*"
           actions:
             - all
+      replicatedmap:
+        - name: "*"
+          actions:
+            - all
     client-block-unmapped-actions: true
     security-interceptors:
       - com.your-package.YourSecurityInterceptorImplementation

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -537,13 +537,19 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                                         .setUsage(LoginModuleConfig.LoginModuleUsage.REQUIRED))))
                         .setUsernamePasswordIdentityConfig("username", "password"))
                 .setMemberRealmConfig("mr", memberRealm)
-                .setClientPermissionConfigs(new HashSet<>(singletonList(
+                .setClientPermissionConfigs(new HashSet<>(asList(
                         new PermissionConfig()
                                 .setActions(newHashSet("read", "remove"))
                                 .setEndpoints(newHashSet("127.0.0.1", "127.0.0.2"))
                                 .setType(PermissionConfig.PermissionType.ATOMIC_LONG)
                                 .setName("mycounter")
-                                .setPrincipal("devos"))));
+                                .setPrincipal("devos"),
+                        new PermissionConfig()
+                                .setActions(newHashSet("read", "create"))
+                                .setType(PermissionConfig.PermissionType.REPLICATEDMAP)
+                                .setName("rmap")
+                                .setPrincipal("monitor")
+                        )));
 
         cfg.setSecurityConfig(expectedConfig);
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -894,6 +894,11 @@
                     <action>all</action>
                 </actions>
             </reliable-topic-permission>
+            <replicatedmap-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </replicatedmap-permission>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
     </security>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -841,6 +841,11 @@ hazelcast:
           principal: "*"
           actions:
             - all
+      replicatedmap:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
       reliable-topic:
         - name: "*"
           principal: "*"


### PR DESCRIPTION
Backport of #17810 to the `4.1.z` patch stream branch.