### PR TITLE
[BACKPORT] Bump guava from 24.1.1-jre to 30.0-jre

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -37,7 +37,7 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
 
         <calcite.version>1.23.0</calcite.version>
-        <guava.version>24.1.1-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
 


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/17743