### PR TITLE
Try context classloader even the classname starts with 'com.hazelcast'

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -225,32 +225,34 @@ public final class ClassLoaderUtil {
         if (primitiveClass != null) {
             return primitiveClass;
         }
-        ClassLoader theClassLoader = classLoaderHint;
-        if (theClassLoader == null) {
-            theClassLoader = Thread.currentThread().getContextClassLoader();
-        }
 
-        // first try to load it through the given classloader
-        if (theClassLoader != null) {
+        // Try to load it using the hinted classloader if not null
+        if (classLoaderHint != null) {
             try {
-                return tryLoadClass(className, theClassLoader);
+                return tryLoadClass(className, classLoaderHint);
             } catch (ClassNotFoundException ignore) {
-                // reset selected classloader and try with others
-                theClassLoader = null;
             }
         }
 
-        // if failed and this is a Hazelcast class, try again with our classloader
-        if (className.startsWith(HAZELCAST_BASE_PACKAGE) || className.startsWith(HAZELCAST_ARRAY)) {
-            theClassLoader = ClassLoaderUtil.class.getClassLoader();
+        // If this is a Hazelcast class, try to load it using our classloader
+        ClassLoader theClassLoader = ClassLoaderUtil.class.getClassLoader();
+        if (theClassLoader != null && belongsToHazelcastPackage(className)) {
+            try {
+                return tryLoadClass(className, ClassLoaderUtil.class.getClassLoader());
+            } catch (ClassNotFoundException ignore) {
+            }
         }
-        if (theClassLoader == null) {
-            theClassLoader = Thread.currentThread().getContextClassLoader();
-        }
-        if (theClassLoader != null) {
-            return tryLoadClass(className, theClassLoader);
+
+        // Try to load it using context class loader if not null
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader != null) {
+            return tryLoadClass(className, contextClassLoader);
         }
         return Class.forName(className);
+    }
+
+    private static boolean belongsToHazelcastPackage(String className) {
+        return className.startsWith(HAZELCAST_BASE_PACKAGE) || className.startsWith(HAZELCAST_ARRAY);
     }
 
     private static Class<?> tryPrimitiveClass(String className) {


### PR DESCRIPTION
forward-port of #17584

If user-code-deployment is enabled, we first try to load the class
using user-code-deployment classloader. If it fails, we check if the
classname starts with 'com.hazelcast' and if so we use our classloader.
And we don't try to load the class with context classloader of the
current thread.

With the fix, we try to load it using hinted classloader. Then we try
to load it using our classloader if classname starts with `com.hazelcast`.
Finally we try to load it using context classloader.