### PR TITLE
Added quotation mark

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -822,7 +822,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig {
     public String toString() {
         return "MapConfig{"
                 + "name='" + name + '\''
-                + ", inMemoryFormat=" + inMemoryFormat + '\''
+                + ", inMemoryFormat='" + inMemoryFormat + '\''
                 + ", metadataPolicy=" + metadataPolicy
                 + ", backupCount=" + backupCount
                 + ", asyncBackupCount=" + asyncBackupCount


### PR DESCRIPTION
Added quotation mark, which is missing when displaying the inMemoryFormat variable in the com.hazelcast.config.MapConfig # toString method