### PR TITLE
Fixes read of generic record

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractGenericRecord.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.nio.serialization.FieldType;
+import com.hazelcast.nio.serialization.GenericRecord;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Implementation of GenericRecord interface to give common equals and hashCode implementations.
+ */
+@SuppressWarnings({"checkstyle:returncount", "checkstyle:cyclomaticcomplexity"})
+public abstract class AbstractGenericRecord implements GenericRecord {
+
+    /**
+     * @return a unique identifier for each class.
+     * Note that identifiers should be different for for the different version of the same class as well.
+     */
+    protected abstract Object getClassIdentifier();
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AbstractGenericRecord)) {
+            return false;
+        }
+        AbstractGenericRecord that = (AbstractGenericRecord) o;
+        if (!that.getClassIdentifier().equals(getClassIdentifier())) {
+            return false;
+        }
+        Set<String> thatFieldNames = that.getFieldNames();
+        Set<String> thisFieldNames = getFieldNames();
+        if (!Objects.equals(thatFieldNames, thisFieldNames)) {
+            return false;
+        }
+        for (String fieldName : thatFieldNames) {
+            FieldType thatFieldType = that.getFieldType(fieldName);
+            FieldType thisFieldType = getFieldType(fieldName);
+            if (!thatFieldType.equals(thisFieldType)) {
+                return false;
+            }
+            if (thatFieldType.isArrayType()) {
+                if (!Objects.deepEquals(readAny(that, fieldName, thatFieldType), readAny(this, fieldName, thisFieldType))) {
+                    return false;
+                }
+            } else {
+                if (!Objects.equals(readAny(that, fieldName, thatFieldType), readAny(this, fieldName, thisFieldType))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public int hashCode() {
+        int result = 0;
+        Set<String> fieldNames = getFieldNames();
+        for (String fieldName : fieldNames) {
+            FieldType fieldType = getFieldType(fieldName);
+            if (fieldType.isArrayType()) {
+                result = 31 * result + arrayHashCode(this, fieldName, fieldType);
+            } else {
+                result = 31 * result + Objects.hashCode(readAny(this, fieldName, fieldType));
+            }
+        }
+        return result;
+    }
+
+    private static int arrayHashCode(GenericRecord record, String path, FieldType type) {
+        switch (type) {
+            case BYTE_ARRAY:
+                return Arrays.hashCode(record.readByteArray(path));
+            case SHORT_ARRAY:
+                return Arrays.hashCode(record.readShortArray(path));
+            case INT_ARRAY:
+                return Arrays.hashCode(record.readIntArray(path));
+            case LONG_ARRAY:
+                return Arrays.hashCode(record.readLongArray(path));
+            case FLOAT_ARRAY:
+                return Arrays.hashCode(record.readFloatArray(path));
+            case DOUBLE_ARRAY:
+                return Arrays.hashCode(record.readDoubleArray(path));
+            case BOOLEAN_ARRAY:
+                return Arrays.hashCode(record.readBooleanArray(path));
+            case CHAR_ARRAY:
+                return Arrays.hashCode(record.readCharArray(path));
+            case UTF_ARRAY:
+                return Arrays.hashCode(record.readUTFArray(path));
+            case PORTABLE_ARRAY:
+                return Arrays.hashCode(record.readGenericRecordArray(path));
+            default:
+                throw new IllegalArgumentException("Unsupported type " + type);
+        }
+    }
+
+    private static Object readAny(GenericRecord record, String path, FieldType type) {
+        switch (type) {
+            case BYTE:
+                return record.readByte(path);
+            case BYTE_ARRAY:
+                return record.readByteArray(path);
+            case SHORT:
+                return record.readShort(path);
+            case SHORT_ARRAY:
+                return record.readShortArray(path);
+            case INT:
+                return record.readInt(path);
+            case INT_ARRAY:
+                return record.readIntArray(path);
+            case LONG:
+                return record.readLong(path);
+            case LONG_ARRAY:
+                return record.readLongArray(path);
+            case FLOAT:
+                return record.readFloat(path);
+            case FLOAT_ARRAY:
+                return record.readFloatArray(path);
+            case DOUBLE:
+                return record.readDouble(path);
+            case DOUBLE_ARRAY:
+                return record.readDoubleArray(path);
+            case BOOLEAN:
+                return record.readBoolean(path);
+            case BOOLEAN_ARRAY:
+                return record.readBooleanArray(path);
+            case CHAR:
+                return record.readChar(path);
+            case CHAR_ARRAY:
+                return record.readCharArray(path);
+            case UTF:
+                return record.readUTF(path);
+            case UTF_ARRAY:
+                return record.readUTFArray(path);
+            case PORTABLE:
+                return record.readGenericRecord(path);
+            case PORTABLE_ARRAY:
+                return record.readGenericRecordArray(path);
+            default:
+                throw new IllegalArgumentException("Unsupported type " + type);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder(getClassIdentifier().toString());
+        str.append("\n{");
+        Set<String> thisFieldNames = getFieldNames();
+        for (String fieldName : thisFieldNames) {
+            FieldType fieldType = getFieldType(fieldName);
+            Object field = readAny(this, fieldName, fieldType);
+            str.append("\"").append(fieldName).append("\" : ");
+            if (fieldType.isArrayType()) {
+                switch (fieldType) {
+                    case BYTE_ARRAY:
+                        str.append(Arrays.toString((byte[]) field));
+                        break;
+                    case SHORT_ARRAY:
+                        str.append(Arrays.toString((short[]) field));
+                        break;
+                    case INT_ARRAY:
+                        str.append(Arrays.toString((int[]) field));
+                        break;
+                    case LONG_ARRAY:
+                        str.append(Arrays.toString((long[]) field));
+                        break;
+                    case FLOAT_ARRAY:
+                        str.append(Arrays.toString((float[]) field));
+                        break;
+                    case DOUBLE_ARRAY:
+                        str.append(Arrays.toString((double[]) field));
+                        break;
+                    case BOOLEAN_ARRAY:
+                        str.append(Arrays.toString((boolean[]) field));
+                        break;
+                    case CHAR_ARRAY:
+                        str.append(Arrays.toString((char[]) field));
+                        break;
+                    case UTF_ARRAY:
+                    case PORTABLE_ARRAY:
+                        str.append(Arrays.toString((Object[]) field));
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported type " + fieldType);
+                }
+            } else {
+                str.append(field.toString());
+            }
+            str.append(", \n");
+        }
+        str.append("}");
+        return str.toString();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl.portable;
 
+import com.hazelcast.internal.serialization.impl.AbstractGenericRecord;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
@@ -25,8 +26,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Set;
 
-public class PortableGenericRecord implements GenericRecord {
+public class PortableGenericRecord extends AbstractGenericRecord {
 
     private final ClassDefinition classDefinition;
     private final Object[] objects;
@@ -51,6 +53,12 @@ public class PortableGenericRecord implements GenericRecord {
     @Override
     public Builder cloneWithBuilder() {
         return new PortableGenericRecordBuilder(classDefinition, Arrays.copyOf(objects, objects.length));
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getFieldNames() {
+        return classDefinition.getFieldNames();
     }
 
     @Override
@@ -186,9 +194,12 @@ public class PortableGenericRecord implements GenericRecord {
     }
 
     @Override
+    protected Object getClassIdentifier() {
+        return classDefinition;
+    }
+
+    @Override
     public String toString() {
-        return "PortableGenericRecord{classDefinition=" + classDefinition
-                + ", objects=" + Arrays.toString(objects)
-                + '}';
+        return "PortableGenericRecord:" + super.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
@@ -309,7 +309,7 @@ public final class PortableSerializer implements StreamSerializer<Object> {
     private <T> T readPortableGenericRecord(BufferObjectDataInput in, int factoryId, int classId) throws IOException {
         int version = in.readInt();
         ClassDefinition cd = setupPositionAndDefinition(in, factoryId, classId, version);
-        GenericRecord reader = new PortableInternalGenericRecord(this, in, cd, false);
+        PortableInternalGenericRecord reader = new PortableInternalGenericRecord(this, in, cd, false);
         GenericRecord.Builder genericRecordBuilder = GenericRecord.Builder.portable(cd);
         for (String fieldName : cd.getFieldNames()) {
             switch (cd.getFieldType(fieldName)) {
@@ -377,6 +377,7 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                     throw new IllegalStateException("Unexpected value: " + cd.getFieldType(fieldName));
             }
         }
+        reader.end();
         return (T) genericRecordBuilder.build();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * A generic object interface that is returned to user when the domain class can not be created from any of the distributed
@@ -104,6 +105,12 @@ public interface GenericRecord {
      */
     @Nonnull
     Builder cloneWithBuilder();
+
+    /**
+     * @return set of field names of this GenericRecord
+     */
+    @Nonnull
+    Set<String> getFieldNames();
 
     /**
      * @param fieldName the name of the field


### PR DESCRIPTION
Position of BufferObjectDataInput is corrected so that
subsequent items can be read correctly after reading a
generic record.

(cherry picked from commit b457d201635740af365976c2e9de9eff0e3295be)
backport of https://github.com/hazelcast/hazelcast/pull/18000