### PR TITLE
Exclude StaticLoggerBinder from sql jar

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -106,6 +106,12 @@
                                         <include>**/Parser.jj</include>
                                     </includes>
                                 </filter>
+                                <filter>
+                                    <artifact>${project.groupId}:${project.artifactId}</artifact>
+                                    <excludes>
+                                        <exclude>org/slf4j/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Excluded `StaticLoggerBinder` from _slim_ sql jar.

Fixes https://github.com/hazelcast/hazelcast-jet/issues/2687