### PR TITLE
[BACKPORT 4.1.z] Fix violations from zero-dependency policy and add regression tests

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -73,7 +73,6 @@
                         </goals>
                         <configuration>
                             <shadedArtifactId>hazelcast-all</shadedArtifactId>
-                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
                             <minimizeJar>false</minimizeJar>
                             <createSourcesJar>true</createSourcesJar>

--- a/hazelcast-all/src/test/java/com/hazelcast/it/DependencyReducedPomAllIT.java
+++ b/hazelcast-all/src/test/java/com/hazelcast/it/DependencyReducedPomAllIT.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.it;
+
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class DependencyReducedPomAllIT  extends DependencyReducedPomIT {
+}

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -126,21 +126,11 @@
                             <finalName>${project.build.finalName}</finalName>
                             <createSourcesJar>true</createSourcesJar>
                             <shadeSourcesContent>true</shadeSourcesContent>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadeTestJar>false</shadeTestJar>
                             <artifactSet>
-                                <includes>
-                                    <include>com.fasterxml.jackson.core:jackson-core</include>
-                                    <include>com.google.guava:guava</include>
-                                    <include>com.jayway.jsonpath:json-path</include>
-                                    <include>org.apache.calcite.avatica:avatica-core</include>
-                                    <include>org.apache.calcite:calcite-core</include>
-                                    <include>org.apache.calcite:calcite-linq4j</include>
-                                    <include>org.codehaus.janino:commons-compiler</include>
-                                    <include>org.codehaus.janino:janino</include>
-                                    <include>org.slf4j:slf4j-api</include>
-                                    <include>commons-codec:commons-codec</include>
-                                </includes>
+                                <excludes>
+                                    <exclude>com.hazelcast:hazelcast</exclude>
+                                </excludes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
@@ -346,6 +336,24 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/hazelcast-sql/src/test/java/com/hazelcast/it/DependencyReducedPomSqlIT.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/it/DependencyReducedPomSqlIT.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.it;
+
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class DependencyReducedPomSqlIT  extends DependencyReducedPomIT {
+
+    // The com.hazelcast:hazelcast dependency is expected.
+    protected int expectedDependencies() {
+        return 1;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -31,7 +31,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,6 +41,7 @@ import java.util.Properties;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 
 /**
  * Loads the {@link com.hazelcast.client.config.ClientConfig} using XML.
@@ -114,10 +114,7 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
 
     @Override
     protected Document parse(InputStream inputStream) throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        DocumentBuilder builder = dbf.newDocumentBuilder();
+        DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
         try {
             return builder.parse(inputStream);
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
@@ -32,7 +32,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -43,6 +42,7 @@ import java.util.Properties;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 
 /**
  * Loads the {@link com.hazelcast.client.config.ClientFailoverConfig} using XML.
@@ -122,10 +122,7 @@ public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
 
     @Override
     protected Document parse(InputStream inputStream) throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        DocumentBuilder builder = dbf.newDocumentBuilder();
+        DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
         try {
             return builder.parse(inputStream);
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -28,7 +28,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -41,6 +40,7 @@ import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRI
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 
 /**
  * A XML {@link ConfigBuilder} implementation.
@@ -188,10 +188,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements Config
 
     @Override
     protected Document parse(InputStream is) throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        DocumentBuilder builder = dbf.newDocumentBuilder();
+        DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
         Document doc;
         try {
             doc = builder.parse(is);

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
@@ -24,7 +24,6 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathException;
@@ -46,6 +45,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.internal.util.StringUtil.trim;
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 import static java.lang.String.format;
 
 /**
@@ -177,10 +177,7 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
 
     private static Properties loadPropertiesFromConfig(FileInputStream fileInputStream) throws Exception {
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            DocumentBuilder builder = dbf.newDocumentBuilder();
+            DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
             Document doc = builder.parse(fileInputStream);
             Element root = doc.getDocumentElement();
             return loadProperties(findReplacerDefinition(root));

--- a/hazelcast/src/test/java/com/hazelcast/config/IterableNodeListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IterableNodeListTest.java
@@ -28,13 +28,13 @@ import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import static com.hazelcast.internal.config.DomConfigHelper.asElementIterable;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -47,9 +47,7 @@ public class IterableNodeListTest {
 
     @Before
     public void setup() throws ParserConfigurationException, SAXException, IOException {
-        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        final DocumentBuilder builder = dbf.newDocumentBuilder();
+        DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
         final String testXml = "<rOOt><element></element><element></element><element></element></rOOt>";
         document = builder.parse(new ByteArrayInputStream(testXml.getBytes()));
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigSchemaLocationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigSchemaLocationTest.java
@@ -41,6 +41,8 @@ import org.w3c.dom.Element;
 import javax.net.ssl.SSLContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.InputStream;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
@@ -48,6 +50,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static org.junit.Assert.assertEquals;
 
@@ -69,10 +72,9 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
     public TestName testName = new TestName();
 
     @Before
-    public void setUp() {
+    public void setUp() throws ParserConfigurationException {
         httpClient = HttpClients.createDefault();
-        documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        documentBuilderFactory.setNamespaceAware(true);
+        documentBuilderFactory = getNsAwareDocumentBuilderFactory();
         validUrlsCache = new HashSet<String>();
     }
 
@@ -90,6 +92,7 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
         Set<String> resources = reflections.getResources(Pattern.compile(".*\\.xml"));
         ClassLoader classLoader = getClass().getClassLoader();
         for (String resource : resources) {
+            System.out.println(resource);
             URL resourceUrl = classLoader.getResource(resource);
             String protocol = resourceUrl.getProtocol();
 
@@ -118,7 +121,6 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
             if (shouldSkipValidation(nameSpaceUrl)) {
                 continue;
             }
-            System.out.println("Validating " + nameSpaceUrl);
             int responseCode;
             try {
                 responseCode = getResponseCode(nameSpaceUrl);

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
@@ -36,7 +36,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -54,6 +53,7 @@ import java.io.StringWriter;
 import java.net.URL;
 
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -200,9 +200,7 @@ public class XmlOnlyConfigBuilderTest {
     public void testAddWhitespaceToNonSpaceStrings() throws Exception {
         // parse the default config file
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-default.xml");
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        DocumentBuilder builder = dbf.newDocumentBuilder();
+        DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
         Document doc = builder.parse(xmlResource);
         // validate to augment with type information
         Validator validator = getValidator();

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/XmlUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/XmlUtilTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.validation.SchemaFactory;
 
@@ -80,5 +82,16 @@ public class XmlUtilTest {
         assertThrows(IllegalArgumentException.class, () -> XmlUtil.setAttribute(transformerFactory, "test://no-such-property"));
         ignoreXxeFailureProp.setOrClearProperty("true");
         XmlUtil.setAttribute(transformerFactory, "test://no-such-property");
+    }
+
+    @Test
+    public void testGetDocumentBuilderFactory() throws Exception {
+        DocumentBuilderFactory dbf = XmlUtil.getNsAwareDocumentBuilderFactory();
+        assertNotNull(dbf);
+        assertThrows(ParserConfigurationException.class, () -> XmlUtil.setFeature(dbf, "test://no-such-feature"));
+        ignoreXxeFailureProp.setOrClearProperty("false");
+        assertThrows(ParserConfigurationException.class, () -> XmlUtil.setFeature(dbf, "test://no-such-feature"));
+        ignoreXxeFailureProp.setOrClearProperty("true");
+        XmlUtil.setFeature(dbf, "test://no-such-feature");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/it/DependencyReducedPomIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/it/DependencyReducedPomIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.it;
+
+import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
+import static org.junit.Assert.assertEquals;
+
+import java.io.FileInputStream;
+import java.util.Iterator;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class DependencyReducedPomIT {
+
+    @Test
+    public void testZeroCompileScopedDeps() throws Exception {
+        DocumentBuilder builder = getNsAwareDocumentBuilderFactory().newDocumentBuilder();
+        Document xmlDocument = null;
+        try (FileInputStream fis = new FileInputStream("dependency-reduced-pom.xml")) {
+            xmlDocument = builder.parse(fis);
+        }
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        xPath.setNamespaceContext(new NamespaceContext() {
+
+            @Override
+            public Iterator getPrefixes(String namespaceURI) {
+                return null;
+            }
+
+            @Override
+            public String getPrefix(String namespaceURI) {
+                return null;
+            }
+
+            @Override
+            public String getNamespaceURI(String prefix) {
+                if ("m".equals(prefix)) {
+                    return "http://maven.apache.org/POM/4.0.0";
+                }
+                return null;
+            }
+        });
+        // check first we are making valid XPath selections
+        NodeList expectedProjectsList = (NodeList) xPath.compile("//m:project").evaluate(xmlDocument, XPathConstants.NODESET);
+        assertEquals(1, expectedProjectsList.getLength());
+
+        // verify there is no compile-scoped dependency
+        NodeList unexpectedDepsList = (NodeList) xPath.compile("/m:project/m:dependencies/m:dependency[m:scope/text()='compile']")
+                .evaluate(xmlDocument, XPathConstants.NODESET);
+        for (int i = 0; i < unexpectedDepsList.getLength(); i++) {
+            // make debugging easier, fail after printing out the problematic dependencies
+            System.err.println("Dependency found: " + unexpectedDepsList.item(i).getTextContent());
+        }
+        assertEquals(expectedDependencies(), unexpectedDepsList.getLength());
+    }
+
+    protected int expectedDependencies() {
+        return 0;
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -18,7 +18,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.1.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>


### PR DESCRIPTION
Clean cherry-pick of #17891 to `4.1.z` patch stream