### PR TITLE
Ensure AuditLog config is not overwritten during parsing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.AttributeConfig;
-import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.AutoDetectionConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.CacheDeserializedValues;
@@ -343,7 +342,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         } else if (matches(CP_SUBSYSTEM.getName(), nodeName)) {
             handleCPSubsystem(node);
         } else if (matches(AUDITLOG.getName(), nodeName)) {
-            config.setAuditlogConfig(fillFactoryWithPropertiesConfig(node, new AuditlogConfig()));
+            fillFactoryWithPropertiesConfig(node, config.getAuditlogConfig());
         } else if (matches(METRICS.getName(), nodeName)) {
             handleMetrics(node);
         } else if (matches(INSTANCE_TRACKING.getName(), nodeName)) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -344,6 +344,26 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         assertFalse(config.getMultiMapConfig("foo").isBinary());
     }
 
+    @Test
+    public void shouldHandleAuditLogConfig() throws Exception {
+        Config config = new Config();
+        config.getAuditlogConfig()
+          .setEnabled(false)
+          .setFactoryClassName("com.acme.AuditlogToSyslogFactory")
+          .setProperty("host", "syslogserver.acme.com")
+          .setProperty("port", "514")
+          .setProperty("type", "tcp");
+
+        withEnvironmentVariable("HZ_AUDITLOG_ENABLED", "true")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertTrue(config.getAuditlogConfig().isEnabled());
+        assertEquals("com.acme.AuditlogToSyslogFactory", config.getAuditlogConfig().getFactoryClassName());
+        assertEquals("syslogserver.acme.com", config.getAuditlogConfig().getProperty("host"));
+        assertEquals("514", config.getAuditlogConfig().getProperty("port"));
+        assertEquals("tcp", config.getAuditlogConfig().getProperty("type"));
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void shouldDisallowConflictingEntries() throws Exception {
         withEnvironmentVariable("HZ_CLUSTERNAME", "test")


### PR DESCRIPTION
Related: #17874