### PR TITLE
Introduce NODE_AWARE partitioning group type

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -83,11 +83,6 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * <p>
  * You can define as many <code>member-group</code>s as you want. Hazelcast will always store backups in a different
  * member-group to the primary partition.
- * <code>
- * <pre>
- * &lt;partition-group enabled="true" group-type="ZONE_AWARE"/&gt;
- * </pre>
- * </code>
  *
  * <h1>Zone Aware Partition Groups</h1>
  * In this scheme, groups are allocated according to the metadata provided by Discovery SPI Partitions are not
@@ -95,12 +90,27 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * zones or different racks without providing the IP addresses to the config ahead.
  * <code>
  * <pre>
- * &lt;partition-group enabled="true" group-type="SPI"/&gt;
+ * &lt;partition-group enabled="true" group-type="ZONE_AWARE"/&gt;
+ * </pre>
+ * </code>
+ *
+ * <h1>Node Aware Partition Groups</h1>
+ * In this scheme, groups are allocated according to the metadata provided by Discovery SPI Partitions are not
+ * written to the same group. This is very useful for ensuring partitions are written to different Kubernetes nodes
+ * without providing the IP addresses to the config ahead.
+ * <code>
+ * <pre>
+ * &lt;partition-group enabled="true" group-type="NODE_AWARE"/&gt;
  * </pre>
  * </code>
  *
  * <h1>SPI Aware Partition Groups</h1>
  * In this scheme, groups are allocated according to the implementation provided by Discovery SPI.
+ * <code>
+ * <pre>
+ * &lt;partition-group enabled="true" group-type="SPI"/&gt;
+ * </pre>
+ * </code>
  *
  * <h2>Overlapping Groups</h2>
  * Care should be taken when selecting overlapping groups, e.g.
@@ -151,6 +161,11 @@ public class PartitionGroupConfig {
          * If only one zone is available, backups will be created in the same zone.
          */
         ZONE_AWARE,
+        /**
+         * Node Aware. Backups will be created in other Kubernetes nodes/physical machines.
+         * If only one node is available, backups will be created in the same node.
+         */
+        NODE_AWARE,
         /**
          * MemberGroup implementation will be provided by the user via Discovery SPI.
          */

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -85,9 +85,10 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * member-group to the primary partition.
  *
  * <h1>Zone Aware Partition Groups</h1>
- * In this scheme, groups are allocated according to the metadata provided by Discovery SPI Partitions are not
- * written to the same group. This is very useful for ensuring partitions are written to availability
- * zones or different racks without providing the IP addresses to the config ahead.
+ * In this scheme, groups are allocated according to the metadata provided by Discovery SPI
+ * These metadata are availability zone, rack and host. Partitions are not written to
+ * the same group so this is very useful for ensuring partitions are written to
+ * different availability zones without providing the IP addresses to the config ahead.
  * <code>
  * <pre>
  * &lt;partition-group enabled="true" group-type="ZONE_AWARE"/&gt;
@@ -95,9 +96,12 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * </code>
  *
  * <h1>Node Aware Partition Groups</h1>
- * In this scheme, groups are allocated according to the metadata provided by Discovery SPI Partitions are not
- * written to the same group. This is very useful for ensuring partitions are written to different Kubernetes nodes
- * without providing the IP addresses to the config ahead.
+ * In this scheme, groups are allocated according to node name metadata provided by Discovery SPI.
+ * For container orchestration tools like Kubernetes and Docker Swarm, node is the term used to refer
+ * machine that containers/pods run on. A node may be a virtual or physical machine.
+ * Partitions are not written to the same group so this is very useful for ensuring partitions
+ * are written to different nodes without providing the IP addresses to the config ahead.
+ *
  * <code>
  * <pre>
  * &lt;partition-group enabled="true" group-type="NODE_AWARE"/&gt;
@@ -162,7 +166,7 @@ public class PartitionGroupConfig {
          */
         ZONE_AWARE,
         /**
-         * Node Aware. Backups will be created in other Kubernetes nodes/physical machines.
+         * Node Aware. Backups will be created in other nodes.
          * If only one node is available, backups will be created in the same node.
          */
         NODE_AWARE,

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -86,8 +86,8 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  *
  * <h1>Zone Aware Partition Groups</h1>
  * In this scheme, groups are allocated according to the metadata provided by Discovery SPI
- * These metadata are availability zone, rack and host. Partitions are not written to
- * the same group so this is very useful for ensuring partitions are written to
+ * These metadata are availability zone, rack and host. The backups of the partitions are not
+ * placed on the same group so this is very useful for ensuring partitions are placed on
  * different availability zones without providing the IP addresses to the config ahead.
  * <code>
  * <pre>
@@ -99,8 +99,8 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * In this scheme, groups are allocated according to node name metadata provided by Discovery SPI.
  * For container orchestration tools like Kubernetes and Docker Swarm, node is the term used to refer
  * machine that containers/pods run on. A node may be a virtual or physical machine.
- * Partitions are not written to the same group so this is very useful for ensuring partitions
- * are written to different nodes without providing the IP addresses to the config ahead.
+ * The backups of the partitions are not placed on same group so this is very useful for ensuring partitions
+ * are placed on different nodes without providing the IP addresses to the config ahead.
  *
  * <code>
  * <pre>

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactoryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactoryFactory.java
@@ -43,6 +43,8 @@ public final class MemberGroupFactoryFactory {
                 return new SingleMemberGroupFactory();
             case ZONE_AWARE:
                 return new ZoneAwareMemberGroupFactory();
+            case NODE_AWARE:
+                return new NodeAwareMemberGroupFactory();
             case SPI:
                 return new SPIAwareMemberGroupFactory(discoveryService);
             default:

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
@@ -29,9 +29,12 @@ import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * NodeAwareMemberGroupFactory is responsible for MemberGroups
- * creation according to the Kubernetes Node metadata provided by
+ * creation according to name of the node metadata. For container orchestration
+ * tools like Kubernetes and Docker Swarm, node is the term used to refer
+ * machine that containers/pods run on. A node may be a virtual or physical machine.
+ * Node name metadata provided by
  * {@link DiscoveryStrategy#discoverLocalMetadata()}
- * @since 3.7
+ * @since 3.12.11
  */
 public class NodeAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
 
@@ -42,7 +45,7 @@ public class NodeAwareMemberGroupFactory extends BackupSafeMemberGroupFactory im
             final String nodeInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE);
             if (nodeInfo == null) {
                 throw new IllegalArgumentException("Not enough metadata information is provided. "
-                        + "Kubernetes node name information must be provided with NODE_AWARE partition group.");
+                        + "Node name information must be provided with NODE_AWARE partition group.");
             }
             MemberGroup group = groups.get(nodeInfo);
             if (group == null) {
@@ -51,6 +54,6 @@ public class NodeAwareMemberGroupFactory extends BackupSafeMemberGroupFactory im
             }
             group.addMember(member);
         }
-        return new HashSet<MemberGroup>(groups.values());
+        return new HashSet<>(groups.values());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
@@ -34,7 +34,6 @@ import static com.hazelcast.util.MapUtil.createHashMap;
  * machine that containers/pods run on. A node may be a virtual or physical machine.
  * Node name metadata provided by
  * {@link DiscoveryStrategy#discoverLocalMetadata()}
- * @since 3.12.11
  */
 public class NodeAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition.membergroup;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.partitiongroup.PartitionGroupMetaData;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+
+/**
+ * NodeAwareMemberGroupFactory is responsible for MemberGroups
+ * creation according to the Kubernetes Node metadata provided by
+ * {@link DiscoveryStrategy#discoverLocalMetadata()}
+ * @since 3.7
+ */
+public class NodeAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
+
+    @Override
+    protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
+        Map<String, MemberGroup> groups = createHashMap(allMembers.size());
+        for (Member member : allMembers) {
+            final String nodeInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE);
+            if (nodeInfo == null) {
+                throw new IllegalArgumentException("Not enough metadata information is provided. "
+                        + "Kubernetes node name information must be provided with NODE_AWARE partition group.");
+            }
+            MemberGroup group = groups.get(nodeInfo);
+            if (group == null) {
+                group = new DefaultMemberGroup();
+                groups.put(nodeInfo, group);
+            }
+            group.addMember(member);
+        }
+        return new HashSet<MemberGroup>(groups.values());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/NodeAwareMemberGroupFactory.java
@@ -54,6 +54,6 @@ public class NodeAwareMemberGroupFactory extends BackupSafeMemberGroupFactory im
             }
             group.addMember(member);
         }
-        return new HashSet<>(groups.values());
+        return new HashSet<MemberGroup>(groups.values());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -78,7 +78,7 @@ public interface DiscoveryStrategy {
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information
      * may include, but are not limited, to location information like datacenter, rack, host,
-     * Kubernetes node name or additional tags to be used for custom purpose.
+     * node name or additional tags to be used for custom purpose.
      * <p/>
      * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
      * attributes. Existing attributes will not be overridden, that way local attribute configuration

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -77,8 +77,8 @@ public interface DiscoveryStrategy {
 
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information
-     * may include, but are not limited, to location information like datacenter, rack, host or additional
-     * tags to be used for custom purpose.
+     * may include, but are not limited, to location information like datacenter, rack, host,
+     * Kubernetes node name or additional tags to be used for custom purpose.
      * <p/>
      * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
      * attributes. Existing attributes will not be overridden, that way local attribute configuration

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -69,7 +69,7 @@ public interface DiscoveryService {
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information
      * may include, but are not limited, to location information like datacenter, rack, host,
-     * Kubernetes node name or additional tags to be used for custom purpose.
+     * node name or additional tags to be used for custom purpose.
      * <p/>
      * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
      * attributes. Existing attributes will not be overridden, that way local attribute configuration

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -68,8 +68,8 @@ public interface DiscoveryService {
 
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information
-     * may include, but are not limited, to location information like datacenter, rack, host or additional
-     * tags to be used for custom purpose.
+     * may include, but are not limited, to location information like datacenter, rack, host,
+     * Kubernetes node name or additional tags to be used for custom purpose.
      * <p/>
      * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
      * attributes. Existing attributes will not be overridden, that way local attribute configuration

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -18,7 +18,7 @@ package com.hazelcast.spi.partitiongroup;
 
 /**
  * This class contains the definition of known Discovery SPI metadata to support automatic
- * generation of zone aware and Kubernetes node aware backup strategies.
+ * generation of zone aware and node aware backup strategies.
  *
  * Zone aware backup strategies are based on cloud or service discovery provided information.
  * These information are split into three different levels of granularity:

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -28,7 +28,9 @@ package com.hazelcast.spi.partitiongroup;
  * <li><b>Host:</b> A low-latency link on a shared physical node, in case of virtualization being used</li>
  * </ul>
  *
- * Kubernetes node aware backup strategy is based on name of the node which is provided by Kubernetes API itself.
+ * Node aware backup strategy is based on name of the node which is provided by container orchestration tool.
+ * like Kubernetes, Docker Swarm and ECS. A node is the term used to refer machine that containers/pods run on.
+ * A node may be a virtual or physical machine.
  */
 public enum PartitionGroupMetaData {
     ;
@@ -49,8 +51,7 @@ public enum PartitionGroupMetaData {
     public static final String PARTITION_GROUP_HOST = "hazelcast.partition.group.host";
 
     /**
-     * Kubernetes runs containers into Pods to run on Nodes.
-     * A node may be a virtual or physical machine, depending on the cluster.
+     * Metadata key definition for a node machine that containers/pods run on, in case of container orchestration tools being used.
      */
     public static final String PARTITION_GROUP_NODE = "hazelcast.partition.group.node";
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -18,13 +18,17 @@ package com.hazelcast.spi.partitiongroup;
 
 /**
  * This class contains the definition of known Discovery SPI metadata to support automatic
- * generation of zone aware backup strategies based on cloud or service discovery provided
- * information. These information are split into three different levels of granularity:
+ * generation of zone aware and Kubernetes node aware backup strategies.
+ *
+ * Zone aware backup strategies are based on cloud or service discovery provided information.
+ * These information are split into three different levels of granularity:
  * <ul>
  * <li><b>Zone:</b> A low-latency link between (virtual) data centers in the same area</li>
  * <li><b>Rack:</b> A low-latency link inside the same data center but for different racks</li>
  * <li><b>Host:</b> A low-latency link on a shared physical node, in case of virtualization being used</li>
  * </ul>
+ *
+ * Kubernetes node aware backup strategy is based on name of the node which is provided by Kubernetes API itself.
  */
 public enum PartitionGroupMetaData {
     ;
@@ -43,4 +47,10 @@ public enum PartitionGroupMetaData {
      * Metadata key definition for a low-latency link on a shared physical node, in case of virtualization being used
      */
     public static final String PARTITION_GROUP_HOST = "hazelcast.partition.group.host";
+
+    /**
+     * Kubernetes runs containers into Pods to run on Nodes.
+     * A node may be a virtual or physical machine, depending on the cluster.
+     */
+    public static final String PARTITION_GROUP_NODE = "hazelcast.partition.group.node";
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -51,7 +51,8 @@ public enum PartitionGroupMetaData {
     public static final String PARTITION_GROUP_HOST = "hazelcast.partition.group.host";
 
     /**
-     * Metadata key definition for a node machine that containers/pods run on, in case of container orchestration tools being used.
+     * Metadata key definition for a node machine that containers/pods run on,
+     * in case of container orchestration tools being used.
      */
     public static final String PARTITION_GROUP_NODE = "hazelcast.partition.group.node";
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
@@ -22,7 +22,7 @@ import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
 /**
  * <p>A <tt>PartitionGroupStrategy</tt> implementation defines a strategy
  * how backup groups are designed. Backup groups are units containing
- * one or more Hazelcast nodes to share the same physical host, rack or
+ * one or more Hazelcast nodes to share the same physical host/Kubernetes node, rack or
  * zone and backups are stored on nodes being part of a different
  * backup group. This behavior builds an additional layer of data
  * reliability by making sure that, in case of two racks, if rack A

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
@@ -22,12 +22,12 @@ import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
 /**
  * <p>A <tt>PartitionGroupStrategy</tt> implementation defines a strategy
  * how backup groups are designed. Backup groups are units containing
- * one or more Hazelcast nodes to share the same physical host/Kubernetes node, rack or
+ * one or more Hazelcast nodes to share the same physical host/node, rack or
  * zone and backups are stored on nodes being part of a different
  * backup group. This behavior builds an additional layer of data
- * reliability by making sure that, in case of two racks, if rack A
- * fails, rack B will still have all the backups and is guaranteed
- * to still provide all data. Similar is true for zones or physical hosts.</p>
+ * reliability by making sure that, in case of two zones, if zone A
+ * fails, zone B will still have all the backups and is guaranteed
+ * to still provide all data. Similar is true for nodes or physical hosts.</p>
  * <p>Custom implementations of the PartitionGroupStrategy may add specific
  * or additional behavior based on the provided environment and can
  * be injected into Hazelcast by overriding

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2702,6 +2702,7 @@
                     <xs:enumeration value="CUSTOM"/>
                     <xs:enumeration value="PER_MEMBER"/>
                     <xs:enumeration value="ZONE_AWARE"/>
+                    <xs:enumeration value="NODE_AWARE"/>
                     <xs:enumeration value="SPI"/>
                 </xs:restriction>
             </xs:simpleType>

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -220,6 +220,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testPartitionGroupZoneAware();
 
     @Test
+    public abstract void testPartitionGroupNodeAware();
+
+    @Test
     public abstract void testPartitionGroupSPI();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1332,6 +1332,19 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testPartitionGroupNodeAware() {
+        String xml = HAZELCAST_START_TAG
+                + "<partition-group enabled=\"true\" group-type=\"NODE_AWARE\" />"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
+        assertTrue(partitionGroupConfig.isEnabled());
+        assertEquals(PartitionGroupConfig.MemberGroupType.NODE_AWARE, partitionGroupConfig.getGroupType());
+    }
+
+    @Override
+    @Test
     public void testPartitionGroupSPI() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"SPI\" />"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1354,6 +1354,21 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testPartitionGroupNodeAware() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  partition-group:\n"
+                + "    enabled: true\n"
+                + "    group-type: NODE_AWARE\n";
+
+        Config config = buildConfig(yaml);
+        PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
+        assertTrue(partitionGroupConfig.isEnabled());
+        assertEquals(PartitionGroupConfig.MemberGroupType.NODE_AWARE, partitionGroupConfig.getGroupType());
+    }
+
+    @Override
+    @Test
     public void testPartitionGroupSPI() {
         String yaml = ""
                 + "hazelcast:\n"

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -82,6 +82,35 @@ public class MemberGroupFactoryTest {
     }
 
     @Test
+    public void testNodeMetadataAwareMemberGroupFactoryCreateMemberGroups() {
+        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithNodeAwareMetadata();
+        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
+
+        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        for (MemberGroup memberGroup : memberGroups) {
+            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
+        }
+    }
+
+    private Collection<Member> createMembersWithNodeAwareMetadata() {
+        Collection<Member> members = new HashSet<Member>();
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
+        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-f7cw");
+
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
+        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-f7cw");
+
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
+        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-hgdl");
+
+        members.add(member1);
+        members.add(member2);
+        members.add(member3);
+        return members;
+    }
+
+    @Test
     public void testZoneMetadataAwareMemberGroupFactoryCreateMemberGroups() {
         MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithZoneAwareMetadata();

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -83,7 +83,7 @@ public class MemberGroupFactoryTest {
 
     @Test
     public void testNodeMetadataAwareMemberGroupFactoryCreateMemberGroups() {
-        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
+        MemberGroupFactory groupFactory = new NodeAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithNodeAwareMetadata();
         Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
 
@@ -99,10 +99,10 @@ public class MemberGroupFactoryTest {
         member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-f7cw");
 
         MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-f7cw");
+        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-hgdl");
 
         MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-hgdl");
+        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_NODE, "kubernetes-node-f0bbd602-0zjs");
 
         members.add(member1);
         members.add(member2);

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -110,6 +110,18 @@ public class MemberGroupFactoryTest {
         return members;
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNodeAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
+        MemberGroupFactory groupFactory = new NodeAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithNoMetadata();
+        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
+
+        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        for (MemberGroup memberGroup : memberGroups) {
+            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
+        }
+    }
+
     @Test
     public void testZoneMetadataAwareMemberGroupFactoryCreateMemberGroups() {
         MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();


### PR DESCRIPTION
For Kubernetes based environments, user might want to store their backups at another [Kubernetes node](https://kubernetes.io/docs/concepts/architecture/nodes/). They can easily decide which pod will be running on which node via defining [affinity or node-selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). To satisfy these kind of specific requirements, `NODE_AWARE` partition group type is introduced with this PR. Newly created `NodeAwareMemberGroupFactory` class is just simplified version of [ZoneAwareMemberGroupFactory](https://github.com/hazelcast/hazelcast/blob/3.12.z/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java) actually. Here is the related [PRD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1770291566/Kubernetes+Node+Aware+Partition+Grouping+Support).

These changes will be forward-port to `4.0.z`, `4.1.z` and `master` branches.

Todo:

- [x]  Create related doc section at [Partitioning Group Types ](https://docs.hazelcast.org/docs/3.12.10/manual/html-single/#grouping-types) --> https://github.com/hazelcast/hazelcast-reference-manual/pull/904