### PR TITLE
Fixes serialization of PreJoinCacheConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -77,7 +77,7 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements Versi
     @Override
     protected void writeTenant(ObjectDataOutput out) throws IOException {
         // RU_COMPAT_4_1
-        if (out.getVersion().isLessOrEqual(Versions.V4_2)) {
+        if (out.getVersion().isUnknownOrLessThan(Versions.V4_2)) {
             out.writeObject(TenantControl.NOOP_TENANT_CONTROL);
         }
     }
@@ -85,7 +85,7 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements Versi
     @Override
     protected void readTenant(ObjectDataInput in) throws IOException {
         // RU_COMPAT_4_1
-        if (in.getVersion().isLessOrEqual(Versions.V4_2)) {
+        if (in.getVersion().isUnknownOrLessThan(Versions.V4_2)) {
             in.readObject();
         }
     }


### PR DESCRIPTION
Starting with 4.2, `Tenant` object should not
be part of its serialized form. Additionally,
`PreJoinCacheConfig`s serialized from 4.1 will have
an unknown version (due to `PreJoinCacheConfig`
not implementing Versioned in 4.1). So the correct
version comparison is `isUnknownOrLessThan`.

Fixes compatibility test failures on EE side.