### PR TITLE
Allow disabling XXE protection

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -22,11 +22,11 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.internal.util.XmlUtil;
 import com.hazelcast.spi.annotation.PrivateApi;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
-import javax.xml.XMLConstants;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerFactory;
@@ -105,16 +105,12 @@ public abstract class AbstractXmlConfigHelper {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Source xmlSource = new DOMSource(doc);
         Result outputTarget = new StreamResult(outputStream);
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        TransformerFactory transformerFactory = XmlUtil.getTransformerFactory();
         transformerFactory.newTransformer().transform(xmlSource, outputTarget);
         InputStream is = new ByteArrayInputStream(outputStream.toByteArray());
 
         // schema validation
-        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        SchemaFactory schemaFactory = XmlUtil.getSchemaFactory();
         Schema schema = schemaFactory.newSchema(schemas.toArray(new Source[0]));
         Validator validator = schema.newValidator();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -29,26 +29,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
-import javax.xml.XMLConstants;
-import javax.xml.transform.ErrorListener;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static java.lang.Character.isLetter;
 import static java.lang.Character.isLowerCase;
 import static java.lang.Character.toLowerCase;
-
-import java.io.StringReader;
-import java.io.StringWriter;
 
 /**
  * Utility class for Strings.
@@ -74,8 +58,6 @@ public final class StringUtil {
             = Pattern.compile("^(\\d+)\\.(\\d+)(\\.(\\d+))?(-\\w+(?:-\\d+)?)?(-SNAPSHOT)?$");
 
     private static final String GETTER_PREFIX = "get";
-
-    private static final ILogger LOGGER = Logger.getLogger(StringUtil.class);
 
     private StringUtil() {
     }
@@ -475,86 +457,10 @@ public final class StringUtil {
      * @param indent indentation (number of spaces used for one indentation level)
      * @return formatted XML String or the original String if the formatting fails.
      * @throws IllegalArgumentException when indentation is equal to zero
+     * @deprecated Use directly {@link XmlUtil#format(String, int)}
      */
-    @SuppressWarnings("checkstyle:NPathComplexity")
+    @Deprecated
     public static String formatXml(@Nullable String input, int indent) throws IllegalArgumentException {
-        if (input == null || indent < 0) {
-            return input;
-        }
-        if (indent == 0) {
-            throw new IllegalArgumentException("Indentation must not be 0.");
-        }
-        StreamResult xmlOutput = null;
-        try {
-            Source xmlInput = new StreamSource(new StringReader(input));
-            xmlOutput = new StreamResult(new StringWriter());
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-            /*
-             * Older versions of Xalan still use this method of setting indent values.
-             * Attempt to make this work but don't completely fail if it's a problem.
-             */
-            try {
-                transformerFactory.setAttribute("indent-number", indent);
-            } catch (IllegalArgumentException e) {
-                if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("Failed to set indent-number attribute; cause: " + e.getMessage());
-                }
-            }
-            Transformer transformer = transformerFactory.newTransformer();
-            // workaround IBM Java behavior - the silent ignorance of issues during the transformation.
-            transformer.setErrorListener(ThrowingErrorListener.INSTANCE);
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            /*
-             * Newer versions of Xalan will look for a fully-qualified output property in order to specify amount of
-             * indentation to use. Attempt to make this work as well but again don't completely fail if it's a problem.
-             */
-            try {
-                transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", Integer.toString(indent));
-            } catch (IllegalArgumentException e) {
-                if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("Failed to set indent-amount property; cause: " + e.getMessage());
-                }
-            }
-            transformer.transform(xmlInput, xmlOutput);
-            return xmlOutput.getWriter().toString();
-        } catch (Exception e) {
-            LOGGER.warning(e);
-            return input;
-        } finally {
-            if (xmlOutput != null) {
-                closeResource(xmlOutput.getWriter());
-            }
-        }
-    }
-
-    /**
-     * ErrorListener implementation which just throws the error. It workarounds IBM Java default behaviour when
-     * {@link Transformer#transform(Source, javax.xml.transform.Result)} finishes without problems even if an exception is
-     * thrown within the call. If an error happens, we want to know about it and handle it properly.
-     */
-    static final class ThrowingErrorListener implements ErrorListener {
-        public static final ThrowingErrorListener INSTANCE = new ThrowingErrorListener();
-
-        private ThrowingErrorListener() {
-        }
-
-        @Override
-        public void warning(TransformerException exception) throws TransformerException {
-            throw exception;
-        }
-
-        @Override
-        public void fatalError(TransformerException exception) throws TransformerException {
-            throw exception;
-        }
-
-        @Override
-        public void error(TransformerException exception) throws TransformerException {
-            throw exception;
-        }
+        return XmlUtil.format(input, indent);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/XmlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/XmlUtil.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import static com.hazelcast.internal.nio.IOUtil.closeResource;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.annotation.Nullable;
+import javax.xml.XMLConstants;
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+
+import org.xml.sax.SAXException;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+/**
+ * Utility class for XML processing.
+ */
+public final class XmlUtil {
+
+    /**
+     * System property name which allows ignoring failures during enabling the XML External Entity protection.
+     * This property should only be used as a last
+     * resort. Hazelcast uses the XXE protection by setting properties {@link XMLConstants#ACCESS_EXTERNAL_DTD} and
+     * {@link XMLConstants#ACCESS_EXTERNAL_SCHEMA}. These properties are supported in modern XML processors (JAXP 1.5+, Java
+     * 8+). Old JAXP implementations on the classpath (e.g. Xerces, Xalan) may miss the support and they throw exception
+     * during enabling the XXE protection. Setting this system property to true suppresses/ignores such Exceptions.
+     */
+    public static final String SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES = "hazelcast.ignoreXxeProtectionFailures";
+
+    private static final ILogger LOGGER = Logger.getLogger(XmlUtil.class);
+
+    private XmlUtil() {
+    }
+
+    /**
+     * Returns {@link TransformerFactory} with XXE protection enabled.
+     */
+    public static TransformerFactory getTransformerFactory() {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        setAttribute(transformerFactory, XMLConstants.ACCESS_EXTERNAL_DTD);
+        setAttribute(transformerFactory, XMLConstants.ACCESS_EXTERNAL_STYLESHEET);
+        return transformerFactory;
+    }
+
+    /**
+     * Returns {@link SchemaFactory} with XXE protection enabled.
+     */
+    public static SchemaFactory getSchemaFactory() throws SAXException {
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        setProperty(schemaFactory, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+        setProperty(schemaFactory, XMLConstants.ACCESS_EXTERNAL_DTD);
+        return schemaFactory;
+    }
+
+    /**
+     * Formats given XML String with the given indentation used. If the {@code input} XML string is {@code null}, or
+     * {@code indent} parameter is negative, or XML transformation fails, then the original value is returned unchanged. The
+     * {@link IllegalArgumentException} is thrown when {@code indent==0}.
+     *
+     * @param input the XML String
+     * @param indent indentation (number of spaces used for one indentation level)
+     * @return formatted XML String or the original String if the formatting fails.
+     * @throws IllegalArgumentException when indentation is equal to zero
+     */
+    @SuppressWarnings("checkstyle:NPathComplexity")
+    public static String format(@Nullable String input, int indent) throws IllegalArgumentException {
+        if (input == null || indent < 0) {
+            return input;
+        }
+        if (indent == 0) {
+            throw new IllegalArgumentException("Indentation must not be 0.");
+        }
+        StreamResult xmlOutput = null;
+        try {
+            Source xmlInput = new StreamSource(new StringReader(input));
+            xmlOutput = new StreamResult(new StringWriter());
+            TransformerFactory transformerFactory = getTransformerFactory();
+            /*
+             * Older versions of Xalan still use this method of setting indent values.
+             * Attempt to make this work but don't completely fail if it's a problem.
+             */
+            try {
+                transformerFactory.setAttribute("indent-number", indent);
+            } catch (IllegalArgumentException e) {
+                if (LOGGER.isFinestEnabled()) {
+                    LOGGER.finest("Failed to set indent-number attribute; cause: " + e.getMessage());
+                }
+            }
+            Transformer transformer = transformerFactory.newTransformer();
+            // workaround IBM Java behavior - the silent ignorance of issues during the transformation.
+            transformer.setErrorListener(ThrowingErrorListener.INSTANCE);
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            /*
+             * Newer versions of Xalan will look for a fully-qualified output property in order to specify amount of
+             * indentation to use. Attempt to make this work as well but again don't completely fail if it's a problem.
+             */
+            try {
+                transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", Integer.toString(indent));
+            } catch (IllegalArgumentException e) {
+                if (LOGGER.isFinestEnabled()) {
+                    LOGGER.finest("Failed to set indent-amount property; cause: " + e.getMessage());
+                }
+            }
+            transformer.transform(xmlInput, xmlOutput);
+            return xmlOutput.getWriter().toString();
+        } catch (Exception e) {
+            LOGGER.warning(e);
+            return input;
+        } finally {
+            if (xmlOutput != null) {
+                closeResource(xmlOutput.getWriter());
+            }
+        }
+    }
+
+    /**
+     * Returns ErrorListener implementation which just throws the original error.
+     */
+    public ErrorListener getErrorListener() {
+        return ThrowingErrorListener.INSTANCE;
+    }
+
+    static void setAttribute(TransformerFactory transformerFactory, String attributeName) {
+        try {
+            transformerFactory.setAttribute(attributeName, "");
+        } catch (IllegalArgumentException iae) {
+            if (Boolean.getBoolean(SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES)) {
+                LOGGER.warning("Enabling XXE protection failed. The attribute " + attributeName
+                        + " is not supported by the TransformerFactory. The " + SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES
+                        + " system property is used so the XML processing continues in the UNSECURE mode"
+                        + " with XXE protection disabled!!!");
+            } else {
+                LOGGER.severe("Enabling XXE protection failed. The attribute " + attributeName
+                        + " is not supported by the TransformerFactory. This usually mean an outdated XML processor"
+                        + " is present on the classpath (e.g. Xerces, Xalan). If you are not able to resolve the issue by"
+                        + " fixing the classpath, the " + SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES
+                        + " system property can be used to disable XML External Entity protections."
+                        + " We don't recommend disabling the XXE as such the XML processor configuration is unsecure!!!", iae);
+                throw iae;
+            }
+        }
+    }
+
+    static void setProperty(SchemaFactory schemaFactory, String propertyName) throws SAXException {
+        try {
+            schemaFactory.setProperty(propertyName, "");
+        } catch (SAXException e) {
+            if (Boolean.getBoolean(SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES)) {
+                LOGGER.warning("Enabling XXE protection failed. The property " + propertyName
+                        + " is not supported by the SchemaFactory. The " + SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES
+                        + " system property is used so the XML processing continues in the UNSECURE mode"
+                        + " with XXE protection disabled!!!");
+            } else {
+                LOGGER.severe("Enabling XXE protection failed. The property " + propertyName
+                        + " is not supported by the SchemaFactory. This usually mean an outdated XML processor"
+                        + " is present on the classpath (e.g. Xerces, Xalan). If you are not able to resolve the issue by"
+                        + " fixing the classpath, the " + SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES
+                        + " system property can be used to disable XML External Entity protections."
+                        + " We don't recommend disabling the XXE as such the XML processor configuration is unsecure!!!", e);
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * ErrorListener implementation which just throws the error. It workarounds IBM Java default behaviour when
+     * {@link Transformer#transform(Source, javax.xml.transform.Result)} finishes without problems even if an exception is
+     * thrown within the call. If an error happens, we want to know about it and handle it properly.
+     */
+    static final class ThrowingErrorListener implements ErrorListener {
+        public static final ThrowingErrorListener INSTANCE = new ThrowingErrorListener();
+
+        private ThrowingErrorListener() {
+        }
+
+        @Override
+        public void warning(TransformerException exception) throws TransformerException {
+            throw exception;
+        }
+
+        @Override
+        public void fatalError(TransformerException exception) throws TransformerException {
+            throw exception;
+        }
+
+        @Override
+        public void error(TransformerException exception) throws TransformerException {
+            throw exception;
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.Locale;
 
 import static com.hazelcast.internal.util.StringUtil.VERSION_PATTERN;
-import static com.hazelcast.internal.util.StringUtil.formatXml;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -165,26 +164,6 @@ public class StringUtilTest extends HazelcastTestSupport {
         assertEquals("a", StringUtil.stripTrailingSlash("a/"));
         assertEquals("a/a", StringUtil.stripTrailingSlash("a/a"));
         assertEquals("a/", StringUtil.stripTrailingSlash("a//"));
-    }
-
-    @Test
-    public void testFormatXml() throws Exception {
-        assertEquals("<a> <b>c</b></a>", formatXml("<a><b>c</b></a>", 1).replaceAll("[\r\n]", ""));
-        assertEquals("<a>   <b>c</b></a>", formatXml("<a><b>c</b></a>", 3).replaceAll("[\r\n]", ""));
-        assertEquals("<a><b>c</b></a>", formatXml("<a><b>c</b></a>", -21));
-
-        assertThrows(IllegalArgumentException.class, () -> formatXml("<a><b>c</b></a>", 0));
-
-        // check if the XXE protection is enabled
-        String xxeAttack = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-                + "  <!DOCTYPE test [\n"
-                + "    <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n"
-                + "  ]>"
-                + "<a><b>&xxe;</b></a>";
-        assertEquals(xxeAttack, formatXml(xxeAttack, 1));
-
-        // wrongly formatted XML
-        assertEquals("<a><b>c</b><a>", formatXml("<a><b>c</b><a>", 1));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/XmlUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/XmlUtilTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import static com.hazelcast.internal.util.XmlUtil.SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES;
+import static com.hazelcast.internal.util.XmlUtil.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({ QuickTest.class })
+public class XmlUtilTest {
+
+    @Rule
+    public OverridePropertyRule ignoreXxeFailureProp = OverridePropertyRule
+            .clear(SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES);
+
+    @Test
+    public void testFormat() throws Exception {
+        assertEquals("<a> <b>c</b></a>", format("<a><b>c</b></a>", 1).replaceAll("[\r\n]", ""));
+        assertEquals("<a>   <b>c</b></a>", format("<a><b>c</b></a>", 3).replaceAll("[\r\n]", ""));
+        assertEquals("<a><b>c</b></a>", format("<a><b>c</b></a>", -21));
+
+        assertThrows(IllegalArgumentException.class, () -> format("<a><b>c</b></a>", 0));
+
+        // check if the XXE protection is enabled
+        String xxeAttack = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "  <!DOCTYPE test [\n"
+                + "    <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n" + "  ]>" + "<a><b>&xxe;</b></a>";
+        assertEquals(xxeAttack, format(xxeAttack, 1));
+
+        // wrongly formatted XML
+        assertEquals("<a><b>c</b><a>", format("<a><b>c</b><a>", 1));
+    }
+
+    @Test
+    public void testGetSchemaFactory() throws Exception {
+        SchemaFactory schemaFactory = XmlUtil.getSchemaFactory();
+        assertNotNull(schemaFactory);
+        assertThrows(SAXException.class, () -> XmlUtil.setProperty(schemaFactory, "test://no-such-property"));
+        ignoreXxeFailureProp.setOrClearProperty("false");
+        assertThrows(SAXException.class, () -> XmlUtil.setProperty(schemaFactory, "test://no-such-property"));
+        ignoreXxeFailureProp.setOrClearProperty("true");
+        XmlUtil.setProperty(schemaFactory, "test://no-such-property");
+    }
+
+    @Test
+    public void testGetTransformerFactory() throws Exception {
+        TransformerFactory transformerFactory = XmlUtil.getTransformerFactory();
+        assertNotNull(transformerFactory);
+        assertThrows(IllegalArgumentException.class, () -> XmlUtil.setAttribute(transformerFactory, "test://no-such-property"));
+        ignoreXxeFailureProp.setOrClearProperty("false");
+        assertThrows(IllegalArgumentException.class, () -> XmlUtil.setAttribute(transformerFactory, "test://no-such-property"));
+        ignoreXxeFailureProp.setOrClearProperty("true");
+        XmlUtil.setAttribute(transformerFactory, "test://no-such-property");
+    }
+}


### PR DESCRIPTION
Resolves #17839 

This PR introduces a workaround for outdated JAXP on the classpath.
By setting the system property `com.hazelcast.ignoreXxeProtectionFailures=true`, users can configure Hazelcast to ignore errors during enabling the XXE protection.

**Background**
Hazelcast 4.1 enabled External XML Entity (XXE) protection and this was also backported to older versions. The feature works with JAXP 1.5 (Java 7 u40) and newer. So the default XML processing implementations in Java just work with the properties we configure. The problem comes when an old JAXP implementation is added to the classpath (e.g. Xerces, Xalan). The old libraries don't support the properties we use to enable XXE protection and the exception is thrown.
