### PR TITLE
[4.1.1 BACKPORT] Fix broken sources produced by the "shade" plugin

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -85,16 +85,39 @@
                                 </excludes>
                             </artifactSet>
                             <relocations>
+                                <!--
+                                    List relocations for every product explicitly, instead of definining "com" and "org"
+                                    wildcards. Otherwise, the "shade" plugin breaks the generated source code. For example,
+                                    for the wildcard "com." the package "com.google.common" is replaced with the shaded
+                                    pattern twice: "[com].google.[com]mon".
+                                 -->
                                 <relocation>
-                                    <pattern>com.</pattern>
-                                    <shadedPattern>${relocation.root}.com.</shadedPattern>
-                                    <excludes>
-                                        <exclude>com.hazelcast.**</exclude>
-                                    </excludes>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>${relocation.root}.com.fasterxml</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.</pattern>
-                                    <shadedPattern>${relocation.root}.org.</shadedPattern>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>${relocation.root}.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.jayway</pattern>
+                                    <shadedPattern>${relocation.root}.com.jayway</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>${relocation.root}.org.apache</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>${relocation.root}.org.codehaus</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.slf4</pattern>
+                                    <shadedPattern>${relocation.root}.org.slf4</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.snakeyaml</pattern>
+                                    <shadedPattern>${relocation.root}.org.snakeyaml</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>


### PR DESCRIPTION
This PR fixes the broken sources produced by the "shade" module. 

Before the fix, we used the following relocation patterns:
```
com. -> com.hazelcast.com.
org. -> com.hazelcast.org.
```
They worked well for the bytecode, but broken the generated source code. For example, the `com.google.common` package was processed as `[com].google.[com]mon`, resulting in `com.hazelcast.com.google.com.hazelast.mon`. 

With the fix, we use more specific relocation patterns, which fixes the problem.

1:1 backport of https://github.com/hazelcast/hazelcast/pull/17949