### PR TITLE
Compress metric units defensively

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
@@ -16,8 +16,25 @@
 
 package com.hazelcast.internal.metrics;
 
+import com.hazelcast.internal.metrics.impl.MetricsCompressor;
+
 /**
  * Measurement unit of a Probe. Not used on member, becomes a part of the key.
+ * <p>
+ * <b>NOTE</b>: The enum ordinals are used by {@link MetricsCompressor},
+ * therefore, the ordinal values should remain stable between versions to
+ * ensure version compatibility.
+ * <p>
+ * When modifying this enum, please be aware of the following rules
+ * <ul>
+ *     <li>do not reorder the values of this enum,
+ *     <li>do not delete any value from this enum,
+ *     <li>add new values at the end of the list,
+ *     <li>when introducing a new enum value, mark the value as new by
+ *     setting {{@link #newUnit}} to {@code true} and add the version
+ *     dependent RU_COMPAT_X_Y.
+ * </ul>
+ * <p>
  */
 public enum ProbeUnit {
     /** Size, counter, represented in bytes */
@@ -35,7 +52,7 @@ public enum ProbeUnit {
     /** 0..n, ordinal of an enum */
     ENUM,
     /** Timestamp or duration represented in µs */
-    // RU_COMPAT_4_2
+    // RU_COMPAT_4_1
     // remove constructor argument in 4.3
     US(true);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
@@ -24,8 +24,6 @@ public enum ProbeUnit {
     BYTES,
     /** Timestamp or duration represented in ms */
     MS,
-    /** Timestamp or duration represented in µs */
-    US,
     /** Timestamp or duration represented in nanoseconds */
     NS,
     /** An integer mostly in range 0..100 or a double mostly in range 0..1 */
@@ -36,4 +34,26 @@ public enum ProbeUnit {
     BOOLEAN,
     /** 0..n, ordinal of an enum */
     ENUM,
+    /** Timestamp or duration represented in µs */
+    // RU_COMPAT_4_2
+    // remove constructor argument in 4.3
+    US(true);
+
+    /**
+     * Setting to {@code true} indicates that when compressing a metric with this
+     * unit, the unit should be converted to a tag to ensure backwards compatibility.
+     */
+    private final boolean newUnit;
+
+    ProbeUnit() {
+        this(false);
+    }
+
+    ProbeUnit(boolean newUnit) {
+        this.newUnit = newUnit;
+    }
+
+    public boolean isNewUnit() {
+        return newUnit;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeUnitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeUnitTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ProbeUnitTest {
 
-    // RU_COMPAT_4_2
+    // RU_COMPAT_4_1
     // set to the current unit count
     // add "RU_COMPAT_X_Y" when introducing a new unit
     private static final int HIGHEST_UNIT_ORDINAL_IN_LAST_VERSION = 6;

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeUnitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeUnitTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ProbeUnitTest {
+
+    // RU_COMPAT_4_2
+    // set to the current unit count
+    // add "RU_COMPAT_X_Y" when introducing a new unit
+    private static final int HIGHEST_UNIT_ORDINAL_IN_LAST_VERSION = 6;
+    private static final int UNIT_COUNT_IN_CURRENT_VERSION = 8;
+
+    @Test
+    public void testNoReorder() {
+        assertEquals(0, ProbeUnit.BYTES.ordinal());
+        assertEquals(1, ProbeUnit.MS.ordinal());
+        assertEquals(2, ProbeUnit.NS.ordinal());
+        assertEquals(3, ProbeUnit.PERCENT.ordinal());
+        assertEquals(4, ProbeUnit.COUNT.ordinal());
+        assertEquals(5, ProbeUnit.BOOLEAN.ordinal());
+        assertEquals(6, ProbeUnit.ENUM.ordinal());
+        assertEquals(7, ProbeUnit.US.ordinal());
+    }
+
+    @Test
+    public void testUnitCount() {
+        // this test intentionally compares against a constant value
+        // the purpose of this test is to fail if a new unit is introduced to make sure the other test cases are
+        // getting updated with the new unit
+        // please add the unit with its ordinal to testNoReorder and increase the expected count here
+        assertEquals(UNIT_COUNT_IN_CURRENT_VERSION, ProbeUnit.values().length);
+    }
+
+    @Test
+    public void testNewUnitIsMarkedAsNew() {
+        ProbeUnit[] units = ProbeUnit.values();
+        for (int i = HIGHEST_UNIT_ORDINAL_IN_LAST_VERSION + 1; i < units.length; i++) {
+            assertTrue(units[i].isNewUnit());
+        }
+    }
+}


### PR DESCRIPTION
The units of the metrics are directly derived from the `ProbeUnit` enum
and the `MetricCompressor` takes the ordinal when creating the blob. On
the consumer side, this ordinal is taken and a lookup is made with the
ordinal potentially leading to `IndexOutOfBoundsException` if the ordinal
is higher than the size of the array holding the possible values of the
units. This can be the case every time we add a new unit to the
`ProbeUnit` enum, which the `MetricCompressor` is not aware of.

To prevent potential issues, we make the unit compression and extraction
more defensive. We change the compression to convert the marked units to
a tag with the name `"metric-unit"` and set the unit to `null`. With this, the
metric can still be processed by MC and the consumers using a metric
extractor and retain the information about the unit. The extractor is
made more defensive by adding a bound check to prevent the
`IndexOutOfBoundsException` in the mentioned case.