### PR TITLE
Workaround for missing hazelcast-sql-javadoc.jar

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -215,6 +215,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+                            <excludes>
+                                <exclude>.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR adds an empty `hazelast-sql-javadoc.jar` as a workaround for Sonatype's Javadoc release requirements.
