### PR TITLE
Ensure Map's MerkleTree/EventJournal configs are not overwritten during parsing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -62,7 +62,6 @@ import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MergePolicyConfig;
-import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.MetricsConfig;
 import com.hazelcast.config.MetricsJmxConfig;
@@ -774,8 +773,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             } else if (matches("outbound-ports", nodeName)) {
                 handleOutboundPorts(child);
             } else if (matches("public-address", nodeName)) {
-                String address = getTextContent(child);
-                config.getNetworkConfig().setPublicAddress(address);
+                config.getNetworkConfig().setPublicAddress(getTextContent(child));
             } else if (matches("join", nodeName)) {
                 handleJoin(child, false);
             } else if (matches("interfaces", nodeName)) {
@@ -1712,11 +1710,9 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 MergePolicyConfig mergePolicyConfig = createMergePolicyConfig(node);
                 mapConfig.setMergePolicyConfig(mergePolicyConfig);
             } else if (matches("merkle-tree", nodeName)) {
-                MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig();
-                handleViaReflection(node, mapConfig, merkleTreeConfig);
+                handleViaReflection(node, mapConfig, mapConfig.getMerkleTreeConfig());
             } else if (matches("event-journal", nodeName)) {
-                EventJournalConfig eventJournalConfig = new EventJournalConfig();
-                handleViaReflection(node, mapConfig, eventJournalConfig);
+                handleViaReflection(node, mapConfig, mapConfig.getEventJournalConfig());
             } else if (matches("hot-restart", nodeName)) {
                 mapConfig.setHotRestartConfig(createHotRestartConfig(node));
             } else if (matches("read-backup-data", nodeName)) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -17,7 +17,9 @@
 package com.hazelcast.internal.config.override;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.config.UserCodeDeploymentConfig;
@@ -314,6 +316,46 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
 
         assertEquals(2, config.getMapConfig("foo").getBackupCount());
         assertEquals(100, config.getMapConfig("foo").getMaxIdleSeconds());
+    }
+
+    @Test
+    public void shouldHandleMapMerkleTreeConfig() throws Exception {
+        Config config = new Config();
+        MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig()
+          .setEnabled(false)
+          .setDepth(5);
+
+        config.getMapConfig("foo1")
+          .setBackupCount(4)
+          .setMerkleTreeConfig(merkleTreeConfig);
+
+        withEnvironmentVariable("HZ_MAP_FOO1_BACKUPCOUNT", "2")
+          .and("HZ_MAP_FOO1_MERKLETREE_ENABLED", "true")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertEquals(2, config.getMapConfig("foo1").getBackupCount());
+        assertTrue(config.getMapConfig("foo1").getMerkleTreeConfig().isEnabled());
+        assertEquals(5, config.getMapConfig("foo1").getMerkleTreeConfig().getDepth());
+    }
+
+    @Test
+    public void shouldHandleMapEventJournalConfig() throws Exception {
+        Config config = new Config();
+        EventJournalConfig eventJournalConfig = new EventJournalConfig()
+          .setEnabled(false)
+          .setCapacity(10);
+
+        config.getMapConfig("foo1")
+          .setBackupCount(4)
+          .setEventJournalConfig(eventJournalConfig);
+
+        withEnvironmentVariable("HZ_MAP_FOO1_BACKUPCOUNT", "2")
+          .and("HZ_MAP_FOO1_EVENTJOURNAL_ENABLED", "true")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertEquals(2, config.getMapConfig("foo1").getBackupCount());
+        assertTrue(config.getMapConfig("foo1").getEventJournalConfig().isEnabled());
+        assertEquals(10, config.getMapConfig("foo1").getEventJournalConfig().getCapacity());
     }
 
     @Test


### PR DESCRIPTION
Related: #17874