### PR TITLE
Implement ManagedBlocker for DistributedObjectFuture

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -464,20 +464,12 @@ public final class ProxyManager {
                 return true;
             }
 
-            boolean interrupted = false;
             synchronized (this) {
                 while (proxy == null) {
-                    try {
-                        wait();
-                    } catch (InterruptedException e) {
-                        interrupted = true;
-                    }
+                    wait();
                 }
             }
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-                return true;
-            }
+
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -472,7 +472,6 @@ public final class ProxyManager {
                     } catch (InterruptedException e) {
                         interrupted = true;
                     }
-                    wait();
                 }
             }
             if (interrupted) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -464,10 +464,20 @@ public final class ProxyManager {
                 return true;
             }
 
+            boolean interrupted = false;
             synchronized (this) {
                 while (proxy == null) {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        interrupted = true;
+                    }
                     wait();
                 }
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+                return true;
             }
 
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -85,6 +85,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ForkJoinPool;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -427,26 +428,19 @@ public final class ProxyManager {
         }
     }
 
-    private static class ClientProxyFuture {
+    private static class ClientProxyFuture implements ForkJoinPool.ManagedBlocker {
 
         volatile Object proxy;
 
         ClientProxy get() {
-            if (proxy == null) {
-                boolean interrupted = false;
-                synchronized (this) {
-                    while (proxy == null) {
-                        try {
-                            wait();
-                        } catch (InterruptedException e) {
-                            interrupted = true;
-                        }
-                    }
-                }
-                if (interrupted) {
-                    Thread.currentThread().interrupt();
-                }
+            // Ensure sufficient parallelism if
+            // caller thread is a ForkJoinPool thread
+            try {
+                ForkJoinPool.managedBlock(this);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
+
             if (proxy instanceof Throwable) {
                 throw rethrow((Throwable) proxy);
             }
@@ -461,6 +455,35 @@ public final class ProxyManager {
                 proxy = o;
                 notifyAll();
             }
+        }
+
+        @Override
+        public boolean block() throws InterruptedException {
+            if (Thread.currentThread().isInterrupted()
+                    || isReleasable()) {
+                return true;
+            }
+
+            boolean interrupted = false;
+            synchronized (this) {
+                while (proxy == null) {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        interrupted = true;
+                    }
+                }
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+                return true;
+            }
+            return true;
+        }
+
+        @Override
+        public boolean isReleasable() {
+            return proxy != null;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -57,6 +57,7 @@ import static java.util.concurrent.locks.LockSupport.unpark;
 
 /**
  * Custom implementation of {@link java.util.concurrent.CompletableFuture}.
+ *
  * @param <V>
  */
 @SuppressFBWarnings(value = "DLS_DEAD_STORE_OF_CLASS_LITERAL", justification = "Recommended way to prevent classloading bug")
@@ -155,12 +156,12 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> thenAcceptAsync(@Nonnull Consumer<? super V> action,
-                                                   @Nonnull Executor executor) {
+                                                           @Nonnull Executor executor) {
         requireNonNull(action);
         requireNonNull(executor);
         final InternalCompletableFuture<Void> future = newCompletableFuture();
         if (isDone()) {
-           unblockAccept(action, executor, future);
+            unblockAccept(action, executor, future);
         } else {
             Object result = registerWaiter(new AcceptNode<>(future, action), executor);
             if (result != UNRESOLVED) {
@@ -208,7 +209,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U> InternalCompletableFuture<U> handleAsync(@Nonnull BiFunction<? super V, Throwable, ? extends U> fn,
-                                                @Nonnull Executor executor) {
+                                                        @Nonnull Executor executor) {
         requireNonNull(fn);
         requireNonNull(executor);
         final InternalCompletableFuture<U> future = newCompletableFuture();
@@ -235,7 +236,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<V> whenCompleteAsync(@Nonnull BiConsumer<? super V, ? super Throwable> action,
-                                                  @Nonnull Executor executor) {
+                                                          @Nonnull Executor executor) {
         requireNonNull(action);
         requireNonNull(executor);
         final InternalCompletableFuture<V> future = newCompletableFuture();
@@ -262,7 +263,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U> InternalCompletableFuture<U> thenComposeAsync(@Nonnull Function<? super V, ? extends CompletionStage<U>> fn,
-                                                     @Nonnull Executor executor) {
+                                                             @Nonnull Executor executor) {
         requireNonNull(fn);
         requireNonNull(executor);
         final InternalCompletableFuture<U> future = newCompletableFuture();
@@ -279,20 +280,20 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U, R> InternalCompletableFuture<R> thenCombine(@Nonnull CompletionStage<? extends U> other,
-                                                 @Nonnull BiFunction<? super V, ? super U, ? extends R> fn) {
+                                                           @Nonnull BiFunction<? super V, ? super U, ? extends R> fn) {
         return thenCombineAsync(other, fn, defaultExecutor());
     }
 
     @Override
     public <U, R> InternalCompletableFuture<R> thenCombineAsync(@Nonnull CompletionStage<? extends U> other,
-                                                        @Nonnull BiFunction<? super V, ? super U, ? extends R> fn) {
+                                                                @Nonnull BiFunction<? super V, ? super U, ? extends R> fn) {
         return thenCombineAsync(other, fn, defaultExecutor());
     }
 
     @Override
     public <U, R> InternalCompletableFuture<R> thenCombineAsync(@Nonnull CompletionStage<? extends U> other,
-                                                        @Nonnull BiFunction<? super V, ? super U, ? extends R> fn,
-                                                        @Nonnull Executor executor) {
+                                                                @Nonnull BiFunction<? super V, ? super U, ? extends R> fn,
+                                                                @Nonnull Executor executor) {
         requireNonNull(other);
         requireNonNull(fn);
         requireNonNull(executor);
@@ -310,20 +311,20 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U> InternalCompletableFuture<Void> thenAcceptBoth(@Nonnull CompletionStage<? extends U> other,
-                                                      @Nonnull BiConsumer<? super V, ? super U> action) {
+                                                              @Nonnull BiConsumer<? super V, ? super U> action) {
         return thenAcceptBothAsync(other, action, defaultExecutor());
     }
 
     @Override
     public <U> InternalCompletableFuture<Void> thenAcceptBothAsync(@Nonnull CompletionStage<? extends U> other,
-                                                           @Nonnull BiConsumer<? super V, ? super U> action) {
+                                                                   @Nonnull BiConsumer<? super V, ? super U> action) {
         return thenAcceptBothAsync(other, action, defaultExecutor());
     }
 
     @Override
     public <U> InternalCompletableFuture<Void> thenAcceptBothAsync(@Nonnull CompletionStage<? extends U> other,
-                                                           @Nonnull BiConsumer<? super V, ? super U> action,
-                                                           @Nonnull Executor executor) {
+                                                                   @Nonnull BiConsumer<? super V, ? super U> action,
+                                                                   @Nonnull Executor executor) {
         requireNonNull(action);
         requireNonNull(executor);
         final InternalCompletableFuture<Void> future = newCompletableFuture();
@@ -353,8 +354,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> runAfterBothAsync(@Nonnull CompletionStage<?> other,
-                                                     @Nonnull Runnable action,
-                                                     @Nonnull Executor executor) {
+                                                             @Nonnull Runnable action,
+                                                             @Nonnull Executor executor) {
         requireNonNull(other);
         requireNonNull(action);
         requireNonNull(executor);
@@ -375,20 +376,20 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public <U> InternalCompletableFuture<U> applyToEither(@Nonnull CompletionStage<? extends V> other,
-                                                  @Nonnull Function<? super V, U> fn) {
+                                                          @Nonnull Function<? super V, U> fn) {
         return applyToEitherAsync(other, fn, defaultExecutor());
     }
 
     @Override
     public <U> InternalCompletableFuture<U> applyToEitherAsync(@Nonnull CompletionStage<? extends V> other,
-                                                       @Nonnull Function<? super V, U> fn) {
+                                                               @Nonnull Function<? super V, U> fn) {
         return applyToEitherAsync(other, fn, defaultExecutor());
     }
 
     @Override
     public <U> InternalCompletableFuture<U> applyToEitherAsync(@Nonnull CompletionStage<? extends V> other,
-                                                       @Nonnull Function<? super V, U> fn,
-                                                       @Nonnull Executor executor) {
+                                                               @Nonnull Function<? super V, U> fn,
+                                                               @Nonnull Executor executor) {
         requireNonNull(other);
         requireNonNull(fn);
         requireNonNull(executor);
@@ -413,20 +414,20 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> acceptEither(@Nonnull CompletionStage<? extends V> other,
-                                                @Nonnull Consumer<? super V> action) {
+                                                        @Nonnull Consumer<? super V> action) {
         return acceptEitherAsync(other, action, defaultExecutor());
     }
 
     @Override
     public InternalCompletableFuture<Void> acceptEitherAsync(@Nonnull CompletionStage<? extends V> other,
-                                                     @Nonnull Consumer<? super V> action) {
+                                                             @Nonnull Consumer<? super V> action) {
         return acceptEitherAsync(other, action, defaultExecutor());
     }
 
     @Override
     public InternalCompletableFuture<Void> acceptEitherAsync(@Nonnull CompletionStage<? extends V> other,
-                                                     @Nonnull Consumer<? super V> action,
-                                                     @Nonnull Executor executor) {
+                                                             @Nonnull Consumer<? super V> action,
+                                                             @Nonnull Executor executor) {
         requireNonNull(other);
         requireNonNull(action);
         requireNonNull(executor);
@@ -461,8 +462,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @Override
     public InternalCompletableFuture<Void> runAfterEitherAsync(@Nonnull CompletionStage<?> other,
-                                                       @Nonnull Runnable action,
-                                                       @Nonnull Executor executor) {
+                                                               @Nonnull Runnable action,
+                                                               @Nonnull Executor executor) {
         requireNonNull(other);
         requireNonNull(action);
         requireNonNull(executor);
@@ -546,15 +547,15 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
         boolean interrupted = false;
         try {
-            for (; ; ) {
-                manageParking(false, 0);
+            do {
+                manageParking(0);
                 if (isDone()) {
                     return resolveAndThrowWithJoinConvention(state);
                 } else if (Thread.interrupted()) {
                     interrupted = true;
                     onInterruptDetected();
                 }
-            }
+            } while (true);
         } finally {
             restoreInterrupt(interrupted);
         }
@@ -577,15 +578,15 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
         boolean interrupted = false;
         try {
-            for (; ; ) {
-                manageParking(false, 0);
+            do {
+                manageParking(0);
                 if (isDone()) {
                     return resolveAndThrowForJoinInternal(state);
                 } else if (Thread.interrupted()) {
                     interrupted = true;
                     onInterruptDetected();
                 }
-            }
+            } while (true);
         } finally {
             restoreInterrupt(interrupted);
         }
@@ -610,15 +611,15 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
         boolean interrupted = false;
         try {
-            for (; ; ) {
-                manageParking(false, 0);
+            do {
+                manageParking(0);
                 if (isDone()) {
                     return resolveAndThrowIfException(state);
                 } else if (Thread.interrupted()) {
                     interrupted = true;
                     onInterruptDetected();
                 }
-            }
+            } while (true);
         } finally {
             restoreInterrupt(interrupted);
         }
@@ -637,7 +638,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         try {
             long timeoutNanos = unit.toNanos(timeout);
             while (timeoutNanos > 0) {
-                manageParking(true, timeoutNanos);
+                manageParking(timeoutNanos);
                 timeoutNanos = deadlineNanos - System.nanoTime();
 
                 if (isDone()) {
@@ -657,11 +658,10 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     // Use when the caller thread is a ForkJoinWorkerThread
     class ManagedBlocker implements ForkJoinPool.ManagedBlocker {
-        private boolean timed;
-        private long timeoutNanos;
 
-        ManagedBlocker(boolean timed, long timeoutNanos) {
-            this.timed = timed;
+        private final long timeoutNanos;
+
+        ManagedBlocker(long timeoutNanos) {
             this.timeoutNanos = timeoutNanos;
         }
 
@@ -675,7 +675,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         public boolean block() throws InterruptedException {
             if (isReleasable()) {
                 return true;
-            } else if (!timed) {
+            } else if (timeoutNanos == 0) {
                 park();
             } else if (timeoutNanos > 0) {
                 parkNanos(timeoutNanos);
@@ -684,12 +684,12 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
     }
 
-    private void manageParking(boolean timed, long timeoutNanos) {
+    private void manageParking(long timeoutNanos) {
         try {
             // if the caller thread is a ForkJoinWorkerThread
             if (ForkJoinTask.inForkJoinPool()) {
-                ForkJoinPool.managedBlock(new ManagedBlocker(timed, timeoutNanos));
-            } else if (!timed) {
+                ForkJoinPool.managedBlock(new ManagedBlocker(timeoutNanos));
+            } else if (timeoutNanos == 0) {
                 park();
             } else if (timeoutNanos > 0) {
                 parkNanos(timeoutNanos);
@@ -763,8 +763,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     private void unblockAccept(@Nonnull final Consumer<? super V> consumer,
-                                                    @Nonnull Executor executor,
-                                                    @Nonnull InternalCompletableFuture<Void> future) {
+                               @Nonnull Executor executor,
+                               @Nonnull InternalCompletableFuture<Void> future) {
         final Object value = resolve(state);
         if (cascadeException(value, future)) {
             return;
@@ -784,8 +784,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     /**
-     * @param waiter    the current wait node, see javadoc of {@link #state state field}
-     * @param executor  the {@link Executor} on which to execute the action associated with {@code waiter}
+     * @param waiter   the current wait node, see javadoc of {@link #state state field}
+     * @param executor the {@link Executor} on which to execute the action associated with {@code waiter}
      */
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     protected void unblockOtherNode(Object waiter, Executor executor) {
@@ -820,11 +820,11 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     /**
-     * @param   value   the resolved state of this future
-     * @return  an {@link ExceptionalResult} wrapping a {@link Throwable} in case value is resolved
-     *          to an exception, or the normal completion value. Subclasses may choose to treat
-     *          specific normal completion values in a special way (eg deserialize when the completion
-     *          value is an instance of {@code Data}.
+     * @param value the resolved state of this future
+     * @return an {@link ExceptionalResult} wrapping a {@link Throwable} in case value is resolved
+     * to an exception, or the normal completion value. Subclasses may choose to treat
+     * specific normal completion values in a special way (eg deserialize when the completion
+     * value is an instance of {@code Data}.
      */
     protected Object resolve(Object value) {
         return value;
@@ -857,8 +857,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     protected void unblockRun(@Nonnull final Runnable runnable,
-                                                 @Nonnull Executor executor,
-                                                 @Nonnull CompletableFuture<Void> future) {
+                              @Nonnull Executor executor,
+                              @Nonnull CompletableFuture<Void> future) {
         final Object value = resolve(state);
         if (cascadeException(value, future)) {
             return;
@@ -867,8 +867,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     protected <U> void unblockHandle(@Nonnull BiFunction<? super V, Throwable, ? extends U> fn,
-                                                     @Nonnull Executor executor,
-                                                     @Nonnull CompletableFuture<U> future) {
+                                     @Nonnull Executor executor,
+                                     @Nonnull CompletableFuture<U> future) {
         final Object result = resolve(state);
         V value;
         Throwable throwable;
@@ -940,8 +940,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     protected <U> void unblockCompose(@Nonnull final Function<? super V, ? extends CompletionStage<U>> function,
-                                                      @Nonnull Executor executor,
-                                                      @Nonnull CompletableFuture<U> future) {
+                                      @Nonnull Executor executor,
+                                      @Nonnull CompletableFuture<U> future) {
         Object result = resolve(state);
         if (cascadeException(result, future)) {
             return;
@@ -969,9 +969,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @SuppressWarnings("checkstyle:npathcomplexity")
     protected <U, R> void unblockCombine(@Nonnull CompletionStage<? extends U> other,
-                                                         @Nonnull final BiFunction<? super V, ? super U, ? extends R> function,
-                                                         @Nonnull Executor executor,
-                                                         @Nonnull InternalCompletableFuture<R> future) {
+                                         @Nonnull final BiFunction<? super V, ? super U, ? extends R> function,
+                                         @Nonnull Executor executor,
+                                         @Nonnull InternalCompletableFuture<R> future) {
         Object result = resolve(state);
         final CompletableFuture<? extends U> otherFuture =
                 (other instanceof CompletableFuture) ? (CompletableFuture<? extends U>) other : other.toCompletableFuture();
@@ -1025,9 +1025,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
     @SuppressWarnings("checkstyle:npathcomplexity")
     private <U> void unblockAcceptBoth(@Nonnull CompletableFuture<? extends U> otherFuture,
-                                         @Nonnull final BiConsumer<? super V, ? super U> action,
-                                         @Nonnull Executor executor,
-                                         @Nonnull InternalCompletableFuture<Void> future) {
+                                       @Nonnull final BiConsumer<? super V, ? super U> action,
+                                       @Nonnull Executor executor,
+                                       @Nonnull InternalCompletableFuture<Void> future) {
         final Object value = resolve(state);
         // in case this future is completed exceptionally, the result is also exceptionally completed
         // without checking whether otherFuture is completed or not
@@ -1072,9 +1072,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     private void unblockRunAfterBoth(@Nonnull CompletableFuture<?> otherFuture,
-                                       @Nonnull final Runnable action,
-                                       @Nonnull Executor executor,
-                                       @Nonnull CompletableFuture<Void> future) {
+                                     @Nonnull final Runnable action,
+                                     @Nonnull Executor executor,
+                                     @Nonnull CompletableFuture<Void> future) {
         Object result = resolve(state);
         // in case this future is completed exceptionally, the result is also exceptionally completed
         // without checking whether otherFuture is completed or not
@@ -1333,7 +1333,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
      *
      * @param resolved  a resolved state, as returned from {@link #resolve(Object)}
      * @param dependent a dependent {@link CompletableFuture}
-     * @return          {@code true} in case the dependent was completed exceptionally, otherwise {@code false}
+     * @return {@code true} in case the dependent was completed exceptionally, otherwise {@code false}
      */
     private static boolean cascadeException(Object resolved, CompletableFuture dependent) {
         if (resolved instanceof ExceptionalResult) {
@@ -1375,7 +1375,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     static final class WaitNode {
         final Object waiter;
         volatile Object next;
-        private final @Nonnull Executor executor;
+        private final @Nonnull
+        Executor executor;
 
         WaitNode(Object waiter, @Nullable Executor executor) {
             this.waiter = waiter;
@@ -1686,7 +1687,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         final AtomicBoolean executed;
 
         AbstractBiNode(CompletableFuture<R> future,
-                           CompletableFuture<? extends U> otherFuture) {
+                       CompletableFuture<? extends U> otherFuture) {
             this.result = future;
             this.otherFuture = otherFuture;
             this.executed = new AtomicBoolean();
@@ -1749,8 +1750,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         final BiFunction<? super T, ? super U, ? extends R> function;
 
         CombineNode(CompletableFuture<R> future,
-                           CompletableFuture<? extends U> otherFuture,
-                           BiFunction<? super T, ? super U, ? extends R> function) {
+                    CompletableFuture<? extends U> otherFuture,
+                    BiFunction<? super T, ? super U, ? extends R> function) {
             super(future, otherFuture);
             this.function = function;
         }
@@ -1765,8 +1766,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         final BiConsumer<? super T, ? super U> action;
 
         AcceptBothNode(CompletableFuture<Void> future,
-                           CompletableFuture<? extends U> otherFuture,
-                              BiConsumer<? super T, ? super U> action) {
+                       CompletableFuture<? extends U> otherFuture,
+                       BiConsumer<? super T, ? super U> action) {
             super(future, otherFuture);
             this.action = action;
         }
@@ -1782,8 +1783,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         final Runnable action;
 
         RunAfterBothNode(CompletableFuture<Void> future,
-                           CompletableFuture<? extends U> otherFuture,
-                              Runnable action) {
+                         CompletableFuture<? extends U> otherFuture,
+                         Runnable action) {
             super(future, otherFuture);
             this.action = action;
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
@@ -16,34 +16,94 @@
 
 package com.hazelcast.client.impl.spi;
 
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.impl.HazelcastRunningInForkJoinPoolTest;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.MapStoreAdapter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientHazelcastRunningInForkJoinPoolTest extends HazelcastRunningInForkJoinPoolTest {
+public class ClientHazelcastRunningInForkJoinPoolTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Override
-    public void setUp() throws Exception {
-        HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.addNearCacheConfig(getNearCacheConfig());
-        HazelcastInstance hz = hazelcastFactory.newHazelcastClient(clientConfig);
-        this.hz = hz;
-    }
+    private HazelcastInstance client;
+    private HazelcastInstance server;
+    private IMap serverMap;
+    private IMap clientMap;
+    private String mapName = "loading-takes-ages";
+    private String innocentMap = "innocent";
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Before
+    public void setup() {
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setImplementation(new MapStoreAdapter() {
+            @Override
+            public Object load(Object key) {
+                sleepSeconds(1000);
+                return super.load(key);
+            }
+        });
+
+        MapConfig mapConfig = new MapConfig(
+                mapName);
+        mapConfig.setMapStoreConfig(mapStoreConfig);
+
+        Config config = getConfig().addMapConfig(mapConfig);
+
+        server = hazelcastFactory.newHazelcastInstance(config);
+        client = hazelcastFactory.newHazelcastClient();
+
+        serverMap = server.getMap(innocentMap);
+        clientMap = client.getMap(mapName);
+    }
+
+    @Test
+    public void slow_data_loading_does_not_block_entry_listener_addition() {
+        // 1. Let's simulate 1000 parallel tasks
+        // contend on loading 1 item from a database.
+        Collection<Future> tasks = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            tasks.add(ForkJoinPool.commonPool().submit(new ACallable()));
+        }
+
+        // 2. In parallel, adding a listener to a different
+        // map must not affected by loading phase at step 1.
+        serverMap.addEntryListener(new EntryAdapter<>(), true);
+    }
+
+    class ACallable implements Callable<Object> {
+
+        @Override
+        public Object call() throws Exception {
+            clientMap.get(1);
+            return null;
+        }
+
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.spi;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.HazelcastRunningInForkJoinPoolTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientHazelcastRunningInForkJoinPoolTest extends HazelcastRunningInForkJoinPoolTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Override
+    public void setUp() throws Exception {
+        HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addNearCacheConfig(getNearCacheConfig());
+        HazelcastInstance hz = hazelcastFactory.newHazelcastClient(clientConfig);
+        this.hz = hz;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        hazelcastFactory.terminateAll();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/HazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/HazelcastRunningInForkJoinPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/HazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/HazelcastRunningInForkJoinPoolTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HazelcastRunningInForkJoinPoolTest extends HazelcastTestSupport {
+
+    protected static final String MAP_NAME = "near-cached-map";
+
+    protected HazelcastInstance hz;
+
+    @Before
+    public void setUp() throws Exception {
+        Config config = getConfig();
+
+        MapConfig mapConfig = config.getMapConfig(MAP_NAME);
+        mapConfig.setNearCacheConfig(getNearCacheConfig());
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        hz = factory.newHazelcastInstance(config);
+        hz = factory.newHazelcastInstance(config);
+    }
+
+    protected static NearCacheConfig getNearCacheConfig() {
+        return new NearCacheConfig(MAP_NAME)
+                .setInvalidateOnChange(true);
+    }
+
+    /**
+     * Java's parallel-stream-api and Hazelcast both use
+     * {@link ForkJoinPool#commonPool()} for their internal
+     * mechanisms to run. We are testing whether or not
+     * there is a deadlock during proxy initialization. With
+     * near cache enabled, iMap tries to attach listeners at
+     * proxy init phase and this triggers deadlock situation.
+     */
+    @Test
+    public void no_deadlock_during_proxy_initialization() {
+        List<IMap<Object, Object>> maps = IntStream.range(0, 100)
+                .boxed()
+                .parallel()
+                // init proxy in parallel
+                .map(i -> hz.getMap(MAP_NAME))
+                .collect(Collectors.toList());
+
+        assertEquals(100, maps.size());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/HazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/HazelcastRunningInForkJoinPoolTest.java
@@ -64,7 +64,7 @@ public class HazelcastRunningInForkJoinPoolTest extends HazelcastTestSupport {
     }
 
     /**
-     * Java's parallel-stream-api and Hazelcast both use
+     * Both Java's parallel-stream-api and Hazelcast use
      * {@link ForkJoinPool#commonPool()} for their internal
      * mechanisms to run. We are testing whether or not
      * there is a deadlock during proxy initialization. With


### PR DESCRIPTION
fix candidate for https://github.com/hazelcast/hazelcast/issues/17959

__Issue:__
Stream api and hazelcast internal uses default common-fork-join-pool, if `parallel` call from stream api also calls hazelcast api, like getMap, which initializes proxy, all FJP threads can be in waiting state and there can be  a deadlock as in the reproducer in the referenced issue. Deadlock is seen because proxy creation doesn't finish due to the lack of available thread in FJP. This happens when stream api asks more task parallelism than FJP default. Example snippet:

```
IntStream.range(0, 102)
                .parallel()
				.map(i -> hzInstance.getMap("A")))
```

__Fix:__
Implemented `ManagedBlocker` which is aware whether the caller thread is a ForkJoinWorkerThread and ensures sufficient parallelism while the current thread is blocked.

