### PR TITLE
Java util optional serialization support

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -132,8 +132,6 @@ public final class SerializationConstants {
     // NUMBER OF CONSTANT SERIALIZERS...
     public static final int CONSTANT_SERIALIZERS_LENGTH = 51;
 
-    public static final int JAVA_DEFAULT_TYPE_ENUM = -51;
-
     // ------------------------------------------------------------
     // JAVA SERIALIZATION
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -127,10 +127,12 @@ public final class SerializationConstants {
 
     public static final int JAVA_DEFAULT_TYPE_PRIORITY_QUEUE = -49;
 
-    // NUMBER OF CONSTANT SERIALIZERS...
-    public static final int CONSTANT_SERIALIZERS_LENGTH = 50;
+    public static final int JAVA_DEFAULT_TYPE_OPTIONAL = -50;
 
-    public static final int JAVA_DEFAULT_TYPE_ENUM = -50;
+    // NUMBER OF CONSTANT SERIALIZERS...
+    public static final int CONSTANT_SERIALIZERS_LENGTH = 51;
+
+    public static final int JAVA_DEFAULT_TYPE_ENUM = -51;
 
     // ------------------------------------------------------------
     // JAVA SERIALIZATION

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -37,6 +37,7 @@ import com.hazelcast.internal.serialization.impl.defaultserializers.DelayQueueSt
 import com.hazelcast.internal.serialization.impl.defaultserializers.HashMapStreamSerializer;
 import com.hazelcast.internal.serialization.impl.defaultserializers.HashSetStreamSerializer;
 import com.hazelcast.internal.serialization.impl.defaultserializers.JavaDefaultSerializers;
+import com.hazelcast.internal.serialization.impl.defaultserializers.JavaDefaultSerializers.OptionalSerializer;
 import com.hazelcast.internal.serialization.impl.defaultserializers.LinkedBlockingQueueStreamSerializer;
 import com.hazelcast.internal.serialization.impl.defaultserializers.LinkedHashMapStreamSerializer;
 import com.hazelcast.internal.serialization.impl.defaultserializers.LinkedHashSetStreamSerializer;
@@ -80,6 +81,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeMap;
@@ -222,6 +224,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     private void registerJavaTypeSerializers() {
         //Java extensions: more serializers
         registerConstant(Class.class, new ClassSerializer());
+        registerConstant(Optional.class, new OptionalSerializer());
         registerConstant(Date.class, new DateSerializer());
         registerConstant(BigInteger.class, new BigIntegerSerializer());
         registerConstant(BigDecimal.class, new BigDecimalSerializer());

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
+import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -44,6 +45,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.J
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_CLASS;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_DATE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_EXTERNALIZABLE;
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_OPTIONAL;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_SERIALIZABLE;
 import static com.hazelcast.internal.nio.IOUtil.newObjectInputStream;
 import static java.lang.Math.max;
@@ -294,6 +296,34 @@ public final class JavaDefaultSerializers {
         @Override
         public void write(final ObjectDataOutput out, final Class obj) throws IOException {
             out.writeUTF(obj.getName());
+        }
+    }
+
+    public static final class OptionalSerializer extends SingletonSerializer<Optional> {
+
+        @Override
+        public int getTypeId() {
+            return JAVA_DEFAULT_TYPE_OPTIONAL;
+        }
+
+        @Override
+        public Optional read(final ObjectDataInput in) throws IOException {
+            final boolean present = in.readBoolean();
+            if (present) {
+                return Optional.of(in.readObject());
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public void write(final ObjectDataOutput out, final Optional obj) throws IOException {
+            if (obj.isPresent()) {
+                out.writeBoolean(true);
+                out.writeObject(obj.get());
+            } else {
+                out.writeBoolean(false);
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -157,6 +158,8 @@ class ReferenceObjects {
     static BigInteger aBigInteger = new BigInteger("1314432323232411");
     static BigDecimal aBigDecimal = new BigDecimal(31231);
     static Class aClass = BigDecimal.class;
+    static Optional<String> aFullOptional = Optional.of("SERIALIZEDSTRING");
+    static Optional<String> anEmptyOptional = Optional.empty();
     static Enum anEnum = EntryEventType.ADDED;
 
     static Serializable serializable = new AJavaSerialiazable(anInt, aFloat);
@@ -169,7 +172,7 @@ class ReferenceObjects {
             booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
             aCustomStreamSerializable, aCustomByteArraySerializable,
             anIdentifiedDataSerializable, aPortable,
-            aDate, aBigInteger, aBigDecimal, aClass, anEnum, aSimpleMapEntry, aSimpleImmutableMapEntry,
+            aDate, aBigInteger, aBigDecimal, aClass, anEmptyOptional, aFullOptional, anEnum, aSimpleMapEntry, aSimpleImmutableMapEntry,
             serializable, externalizable));
 
     static ArrayList arrayList = new ArrayList(asList(aNullObject, nonNullList));
@@ -222,7 +225,7 @@ class ReferenceObjects {
             aSimpleMapEntry, aSimpleImmutableMapEntry, booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
             aCustomStreamSerializable, aCustomByteArraySerializable,
             anIdentifiedDataSerializable, aPortable,
-            aDate, aBigInteger, aBigDecimal, aClass, anEnum,
+            aDate, aBigInteger, aBigDecimal, aClass, aFullOptional, anEnum,
             serializable, externalizable,
             arrayList, linkedList, copyOnWriteArrayList, concurrentSkipListMap, concurrentHashMap, linkedHashMap, treeMap,
             hashSet, treeSet, linkedHashSet, copyOnWriteArraySet, concurrentSkipListSet, arrayDeque, linkedBlockingQueue,


### PR DESCRIPTION
In relation to https://github.com/payara/Payara/issues/5026 I prepared pull request, that should add serialization support of java.util.Optional.

Motivation:
```
@CacheResult(name = "not-a-cheap-value-cache")
Optional<NotACheapValue> calculateNotACheapValue(SomeParametersUsedInConstruction p)
```