### PR TITLE
Verify if client is active in TcpClientConnectionManager once

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -460,7 +460,9 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                 }
                 // If the address providers load no addresses (which seems to be possible), then the above loop is not entered
                 // and the lifecycle check is missing, hence we need to repeat the same check at this point.
-                checkClientActive();
+                if (addresses.isEmpty()) {
+                    checkClientActive();
+                }
             } while (waitStrategy.sleep());
         } catch (ClientNotAllowedInClusterException | InvalidConfigurationException e) {
             logger.warning("Stopped trying on the cluster: " + context.getClusterName()


### PR DESCRIPTION
If address providers load more than zero addresses, there's an extra lifecycle check which provides no value.