### PR TITLE
Make SqlResult.close(exception) non null

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/index/IndexRexVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/index/IndexRexVisitor.java
@@ -29,7 +29,7 @@ import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexVisitorImpl;
 
 /**
- * Visitor that checks whether the given epression is valid for index filter creation.
+ * Visitor that checks whether the given expression is valid for index filter creation.
  * <p>
  * Consider the expression {@code a > exp}. If there is an index on the column {@code [a]}, then
  * it can be used only if the {@code exp} will produce the same result for all rows. That is, it
@@ -96,11 +96,13 @@ public final class IndexRexVisitor extends RexVisitorImpl<Void> {
         return markInvalid();
     }
 
-    @Override public Void visitTableInputRef(RexTableInputRef ref) {
+    @Override
+    public Void visitTableInputRef(RexTableInputRef ref) {
         return markInvalid();
     }
 
-    @Override public Void visitPatternFieldRef(RexPatternFieldRef fieldRef) {
+    @Override
+    public Void visitPatternFieldRef(RexPatternFieldRef fieldRef) {
         return markInvalid();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/AbstractSqlResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/AbstractSqlResult.java
@@ -20,7 +20,6 @@ import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public abstract class AbstractSqlResult implements SqlResult {
 
@@ -29,15 +28,15 @@ public abstract class AbstractSqlResult implements SqlResult {
     /**
      * Closes the result, releasing all the resources.
      *
-     * @param exception exception that caused the close operation or {@code null} if the query is closed due to user request
+     * @param exception exception that caused the close operation
      */
-    public abstract void close(@Nullable QueryException exception);
+    public abstract void close(@Nonnull QueryException exception);
 
     @Nonnull @Override
     public abstract ResultIterator<SqlRow> iterator();
 
     @Override
     public void close() {
-        close(null);
+        close(QueryException.cancelledByUser());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryResultProducer.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryResultProducer.java
@@ -18,6 +18,8 @@ package com.hazelcast.sql.impl;
 
 import com.hazelcast.sql.impl.row.Row;
 
+import javax.annotation.Nonnull;
+
 /**
  * Generic interface which produces iterator over results which are then delivered to users.
  * Returned iterator must provide rows which were not returned yet.
@@ -35,5 +37,5 @@ public interface QueryResultProducer {
      *
      * @param error Error.
      */
-    void onError(QueryException error);
+    void onError(@Nonnull QueryException error);
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlResultImpl.java
@@ -89,7 +89,7 @@ public final class SqlResultImpl extends AbstractSqlResult {
     }
 
     @Override
-    public void close(@Nullable QueryException error) {
+    public void close(@Nonnull QueryException error) {
         if (state != null) {
             state.cancel(error, false);
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/root/BlockingRootResultConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/root/BlockingRootResultConsumer.java
@@ -20,6 +20,7 @@ import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.ResultIterator;
 import com.hazelcast.sql.impl.row.Row;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +83,7 @@ public class BlockingRootResultConsumer implements RootResultConsumer {
     }
 
     @Override
-    public void onError(QueryException error) {
+    public void onError(@Nonnull QueryException error) {
         synchronized (mux) {
             if (!done) {
                 done = true;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java
@@ -16,16 +16,16 @@
 
 package com.hazelcast.sql.impl.state;
 
-import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.impl.ClockProvider;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.QueryResultProducer;
-import com.hazelcast.sql.impl.plan.cache.CachedPlanInvalidationCallback;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.plan.Plan;
+import com.hazelcast.sql.impl.plan.cache.CachedPlanInvalidationCallback;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -190,15 +190,10 @@ public final class QueryState implements QueryStateCallback {
     }
 
     @Override
-    public void cancel(@Nullable Exception error, boolean local) {
+    public void cancel(@Nonnull Exception error, boolean local) {
         // Make sure that cancel is performed only once.
         if (!completionGuard.compareAndSet(false, true)) {
             return;
-        }
-
-        // Prepare the normalized exception object.
-        if (error == null) {
-            error = QueryException.cancelledByUser();
         }
 
         QueryException error0 = prepareCancelError(error);


### PR DESCRIPTION
The `AbstractSqlResult.close(QueryException)` currently expects nullable argument. If it's null, the code later replaces it with `QueryException.cancelledByUser()`. This PR makes the `close` method argument non-null and `AbstractSqlResult.close()` immediately passes the `QueryException.cancelledByUser()`. This removes the burden from every subclass to handle the null value, which was an issue in Jet.

Fixes hazelcast/hazelcast-jet#2697

I plan to backport this change to 4.1.1 after it's approved.