### PR TITLE
Cleanup of Rack and Host metadata from Zone Aware group

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
@@ -38,43 +38,17 @@ public class ZoneAwareMemberGroupFactory extends BackupSafeMemberGroupFactory im
     protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
         Map<String, MemberGroup> groups = new HashMap<String, MemberGroup>();
         for (Member member : allMembers) {
-
             final String zoneInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE);
-            final String rackInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK);
-            final String hostInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST);
-
-            if (zoneInfo == null && rackInfo == null && hostInfo == null) {
+            if (zoneInfo == null) {
                 throw new IllegalArgumentException("Not enough metadata information is provided. "
-                        + "At least one of availability zone, rack or host information must be provided "
-                        + "with ZONE_AWARE partition group.");
+                        + "Availability zone information must be provided with ZONE_AWARE partition group.");
             }
-
-            if (zoneInfo != null) {
-                MemberGroup group = groups.get(zoneInfo);
-                if (group == null) {
-                    group = new DefaultMemberGroup();
-                    groups.put(zoneInfo, group);
-                }
-                group.addMember(member);
-            } else {
-                if (rackInfo != null) {
-                    MemberGroup group = groups.get(rackInfo);
-                    if (group == null) {
-                        group = new DefaultMemberGroup();
-                        groups.put(rackInfo, group);
-                    }
-                    group.addMember(member);
-                } else {
-                    if (hostInfo != null) {
-                        MemberGroup group = groups.get(hostInfo);
-                        if (group == null) {
-                            group = new DefaultMemberGroup();
-                            groups.put(hostInfo, group);
-                        }
-                        group.addMember(member);
-                    }
-                }
+            MemberGroup group = groups.get(zoneInfo);
+            if (group == null) {
+                group = new DefaultMemberGroup();
+                groups.put(zoneInfo, group);
             }
+            group.addMember(member);
         }
         return new HashSet<MemberGroup>(groups.values());
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -77,7 +77,7 @@ public interface DiscoveryStrategy {
 
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information
-     * may include, but are not limited, to location information like datacenter, rack, host or additional
+     * may include, but are not limited, to location information like datacenter or additional
      * tags to be used for custom purpose.
      * <p/>
      * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -68,7 +68,7 @@ public interface DiscoveryService {
 
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information
-     * may include, but are not limited, to location information like datacenter, rack, host or additional
+     * may include, but are not limited, to location information like datacenter or additional
      * tags to be used for custom purpose.
      * <p/>
      * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -19,11 +19,9 @@ package com.hazelcast.spi.partitiongroup;
 /**
  * This class contains the definition of known Discovery SPI metadata to support automatic
  * generation of zone aware backup strategies based on cloud or service discovery provided
- * information. These information are split into three different levels of granularity:
+ * information.
  * <ul>
  * <li><b>Zone:</b> A low-latency link between (virtual) data centers in the same area</li>
- * <li><b>Rack:</b> A low-latency link inside the same data center but for different racks</li>
- * <li><b>Host:</b> A low-latency link on a shared physical node, in case of virtualization being used</li>
  * </ul>
  */
 public enum PartitionGroupMetaData {
@@ -33,14 +31,4 @@ public enum PartitionGroupMetaData {
      * Metadata key definition for a low-latency link between (virtual) data centers in the same area
      */
     public static final String PARTITION_GROUP_ZONE = "hazelcast.partition.group.zone";
-
-    /**
-     * Metadata key definition for a low-latency link inside the same data center but for different racks
-     */
-    public static final String PARTITION_GROUP_RACK = "hazelcast.partition.group.rack";
-
-    /**
-     * Metadata key definition for a low-latency link on a shared physical node, in case of virtualization being used
-     */
-    public static final String PARTITION_GROUP_HOST = "hazelcast.partition.group.host";
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
@@ -22,12 +22,12 @@ import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
 /**
  * <p>A <tt>PartitionGroupStrategy</tt> implementation defines a strategy
  * how backup groups are designed. Backup groups are units containing
- * one or more Hazelcast nodes to share the same physical host, rack or
+ * one or more Hazelcast nodes to share the same or
  * zone and backups are stored on nodes being part of a different
  * backup group. This behavior builds an additional layer of data
- * reliability by making sure that, in case of two racks, if rack A
- * fails, rack B will still have all the backups and is guaranteed
- * to still provide all data. Similar is true for zones or physical hosts.</p>
+ * reliability by making sure that, in case of two zones, if zone A
+ * fails, zone B will still have all the backups and is guaranteed
+ * to still provide all data.</p>
  * <p>Custom implementations of the PartitionGroupStrategy may add specific
  * or additional behavior based on the provided environment and can
  * be injected into Hazelcast by overriding

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -110,64 +110,6 @@ public class MemberGroupFactoryTest {
         return members;
     }
 
-    @Test
-    public void testRackMetadataAwareMemberGroupFactoryCreateMemberGroups() {
-        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
-        Collection<Member> members = createMembersWithRackAwareMetadata();
-        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
-
-        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
-        for (MemberGroup memberGroup : memberGroups) {
-            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
-        }
-    }
-
-    private Collection<Member> createMembersWithRackAwareMetadata() {
-        Collection<Member> members = new HashSet<Member>();
-        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
-        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-1");
-
-        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-2");
-
-        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-3");
-
-        members.add(member1);
-        members.add(member2);
-        members.add(member3);
-        return members;
-    }
-
-    @Test
-    public void testHostMetadataAwareMemberGroupFactoryCreateMemberGroups() {
-        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
-        Collection<Member> members = createMembersWithHostAwareMetadata();
-        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
-
-        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
-        for (MemberGroup memberGroup : memberGroups) {
-            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
-        }
-    }
-
-    private Collection<Member> createMembersWithHostAwareMetadata() {
-        Collection<Member> members = new HashSet<Member>();
-        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
-        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-1");
-
-        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-2");
-
-        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-3");
-
-        members.add(member1);
-        members.add(member2);
-        members.add(member3);
-        return members;
-    }
-
     /**
      * When there is a matching {@link MemberGroupConfig} for a {@link Member}, it will be assigned to a {@link MemberGroup}.
      * <p>


### PR DESCRIPTION
`HOST` and `RACK` informations at `ZoneAwareMemberGroupFactory` class are not used by any discovery plugin actively. Currently, only JClouds plugin uses `HOST` metadata but this plugins is already deprecated:
https://github.com/hazelcast/hazelcast-jclouds/blob/master/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategy.java#L40

Azure plugin had used HOST before but it was removed via below commit:
https://github.com/hazelcast/hazelcast-azure/pull/13/files#diff-85cbec642184a3be0fa069a24feaa31789985fe61f84c6bac446de637476fd04L270

As far as I can understand from [PR](https://github.com/hazelcast/hazelcast/pull/8187) and [PRD](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/88899702/More+Partition+Group+Strategies+AWS+Availability+Zones+and+Azure+Failure+Domains+Design) that added these metadata into the codebase, they are JClouds and Azure plugin specific parameters. 

Todo:
- [ ] [IMDG doc update](https://docs.hazelcast.org/docs/latest/manual/html-single/#zone_aware)