### PR TITLE
Ensure that RestApiConfig configuration parsing doesn't overwrite existing values

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2653,8 +2653,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     private void handleRestApi(Node node) {
-        RestApiConfig restApiConfig = new RestApiConfig();
-        config.getNetworkConfig().setRestApiConfig(restApiConfig);
+        RestApiConfig restApiConfig = config.getNetworkConfig().getRestApiConfig();
         boolean enabled = getBooleanValue(getAttribute(node, "enabled"));
         restApiConfig.setEnabled(enabled);
         handleRestApiEndpointGroups(node);

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -29,6 +29,7 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironment
 import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.runWithSystemProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -59,14 +60,27 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         assertFalse(config.getNetworkConfig().getJoin().isAutoDetectionEnabled());
     }
 
+    @Test
+    public void shouldHandleNetworkRestApiConfig() throws Exception {
+        Config config = new Config();
+        config.getNetworkConfig()
+          .getRestApiConfig()
+          .disableAllGroups();
+
+        withEnvironmentVariable("HZ_NETWORK_RESTAPI_ENABLED", "true")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().isEmpty());
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void shouldDisallowConflictingEntries() throws Exception {
         withEnvironmentVariable("HZ_CLUSTERNAME", "test")
           .execute(
-              () -> runWithSystemProperty("hz.cluster-name", "test2", () -> {
-                  Config config = new Config();
-                  new ExternalConfigurationOverride().overwriteMemberConfig(config);
-              })
+            () -> runWithSystemProperty("hz.cluster-name", "test2", () -> {
+                Config config = new Config();
+                new ExternalConfigurationOverride().overwriteMemberConfig(config);
+            })
           );
     }
 }


### PR DESCRIPTION
Related: https://github.com/hazelcast/hazelcast/issues/17874
Fixes: https://github.com/hazelcast/hazelcast/issues/17675