### PR TITLE
Release acquired sessions on failure for SessionAwareSemaphore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cp.internal.datastructures.semaphore.proxy.SessionAwareSemaphoreProxy.DRAIN_SESSION_ACQ_COUNT;
 import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
@@ -99,6 +100,9 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
                 sessionManager.releaseSession(this.groupId, sessionId, permits);
                 throw new IllegalStateException("Semaphore[" + objectName + "] not acquired because the acquire call "
                         + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
+            } catch (Throwable t) {
+                sessionManager.releaseSession(this.groupId, sessionId, permits);
+                throw rethrow(t);
             }
         }
     }
@@ -147,6 +151,9 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
             } catch (WaitKeyCancelledException e) {
                 sessionManager.releaseSession(this.groupId, sessionId, permits);
                 return false;
+            } catch (Throwable t) {
+                sessionManager.releaseSession(this.groupId, sessionId, permits);
+                throw rethrow(t);
             }
         }
     }
@@ -204,6 +211,9 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
                 return count;
             } catch (SessionExpiredException e) {
                 sessionManager.invalidateSession(this.groupId, sessionId);
+            } catch (Throwable t) {
+                sessionManager.releaseSession(this.groupId, sessionId, DRAIN_SESSION_ACQ_COUNT);
+                throw rethrow(t);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreProxy.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cp.internal.datastructures.semaphore.proxy.SessionAwareSemaphoreProxy.DRAIN_SESSION_ACQ_COUNT;
 import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
-import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
@@ -100,9 +99,9 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
                 sessionManager.releaseSession(this.groupId, sessionId, permits);
                 throw new IllegalStateException("Semaphore[" + objectName + "] not acquired because the acquire call "
                         + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
-            } catch (Throwable t) {
+            } catch (RuntimeException e) {
                 sessionManager.releaseSession(this.groupId, sessionId, permits);
-                throw rethrow(t);
+                throw e;
             }
         }
     }
@@ -151,9 +150,9 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
             } catch (WaitKeyCancelledException e) {
                 sessionManager.releaseSession(this.groupId, sessionId, permits);
                 return false;
-            } catch (Throwable t) {
+            } catch (RuntimeException e) {
                 sessionManager.releaseSession(this.groupId, sessionId, permits);
-                throw rethrow(t);
+                throw e;
             }
         }
     }
@@ -211,9 +210,9 @@ public class SessionAwareSemaphoreProxy extends ClientProxy implements ISemaphor
                 return count;
             } catch (SessionExpiredException e) {
                 sessionManager.invalidateSession(this.groupId, sessionId);
-            } catch (Throwable t) {
+            } catch (RuntimeException e) {
                 sessionManager.releaseSession(this.groupId, sessionId, DRAIN_SESSION_ACQ_COUNT);
-                throw rethrow(t);
+                throw e;
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/proxy/SessionAwareSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/proxy/SessionAwareSemaphoreProxy.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
-import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
@@ -102,9 +101,9 @@ public class SessionAwareSemaphoreProxy extends SessionAwareProxy implements ISe
                 releaseSession(sessionId, permits);
                 throw new IllegalStateException("Semaphore[" + objectName + "] not acquired because the acquire call "
                         + "on the CP group is cancelled, possibly because of another indeterminate call from the same thread.");
-            } catch (Throwable t) {
+            } catch (RuntimeException e) {
                 releaseSession(sessionId, permits);
-                throw rethrow(t);
+                throw e;
             }
         }
     }
@@ -151,9 +150,9 @@ public class SessionAwareSemaphoreProxy extends SessionAwareProxy implements ISe
             } catch (WaitKeyCancelledException e) {
                 releaseSession(sessionId, permits);
                 return false;
-            } catch (Throwable t) {
+            } catch (RuntimeException e) {
                 releaseSession(sessionId, permits);
-                throw rethrow(t);
+                throw e;
             }
         }
     }
@@ -203,9 +202,9 @@ public class SessionAwareSemaphoreProxy extends SessionAwareProxy implements ISe
                 return count;
             } catch (SessionExpiredException e) {
                 invalidateSession(sessionId);
-            } catch (Throwable t) {
+            } catch (RuntimeException e) {
                 releaseSession(sessionId, DRAIN_SESSION_ACQ_COUNT);
-                throw rethrow(t);
+                throw e;
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.cp.internal.datastructures.semaphore;
 
 import com.hazelcast.client.cp.internal.session.ClientProxySessionManager;

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -1,0 +1,126 @@
+package com.hazelcast.client.cp.internal.datastructures.semaphore;
+
+import com.hazelcast.client.cp.internal.session.ClientProxySessionManager;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.RaftGroupId;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that acquire, tryAcquire and drainPermits methods
+ * properly release the acquired sessions on errors
+ * other than SessionExpiredException and WaitKeyCancelledException.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends HazelcastRaftTestSupport {
+
+    private SessionAwareSemaphoreProxy semaphore;
+    private ClientProxySessionManager sessionManager;
+    private RaftGroupId groupId;
+
+    @Before
+    public void setup() {
+        newInstances(3);
+        String proxyName = "semaphore@group";
+        HazelcastInstance client = ((TestHazelcastFactory) factory).newHazelcastClient();
+        sessionManager = (((HazelcastClientProxy) client).client).getProxySessionManager();
+        semaphore = (SessionAwareSemaphoreProxy) client.getCPSubsystem().getSemaphore(proxyName);
+        groupId = (RaftGroupId) semaphore.getGroupId();
+    }
+
+    @Override
+    protected TestHazelcastInstanceFactory createTestFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Test
+    public void testAcquire_shouldReleaseSessionsOnRuntimeError() throws InterruptedException {
+        initSemaphoreAndAcquirePermits(10, 5);
+        assertEquals(getSessionAcquireCount(), 5);
+        Future future = spawn(() -> {
+            Thread.currentThread().interrupt();
+            semaphore.acquire(5);
+        });
+
+        try {
+            future.get();
+            fail("Acquire request should have been completed with InterruptedException");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof HazelcastException);
+            assertTrue(e.getCause().getCause() instanceof InterruptedException);
+        }
+        assertEquals(getSessionAcquireCount(), 5);
+    }
+
+    @Test
+    public void testTryAcquire_shouldReleaseSessionsOnRuntimeError() throws InterruptedException {
+        initSemaphoreAndAcquirePermits(2, 1);
+        assertEquals(getSessionAcquireCount(), 1);
+        Future future = spawn(() -> {
+            Thread.currentThread().interrupt();
+            semaphore.tryAcquire(10, TimeUnit.MINUTES);
+        });
+
+        try {
+            future.get();
+            fail("TryAcquire request should have been completed with InterruptedException");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof HazelcastException);
+            assertTrue(e.getCause().getCause() instanceof InterruptedException);
+        }
+        assertEquals(getSessionAcquireCount(), 1);
+    }
+
+    @Test
+    public void testDrainPermits_shouldReleaseSessionsOnRuntimeError() throws InterruptedException {
+        initSemaphoreAndAcquirePermits(42, 2);
+        assertEquals(getSessionAcquireCount(), 2);
+        Future future = spawn(() -> {
+            Thread.currentThread().interrupt();
+            semaphore.drainPermits();
+        });
+
+        try {
+            future.get();
+            fail("DrainPermits request should have been completed with InterruptedException");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof HazelcastException);
+            assertTrue(e.getCause().getCause() instanceof InterruptedException);
+        }
+        assertEquals(getSessionAcquireCount(), 2);
+    }
+
+    private void initSemaphoreAndAcquirePermits(int initialPermits, int acquiredPermits) {
+        // Make sure that we have a session id initialized so that the further
+        // requests to acquire sessions do not make a remote call.
+        semaphore.init(initialPermits);
+        semaphore.acquire(acquiredPermits);
+    }
+
+    private long getSessionAcquireCount() {
+        long sessionId = sessionManager.getSession(groupId);
+        assertNotEquals(sessionId, NO_SESSION_ID);
+        return sessionManager.getSessionAcquireCount(groupId, sessionId);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.cp.internal.datastructures.semaphore;
 
 import com.hazelcast.config.Config;
@@ -69,7 +85,6 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
         try {
             semaphore.acquire(5);
             fail("Acquire operation should have been dropped and failed with OperationTimeoutException");
-
         } catch (OperationTimeoutException ignored) {
         }
         assertEquals(getSessionAcquireCount(), 5);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -1,0 +1,122 @@
+package com.hazelcast.cp.internal.datastructures.semaphore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.RaftGroupId;
+import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
+import com.hazelcast.cp.internal.datastructures.semaphore.proxy.SessionAwareSemaphoreProxy;
+import com.hazelcast.cp.internal.session.ProxySessionManagerService;
+import com.hazelcast.cp.internal.session.SessionAwareProxy;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that acquire, tryAcquire and drainPermits methods
+ * properly release the acquired sessions on errors
+ * other than SessionExpiredException and WaitKeyCancelledException.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends HazelcastRaftTestSupport {
+
+    private HazelcastInstance proxyInstance;
+    private ProxySessionManagerService sessionManagerService;
+    private SessionAwareSemaphoreProxy semaphore;
+    private RaftGroupId groupId;
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] instances = newInstances(3);
+        String proxyName = "semaphore@group";
+        SessionAwareProxy proxy = (SessionAwareProxy) instances[0].getCPSubsystem().getSemaphore(proxyName);
+        proxyInstance = getRandomFollowerInstance(instances, proxy.getGroupId());
+        semaphore = (SessionAwareSemaphoreProxy) proxyInstance.getCPSubsystem().getSemaphore(proxyName);
+        groupId = semaphore.getGroupId();
+        sessionManagerService = getNodeEngineImpl(proxyInstance).getService(ProxySessionManagerService.SERVICE_NAME);
+    }
+
+    @Override
+    protected Config createConfig(int cpNodeCount, int groupSize) {
+        Config config = super.createConfig(cpNodeCount, groupSize);
+        config.setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "5000");
+        return config;
+    }
+
+    @Test
+    public void testAcquire_shouldReleaseSessionsOnRuntimeError() {
+        initSemaphoreAndAcquirePermits(10, 5);
+        assertEquals(getSessionAcquireCount(), 5);
+        dropReplicateOperations();
+        try {
+            semaphore.acquire(5);
+            fail("Acquire operation should have been dropped and failed with OperationTimeoutException");
+
+        } catch (OperationTimeoutException ignored) {
+        }
+        assertEquals(getSessionAcquireCount(), 5);
+    }
+
+
+    @Test
+    public void testTryAcquire_shouldReleaseSessionsOnRuntimeError() {
+        initSemaphoreAndAcquirePermits(2, 1);
+        assertEquals(getSessionAcquireCount(), 1);
+        dropReplicateOperations();
+        try {
+            semaphore.tryAcquire(10, TimeUnit.MINUTES);
+            fail("Acquire operation should have been dropped and failed with OperationTimeoutException");
+        } catch (OperationTimeoutException ignored) {
+        }
+        assertEquals(getSessionAcquireCount(), 1);
+    }
+
+    @Test
+    public void testDrainPermits_shouldReleaseSessionsOnRuntimeError() {
+        initSemaphoreAndAcquirePermits(42, 2);
+        assertEquals(getSessionAcquireCount(), 2);
+        dropReplicateOperations();
+        try {
+            semaphore.drainPermits();
+            fail("DrainPermits operation should have been dropped and failed with OperationTimeoutException");
+        } catch (OperationTimeoutException ignored) {
+        }
+        assertEquals(getSessionAcquireCount(), 2);
+    }
+
+    private void initSemaphoreAndAcquirePermits(int initialPermits, int acquiredPermits) {
+        // Make sure that we have a session id initialized so that the further
+        // requests to acquire sessions do not make a remote call.
+        semaphore.init(initialPermits);
+        semaphore.acquire(acquiredPermits);
+    }
+
+    private void dropReplicateOperations() {
+        List<Integer> opTypes = Collections.singletonList(RaftServiceDataSerializerHook.DEFAULT_RAFT_GROUP_REPLICATE_OP);
+        dropOperationsFrom(proxyInstance, RaftServiceDataSerializerHook.F_ID, opTypes);
+    }
+
+    private long getSessionAcquireCount() {
+        long sessionId = sessionManagerService.getSession(groupId);
+        assertNotEquals(sessionId, NO_SESSION_ID);
+        return sessionManagerService.getSessionAcquireCount(groupId, sessionId);
+    }
+}


### PR DESCRIPTION
In case of an unspecified exception, `acquire`, `tryAcquire` and
`drainPermits` methods were not releasing the acquired permits.
This is an attempt to fix that problem by catching unspecified errors,
releasing the number of acquired permits, and rethrowing.

I will prepare backports once this PR is approved and merged.