### PR TITLE
Initialize SplitBrainProtectionConfig with valid values

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/SplitBrainProtectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SplitBrainProtectionConfig.java
@@ -70,7 +70,7 @@ public class SplitBrainProtectionConfig implements IdentifiedDataSerializable, N
 
     private String name;
     private boolean enabled;
-    private int minimumClusterSize;
+    private int minimumClusterSize = 2;
     private List<SplitBrainProtectionListenerConfig> listenerConfigs = new ArrayList<SplitBrainProtectionListenerConfig>();
     private SplitBrainProtectionOn protectOn = READ_WRITE;
     private String functionClassName;


### PR DESCRIPTION
When relying on the `SplitBrainProtectionConfig` constructors, it ends up initialized in an invalid state.

The minimum cluster size configured for split-brain protection can't be lower than 2, but it defaults to 0:

```
SplitBrainProtectionConfig splitBrainProtectionConfig = new SplitBrainProtectionConfig();
System.out.println(splitBrainProtectionConfig.getMinimumClusterSize()); // 0
```

