### PR TITLE
Moves top slowest serial tests to SlowTest category

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,7 +40,7 @@ import static classloading.ThreadLeakTestUtils.assertHazelcastThreadShutdown;
 import static classloading.ThreadLeakTestUtils.getThreads;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class ThreadLeakClientTest {
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Test;
@@ -52,7 +53,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
 
     @After
@@ -62,6 +63,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
     }
 
     @Test
+    @Category(QuickTest.class)
     public void testClientPortConnection() {
         Config config1 = new Config();
         config1.setClusterName("foo");

--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class HazelcastClientTest extends HazelcastTestSupport {
 
     private static final String CLIENT_CONFIG_PROP_NAME = "hazelcast.client.config";

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/ConnectMemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/ConnectMemberListTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class ConnectMemberListTest extends ClientTestSupport {
 
     @Parameterized.Parameters(name = "shuffleMemberList == {0}")

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -50,6 +50,7 @@ import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Test;
@@ -84,7 +85,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
     private static final ILogger LOGGER = Logger.getLogger(ClientDiscoverySpiTest.class);
@@ -110,6 +111,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     }
 
     @Test
+    @Category(QuickTest.class)
     public void testParsing() {
         String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
         InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);

--- a/hazelcast/src/test/java/com/hazelcast/client/io/AdvancedNetworkClientIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/io/AdvancedNetworkClientIntegrationTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.partition.Partition;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.IScheduledFuture;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -60,7 +61,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class AdvancedNetworkClientIntegrationTest {
 
     private static final int CLUSTER_SIZE = 3;
@@ -86,6 +87,7 @@ public class AdvancedNetworkClientIntegrationTest {
     }
 
     @Test
+    @Category(QuickTest.class)
     public void clientSmokeTest() {
         client = HazelcastClient.newHazelcastClient(getClientConfig());
         IMap<Integer, Integer> map = client.getMap("test");

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -42,7 +42,7 @@ import java.io.FilenameFilter;
 import java.util.concurrent.CountDownLatch;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AutoDetectionJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AutoDetectionJoinTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.cluster;
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -27,7 +28,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class AutoDetectionJoinTest extends AbstractJoinTest {
 
     @Before
@@ -37,6 +38,7 @@ public class AutoDetectionJoinTest extends AbstractJoinTest {
     }
 
     @Test
+    @Category(QuickTest.class)
     public void defaultConfig() throws Exception {
         testJoinEventually(new Config());
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -38,16 +39,16 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.closeConnectionBetween;
-import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class LiteMemberJoinTest {
 
     @Rule
@@ -64,6 +65,7 @@ public class LiteMemberJoinTest {
     }
 
     @Test
+    @Category(QuickTest.class)
     public void test_liteMemberIsCreated() {
         final Config liteConfig = new Config().setLiteMember(true);
         final HazelcastInstance liteInstance = Hazelcast.newHazelcastInstance(liteConfig);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,7 +40,7 @@ import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class MulticastJoinTest extends AbstractJoinTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class TcpIpJoinTest extends AbstractJoinTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -32,7 +32,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,7 +73,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class CacheConfigTest extends HazelcastTestSupport {
 
     private final URL configUrl1 = getClass().getClassLoader().getResource("test-hazelcast-jcache.xml");

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastInstanceFactoryTest.java
@@ -18,13 +18,13 @@ package com.hazelcast.instance.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.instance.TestNodeContext;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     private static Set<Thread> oldThreads;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkIntegrationTest.java
@@ -16,22 +16,24 @@
 
 package com.hazelcast.internal.networking.nio;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.cluster.Member;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Set;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
@@ -39,13 +41,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class AdvancedNetworkIntegrationTest extends AbstractAdvancedNetworkIntegrationTest {
 
     @Rule
     public ExpectedException expect = ExpectedException.none();
 
     @Test
+    @Category(QuickTest.class)
     public void testCompleteMultisocketConfig() {
         Config config = createCompleteMultiSocketConfig();
         newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.server.tcp.TcpServer;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class NioChannelMemoryLeakTest extends HazelcastTestSupport {
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/HttpRestEndpointGroupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/ascii/HttpRestEndpointGroupsTest.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.internal.nio.ascii;
 
+import com.hazelcast.config.RestEndpointGroup;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -24,17 +28,12 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import com.hazelcast.config.RestEndpointGroup;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.annotation.QuickTest;
-
 /**
  * Tests if HTTP REST URLs are protected by the correct REST endpoint groups.
  */
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class HttpRestEndpointGroupsTest extends RestApiConfigTestBase {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_MemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_MemoryLeakTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class TcpServerConnectionManager_MemoryLeakTest
         extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindUponMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindUponMigrationTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.map.impl.mapstore.TestEntryStore;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class WriteBehindUponMigrationTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.OverridePropertyRule;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +38,7 @@ import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.OverridePropertyRule.set;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
 
     @Rule


### PR DESCRIPTION
Some tests are maintained in quick test category
to ensure basic tests are executed in PR builder.