### PR TITLE
External Smart Client Public Address Discovery

### DIFF
--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -21,7 +21,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.1.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.2.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -4593,7 +4593,7 @@
             </xs:element>
             <xs:element name="socket-options" type="endpoint-socket-options" minOccurs="0"/>
         </xs:all>
-        <xs:attribute name="name" type="xs:string" use="optional" default=""/>
+        <xs:attribute name="name" type="xs:string" use="optional"/>
         <xs:attribute name="public-address" type="xs:string"/>
         <xs:attribute name="port" type="xs:string" use="required"/>
         <xs:attribute name="port-auto-increment" type="xs:string" default="true"/>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.1.xsd
@@ -4593,7 +4593,7 @@
             </xs:element>
             <xs:element name="socket-options" type="endpoint-socket-options" minOccurs="0"/>
         </xs:all>
-        <xs:attribute name="name" type="xs:string" use="optional"/>
+        <xs:attribute name="name" type="xs:string" use="optional" default=""/>
         <xs:attribute name="public-address" type="xs:string"/>
         <xs:attribute name="port" type="xs:string" use="required"/>
         <xs:attribute name="port-auto-increment" type="xs:string" default="true"/>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.2.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.2.xsd
@@ -4593,7 +4593,7 @@
             </xs:element>
             <xs:element name="socket-options" type="endpoint-socket-options" minOccurs="0"/>
         </xs:all>
-        <xs:attribute name="name" type="xs:string" use="optional" default=""/>
+        <xs:attribute name="name" type="xs:string" use="optional"/>
         <xs:attribute name="public-address" type="xs:string"/>
         <xs:attribute name="port" type="xs:string" use="required"/>
         <xs:attribute name="port-auto-increment" type="xs:string" default="true"/>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -120,7 +120,8 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
     private static final int DEFAULT_SMART_CLIENT_THREAD_COUNT = 3;
     private static final int EXECUTOR_CORE_POOL_SIZE = 10;
     private static final int SMALL_MACHINE_PROCESSOR_COUNT = 8;
-
+    private static final EndpointQualifier CLIENT_PUBLIC_ENDPOINT_QUALIFIER =
+            EndpointQualifier.resolve(ProtocolType.CLIENT, "public");
     protected final AtomicInteger connectionIdGen = new AtomicInteger();
 
     private final AtomicBoolean isAlive = new AtomicBoolean();
@@ -682,7 +683,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
 
     private Address translate(Member member) {
         if (client.getClientClusterService().translateToPublicAddress()) {
-            Address publicAddress = member.getAddressMap().get(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"));
+            Address publicAddress = member.getAddressMap().get(CLIENT_PUBLIC_ENDPOINT_QUALIFIER);
             if (publicAddress != null) {
                 return publicAddress;
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -48,6 +48,8 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.nio.NioNetworking;
@@ -582,8 +584,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
             return connection;
         }
 
-        Address address = member.getAddress();
-        address = translate(address);
+        Address address = translate(member);
         connection = createSocketConnection(address);
         ClientAuthenticationCodec.ResponseParameters response = authenticateOnCluster(connection);
         return onAuthenticated(connection, response);
@@ -677,6 +678,17 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
             logger.finest(e);
             throw rethrow(e);
         }
+    }
+
+    private Address translate(Member member) {
+        if (client.getClientClusterService().translateToPublicAddress()) {
+            Address publicAddress = member.getAddressMap().get(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"));
+            if (publicAddress != null) {
+                return publicAddress;
+            }
+            return member.getAddress();
+        }
+        return translate(member.getAddress());
     }
 
     private Address translate(Address target) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
@@ -83,6 +83,13 @@ public interface ClientClusterService {
     long getClusterTime();
 
     /**
+     * Returns if member internal address should be translated into its public address.
+     *
+     * @return true if member address should be translated into its public address.
+     */
+    boolean translateToPublicAddress();
+
+    /**
      * @param listener The listener to be registered.
      * @return The registration ID
      */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
@@ -83,7 +83,7 @@ public interface ClientClusterService {
     long getClusterTime();
 
     /**
-     * Returns if member internal address should be translated into its public address.
+     * Returns {@code true} if member internal address should be translated into its public address.
      *
      * @return true if member address should be translated into its public address.
      */

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -82,10 +82,10 @@ public class ClientClusterServiceImpl
     private final ILogger logger;
     private final ClientConnectionManager connectionManager;
     private final Object clusterViewLock = new Object();
+    private final TranslateToPublicAddressProvider translateToPublicAddress;
     //read and written under clusterViewLock
     private CountDownLatch initialListFetchedLatch = new CountDownLatch(1);
 
-    private TranslateToPublicAddressProvider translateToPublicAddress;
 
     private static final class MemberListSnapshot {
         private final int version;
@@ -102,8 +102,7 @@ public class ClientClusterServiceImpl
         labels = unmodifiableSet(client.getClientConfig().getLabels());
         logger = client.getLoggingService().getLogger(ClientClusterService.class);
         connectionManager = client.getConnectionManager();
-        this.translateToPublicAddress = new TranslateToPublicAddressProvider(client.getClientConfig(),
-                client.getProperties(), logger);
+        translateToPublicAddress = new TranslateToPublicAddressProvider(client.getClientConfig(), client.getProperties(), logger);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -102,7 +102,8 @@ public class ClientClusterServiceImpl
         labels = unmodifiableSet(client.getClientConfig().getLabels());
         logger = client.getLoggingService().getLogger(ClientClusterService.class);
         connectionManager = client.getConnectionManager();
-        translateToPublicAddress = new TranslateToPublicAddressProvider(client.getClientConfig(), client.getProperties(), logger);
+        translateToPublicAddress = new TranslateToPublicAddressProvider(client.getClientConfig().getNetworkConfig(),
+                client.getProperties(), logger);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
@@ -75,7 +75,7 @@ class TranslateToPublicAddressProvider {
             SSLConfig sslConfig = config.getSSLConfig();
             if (sslConfig != null && sslConfig.isEnabled()) {
                 if (logger.isFineEnabled()) {
-                    logger.info("SSL is configured. The client will use internal addresses to communicate with the cluster. If "
+                    logger.fine("SSL is configured. The client will use internal addresses to communicate with the cluster. If "
                             + "members are not reachable via private addresses, "
                             + "please set \"hazelcast.discovery.public.ip.enabled\" to true ");
                 }
@@ -84,7 +84,7 @@ class TranslateToPublicAddressProvider {
 
             if (memberInternalAddressAsDefinedInClientConfig(members)) {
                 if (logger.isFineEnabled()) {
-                    logger.info("There are internal addresses of members used in the config."
+                    logger.fine("There are internal addresses of members used in the config."
                             + " The client will use internal addresses");
                 }
                 return false;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
@@ -58,24 +58,24 @@ class TranslateToPublicAddressProvider {
             return false;
         }
 
+        // Default value of DISCOVERY_SPI_PUBLIC_IP_ENABLED is `null` intentionally.
+        // if DISCOVERY_SPI_PUBLIC_IP_ENABLED is not set to true/false, we don't know the intention of the user,
+        // we will try to decide if we should use private/public address automatically int that case.
         String publicIpEnabledProperty = properties.getString(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED);
-        if ("true".equalsIgnoreCase(publicIpEnabledProperty)) {
-            return true;
-        } else if ("false".equalsIgnoreCase(publicIpEnabledProperty)) {
-            return false;
-        }
+        if (publicIpEnabledProperty == null) {
+            if (members.isEmpty() || memberInternalAddressAsDefinedInClientConfig(members)) {
+                return false;
+            }
 
-        if (members.isEmpty() || memberInternalAddressAsDefinedInClientConfig(members)) {
-            return false;
+            return membersReachableOnlyViaPublicAddress(members);
         }
-
-        return membersReachableOnlyViaPublicAddress(members);
+        return properties.getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED);
     }
 
     /**
      * Checks if any member has its internal address as configured in ClientConfig.
      * <p>
-     * If any member has its internal/private address the same as configured in ClientConfig, then it means that tje client is
+     * If any member has its internal/private address the same as configured in ClientConfig, then it means that the client is
      * able to connect to members via configured address. No need to use make any address translation.
      */
     boolean memberInternalAddressAsDefinedInClientConfig(Collection<MemberInfo> members) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.spi.impl;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.connection.AddressProvider;
+import com.hazelcast.client.properties.ClientProperty;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.HazelcastProperties;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+class TranslateToPublicAddressProvider {
+    private static final int REACHABLE_ADDRESS_TIMEOUT = 1000;
+    private static final int NON_REACHABLE_ADDRESS_TIMEOUT = 3000;
+    private static final int REACHABLE_CHECK_NUMBER = 3;
+
+    private final ClientConfig config;
+    private final HazelcastProperties properties;
+    private final ILogger logger;
+
+    private volatile boolean translateToPublicAddress;
+
+    TranslateToPublicAddressProvider(ClientConfig config, HazelcastProperties properties, ILogger logger) {
+        this.config = config;
+        this.properties = properties;
+        this.logger = logger;
+    }
+
+    void refresh(AddressProvider addressProvider, Collection<MemberInfo> members) {
+        translateToPublicAddress = resolve(addressProvider, members);
+    }
+
+    private boolean resolve(AddressProvider addressProvider, Collection<MemberInfo> members) {
+        if (!(addressProvider instanceof DefaultAddressProvider)) {
+            return false;
+        }
+
+        String publicIpEnabledProperty = properties.getString(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED);
+        if ("true".equalsIgnoreCase(publicIpEnabledProperty)) {
+            return true;
+        } else if ("false".equalsIgnoreCase(publicIpEnabledProperty)) {
+            return false;
+        }
+
+        if (members.isEmpty() || memberInternalAddressAsDefinedInClientConfig(members)) {
+            return false;
+        }
+
+        return membersReachableOnlyViaPublicAddress(members);
+    }
+
+    /**
+     * Checks if any member has its internal address as configured in ClientConfig.
+     * <p>
+     * If any member has its internal/private address the same as configured in ClientConfig, then it means that tje client is
+     * able to connect to members via configured address. No need to use make any address translation.
+     */
+    boolean memberInternalAddressAsDefinedInClientConfig(Collection<MemberInfo> members) {
+        List<String> addresses = config.getNetworkConfig().getAddresses();
+        return members.stream()
+                .map(MemberInfo::getAddress)
+                .anyMatch(a -> addresses.contains(a.getHost())
+                        || addresses.contains(String.format("%s:%s", a.getHost(), a.getPort())));
+    }
+
+    /**
+     * Checks if members are reachable via public addresses, but not reachable via internal addresses.
+     * <p>
+     * We check only limited number of random members to reduce the slowdown of the startup.
+     */
+    private boolean membersReachableOnlyViaPublicAddress(Collection<MemberInfo> members) {
+        Iterator<MemberInfo> iter = members.iterator();
+        for (int i = 0; i < REACHABLE_CHECK_NUMBER; i++) {
+            if (!iter.hasNext()) {
+                iter = members.iterator();
+            }
+            MemberInfo member = iter.next();
+            Address publicAddress = member.getAddressMap().get(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"));
+            if (publicAddress == null) {
+                return false;
+            }
+            Address internalAddress = member.getAddress();
+            if (isReachable(internalAddress, REACHABLE_ADDRESS_TIMEOUT)) {
+                return false;
+            }
+            if (!isReachable(publicAddress, NON_REACHABLE_ADDRESS_TIMEOUT)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isReachable(Address address, int timeoutMs) {
+        try (Socket s = new Socket()) {
+            s.connect(new InetSocketAddress(address.getHost(), address.getPort()), timeoutMs);
+        } catch (Exception e) {
+            logger.fine(e);
+            return false;
+        }
+        return true;
+    }
+
+    boolean get() {
+        return translateToPublicAddress;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
@@ -60,7 +60,7 @@ class TranslateToPublicAddressProvider {
 
         // Default value of DISCOVERY_SPI_PUBLIC_IP_ENABLED is `null` intentionally.
         // if DISCOVERY_SPI_PUBLIC_IP_ENABLED is not set to true/false, we don't know the intention of the user,
-        // we will try to decide if we should use private/public address automatically int that case.
+        // we will try to decide if we should use private/public address automatically in that case.
         String publicIpEnabledProperty = properties.getString(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED);
         if (publicIpEnabledProperty == null) {
             if (members.isEmpty() || memberInternalAddressAsDefinedInClientConfig(members)) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProvider.java
@@ -28,7 +28,9 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -93,10 +95,12 @@ class TranslateToPublicAddressProvider {
      * We check only limited number of random members to reduce the slowdown of the startup.
      */
     private boolean membersReachableOnlyViaPublicAddress(Collection<MemberInfo> members) {
-        Iterator<MemberInfo> iter = members.iterator();
+        List<MemberInfo> shuffledList = new ArrayList<>(members);
+        Collections.shuffle(shuffledList);
+        Iterator<MemberInfo> iter = shuffledList.iterator();
         for (int i = 0; i < REACHABLE_CHECK_NUMBER; i++) {
             if (!iter.hasNext()) {
-                iter = members.iterator();
+                iter = shuffledList.iterator();
             }
             MemberInfo member = iter.next();
             Address publicAddress = member.getAddressMap().get(CLIENT_PUBLIC_ENDPOINT_QUALIFIER);

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -118,7 +118,7 @@ public final class ClientProperty {
      * <p>Discovery SPI is <b>disabled</b> by default</p>
      */
     public static final HazelcastProperty DISCOVERY_SPI_PUBLIC_IP_ENABLED
-            = new HazelcastProperty("hazelcast.discovery.public.ip.enabled", false);
+            = new HazelcastProperty("hazelcast.discovery.public.ip.enabled");
 
     /**
      * Controls the number of IO input threads. Defaults to -1, so the system will decide.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/MemberImpl.java
@@ -28,12 +28,12 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.version.MemberVersion;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
-import static java.util.Collections.singletonMap;
 
 public final class MemberImpl
         extends AbstractMember
@@ -54,11 +54,11 @@ public final class MemberImpl
     }
 
     public MemberImpl(Address address, MemberVersion version, boolean localMember) {
-        this(singletonMap(MEMBER, address), address, version, localMember, null, null, false, NA_MEMBER_LIST_JOIN_VERSION, null);
+        this(newHashMap(MEMBER, address), address, version, localMember, null, null, false, NA_MEMBER_LIST_JOIN_VERSION, null);
     }
 
     public MemberImpl(Address address, MemberVersion version, boolean localMember, UUID uuid) {
-        this(singletonMap(MEMBER, address), address, version, localMember, uuid, null, false, NA_MEMBER_LIST_JOIN_VERSION, null);
+        this(newHashMap(MEMBER, address), address, version, localMember, uuid, null, false, NA_MEMBER_LIST_JOIN_VERSION, null);
     }
 
     private MemberImpl(Map<EndpointQualifier, Address> addresses, MemberVersion version, boolean localMember,
@@ -208,7 +208,7 @@ public final class MemberImpl
 
         public MemberImpl build() {
             if (addressMap == null) {
-                addressMap = singletonMap(MEMBER, address);
+                addressMap = newHashMap(MEMBER, address);
             }
             if (address == null) {
                 address = addressMap.get(MEMBER);
@@ -216,5 +216,11 @@ public final class MemberImpl
             return new MemberImpl(addressMap, address, version, localMember, uuid,
                     attributes, liteMember, memberListJoinVersion, instance);
         }
+    }
+
+    private static Map<EndpointQualifier, Address> newHashMap(EndpointQualifier member, Address address) {
+        Map<EndpointQualifier, Address> result = new HashMap<>();
+        result.put(member, address);
+        return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
@@ -136,18 +136,18 @@ public final class EndpointQualifier
                 + '\'' + '}';
     }
 
-    public static EndpointQualifier resolve(ProtocolType protocolType, String name) {
+    public static EndpointQualifier resolve(ProtocolType protocolType, String identifier) {
         switch (protocolType) {
             case MEMBER:
                 return MEMBER;
             case CLIENT:
-                return new EndpointQualifier(ProtocolType.CLIENT, name);
+                return new EndpointQualifier(ProtocolType.CLIENT, identifier);
             case MEMCACHE:
                 return MEMCACHE;
             case REST:
                 return REST;
             case WAN:
-                return new EndpointQualifier(ProtocolType.WAN, name);
+                return new EndpointQualifier(ProtocolType.WAN, identifier);
             default:
                 throw new IllegalArgumentException("Cannot resolve EndpointQualifier for protocol type " + protocolType);
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
@@ -85,10 +85,6 @@ public final class EndpointQualifier
             return false;
         }
 
-        // Single instance types - identifier doesn't matter
-        if (type.getServerSocketCardinality() == 1) {
-            return true;
-        }
         return identifier != null ? identifier.equals(that.identifier) : that.identifier == null;
     }
 
@@ -145,7 +141,7 @@ public final class EndpointQualifier
             case MEMBER:
                 return MEMBER;
             case CLIENT:
-                return CLIENT;
+                return new EndpointQualifier(ProtocolType.CLIENT, name);
             case MEMCACHE:
                 return MEMCACHE;
             case REST:

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -436,7 +437,9 @@ class DefaultAddressPicker
 
     @Override
     public Map<EndpointQualifier, Address> getPublicAddressMap() {
-        return Collections.singletonMap(MEMBER, publicAddress);
+        return new HashMap<EndpointQualifier, Address>() {{
+            put(MEMBER, publicAddress);
+        }};
     }
 
     void setHostnameResolver(HostnameResolver hostnameResolver) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -16,18 +16,18 @@
 
 package com.hazelcast.instance.impl;
 
-import com.hazelcast.internal.cluster.impl.TcpIpJoiner;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.internal.cluster.impl.TcpIpJoiner;
+import com.hazelcast.internal.util.AddressUtil;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.internal.util.AddressUtil;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -151,7 +151,7 @@ class DefaultAddressPicker
 
         if (logger.isFineEnabled()) {
             logger.fine("Picked " + bindAddress + (endpointQualifier == null ? "" : ", for endpoint " + endpointQualifier)
-                  + ", using socket " + serverSocketChannel.socket() + ", bind any local is " + bindAny);
+                    + ", using socket " + serverSocketChannel.socket() + ", bind any local is " + bindAny);
         }
 
         return getPublicAddress(port);
@@ -269,7 +269,7 @@ class DefaultAddressPicker
     }
 
     private static void appendMatchingInterfaces(Collection<InterfaceDefinition> interfaces,
-            Map<String, String> address2DomainMap, String configInterface) {
+                                                 Map<String, String> address2DomainMap, String configInterface) {
 
         for (Entry<String, String> entry : address2DomainMap.entrySet()) {
             String address = entry.getKey();
@@ -437,9 +437,9 @@ class DefaultAddressPicker
 
     @Override
     public Map<EndpointQualifier, Address> getPublicAddressMap() {
-        return new HashMap<EndpointQualifier, Address>() {{
-            put(MEMBER, publicAddress);
-        }};
+        HashMap<EndpointQualifier, Address> publicAddressMap = new HashMap<>();
+        publicAddressMap.put(MEMBER, publicAddress);
+        return publicAddressMap;
     }
 
     void setHostnameResolver(HostnameResolver hostnameResolver) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.internal.cluster;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -32,12 +32,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.cluster.impl.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readMap;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeMap;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
-import static java.util.Collections.singletonMap;
 
 public class MemberInfo implements IdentifiedDataSerializable {
 
@@ -112,7 +110,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
     }
 
     public MemberImpl toMember() {
-        return new MemberImpl.Builder(singletonMap(MEMBER, address))
+        return new MemberImpl.Builder(address)
                 .version(version)
                 .uuid(uuid)
                 .attributes(attributes)

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -17,6 +17,8 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
@@ -76,10 +78,29 @@ public class DiscoveryJoiner
         for (DiscoveryNode discoveryNode : discoveredNodes) {
             Address discoveredAddress = usePublicAddress ? discoveryNode.getPublicAddress() : discoveryNode.getPrivateAddress();
             if (localAddress.equals(discoveredAddress)) {
+                if (!usePublicAddress && discoveryNode.getPublicAddress() != null) {
+                    // enrich member with client public address
+                    localMember.getAddressMap().put(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"),
+                            publicAddress(localMember, discoveryNode));
+                }
                 continue;
             }
             possibleMembers.add(discoveredAddress);
         }
         return possibleMembers;
+    }
+
+    private Address publicAddress(MemberImpl localMember, DiscoveryNode discoveryNode) {
+        if (localMember.getAddressMap().containsKey(EndpointQualifier.CLIENT)) {
+            try {
+                String publicHost = discoveryNode.getPublicAddress().getHost();
+                int clientPort = localMember.getAddressMap().get(EndpointQualifier.CLIENT).getPort();
+                return new Address(publicHost, clientPort);
+            } catch (Exception e) {
+                logger.fine(e);
+                // Return default public address since public host with the (advanced network) client port cannot be resolved
+            }
+        }
+        return discoveryNode.getPublicAddress();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManagerTranslateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManagerTranslateTest.java
@@ -18,16 +18,24 @@ package com.hazelcast.client.impl.connection.tcp;
 
 import com.google.common.collect.ImmutableList;
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.HazelcastClientUtil;
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.client.impl.connection.Addresses;
+import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.MemberVersion;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,34 +43,25 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.net.UnknownHostException;
+import java.util.UUID;
 
 import static junit.framework.TestCase.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
+    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
 
     private Address privateAddress;
     private Address publicAddress;
-    private TcpClientConnectionManager clientConnectionManager;
 
     @Before
     public void setup() throws Exception {
         Hazelcast.newHazelcastInstance();
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
 
-        TestAddressProvider provider = new TestAddressProvider();
-
-        final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
-        clientConnectionManager = new TcpClientConnectionManager(clientInstanceImpl);
-        clientConnectionManager.start();
-        clientConnectionManager.reset();
-        clientConnectionManager.connect(new Address("127.0.0.1", 5701),
-                o -> clientConnectionManager.getOrConnectToAddress((Address) o));
-
-        provider.shouldTranslate = true;
-
+        // correct private address
         privateAddress = new Address("127.0.0.1", 5701);
+        // incorrect public address
         publicAddress = new Address("192.168.0.1", 5701);
     }
 
@@ -72,9 +71,124 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
         Hazelcast.shutdownAll();
     }
 
+    @Test(expected = Exception.class)
+    public void testTranslateIsUsed() {
+        // given
+        ClientConfig config = new ClientConfig();
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(1000);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(new TestAddressProvider(true), config);
+        TcpClientConnectionManager clientConnectionManager =
+                new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
+
+        // when
+        clientConnectionManager.start();
+
+        // then
+        // throws exception because it can't connect to the cluster using translated public unreachable address
+    }
+
+    @Test
+    public void testTranslateIsNotUsedOnGettingExistingConnection() {
+        // given
+        TestAddressProvider provider = new TestAddressProvider(false);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(provider, new ClientConfig());
+        TcpClientConnectionManager clientConnectionManager =
+                new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
+
+        clientConnectionManager.start();
+        clientConnectionManager.reset();
+
+        clientConnectionManager.getOrConnectToAddress(privateAddress);
+        provider.shouldTranslate = true;
+
+        // when
+        Connection connection = clientConnectionManager.getOrConnectToAddress(privateAddress);
+
+        // then
+        assertNotNull(connection);
+    }
+
+    @Test
+    public void testTranslateIsUsedWhenMemberHasPublicClientAddress() throws UnknownHostException {
+        // given
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.getName(), "true");
+
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(null, clientConfig);
+        TcpClientConnectionManager clientConnectionManager =
+                new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
+        clientConnectionManager.start();
+
+        // private member address is unreachable
+        Member member = new MemberImpl(new Address("192.168.0.1", 5701), VERSION, false, UUID.randomUUID());
+        // public member address is reachable
+        member.getAddressMap().put(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"),
+                new Address("127.0.0.1", 5701));
+
+        // when
+        Connection connection = clientConnectionManager.getOrConnectToMember(member);
+
+        // then
+        assertNotNull(connection);
+    }
+
+    @Test(expected = Exception.class)
+    public void testTranslateIsNotUsedWhenPublicIpDisabled() throws UnknownHostException {
+        // given
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.getName(), "false");
+
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(null, clientConfig);
+        TcpClientConnectionManager clientConnectionManager =
+                new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
+        clientConnectionManager.start();
+
+        // private member address is incorrect
+        Member member = new MemberImpl(new Address("192.168.0.1", 5701), VERSION, false);
+        // public member address is correct
+        member.getAddressMap().put(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"), new Address("127.0.0.1", 5701));
+
+        // when
+        clientConnectionManager.getOrConnectToMember(member);
+
+        // then
+        // throws exception because it can't connect to the incorrect member address
+    }
+
+    @Test(expected = Exception.class)
+    public void testTranslateFromMemberIsNotUsedWhenAlreadyTranslatedByAddressProvider() throws UnknownHostException {
+        // given
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.getName(), "true");
+
+        TestAddressProvider provider = new TestAddressProvider(false);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(provider, clientConfig);
+        TcpClientConnectionManager clientConnectionManager =
+                new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
+        clientConnectionManager.start();
+        provider.shouldTranslate = true;
+        privateAddress = new Address("192.168.0.1", 5702);
+
+        // private member address is correct
+        Member member = new MemberImpl(privateAddress, VERSION, false);
+        // public member address is correct
+        member.getAddressMap().put(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"),
+                new Address("127.0.0.1", 5701));
+
+        // when
+        clientConnectionManager.getOrConnectToMember(member);
+
+        // then
+        // throws exception because it can't connect to the incorrect address
+    }
+
     private class TestAddressProvider implements AddressProvider {
 
-        volatile boolean shouldTranslate = false;
+        private boolean shouldTranslate;
+
+        private TestAddressProvider(boolean shouldTranslate) {
+            this.shouldTranslate = shouldTranslate;
+        }
 
         @Override
         public Address translate(Address address) {
@@ -96,12 +210,5 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
                 return null;
             }
         }
-    }
-
-    @Test
-    public void testTranslatorIsNotUsedOnGetConnection() {
-        Connection connection = clientConnectionManager.connect(privateAddress,
-                o -> clientConnectionManager.getOrConnectToAddress((Address) o));
-        assertNotNull(connection);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManagerTranslateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManagerTranslateTest.java
@@ -170,7 +170,7 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
         privateAddress = new Address("192.168.0.1", 5702);
 
         // private member address is correct
-        Member member = new MemberImpl(privateAddress, VERSION, false);
+        Member member = new MemberImpl(privateAddress, VERSION, false, UUID.randomUUID());
         // public member address is correct
         member.getAddressMap().put(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"),
                 new Address("127.0.0.1", 5701));

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProviderTest.java
@@ -104,19 +104,6 @@ public class TranslateToPublicAddressProviderTest {
     }
 
     @Test
-    public void emptyMemberList() {
-        // given
-        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
-
-        // when
-        translateProvider.refresh(defaultAddressProvider(), emptyList());
-        boolean result = translateProvider.get();
-
-        // then
-        assertFalse(result);
-    }
-
-    @Test
     public void memberInternalAddressAsDefinedInClientConfig() {
         // given
         config.getNetworkConfig().addAddress("127.0.0.1");
@@ -124,6 +111,48 @@ public class TranslateToPublicAddressProviderTest {
 
         // when
         translateProvider.refresh(defaultAddressProvider(), asList(member("192.168.0.1"), member("127.0.0.1")));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void memberInternalAddressAsDefinedInClientConfig_memberUsesHostName() {
+        // given
+        config.getNetworkConfig().addAddress("127.0.0.1");
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member("localhost")));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void memberInternalAddressAsDefinedInClientConfig_clientUsesHostname() {
+        // given
+        config.getNetworkConfig().addAddress("localhost");
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member("127.0.0.1")));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void memberInternalAddressAsDefinedInClientConfig_clientUsesHostnameAndIp() {
+        // given
+        config.getNetworkConfig().addAddress("localhost:5701");
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member("127.0.0.1")));
         boolean result = translateProvider.get();
 
         // then

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProviderTest.java
@@ -151,7 +151,7 @@ public class TranslateToPublicAddressProviderTest {
 
         // when
         translateProvider.refresh(defaultAddressProvider(),
-                asList(member(REACHABLE_HOST, UNREACHABLE_HOST), member(UNREACHABLE_HOST, UNREACHABLE_HOST)));
+                asList(member(REACHABLE_HOST, UNREACHABLE_HOST), member(REACHABLE_HOST, UNREACHABLE_HOST)));
         boolean result = translateProvider.get();
 
         // then
@@ -187,7 +187,8 @@ public class TranslateToPublicAddressProviderTest {
 
     @NotNull
     private TranslateToPublicAddressProvider createTranslateProvider() {
-        return new TranslateToPublicAddressProvider(config, new HazelcastProperties(config.getProperties()), mock(ILogger.class));
+        return new TranslateToPublicAddressProvider(config.getNetworkConfig(),
+                new HazelcastProperties(config.getProperties()), mock(ILogger.class));
     }
 
     @NotNull

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/TranslateToPublicAddressProviderTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.spi.impl;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.connection.AddressProvider;
+import com.hazelcast.client.impl.connection.Addresses;
+import com.hazelcast.client.properties.ClientProperty;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.MemberVersion;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TranslateToPublicAddressProviderTest {
+    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
+    public static final String REACHABLE_HOST = "127.0.0.1";
+    public static final String UNREACHABLE_HOST = "192.168.0.1";
+
+    private final ClientConfig config = new ClientConfig();
+
+    @After
+    public void teardown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void nonDefaultAddressProvider() {
+        // given
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(new TestAddressProvider(), null);
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void propertyTrue() {
+        // given
+        config.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.toString(), "true");
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), null);
+        boolean result = translateProvider.get();
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    public void propertyFalse() {
+        // given
+        config.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.toString(), "false");
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), null);
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void emptyMemberList() {
+        // given
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), emptyList());
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void memberInternalAddressAsDefinedInClientConfig() {
+        // given
+        config.getNetworkConfig().addAddress("127.0.0.1");
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member("192.168.0.1"), member("127.0.0.1")));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void membersWithoutPublicAddresses() {
+        // given
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member("127.0.0.1")));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void membersReachableViaInternalAddress() {
+        // given
+        Hazelcast.newHazelcastInstance();
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(),
+                asList(member(REACHABLE_HOST, UNREACHABLE_HOST), member(UNREACHABLE_HOST, UNREACHABLE_HOST)));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void membersUnreachable() {
+        // given
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member(UNREACHABLE_HOST, UNREACHABLE_HOST)));
+        boolean result = translateProvider.get();
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void membersReachableOnlyViaPublicAddress() {
+        // given
+        Hazelcast.newHazelcastInstance();
+        TranslateToPublicAddressProvider translateProvider = createTranslateProvider();
+
+        // when
+        translateProvider.refresh(defaultAddressProvider(), asList(member(UNREACHABLE_HOST, REACHABLE_HOST)));
+        boolean result = translateProvider.get();
+
+        // then
+        assertTrue(result);
+    }
+
+    @NotNull
+    private TranslateToPublicAddressProvider createTranslateProvider() {
+        return new TranslateToPublicAddressProvider(config, new HazelcastProperties(config.getProperties()), mock(ILogger.class));
+    }
+
+    @NotNull
+    private DefaultAddressProvider defaultAddressProvider() {
+        return new DefaultAddressProvider(config.getNetworkConfig());
+    }
+
+    @NotNull
+    private MemberInfo member(String host) {
+        try {
+            return new MemberInfo(new Address(host, 5701), UUID.randomUUID(), emptyMap(), false, VERSION);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    private MemberInfo member(String host, String publicHost) {
+        try {
+            Address internalAddress = new Address(host, 5701);
+            Address publicAddress = new Address(publicHost, 5701);
+            return new MemberInfo(internalAddress, UUID.randomUUID(), emptyMap(), false, VERSION,
+                    singletonMap(EndpointQualifier.resolve(ProtocolType.CLIENT, "public"), publicAddress));
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private class TestAddressProvider implements AddressProvider {
+        @Override
+        public Address translate(Address address) {
+            return address;
+        }
+
+        @Override
+        public Addresses loadAddresses() {
+            return new Addresses(emptyList());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
@@ -61,11 +63,11 @@ public class DiscoveryJoinerTest {
     @Before
     public void init() throws Exception {
         discoveryNodes = new ArrayList<DiscoveryNode>(2);
-        Address publicAddress = new Address("127.0.0.1", 50001);
-        Address privateAddress = new Address("127.0.0.2", 50001);
+        Address privateAddress = new Address("127.0.0.1", 5701);
+        Address publicAddress = new Address("127.0.0.2", 5701);
         discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
-        publicAddress = new Address("127.0.0.1", 50002);
-        privateAddress = new Address("127.0.0.2", 50002);
+        privateAddress = new Address("127.0.0.1", 5702);
+        publicAddress = new Address("127.0.0.2", 5702);
         discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
         factory = new TestHazelcastInstanceFactory(1);
         hz = factory.newHazelcastInstance();
@@ -81,15 +83,35 @@ public class DiscoveryJoinerTest {
         DiscoveryJoiner joiner = new DiscoveryJoiner(getNode(hz), service, true);
         doReturn(discoveryNodes).when(service).discoverNodes();
         Collection<Address> addresses = joiner.getPossibleAddresses();
-        assertEquals("[[127.0.0.1]:50001, [127.0.0.1]:50002]", addresses.toString());
+        assertEquals("[[127.0.0.2]:5701, [127.0.0.2]:5702]", addresses.toString());
     }
 
     @Test
-    public void test_DiscoveryJoiner_returns_private_address() {
+    public void test_DiscoveryJoiner_returns_private_address_and_enrich_member_with_public_address() {
         DiscoveryJoiner joiner = new DiscoveryJoiner(getNode(hz), service, false);
         doReturn(discoveryNodes).when(service).discoverNodes();
         Collection<Address> addresses = joiner.getPossibleAddresses();
-        assertEquals("[[127.0.0.2]:50001, [127.0.0.2]:50002]", addresses.toString());
+        assertEquals("[[127.0.0.1]:5702]", addresses.toString());
+    }
+
+    @Test
+    public void test_DiscoveryJoiner_enriches_member_with_public_address() {
+        DiscoveryJoiner joiner = new DiscoveryJoiner(getNode(hz), service, false);
+        doReturn(discoveryNodes).when(service).discoverNodes();
+        Collection<Address> addresses = joiner.getPossibleAddresses();
+        assertEquals("[127.0.0.2]:5701", getNode(hz).getLocalMember().getAddressMap()
+                .get(EndpointQualifier.resolve(ProtocolType.CLIENT, "public")).toString());
+    }
+
+    @Test
+    public void test_DiscoveryJoiner_enriches_member_with_public_address_when_advanced_network_used()
+            throws UnknownHostException {
+        DiscoveryJoiner joiner = new DiscoveryJoiner(getNode(hz), service, false);
+        doReturn(discoveryNodes).when(service).discoverNodes();
+        getNode(hz).getLocalMember().getAddressMap().put(EndpointQualifier.CLIENT, new Address("127.0.0.1", 5703));
+        Collection<Address> addresses = joiner.getPossibleAddresses();
+        assertEquals("[127.0.0.2]:5703", getNode(hz).getLocalMember().getAddressMap()
+                .get(EndpointQualifier.resolve(ProtocolType.CLIENT, "public")).toString());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
@@ -103,21 +103,24 @@ public class MemberHandshakeHandlerTest {
     @Parameter
     public ProtocolType protocolType;
 
-    // connection type of TcpIpConnection for which MemberHandshake is processed
     @Parameter(1)
+    public String protocolIdentifier;
+
+    // connection type of TcpIpConnection for which MemberHandshake is processed
+    @Parameter(2)
     public String connectionType;
 
     // this map populates MemberHandshake.localAddresses map
-    @Parameter(2)
+    @Parameter(3)
     public Map<ProtocolType, Collection<Address>> localAddresses;
 
     // MemberHandshake.reply (true to test MemberHandshake from connection initiator to server,
     // false when the other way around)
-    @Parameter(3)
+    @Parameter(4)
     public boolean reply;
 
     // addresses on which the TcpIpConnection is expected to be registered in the connectionsMap
-    @Parameter(4)
+    @Parameter(5)
     public List<Address> expectedAddresses;
 
     private final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
@@ -134,23 +137,23 @@ public class MemberHandshakeHandlerTest {
     public static List<Object> parameters() {
         return Arrays.asList(new Object[]{
                 // on MEMBER connections, only MEMBER addresses are registered
-                new Object[]{ProtocolType.MEMBER, ConnectionType.MEMBER,
+                new Object[]{ProtocolType.MEMBER, null, ConnectionType.MEMBER,
                         localAddresses_memberOnly(), false, singletonList(INITIATOR_MEMBER_ADDRESS)},
-                new Object[]{ProtocolType.MEMBER, ConnectionType.MEMBER,
+                new Object[]{ProtocolType.MEMBER, null, ConnectionType.MEMBER,
                         localAddresses_memberOnly(), true, singletonList(INITIATOR_MEMBER_ADDRESS)},
-                new Object[]{ProtocolType.MEMBER, ConnectionType.MEMBER,
+                new Object[]{ProtocolType.MEMBER, null, ConnectionType.MEMBER,
                         localAddresses_memberWan(), false, singletonList(INITIATOR_MEMBER_ADDRESS)},
                 // when protocol type not supported by BindHandler, nothing is registered
-                new Object[]{ProtocolType.CLIENT, null, localAddresses_memberWan(), false, emptyList()},
+                new Object[]{ProtocolType.CLIENT, null, null, localAddresses_memberWan(), false, emptyList()},
                 // when protocol type is WAN, initiator address is always registered
-                new Object[]{WAN, ConnectionType.MEMBER,
+                new Object[]{WAN, "wan", ConnectionType.MEMBER,
                         localAddresses_memberOnly(), false, singletonList(INITIATOR_CLIENT_SOCKET_ADDRESS)},
-                new Object[]{WAN, ConnectionType.MEMBER,
+                new Object[]{WAN, "wan", ConnectionType.MEMBER,
                         localAddresses_memberWan(), false, singletonList(INITIATOR_CLIENT_SOCKET_ADDRESS)},
-                new Object[]{WAN, ConnectionType.MEMBER,
+                new Object[]{WAN, "wan", ConnectionType.MEMBER,
                         localAddresses_memberOnly(), true, singletonList(INITIATOR_CLIENT_SOCKET_ADDRESS)},
                 // when protocol type is WAN, advertised public WAN server socket from initiator is also registered on the server
-                new Object[]{WAN, ConnectionType.MEMBER,
+                new Object[]{WAN, "wan", ConnectionType.MEMBER,
                         localAddresses_memberWan(), true,
                         Arrays.asList(INITIATOR_CLIENT_SOCKET_ADDRESS, INITIATOR_WAN_ADDRESS)}
         });
@@ -162,7 +165,7 @@ public class MemberHandshakeHandlerTest {
         serializationService = getSerializationService(hz);
         Node node = getNode(hz);
         connectionManager = TcpServerConnectionManager.class.cast(
-                node.getServer().getConnectionManager(EndpointQualifier.resolve(protocolType, "wan")));
+                node.getServer().getConnectionManager(EndpointQualifier.resolve(protocolType, protocolIdentifier)));
         tcpServerControl = getFieldValueReflectively(connectionManager, "serverControl");
 
         // setup mock channel & socket

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/StaticAddressPicker.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/StaticAddressPicker.java
@@ -16,14 +16,15 @@
 
 package com.hazelcast.test.mocknetwork;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.cluster.Address;
 
 import java.nio.channels.ServerSocketChannel;
+import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.singletonMap;
+import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 
 class StaticAddressPicker implements AddressPicker {
 
@@ -48,7 +49,9 @@ class StaticAddressPicker implements AddressPicker {
 
     @Override
     public Map<EndpointQualifier, Address> getPublicAddressMap() {
-        return singletonMap(EndpointQualifier.MEMBER, thisAddress);
+        HashMap<EndpointQualifier, Address> publicAddressMap = new HashMap<>();
+        publicAddressMap.put(MEMBER, thisAddress);
+        return publicAddressMap;
     }
 
     @Override


### PR DESCRIPTION
This PR makes discovery by external smart client way simpler and more secure in the cloud environments. From now on, all that the client needs to know is an address of any member (or a load balancer if members are exposed via load balancer).

* Related [PRD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/2280227357/External+Smart+Client+discovery+via+LoadBalancer)
* Related [TDD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/2689663054/External+Smart+Client+discovery+via+LoadBalancer+TDD)

---------

Example of how it works on **Kubernetes** (GKE)

1. Create 3 members, each exposed by a separate NodePort (or LoadBalancer) service.
```
kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
for i in {1..3}; do \
  NAME=hazelcast-${i}; \
  kubectl create service nodeport $NAME --tcp=5701; \
  kubectl run $NAME --image=leszko/hazelcast:external-client --port=5701 -l "app=${NAME},role=hazelcast"; \
done
```

2. Connect the smart client to any of the `IP:PORT` or members and the smart client just works.

3. You can also expose all members via one LoadBalancer service
```
kubectl create service loadbalancer hazelcast --tcp=5701 -o yaml --dry-run=client | kubectl set selector --local -f - "role=hazelcast" -o yaml | kubectl create -f -
```

4. Check the external IP
```
$ kubectl get svc/hazelcast
NAME        TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)          AGE
hazelcast   LoadBalancer   10.127.245.180   35.223.84.167   5701:31368/TCP   8m57s
```

5. Connect from the Java Client
```
ClientConfig config = new ClientConfig();
config.getNetworkConfig().addAddress("35.223.84.167:5701");
HazelcastInstance instance = HazelcastClient.newHazelcastClient(config);
```

--------

Example of how it works on **AWS**

1. Start 3 Hazelcast on 3 EC2 Instances
2. Assuming EC2 Instances have public IPs, connect to any public IP and smart client works correctly.

The same works for any cloud environment (Azure, GCP).

**Note:** client does not need to know any AWS/Azure/GCP credentials!

---------

Some considerations during the review process:
1. I implemented auto-enabling of this feature, please check [TDD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/2689663054/External+Smart+Client+discovery+via+LoadBalancer+TDD) for more details
2. The implementation is backward and forward compatible, no changes in the client protocol are needed