### PR TITLE
Ensure PNCounter/FlakeIdGenerator configs are not overwritten when parsing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1061,13 +1061,14 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     protected void handlePNCounter(Node node) throws Exception {
-        PNCounterConfig pnCounterConfig = new PNCounterConfig();
+        String name = getAttribute(node, "name");
+        PNCounterConfig pnCounterConfig = config.getPNCounterConfig(name);
         handleViaReflection(node, config, pnCounterConfig);
     }
 
     protected void handleFlakeIdGenerator(Node node) {
         String name = getAttribute(node, "name");
-        FlakeIdGeneratorConfig generatorConfig = new FlakeIdGeneratorConfig(name);
+        FlakeIdGeneratorConfig generatorConfig = config.getFlakeIdGeneratorConfig(name);
         handleFlakeIdGeneratorNode(node, generatorConfig);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -326,8 +326,9 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleFlakeIdGenerator(Node node) {
         for (Node genNode : childElements(node)) {
-            FlakeIdGeneratorConfig genConfig = new FlakeIdGeneratorConfig();
-            genConfig.setName(genNode.getNodeName());
+            FlakeIdGeneratorConfig genConfig = config
+              .getFlakeIdGeneratorConfig(genNode.getNodeName());
+
             handleFlakeIdGeneratorNode(genNode, genConfig);
         }
     }
@@ -369,8 +370,9 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handlePNCounter(Node node) throws Exception {
         for (Node counterNode : childElements(node)) {
-            PNCounterConfig counterConfig = new PNCounterConfig();
-            counterConfig.setName(counterNode.getNodeName());
+            PNCounterConfig counterConfig = config
+              .getPNCounterConfig(counterNode.getNodeName());
+
             handleViaReflection(counterNode, config, counterConfig);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -221,6 +221,34 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         assertEquals("com.foo.SomeClass", config.getSplitBrainProtectionConfig("foo").getFunctionClassName());
     }
 
+    @Test
+    public void shouldHandlePNCounterConfig() throws Exception {
+        Config config = new Config();
+        config.getPNCounterConfig("foo")
+          .setStatisticsEnabled(false)
+          .setReplicaCount(2);
+
+        withEnvironmentVariable("HZ_PNCOUNTER_FOO_STATISTICSENABLED", "true")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertTrue(config.getPNCounterConfig("foo").isStatisticsEnabled());
+        assertEquals(2, config.getPNCounterConfig("foo").getReplicaCount());
+    }
+
+    @Test
+    public void shouldHandleFlakeIdConfig() throws Exception {
+        Config config = new Config();
+        config.getFlakeIdGeneratorConfig("foo")
+          .setStatisticsEnabled(false)
+          .setAllowedFutureMillis(1000);
+
+        withEnvironmentVariable("HZ_FLAKEIDGENERATOR_FOO_STATISTICSENABLED", "true")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertTrue(config.getFlakeIdGeneratorConfig("foo").isStatisticsEnabled());
+        assertEquals(1000, config.getFlakeIdGeneratorConfig("foo").getAllowedFutureMillis());
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void shouldDisallowConflictingEntries() throws Exception {
         withEnvironmentVariable("HZ_CLUSTERNAME", "test")


### PR DESCRIPTION
Related: #17874