### PR TITLE
[FORWARD PORT] Fixes for compatibility tests

### DIFF
--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -86,6 +86,9 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <Premain-Class>com.hazelcast.buildutils.FinalRemovalAgent</Premain-Class>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
@@ -113,6 +116,16 @@
             <scope>test</scope>
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${bytebuddy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${bytebuddy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/FinalRemovalAgent.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/FinalRemovalAgent.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.buildutils;
 
+import com.hazelcast.core.HazelcastException;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.ModifierAdjustment;
 import net.bytebuddy.description.modifier.MethodManifestation;
@@ -27,7 +28,6 @@ import java.lang.instrument.Instrumentation;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -100,8 +100,11 @@ public final class FinalRemovalAgent {
         return builder;
     }
 
-    public static <T> Set<T> setOf(T... items) {
-        List<T> list = Arrays.asList(items);
-        return new HashSet<T>(list);
+    private static <T> Set<T> setOf(T... items) {
+        Set<T> set = new HashSet<>(Arrays.asList(items));
+        if (set.size() < items.length) {
+            throw new HazelcastException("set cannot contain duplicate items");
+        }
+        return set;
     }
 }

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/FinalRemovalAgent.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/FinalRemovalAgent.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.hazelcast.test.compatibility;
+package com.hazelcast.buildutils;
 
-import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.ModifierAdjustment;
 import net.bytebuddy.description.modifier.MethodManifestation;
@@ -25,26 +24,31 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.jar.asm.Opcodes;
 
 import java.lang.instrument.Instrumentation;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
-public final class CompatibilityTestUtils {
+public final class FinalRemovalAgent {
 
     // Class name -> List<final method names> to be processed for
     // removing final modifier
     private static final Map<String, Set<String>> FINAL_METHODS;
+
+    private FinalRemovalAgent() {
+    }
 
     static {
         Map<String, Set<String>> finalMethods = new HashMap<>();
         finalMethods.put("com.hazelcast.cp.internal.session.AbstractProxySessionManager",
                 setOf("getSession", "getSessionAcquireCount"));
         finalMethods.put("com.hazelcast.spi.impl.AbstractInvocationFuture",
-                setOf("get"));
+                setOf("get", "join"));
         finalMethods.put("com.hazelcast.cp.internal.datastructures.spi.blocking.AbstractBlockingService",
                 setOf("getRegistryOrNull"));
         finalMethods.put("com.hazelcast.cp.internal.datastructures.spi.blocking.ResourceRegistry",
@@ -61,22 +65,22 @@ public final class CompatibilityTestUtils {
      * more details see {@link net.bytebuddy.ByteBuddy#rebase(Class)} vs
      * {@link net.bytebuddy.ByteBuddy#redefine(Class)}.
      */
-    public static void attachFinalRemovalAgent() {
-        Instrumentation instrumentation = ByteBuddyAgent.install();
-        new AgentBuilder.Default().with(AgentBuilder.TypeStrategy.Default.REDEFINE)
-                                  .with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
-                                  .type(nameStartsWith("com.hazelcast"))
-                                  .transform((builder, typeDescription, classLoader, module) -> {
-                                      builder = manifestMethodAsPlain(builder, typeDescription);
-                                      int actualModifiers = typeDescription.getActualModifiers(false);
-                                      // unset final modifier
-                                      int nonFinalModifiers = actualModifiers & ~Opcodes.ACC_FINAL;
-                                      if (actualModifiers != nonFinalModifiers) {
-                                          return builder.modifiers(nonFinalModifiers);
-                                      } else {
-                                          return builder;
-                                      }
-                                  }).installOn(instrumentation);
+    public static void premain(String argument, Instrumentation instrumentation) {
+        new AgentBuilder.Default()
+                .with(AgentBuilder.TypeStrategy.Default.REDEFINE)
+                .with(AgentBuilder.InitializationStrategy.NoOp.INSTANCE)
+                .type(nameStartsWith("com.hazelcast"))
+                .transform((builder, typeDescription, classLoader, module) -> {
+                    builder = manifestMethodAsPlain(builder, typeDescription);
+                    int actualModifiers = typeDescription.getActualModifiers(false);
+                    // unset final modifier
+                    int nonFinalModifiers = actualModifiers & ~Opcodes.ACC_FINAL;
+                    if (actualModifiers != nonFinalModifiers) {
+                        return builder.modifiers(nonFinalModifiers);
+                    } else {
+                        return builder;
+                    }
+                }).installOn(instrumentation);
     }
 
     /**
@@ -89,10 +93,15 @@ public final class CompatibilityTestUtils {
         if (FINAL_METHODS.containsKey(typeName)) {
             for (String methodName : FINAL_METHODS.get(typeName)) {
                 builder = builder.visit(new ModifierAdjustment()
-                                .withMethodModifiers(named(methodName), MethodManifestation.PLAIN)
+                        .withMethodModifiers(named(methodName), MethodManifestation.PLAIN)
                 );
             }
         }
         return builder;
+    }
+
+    public static <T> Set<T> setOf(T... items) {
+        List<T> list = Arrays.asList(items);
+        return new HashSet<T>(list);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -30,9 +30,6 @@ import javax.cache.CacheManager;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
 import javax.cache.configuration.MutableConfiguration;
-import javax.cache.event.CacheEntryEvent;
-import javax.cache.event.CacheEntryExpiredListener;
-import javax.cache.event.CacheEntryListenerException;
 import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
@@ -274,7 +271,8 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     @Test
     public void testExpiration() {
         CacheConfig<Integer, String> config = new CacheConfig<>();
-        final SimpleExpiryListener<Integer, String> listener = new SimpleExpiryListener<>();
+        final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener =
+                new CacheFromDifferentNodesTest.SimpleEntryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
                 new MutableCacheEntryListenerConfiguration<>(
                         FactoryBuilder.factoryOf(listener), null, true, true);
@@ -292,7 +290,8 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     @Test
     public void testExpiration_entryWithOwnTtl() {
         CacheConfig<Integer, String> config = new CacheConfig<>();
-        final SimpleExpiryListener<Integer, String> listener = new SimpleExpiryListener<>();
+        final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener
+                = new CacheFromDifferentNodesTest.SimpleEntryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration
                 = new MutableCacheEntryListenerConfiguration<>(
                 FactoryBuilder.factoryOf(listener), null, true, true);
@@ -1068,23 +1067,6 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         @Override
         public String toString() {
             return "foo";
-        }
-    }
-
-    public static class SimpleExpiryListener<K, V>
-            implements CacheEntryExpiredListener<K, V>, Serializable {
-
-        public AtomicInteger expired = new AtomicInteger();
-
-        public SimpleExpiryListener() {
-        }
-
-        @Override
-        public void onExpired(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
-                throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> ignored : cacheEntryEvents) {
-                expired.incrementAndGet();
-            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheFromDifferentNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheFromDifferentNodesTest.java
@@ -45,6 +45,7 @@ import javax.cache.event.CacheEntryRemovedListener;
 import javax.cache.event.CacheEntryUpdatedListener;
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -241,32 +242,36 @@ public class CacheFromDifferentNodesTest
         @Override
         public void onCreated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
-                created.incrementAndGet();
-            }
+            incrementCounter(cacheEntryEvents, created);
         }
 
         @Override
         public void onExpired(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
-                expired.incrementAndGet();
-            }
+            incrementCounter(cacheEntryEvents, expired);
         }
 
         @Override
         public void onRemoved(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
-                removed.incrementAndGet();
-            }
+            incrementCounter(cacheEntryEvents, removed);
         }
 
         @Override
         public void onUpdated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
-                updated.incrementAndGet();
+            incrementCounter(cacheEntryEvents, updated);
+        }
+
+        private void incrementCounter(Iterable iterable, AtomicInteger counter) {
+            // actual CacheEntryEvents don't matter
+            // so we avoid referencing each event for the sake
+            // of compatibility tests which have trouble
+            // delegating to event classes across classloaders
+            Iterator iter = iterable.iterator();
+            while (iter.hasNext()) {
+                counter.incrementAndGet();
+                iter.next();
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.test.bounce.BounceMemberRule;
-import com.hazelcast.test.compatibility.CompatibilityTestUtils;
 import com.hazelcast.test.starter.ReflectionUtils;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
@@ -110,7 +109,6 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         JsrTestUtil.setSystemProperties();
 
         if (isRunningCompatibilityTest()) {
-            CompatibilityTestUtils.attachFinalRemovalAgent();
             System.out.println("Running compatibility tests.");
             // Mock network cannot be used for compatibility testing
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "true");

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -180,5 +181,10 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
 
     private boolean checkResourceExcluded(String resourceName) {
         return (parent instanceof FilteringClassLoader) && ((FilteringClassLoader) parent).checkResourceExcluded(resourceName);
+    }
+
+    @Override
+    public String toString() {
+        return "HazelcastAPIDelegatingClassloader{urls = \"" + Arrays.toString(getURLs()) + "\"}";
     }
 }


### PR DESCRIPTION
* Do not reference CacheEntryEvents which do not matter

In SimpleEntryListener for tests, we only care about
counting the number of events. Referencing each
CacheEntryEvent breaks compatibility tests due to
current inability to reference CacheEntryEvents
across classloaders. So instead of performing a
for-each loop, we just use the iterator interface and
increment the respective counters.

* Moves agent implementation to hazelcast-build-utils
When the FinalRemovalAgent is attached at runtime,
it is possible that some classes may have already been
loaded, resulting in random test failures in
compatibility tests. The hazelcast-build-utils
artifact declares the agent in its manifest
so it can be used with java -javaagent on the
command line.

* Adds AbstractInvocationFuture#join to final methods
for processing by FinalRemovalAgent.


Co-authored-by: Sergey Sitnikov <serge.sitnikov@gmail.com>

Clean forward port cherry-picked from #17760