### PR TITLE
[BACKPORT] catch exception when method can't be make accessible

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
@@ -68,8 +68,12 @@ public final class OperatingSystemMXBeanSupport {
             OperatingSystemMXBean systemMXBean = OPERATING_SYSTEM_MX_BEAN;
             Method method = systemMXBean.getClass().getMethod(methodName);
 
-            // the method is public in Java 9
-            method.setAccessible(true);
+            try {
+                // the method is public in Java 9
+                method.setAccessible(true);
+            } catch (Exception e) {
+                return defaultValue;
+            }
 
             Object value = method.invoke(systemMXBean);
             if (value == null) {


### PR DESCRIPTION
This is a backport of #15892

We get the following exception when MC 3.12 version run on Java 11 Jenkins build:
```
Hazelcast Management Center Service will be shutdown due to exception.
java.lang.ExceptionInInitializerError: null
	at com.hazelcast.memory.DefaultMemoryStats.getTotalPhysical(DefaultMemoryStats.java:32)
	at com.hazelcast.monitor.impl.LocalMemoryStatsImpl.<init>(LocalMemoryStatsImpl.java:71)
	at com.hazelcast.internal.management.TimedMemberStateFactory.getMemoryStats(TimedMemberStateFactory.java:157)
	at com.hazelcast.internal.management.TimedMemberStateFactory.createMemberState(TimedMemberStateFactory.java:196)
	at com.hazelcast.internal.management.TimedMemberStateFactory.createTimedMemberState(TimedMemberStateFactory.java:130)
	at com.hazelcast.internal.management.ManagementCenterService$PrepareStateThread.run(ManagementCenterService.java:440)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getTotalPhysicalMemorySize() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @76a3e297
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:198)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:192)
	at com.hazelcast.util.OperatingSystemMXBeanSupport.readLongAttribute(OperatingSystemMXBeanSupport.java:72)
	at com.hazelcast.memory.MemoryStatsSupport.<clinit>(MemoryStatsSupport.java:26)
	... 6 common frames omitted
```