### PR TITLE
Implement IMap.entrySet() on a PartitionIdSet 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
@@ -544,9 +544,12 @@ abstract class CacheProxySupport<K, V>
         PartitionIdSet partitionIds = new PartitionIdSet(partitions);
 
         Iterator<Data> iterator = keys.iterator();
-        while (iterator.hasNext() && partitionIds.size() < partitions) {
+        int addedPartitions = 0;
+        while (iterator.hasNext() && addedPartitions < partitions) {
             Data key = iterator.next();
-            partitionIds.add(partitionService.getPartitionId(key));
+            if (partitionIds.add(partitionService.getPartitionId(key))) {
+                addedPartitions++;
+            }
         }
         return partitionIds;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/holder/PagingPredicateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/holder/PagingPredicateHolder.java
@@ -24,6 +24,7 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.predicates.PagingPredicateImpl;
 import com.hazelcast.query.impl.predicates.PartitionPredicateImpl;
 
+import javax.annotation.Nonnull;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -32,13 +33,13 @@ import java.util.Map;
 import java.util.Objects;
 
 public class PagingPredicateHolder {
-    private AnchorDataListHolder anchorDataListHolder;
-    private Data predicateData;
-    private Data comparatorData;
-    private int pageSize;
-    private int page;
-    private byte iterationTypeId;
-    private Data partitionKeyData;
+    private final AnchorDataListHolder anchorDataListHolder;
+    private final Data predicateData;
+    private final Data comparatorData;
+    private final int pageSize;
+    private final int page;
+    private final byte iterationTypeId;
+    private final Data partitionKeyData;
 
     public PagingPredicateHolder(AnchorDataListHolder anchorDataListHolder, Data predicateData, Data comparatorData, int pageSize,
                                  int page, byte iterationTypeId, Data partitionKeyData) {
@@ -80,7 +81,6 @@ public class PagingPredicateHolder {
     }
 
     public <K, V> Predicate<K, V> asPredicate(SerializationService serializationService) {
-
         List<Map.Entry<Integer, Map.Entry<K, V>>> anchorList = anchorDataListHolder.asAnchorList(serializationService);
         Predicate predicate = serializationService.toObject(predicateData);
         Comparator comparator = serializationService.toObject(comparatorData);
@@ -91,7 +91,7 @@ public class PagingPredicateHolder {
             return pagingPredicate;
         }
 
-        return new PartitionPredicateImpl<K, V>(serializationService.toObject(partitionKeyData), pagingPredicate);
+        return new PartitionPredicateImpl<>(serializationService.toObject(partitionKeyData), pagingPredicate);
     }
 
     public static <K, V> PagingPredicateHolder of(Predicate<K, V> predicate,
@@ -112,12 +112,8 @@ public class PagingPredicateHolder {
         return buildHolder(serializationService, pagingPredicate, null);
     }
 
-    private static <K, V> PagingPredicateHolder ofInternal(PartitionPredicate<K, V> partitionPredicate,
+    private static <K, V> PagingPredicateHolder ofInternal(@Nonnull PartitionPredicate<K, V> partitionPredicate,
                                                            SerializationService serializationService) {
-        if (partitionPredicate == null) {
-            return null;
-        }
-
         PagingPredicateImpl<K, V> pagingPredicate = (PagingPredicateImpl<K, V>) partitionPredicate.getTarget();
 
         Data partitionKeyData = serializationService.toData(partitionPredicate.getPartitionKey());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
@@ -73,9 +73,12 @@ public class MapExecuteOnKeysMessageTask
         int partitions = partitionService.getPartitionCount();
         PartitionIdSet partitionIds = new PartitionIdSet(partitions);
         Iterator<Data> iterator = parameters.keys.iterator();
-        while (iterator.hasNext() && partitionIds.size() < partitions) {
+        int addedPartitions = 0;
+        while (iterator.hasNext() && addedPartitions < partitions) {
             Data key = iterator.next();
-            partitionIds.add(partitionService.getPartitionId(key));
+            if (partitionIds.add(partitionService.getPartitionId(key))) {
+                addedPartitions++;
+            }
         }
         return partitionIds;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/PartitionIdSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/PartitionIdSet.java
@@ -39,7 +39,8 @@ import java.util.PrimitiveIterator;
  * This set's {@link PartitionIdSet#iterator() iterator} is a view of the actual
  * set, so any changes on the set will be reflected in the iterator and vice versa.
  * <p>
- * This class is not thread-safe.
+ * This class is not thread-safe. Even if used as immutable, surprisingly,
+ * the {@link #size()} method mutates the state and is not thread-safe.
  */
 public class PartitionIdSet extends AbstractSet<Integer> {
 
@@ -86,6 +87,11 @@ public class PartitionIdSet extends AbstractSet<Integer> {
         return new PartitionIdSetIterator();
     }
 
+    /**
+     * Return the number of partitions in the set.
+     * <p>
+     * The method mutates the state of this instance.
+     */
     @Override
     public int size() {
         if (size == SIZE_UNKNOWN) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -269,7 +269,6 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int WRITE_BEHIND_STATE_HOLDER = 104;
     public static final int AGGREGATION_RESULT = 105;
     public static final int QUERY = 106;
-    public static final int TARGET = 107;
     public static final int MAP_INVALIDATION_METADATA = 108;
     public static final int MAP_INVALIDATION_METADATA_RESPONSE = 109;
     public static final int MAP_NEAR_CACHE_STATE_HOLDER = 110;
@@ -432,7 +431,6 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[WRITE_BEHIND_STATE_HOLDER] = arg -> new WriteBehindStateHolder();
         constructors[AGGREGATION_RESULT] = arg -> new AggregationResult();
         constructors[QUERY] = arg -> new Query();
-        constructors[TARGET] = arg -> new Target();
         constructors[MAP_INVALIDATION_METADATA] = arg -> new MapGetInvalidationMetaDataOperation();
         constructors[MAP_INVALIDATION_METADATA_RESPONSE] = arg -> new MapGetInvalidationMetaDataOperation.MetaDataResponse();
         constructors[MAP_NEAR_CACHE_STATE_HOLDER] = arg -> new MapNearCacheStateHolder();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -130,7 +130,6 @@ import com.hazelcast.map.impl.query.QueryPartitionOperation;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.map.impl.query.ResultSegment;
-import com.hazelcast.map.impl.query.Target;
 import com.hazelcast.map.impl.querycache.accumulator.AccumulatorInfo;
 import com.hazelcast.map.impl.querycache.accumulator.ConsumeAccumulatorOperation;
 import com.hazelcast.map.impl.querycache.subscriber.operation.DestroyQueryCacheOperation;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -688,6 +688,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         return executePredicate(predicate, IterationType.KEY, true, Target.ALL_NODES);
     }
 
+    /**
+     * Execute the {@code keySet} operation on all nodes, but only on the given
+     * {@code partitions}.
+     * <p>
+     * <b>Warning:</b> {@code partitions} is mutated during the call.
+     */
     @SuppressWarnings("unchecked")
     public Set<K> keySet(@Nonnull Predicate<K, V> predicate, PartitionIdSet partitions) {
         return executePredicate(predicate, IterationType.KEY, true, Target.createPartitionTarget(partitions));
@@ -705,6 +711,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         return executePredicate(predicate, IterationType.ENTRY, true, Target.ALL_NODES);
     }
 
+    /**
+     * Execute the {@code entrySet} operation on all nodes, but only on the
+     * given {@code partitions}.
+     * <p>
+     * <b>Warning:</b> {@code partitions} is mutated during the call.
+     */
     @SuppressWarnings("unchecked")
     public Set<Map.Entry<K, V>> entrySet(@Nonnull Predicate predicate, PartitionIdSet partitions) {
         return executePredicate(predicate, IterationType.ENTRY, true, Target.createPartitionTarget(partitions));
@@ -722,6 +734,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         return executePredicate(predicate, IterationType.VALUE, false, Target.ALL_NODES);
     }
 
+    /**
+     * Execute the {@code values} operation on all nodes, but only on the given
+     * {@code partitions}.
+     * <p>
+     * <b>Warning:</b> {@code partitions} is mutated during the call.
+     */
     @SuppressWarnings("unchecked")
     public Collection<V> values(@Nonnull Predicate predicate, PartitionIdSet partitions) {
         return executePredicate(predicate, IterationType.VALUE, false, Target.createPartitionTarget(partitions));
@@ -848,6 +866,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         return project(projection, predicate, Target.ALL_NODES);
     }
 
+    /**
+     * Execute the {@code project} operation on all nodes, but only on the
+     * given {@code partitions}.
+     * <p>
+     * <b>Warning:</b> {@code partitions} is mutated during the call.
+     */
     public <R> Collection<R> project(@Nonnull Projection<? super Map.Entry<K, V>, R> projection,
                                      @Nonnull Predicate<K, V> predicate, PartitionIdSet partitions) {
         return project(projection, predicate, Target.createPartitionTarget(partitions));

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.internal.util.IterationType;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
@@ -684,7 +685,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     @SuppressWarnings("unchecked")
     public Set<K> keySet(@Nonnull Predicate<K, V> predicate) {
-        return executePredicate(predicate, IterationType.KEY, true);
+        return executePredicate(predicate, IterationType.KEY, true, Target.ALL_NODES);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Set<K> keySet(@Nonnull Predicate<K, V> predicate, PartitionIdSet partitions) {
+        return executePredicate(predicate, IterationType.KEY, true, Target.createPartitionTarget(partitions));
     }
 
     @Nonnull
@@ -694,8 +700,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<Map.Entry<K, V>> entrySet(@Nonnull Predicate predicate) {
-        return executePredicate(predicate, IterationType.ENTRY, true);
+        return executePredicate(predicate, IterationType.ENTRY, true, Target.ALL_NODES);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Set<Map.Entry<K, V>> entrySet(@Nonnull Predicate predicate, PartitionIdSet partitions) {
+        return executePredicate(predicate, IterationType.ENTRY, true, Target.createPartitionTarget(partitions));
     }
 
     @Nonnull
@@ -707,12 +719,17 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     @SuppressWarnings("unchecked")
     public Collection<V> values(@Nonnull Predicate predicate) {
-        return executePredicate(predicate, IterationType.VALUE, false);
+        return executePredicate(predicate, IterationType.VALUE, false, Target.ALL_NODES);
     }
 
-    private Set executePredicate(Predicate predicate, IterationType iterationType, boolean uniqueResult) {
+    @SuppressWarnings("unchecked")
+    public Collection<V> values(@Nonnull Predicate predicate, PartitionIdSet partitions) {
+        return executePredicate(predicate, IterationType.VALUE, false, Target.createPartitionTarget(partitions));
+    }
+
+    private Set executePredicate(Predicate predicate, IterationType iterationType, boolean uniqueResult, Target target) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
-        QueryResult result = executeQueryInternal(predicate, iterationType, Target.ALL_NODES);
+        QueryResult result = executeQueryInternal(predicate, iterationType, target);
         incrementOtherOperationsStat();
         return transformToSet(serializationService, result, predicate, iterationType, uniqueResult, false);
     }
@@ -828,6 +845,16 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public <R> Collection<R> project(@Nonnull Projection<? super Map.Entry<K, V>, R> projection,
                                      @Nonnull Predicate<K, V> predicate) {
+        return project(projection, predicate, Target.ALL_NODES);
+    }
+
+    public <R> Collection<R> project(@Nonnull Projection<? super Map.Entry<K, V>, R> projection,
+                                     @Nonnull Predicate<K, V> predicate, PartitionIdSet partitions) {
+        return project(projection, predicate, Target.createPartitionTarget(partitions));
+    }
+
+    private <R> Collection<R> project(@Nonnull Projection<? super Map.Entry<K, V>, R> projection,
+                                     @Nonnull Predicate<K, V> predicate, Target target) {
         checkNotNull(projection, NULL_PROJECTION_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         checkNotPagingPredicate(predicate, "project");
@@ -835,7 +862,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         // HazelcastInstanceAware handled by cloning
         projection = serializationService.toObject(serializationService.toData(projection));
 
-        QueryResult result = executeQueryInternal(predicate, null, projection, IterationType.VALUE, Target.ALL_NODES);
+        QueryResult result = executeQueryInternal(predicate, null, projection, IterationType.VALUE, target);
         return transformToSet(serializationService, result, predicate, IterationType.VALUE, false, false);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -689,8 +689,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     /**
-     * Execute the {@code keySet} operation on all nodes, but only on the given
-     * {@code partitions}.
+     * Execute the {@code keySet} operation only on the given {@code
+     * partitions}.
      * <p>
      * <b>Warning:</b> {@code partitions} is mutated during the call.
      */
@@ -712,8 +712,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     /**
-     * Execute the {@code entrySet} operation on all nodes, but only on the
-     * given {@code partitions}.
+     * Execute the {@code entrySet} operation only on the given {@code
+     * partitions}.
      * <p>
      * <b>Warning:</b> {@code partitions} is mutated during the call.
      */
@@ -735,8 +735,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     /**
-     * Execute the {@code values} operation on all nodes, but only on the given
-     * {@code partitions}.
+     * Execute the {@code values} operation only on the given {@code
+     * partitions}.
      * <p>
      * <b>Warning:</b> {@code partitions} is mutated during the call.
      */
@@ -867,8 +867,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     /**
-     * Execute the {@code project} operation on all nodes, but only on the
-     * given {@code partitions}.
+     * Execute the {@code project} operation only on the given {@code
+     * partitions}.
      * <p>
      * <b>Warning:</b> {@code partitions} is mutated during the call.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -764,7 +764,7 @@ abstract class MapProxySupport<K, V>
                     retrySet.add(entry.getKey());
                 }
             }
-            if (retrySet.size() > 0) {
+            if (!retrySet.isEmpty()) {
                 results = retryPartitions(retrySet, operationFactory);
                 iterator = results.entrySet().iterator();
                 TimeUnit.SECONDS.sleep(1);
@@ -1358,7 +1358,7 @@ abstract class MapProxySupport<K, V>
             Data key = toData(partitionPredicate.getPartitionKey());
             int partitionId = partitionService.getPartitionId(key);
             userPredicate = partitionPredicate.getTarget();
-            target = createPartitionTarget(partitionId);
+            target = createPartitionTarget(new PartitionIdSet(partitionService.getPartitionCount(), partitionId));
         }
         handleHazelcastInstanceAwareParams(userPredicate);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResult.java
@@ -32,7 +32,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNu
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullablePartitionIdSet;
 
 /**
- * Contains the result of the evaluation of an aggregation on a specific Partition or Node.
+ * Contains the result of the evaluation of an aggregation on a specific partition or node.
  * <p>
  * At the end of the aggregation execution path all AggregationResults are merged into one AggregationResult.
  */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.map.impl.query;
 
-import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.util.IterationType;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.query.Target.TargetMode;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
@@ -31,20 +35,16 @@ import com.hazelcast.query.impl.predicates.PagingPredicateImpl;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
-import com.hazelcast.internal.partition.IPartitionService;
-import com.hazelcast.internal.util.IterationType;
-import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.PrimitiveIterator;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.IntConsumer;
 
-import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
-import static com.hazelcast.map.impl.query.Target.ALL_NODES;
-import static com.hazelcast.map.impl.query.Target.LOCAL_NODE;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.SetUtil.allPartitionIds;
 import static java.util.Collections.singletonList;
@@ -93,13 +93,13 @@ public class QueryEngineImpl implements QueryEngine {
             case ALL_NODES:
                 return runOnAllPartitions(adjustedQuery);
             case LOCAL_NODE:
-                return runOnGivenPartitions(adjustedQuery, getLocalPartitionIds());
+                return runOnGivenPartitions(adjustedQuery, getLocalPartitionIds(), TargetMode.LOCAL_NODE);
             case PARTITION_OWNER:
                 int solePartition = target.partitions().solePartition();
                 if (solePartition >= 0) {
                     return runOnGivenPartition(adjustedQuery, solePartition);
                 } else {
-                    return runOnGivenPartitions(adjustedQuery, target.partitions());
+                    return runOnGivenPartitions(adjustedQuery, target.partitions(), TargetMode.ALL_NODES);
                 }
             default:
                 throw new IllegalArgumentException("Illegal target " + query);
@@ -120,8 +120,8 @@ public class QueryEngineImpl implements QueryEngine {
     }
 
     // query thread first, fallback to partition thread
-    private Result runOnGivenPartitions(Query query, PartitionIdSet partitions) {
-        Result result = doRunOnQueryThreads(query, partitions, LOCAL_NODE);
+    private Result runOnGivenPartitions(Query query, PartitionIdSet partitions, TargetMode targetMode) {
+        Result result = doRunOnQueryThreads(query, partitions, targetMode);
         if (isResultFromAnyPartitionMissing(partitions)) {
             doRunOnPartitionThreads(query, partitions, result);
         }
@@ -134,7 +134,7 @@ public class QueryEngineImpl implements QueryEngine {
     private Result runOnAllPartitions(Query query) {
         PartitionIdSet mutablePartitionIds = getAllPartitionIds();
 
-        Result result = doRunOnQueryThreads(query, mutablePartitionIds, ALL_NODES);
+        Result result = doRunOnQueryThreads(query, mutablePartitionIds, TargetMode.ALL_NODES);
         if (isResultFromAnyPartitionMissing(mutablePartitionIds)) {
             doRunOnPartitionThreads(query, mutablePartitionIds, result);
         }
@@ -153,16 +153,16 @@ public class QueryEngineImpl implements QueryEngine {
         }
     }
 
-    private Result doRunOnQueryThreads(Query query, PartitionIdSet partitionIds, Target target) {
+    private Result doRunOnQueryThreads(Query query, PartitionIdSet partitionIds, TargetMode targetMode) {
         Result result = populateResult(query, partitionIds);
-        List<Future<Result>> futures = dispatchOnQueryThreads(query, target);
+        List<Future<Result>> futures = dispatchOnQueryThreads(query, partitionIds, targetMode);
         addResultsOfPredicate(futures, result, partitionIds, false);
         return result;
     }
 
-    private List<Future<Result>> dispatchOnQueryThreads(Query query, Target target) {
+    private List<Future<Result>> dispatchOnQueryThreads(Query query, PartitionIdSet partitionIds, TargetMode targetMode) {
         try {
-            return dispatchFullQueryOnQueryThread(query, target);
+            return dispatchFullQueryOnQueryThread(query, partitionIds, targetMode);
         } catch (Throwable t) {
             if (!(t instanceof HazelcastException)) {
                 // these are programmatic errors that needs to be visible
@@ -256,7 +256,8 @@ public class QueryEngineImpl implements QueryEngine {
         return new PartitionIdSet(partitionCount, memberPartitions);
     }
 
-    private PartitionIdSet getAllPartitionIds() {
+    // package-private for tests
+    PartitionIdSet getAllPartitionIds() {
         int partitionCount = partitionService.getPartitionCount();
         return allPartitionIds(partitionCount);
     }
@@ -269,10 +270,14 @@ public class QueryEngineImpl implements QueryEngine {
         return queryResultSizeLimiter;
     }
 
-    protected List<Future<Result>> dispatchFullQueryOnQueryThread(Query query, Target target) {
-        switch (target.mode()) {
+    protected List<Future<Result>> dispatchFullQueryOnQueryThread(
+            Query query,
+            PartitionIdSet partitionIdSet,
+            TargetMode targetMode
+    ) {
+        switch (targetMode) {
             case ALL_NODES:
-                return dispatchFullQueryOnAllMembersOnQueryThread(query);
+                return dispatchFullQueryOnAllMembersOnQueryThread(query, partitionIdSet);
             case LOCAL_NODE:
                 return dispatchFullQueryOnLocalMemberOnQueryThread(query);
             default:
@@ -287,13 +292,17 @@ public class QueryEngineImpl implements QueryEngine {
         return singletonList(result);
     }
 
-    private List<Future<Result>> dispatchFullQueryOnAllMembersOnQueryThread(Query query) {
-        Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
+    private List<Future<Result>> dispatchFullQueryOnAllMembersOnQueryThread(Query query, PartitionIdSet partitionIdSet) {
+        Set<Address> members = new HashSet<>();
+        for (PrimitiveIterator.OfInt iterator = partitionIdSet.intIterator(); iterator.hasNext(); ) {
+            members.add(partitionService.getPartitionOwner(iterator.next()));
+        }
+
         List<Future<Result>> futures = new ArrayList<>(members.size());
-        for (Member member : members) {
+        for (Address address : members) {
             Operation operation = createQueryOperation(query);
             Future<Result> future = operationService.invokeOnTarget(
-                    MapService.SERVICE_NAME, operation, member.getAddress());
+                    MapService.SERVICE_NAME, operation, address);
             futures.add(future);
         }
         return futures;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
@@ -91,7 +91,7 @@ public class QueryEngineImpl implements QueryEngine {
         Query adjustedQuery = adjustQuery(query);
         switch (target.mode()) {
             case ALL_NODES:
-                return runOnAllPartitions(adjustedQuery);
+                return runOnGivenPartitions(adjustedQuery, getAllPartitionIds(), TargetMode.ALL_NODES);
             case LOCAL_NODE:
                 return runOnGivenPartitions(adjustedQuery, getLocalPartitionIds(), TargetMode.LOCAL_NODE);
             case PARTITION_OWNER:
@@ -126,19 +126,6 @@ public class QueryEngineImpl implements QueryEngine {
             doRunOnPartitionThreads(query, partitions, result);
         }
         assertAllPartitionsQueried(partitions);
-
-        return result;
-    }
-
-    // query thread first, fallback to partition thread
-    private Result runOnAllPartitions(Query query) {
-        PartitionIdSet mutablePartitionIds = getAllPartitionIds();
-
-        Result result = doRunOnQueryThreads(query, mutablePartitionIds, TargetMode.ALL_NODES);
-        if (isResultFromAnyPartitionMissing(mutablePartitionIds)) {
-            doRunOnPartitionThreads(query, mutablePartitionIds, result);
-        }
-        assertAllPartitionsQueried(mutablePartitionIds);
 
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.util.collection.PartitionIdSet;
 import java.util.Map;
 
 /**
- * Result of a Query. Each query type implements its own Result.
+ * Result of a query. Each query type implements its own Result.
  *
  * @param <T> type of the result for the concrete implementations
  */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
@@ -30,7 +30,7 @@ import static com.hazelcast.map.impl.query.Target.TargetMode.PARTITION_OWNER;
  *     <li>given partition set
  * </ul>
  */
-public class Target {
+public final class Target {
 
     public static final Target ALL_NODES = new Target(TargetMode.ALL_NODES, null);
     public static final Target LOCAL_NODE = new Target(TargetMode.LOCAL_NODE, null);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
@@ -81,6 +81,9 @@ public class Target implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        if (true) {
+            throw new UnsupportedOperationException();
+        }
         // TODO use IDS
         out.writeObject(partitions);
         out.writeUTF(mode.name());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
@@ -17,12 +17,6 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.internal.util.collection.PartitionIdSet;
-import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-
-import java.io.IOException;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.map.impl.query.Target.TargetMode.PARTITION_OWNER;
@@ -36,7 +30,7 @@ import static com.hazelcast.map.impl.query.Target.TargetMode.PARTITION_OWNER;
  *     <li>given partition set
  * </ul>
  */
-public class Target implements IdentifiedDataSerializable {
+public class Target {
 
     public static final Target ALL_NODES = new Target(TargetMode.ALL_NODES, null);
     public static final Target LOCAL_NODE = new Target(TargetMode.LOCAL_NODE, null);
@@ -67,32 +61,6 @@ public class Target implements IdentifiedDataSerializable {
         LOCAL_NODE,
         ALL_NODES,
         PARTITION_OWNER
-    }
-
-    @Override
-    public int getFactoryId() {
-        return MapDataSerializerHook.F_ID;
-    }
-
-    @Override
-    public int getClassId() {
-        return MapDataSerializerHook.TARGET;
-    }
-
-    @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
-        if (true) {
-            throw new UnsupportedOperationException();
-        }
-        // TODO use IDS
-        out.writeObject(partitions);
-        out.writeUTF(mode.name());
-    }
-
-    @Override
-    public void readData(ObjectDataInput in) throws IOException {
-        this.partitions = in.readObject();
-        this.mode = TargetMode.valueOf(in.readUTF());
     }
 
     public static Target createPartitionTarget(PartitionIdSet partitions) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
@@ -63,7 +63,7 @@ public class Target implements IdentifiedDataSerializable {
         return partitions;
     }
 
-    enum TargetMode {
+    public enum TargetMode {
         LOCAL_NODE,
         ALL_NODES,
         PARTITION_OWNER

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
@@ -35,11 +35,8 @@ public class Target {
     public static final Target ALL_NODES = new Target(TargetMode.ALL_NODES, null);
     public static final Target LOCAL_NODE = new Target(TargetMode.LOCAL_NODE, null);
 
-    private TargetMode mode;
-    private PartitionIdSet partitions;
-
-    public Target() {
-    }
+    private final TargetMode mode;
+    private final PartitionIdSet partitions;
 
     private Target(TargetMode mode, PartitionIdSet partitions) {
         this.mode = checkNotNull(mode);

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -25,14 +25,14 @@ import java.util.Map;
  * This interface is a special Predicate which helps to get a page-by-page result of a query.
  * It can be constructed with a page-size, an inner predicate for filtering, and a comparator for sorting.
  * This class is not thread-safe and stateless. To be able to reuse for another query, one should call
- * {@link #reset()}
+ * {@link #reset()}.
  * <br>
- * Here is an example usage.
+ * Here is an example usage:
  * <pre>
  * Predicate lessEqualThanFour = Predicates.lessEqual("this", 4);
  *
- * // We are constructing our paging predicate with a predicate and page size. In this case query results fetched two
- * by two.
+ * // We are constructing our paging predicate with a predicate and a page size. In this case query results
+ * // are fetched in batches of two.
  * PagingPredicate predicate = Predicates.pagingPredicate(lessEqualThanFour, 2);
  *
  * // we are initializing our map with integers from 0 to 10 as keys and values.
@@ -44,12 +44,12 @@ import java.util.Map;
  * // invoking the query
  * Collection&lt;Integer&gt; values = map.values(predicate);
  * System.out.println("values = " + values) // will print 'values = [0, 1]'
- * predicate.nextPage(); // we are setting up paging predicate to fetch next page in the next call.
+ * predicate.nextPage(); // we are setting up paging predicate to fetch the next page in the next call.
  * values = map.values(predicate);
  * System.out.println("values = " + values);// will print 'values = [2, 3]'
  * Entry anchor = predicate.getAnchor();
  * System.out.println("anchor -&gt; " + anchor); // will print 'anchor -&gt; 1=1',  since the anchor is the last entry of
- * the previous page.
+ *                                               // the previous page.
  * predicate.previousPage(); // we are setting up paging predicate to fetch previous page in the next call
  * values = map.values(predicate);
  * System.out.println("values = " + values) // will print 'values = [0, 1]'

--- a/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
@@ -19,11 +19,11 @@ package com.hazelcast.query;
 import com.hazelcast.internal.serialization.BinaryInterface;
 
 /**
- * A {@link Predicate} that restricts the execution of a Predicate to a single Partition.
+ * A {@link Predicate} that restricts the execution of a {@link Predicate} to a single partition.
  *
  * This can help to speed up query execution since only a single instead of all partitions needs to be queried.
  *
- * This predicate can only be used as an outer predicate.
+ * This predicate only has effect if used as an outermost predicate.
  *
  * @param <K> type of the entry key
  * @param <V> type of the entry value
@@ -33,17 +33,15 @@ import com.hazelcast.internal.serialization.BinaryInterface;
 public interface PartitionPredicate<K, V> extends Predicate<K, V> {
 
     /**
-     * Returns the partition key that determines the partition the target {@link Predicate} is going to execute on.
+     * Returns the partition key that determines the partition the {@linkplain
+     * #getTarget() target} {@link Predicate} is going to execute on.
      *
-     * @return the partition ID
+     * @return the partition key
      */
     Object getPartitionKey();
 
     /**
      * Returns the target {@link Predicate}.
-     *
-     * @return the target {@link Predicate}.
      */
     Predicate<K, V> getTarget();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -68,19 +68,19 @@ import static com.hazelcast.spi.properties.ClusterProperty.PRIORITY_GENERIC_OPER
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * A {@link com.hazelcast.spi.impl.operationexecutor.OperationExecutor} that schedules:
+ * An {@link OperationExecutor} that schedules:
  * <ol>
- * <li>partition specific operations to a specific partition-operation-thread (using a mod on the partition ID)</li>
- * <li>non specific operations to generic-operation-threads</li>
+ * <li>partition-specific operations to a specific-partition operation thread (using a mod on the partition ID)</li>
+ * <li>non-specific operations to generic operation threads</li>
  * </ol>
  * The {@link #execute(Object, int, boolean)} accepts an Object instead of a runnable to prevent needing to
- * create wrapper runnables around tasks. This is done to reduce the amount of object litter and therefor
- * reduce pressure on the GC.
+ * create wrapper Runnables around tasks. This is done to reduce the amount of object litter and therefore
+ * reduce the pressure on the GC.
  * <p>
- * There are 2 category of operation threads:
+ * There are 2 categories of operation threads:
  * <ol>
- * <li>partition specific operation threads: these threads are responsible for executing e.g. a map.put.
- * Operations for the same partition, always end up in the same thread.
+ * <li>partition-specific operation threads: these threads are responsible for executing e.g. a {@code map.put()}.
+ * Operations for the same partition always end up in the same thread.
  * </li>
  * <li>
  * generic operation threads: these threads are responsible for executing operations that are not
@@ -101,7 +101,7 @@ public final class OperationExecutorImpl implements OperationExecutor, StaticMet
     private final OperationRunner[] partitionOperationRunners;
 
     private final OperationQueue genericQueue
-            = new OperationQueueImpl(new LinkedBlockingQueue<Object>(), new LinkedBlockingQueue<Object>());
+            = new OperationQueueImpl(new LinkedBlockingQueue<>(), new LinkedBlockingQueue<>());
 
     // all operations that are not specific for a partition will be executed here, e.g. heartbeat or map.size()
     private final GenericOperationThread[] genericThreads;
@@ -163,9 +163,9 @@ public final class OperationExecutorImpl implements OperationExecutor, StaticMet
         for (int threadId = 0; threadId < threads.length; threadId++) {
             String threadName = createThreadPoolName(hzName, "partition-operation") + threadId;
             // the normalQueue will be a blocking queue. We don't want to idle, because there are many operation threads.
-            MPSCQueue<Object> normalQueue = new MPSCQueue<Object>(idleStrategy);
+            MPSCQueue<Object> normalQueue = new MPSCQueue<>(idleStrategy);
 
-            OperationQueue operationQueue = new OperationQueueImpl(normalQueue, new ConcurrentLinkedQueue<Object>());
+            OperationQueue operationQueue = new OperationQueueImpl(normalQueue, new ConcurrentLinkedQueue<>());
 
             PartitionOperationThread partitionThread = new PartitionOperationThread(threadName, threadId, operationQueue, logger,
                     nodeExtension, partitionOperationRunners, configClassLoader);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -261,9 +261,9 @@ public final class SlowOperationDetector {
         }
 
         private void logWithConfigHint(SlowOperationLog log) {
-            // print a hint once how to enable logging of stacktraces
+            // print a hint once how to enable logging of stack traces
             logger.warning(format("Slow operation detected: %s"
-                            + "%nHint: You can enable the logging of stacktraces with the following system property: -D%s",
+                            + "%nHint: You can enable the logging of stack traces with the following system property: -D%s",
                     log.operation, SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED));
             isFirstLog = false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -27,7 +27,7 @@ import static com.hazelcast.internal.nio.IOUtil.writeObject;
 import static com.hazelcast.spi.impl.SpiDataSerializerHook.NORMAL_RESPONSE;
 
 /**
- * A NormalResponse is send when an Operation needs to return a value. This response value can be a 'normal' value,
+ * A NormalResponse is sent when an Operation needs to return a value. This response value can be a 'normal' value,
  * but it can also contain the exception thrown.
  * <p>
  * Currently there is a limitation in the design that needs to be dealt with in the future: there is no distinction

--- a/hazelcast/src/test/java/com/hazelcast/client/projection/ClientMapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/projection/ClientMapProjectionTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.MapProjectionTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -58,9 +57,9 @@ public class ClientMapProjectionTest extends MapProjectionTest {
                 .addMapConfig(mapConfig);
 
         factory.newInstances(config, nodeCount);
-        HazelcastInstance client = factory.newHazelcastClient();
+        instance0 = factory.newHazelcastClient();
 
-        return client.getMap("aggr");
+        return instance0.getMap("aggr");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/projection/ClientMapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/projection/ClientMapProjectionTest.java
@@ -36,7 +36,7 @@ import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientMapProjectionTest extends MapProjectionTest {
 
-    private TestHazelcastFactory factory;
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
 
     @After
     public void tearDown() {
@@ -48,8 +48,6 @@ public class ClientMapProjectionTest extends MapProjectionTest {
         if (nodeCount < 1) {
             throw new IllegalArgumentException("node count < 1");
         }
-
-        factory = new TestHazelcastFactory();
 
         MapConfig mapConfig = new MapConfig()
                 .setName("aggr")
@@ -63,5 +61,15 @@ public class ClientMapProjectionTest extends MapProjectionTest {
         HazelcastInstance client = factory.newHazelcastClient();
 
         return client.getMap("aggr");
+    }
+
+    @Override
+    public void projection_1Node_objectValue_withPartitionSet() {
+        // ignore the test on client - not implemented on client
+    }
+
+    @Override
+    public void projection_3Nodes_objectValue_withPartitionSet() {
+        // ignore the test on client - not implemented on client
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/PartitionIdSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/PartitionIdSetTest.java
@@ -281,6 +281,15 @@ public class PartitionIdSetTest {
         assertNotEquals(createWithPartitionCount(11, 1, 2), set);
     }
 
+    @Test
+    public void test_solePartition() {
+        assertEquals(0, createWithPartitionCount(10, 0).solePartition());
+        assertEquals(1, createWithPartitionCount(10, 1).solePartition());
+        assertEquals(9, createWithPartitionCount(10, 9).solePartition());
+        assertEquals(-1, createWithPartitionCount(10, 0, 1).solePartition());
+        assertEquals(-1, createWithPartitionCount(10, 0, 9).solePartition());
+    }
+
     private void assertContents(PartitionIdSet set) {
         for (int i = 0; i < 5; i++) {
             assertTrue("Should contain " + i, set.contains(i));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
@@ -121,6 +121,15 @@ public class LocalKeySetTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void whenPartitionPredicate() {
+        map.put(localKey1, "local");
+        map.put(remoteKey1, "remote");
+
+        Predicate<String, String> partitionPredicate = Predicates.partitionPredicate(remoteKey1, Predicates.alwaysTrue());
+        assertEquals(0, map.localKeySet(partitionPredicate).size());
+    }
+
+    @Test
     public void testResultType() {
         map.put(localKey1, "a");
         Set<String> entries = map.localKeySet(Predicates.alwaysTrue());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapEntrySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapEntrySetTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -38,11 +37,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.Accessors.getSerializationService;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -115,20 +112,15 @@ public class MapEntrySetTest extends HazelcastTestSupport {
 
     @Test
     public void whenSelectingPartitionSubset() {
-        NodeEngineImpl nodeEngine = getNodeEngineImpl(instance);
-        int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
-        PartitionIdSet partitionSubset =
-                new PartitionIdSet(partitionCount, IntStream.range(0, partitionCount / 2).boxed().collect(Collectors.toList()));
+        PartitionIdSet partitionSubset = new PartitionIdSet(4, asList(1, 3));
         Set<String> matchingKeys = new HashSet<>();
-        for (int i = 0; i < 10; i++) {
-            String key = String.valueOf(i);
+        for (int i = 0; i < 5; i++) {
+            String key = generateKeyForPartition(instance, i);
             map.put(key, key);
-            if (partitionSubset.contains(nodeEngine.getPartitionService().getPartitionId(key))) {
+            if (partitionSubset.contains(i)) {
                 matchingKeys.add(key);
             }
         }
-        // assert test sanity
-        assertBetween("keyCount", matchingKeys.size(), 1, map.size() - 1);
 
         Set<Entry<String, String>> result =
                 ((MapProxyImpl<String, String>) map).entrySet(Predicates.alwaysTrue(), partitionSubset);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
@@ -32,10 +32,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.query.Predicates.partitionPredicate;
 import static com.hazelcast.test.Accessors.getSerializationService;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Arrays.asList;
@@ -117,6 +119,27 @@ public class MapKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = ((MapProxyImpl<String, String>) map).keySet(Predicates.alwaysTrue(), partitionSubset);
         assertEquals(matchingKeys, result);
+    }
+
+    @Test
+    public void when_selectingPartitionSubset_and_partitionPredicate() {
+        PartitionIdSet partitionSubset = new PartitionIdSet(4, asList(1, 3));
+        Set<String> matchingKeys = new HashSet<>();
+        String key1 = null;
+        for (int i = 0; i < 5; i++) {
+            String key = generateKeyForPartition(instance, i);
+            if (i == 1) {
+                key1 = key;
+            }
+            map.put(key, key);
+            if (partitionSubset.contains(i)) {
+                matchingKeys.add(key);
+            }
+        }
+
+        Set<String> result = ((MapProxyImpl<String, String>) map)
+                .keySet(partitionPredicate(key1, Predicates.alwaysTrue()), partitionSubset);
+        assertEquals(Collections.singleton(key1), result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
@@ -18,11 +18,14 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects;
 import com.hazelcast.query.impl.predicates.InstanceOfPredicate;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -33,8 +36,13 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.Accessors.getSerializationService;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -44,13 +52,13 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MapValuesTest extends HazelcastTestSupport {
 
+    private HazelcastInstance instance;
     private IMap<String, String> map;
     private SerializationService serializationService;
 
     @Before
     public void setup() {
-        HazelcastInstance instance = createHazelcastInstance();
-
+        instance = createHazelcastInstance();
         map = instance.getMap(randomName());
         serializationService = getSerializationService(instance);
     }
@@ -109,6 +117,27 @@ public class MapValuesTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void whenSelectingPartitionSubset() {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(instance);
+        int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
+        PartitionIdSet partitionSubset =
+                new PartitionIdSet(partitionCount, IntStream.range(0, partitionCount / 2).boxed().collect(Collectors.toList()));
+        Set<String> matchingKeys = new HashSet<>();
+        for (int i = 0; i < 10; i++) {
+            String key = String.valueOf(i);
+            map.put(key, key);
+            if (partitionSubset.contains(nodeEngine.getPartitionService().getPartitionId(key))) {
+                matchingKeys.add(key);
+            }
+        }
+        // assert test sanity
+        assertBetween("keyCount", matchingKeys.size(), 1, map.size() - 1);
+
+        Collection<String> result = ((MapProxyImpl<String, String>) map).values(Predicates.alwaysTrue(), partitionSubset);
+        assertEquals(matchingKeys, result);
+    }
+
+    @Test
     public void testResultType() {
         map.put("1", "a");
         Collection<String> entries = map.values(Predicates.alwaysTrue());
@@ -121,7 +150,7 @@ public class MapValuesTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testSerializationServiceNullClassLoaderProblem() throws Exception {
+    public void testSerializationServiceNullClassLoaderProblem() {
         // if the classloader is null the following call throws NullPointerException
         map.values(new InstanceOfPredicate(SampleTestObjects.PortableEmployee.class));
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
@@ -35,10 +35,12 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.query.Predicates.partitionPredicate;
 import static com.hazelcast.test.Accessors.getSerializationService;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -127,6 +129,27 @@ public class MapValuesTest extends HazelcastTestSupport {
 
         Collection<String> result = ((MapProxyImpl<String, String>) map).values(Predicates.alwaysTrue(), partitionSubset);
         assertEquals(matchingKeys, result);
+    }
+
+    @Test
+    public void when_selectingPartitionSubset_and_partitionPredicate() {
+        PartitionIdSet partitionSubset = new PartitionIdSet(4, asList(1, 3));
+        Set<String> matchingKeys = new HashSet<>();
+        String key1 = null;
+        for (int i = 0; i < 5; i++) {
+            String key = generateKeyForPartition(instance, i);
+            if (i == 1) {
+                key1 = key;
+            }
+            map.put(key, key);
+            if (partitionSubset.contains(i)) {
+                matchingKeys.add(key);
+            }
+        }
+
+        Collection<String> result = ((MapProxyImpl<String, String>) map)
+                .values(partitionPredicate(key1, Predicates.alwaysTrue()), partitionSubset);
+        assertEquals(Collections.singleton(key1), result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImplTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.query.Predicate;
@@ -122,7 +123,7 @@ public class QueryEngineImplTest extends HazelcastTestSupport {
         Predicate predicate = Predicates.equal("this", value);
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(ENTRY).build();
 
-        QueryResult result = queryEngine.execute(query, createPartitionTarget(partitionId));
+        QueryResult result = queryEngine.execute(query, createPartitionTarget(new PartitionIdSet(271, partitionId)));
 
         assertEquals(1, result.size());
         assertEquals(key, toObject(((Map.Entry) result.iterator().next()).getKey()));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngine_DispatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngine_DispatchTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.IterationType;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.query.Target.TargetMode;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -77,19 +78,19 @@ public class QueryEngine_DispatchTest extends HazelcastTestSupport {
 
     @Test
     public void dispatchFullQueryOnQueryThread_localMembers() {
-        dispatchFullQueryOnQueryThread(Target.LOCAL_NODE);
+        dispatchFullQueryOnQueryThread(TargetMode.LOCAL_NODE);
     }
 
     @Test
     public void dispatchFullQueryOnQueryThread_allMembers() {
-        dispatchFullQueryOnQueryThread(Target.ALL_NODES);
+        dispatchFullQueryOnQueryThread(TargetMode.ALL_NODES);
     }
 
-    private void dispatchFullQueryOnQueryThread(Target target) {
+    private void dispatchFullQueryOnQueryThread(TargetMode target) {
         Query query = Query.of().mapName(map.getName()).predicate(Predicates.equal("this", value))
                 .iterationType(IterationType.ENTRY).build();
         List<Future<Result>> futures = queryEngine
-                .dispatchFullQueryOnQueryThread(query, target);
+                .dispatchFullQueryOnQueryThread(query, queryEngine.getAllPartitionIds(), target);
         Collection<Result> results = returnWithDeadline(futures, 1, TimeUnit.MINUTES);
         QueryResult result = (QueryResult) results.iterator().next();
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TargetTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -38,7 +39,7 @@ public class TargetTest {
     @Test
     public void testConstructor_withInvalidPartitionId() throws Exception {
         // retrieve the wanted constructor and make it accessible
-        Constructor<Target> constructor = Target.class.getDeclaredConstructor(Target.TargetMode.class, Integer.class);
+        Constructor<Target> constructor = Target.class.getDeclaredConstructor(Target.TargetMode.class, PartitionIdSet.class);
         constructor.setAccessible(true);
 
         // we expect an IllegalArgumentException to be thrown

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -53,6 +53,7 @@ public class MapProjectionTest extends HazelcastTestSupport {
 
     @Rule
     public ExpectedException expected = ExpectedException.none();
+    private HazelcastInstance instance0;
 
     @Test(expected = NullPointerException.class)
     public void null_projection() {
@@ -177,7 +178,7 @@ public class MapProjectionTest extends HazelcastTestSupport {
         Collection<Double> result = ((MapProxyImpl<String, Person>) map)
                 .project(new ObjectValueIncrementingProjection(), Predicates.alwaysTrue(), partitionSubset);
 
-        assertThat(result, containsInAnyOrder(5.0d, 8.0d));
+        assertThat(result, containsInAnyOrder(2.0d, 5.0d));
     }
 
     @Test
@@ -189,7 +190,7 @@ public class MapProjectionTest extends HazelcastTestSupport {
         Collection<Double> result = ((MapProxyImpl<String, Person>) map)
                 .project(new ObjectValueIncrementingProjection(), Predicates.alwaysTrue(), partitionSubset);
 
-        assertThat(result, containsInAnyOrder(5.0d, 8.0d));
+        assertThat(result, containsInAnyOrder(2.0d, 5.0d));
     }
 
     public <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount) {
@@ -208,8 +209,8 @@ public class MapProjectionTest extends HazelcastTestSupport {
 
         doWithConfig(config);
 
-        HazelcastInstance instance = factory.newInstances(config)[0];
-        return instance.getMap("aggr");
+        instance0 = factory.newInstances(config)[0];
+        return instance0.getMap("aggr");
     }
 
     // used by hz-enterprise
@@ -223,9 +224,9 @@ public class MapProjectionTest extends HazelcastTestSupport {
     }
 
     private void populateMapWithPersons(IMap<String, Person> map) {
-        map.put("key3", new Person(1.0d, "NY"));
-        map.put("key4", new Person(4.0d, "DC"));
-        map.put("key5", new Person(7.0d, "OH"));
+        map.put(generateKeyForPartition(instance0, 0), new Person(1.0d, "NY"));
+        map.put(generateKeyForPartition(instance0, 1), new Person(4.0d, "DC"));
+        map.put(generateKeyForPartition(instance0, 2), new Person(7.0d, "OH"));
     }
 
     public static class Person implements DataSerializable {

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -53,7 +53,8 @@ public class MapProjectionTest extends HazelcastTestSupport {
 
     @Rule
     public ExpectedException expected = ExpectedException.none();
-    private HazelcastInstance instance0;
+
+    protected HazelcastInstance instance0;
 
     @Test(expected = NullPointerException.class)
     public void null_projection() {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1392,6 +1392,9 @@ public abstract class HazelcastTestSupport {
         assertNotEquals(format(message, expected, actual), expected, actual);
     }
 
+    /**
+     * Assert that {@code actualValue >= lowerBound && actualValue <= upperBound}.
+     */
     public static void assertBetween(String label, long actualValue, long lowerBound, long upperBound) {
         assertTrue(format("Expected '%s' to be between %d and %d, but was %d", label, lowerBound, upperBound, actualValue),
                 actualValue >= lowerBound && actualValue <= upperBound);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -550,7 +550,6 @@ public abstract class HazelcastTestSupport {
         Cluster cluster = instance.getCluster();
         checkPartitionCountGreaterOrEqualMemberCount(instance);
 
-        Member localMember = cluster.getLocalMember();
         PartitionService partitionService = instance.getPartitionService();
         while (true) {
             String id = randomString();
@@ -565,7 +564,6 @@ public abstract class HazelcastTestSupport {
         Cluster cluster = instance.getCluster();
         checkPartitionCountGreaterOrEqualMemberCount(instance);
 
-        Member localMember = cluster.getLocalMember();
         PartitionService partitionService = instance.getPartitionService();
         while (true) {
             String id = prefix + randomString();
@@ -595,11 +593,8 @@ public abstract class HazelcastTestSupport {
     }
 
     private static void checkPartitionCountGreaterOrEqualMemberCount(HazelcastInstance instance) {
-        Cluster cluster = instance.getCluster();
-        int memberCount = cluster.getMembers().size();
-
-        InternalPartitionService internalPartitionService = Accessors.getPartitionService(instance);
-        int partitionCount = internalPartitionService.getPartitionCount();
+        int memberCount = instance.getCluster().getMembers().size();
+        int partitionCount = instance.getPartitionService().getPartitions().size();
 
         if (partitionCount < memberCount) {
             throw new UnsupportedOperationException("Partition count should be equal or greater than member count!");


### PR DESCRIPTION
This feature is needed for Jet SQL to implement joins. The actual partition ID set will contain local partitions, but we don't want to use `localEntrySet()`, because after migration we want to continue working with some remote partitions, until the job is restarted. Also, there's no `localEntrySet()`...