### PR TITLE
Describe ttl and maxIdle in IMap operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -786,15 +786,18 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * Asynchronously puts the given key and value into this map with a given
      * TTL (time to live) value and max idle time value.
      * <p>
-     * The entry will expire and get evicted after the TTL. If the TTL is 0,
-     * then the entry lives forever. If the TTL is negative, then the TTL
-     * from the map configuration will be used (default: forever).
+     * The entry will expire and get evicted after the TTL. It limits the
+     * lifetime of the entries relative to the time of the last write access
+     * performed on them. If the TTL is 0, then the entry lives forever.
+     * If the TTL is negative, then the TTL from the map configuration will
+     * be used (default: forever).
      * <p>
-     * The entry will expire and get evicted after the Max Idle time. If the
-     * MaxIdle is 0, then the entry lives forever. If the MaxIdle is negative,
-     * then the MaxIdle from the map configuration will be used (default: forever).
-     * The time precision is limited by 1 second. The MaxIdle that less than 1
-     * second can lead to unexpected behaviour.
+     * The entry will expire and get evicted after the Max Idle time. It limits
+     * the lifetime of the entries relative to the time of the last read or write
+     * access performed on them. If the MaxIdle is 0, then the entry lives forever.
+     * If the MaxIdle is negative, then the MaxIdle from the map configuration will
+     * be used (default: forever). The time precision is limited by 1 second.
+     * The MaxIdle that is less than 1 second can lead to unexpected behaviour.
      * <pre>
      *   CompletionStage future = map.putAsync(key, value, ttl, timeunit);
      *   // do some other stuff, when ready get the result
@@ -1042,15 +1045,18 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * value and max idle time value without returning the old value
      * (which is more efficient than {@code put()}).
      * <p>
-     * The entry will expire and get evicted after the TTL. If the TTL is 0, then
-     * the entry lives forever. If the TTL is negative, then the TTL from the
-     * map configuration will be used (default: forever).
+     * The entry will expire and get evicted after the TTL. It limits the
+     * lifetime of the entries relative to the time of the last write access
+     * performed on them. If the TTL is 0, then the entry lives forever.
+     * If the TTL is negative, then the TTL from the map configuration will
+     * be used (default: forever).
      * <p>
-     * The entry will expire and get evicted after the Max Idle time. If the
-     * MaxIdle is 0, then the entry lives forever. If the MaxIdle is negative,
-     * then the MaxIdle from the map configuration will be used (default: forever).
-     * The time precision is limited by 1 second. The MaxIdle that less than 1
-     * second can lead to unexpected behaviour.
+     * The entry will expire and get evicted after the Max Idle time. It limits
+     * the lifetime of the entries relative to the time of the last read or write
+     * access performed on them. If the MaxIdle is 0, then the entry lives forever.
+     * If the MaxIdle is negative, then the MaxIdle from the map configuration will
+     * be used (default: forever). The time precision is limited by 1 second.
+     * The MaxIdle that less than 1 second can lead to unexpected behaviour.
      * <pre>
      *   CompletionStage&lt;Void&gt; future = map.setAsync(key, value, ttl, timeunit);
      *   // do some other stuff, when you want to make sure set operation is complete:
@@ -1284,15 +1290,18 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * Puts an entry into this map with a given TTL (time to live) value and
      * max idle time value.
      * <p>
-     * The entry will expire and get evicted after the TTL. If the TTL is 0,
-     * then the entry lives forever. If the TTL is negative, then the TTL
-     * from the map configuration will be used (default: forever).
+     * The entry will expire and get evicted after the TTL. It limits the
+     * lifetime of the entries relative to the time of the last write access
+     * performed on them. If the TTL is 0, then the entry lives forever.
+     * If the TTL is negative, then the TTL from the map configuration will
+     * be used (default: forever).
      * <p>
-     * The entry will expire and get evicted after the Max Idle time. If the
-     * MaxIdle is 0, then the entry lives forever. If the MaxIdle is negative,
-     * then the MaxIdle from the map configuration will be used (default: forever).
-     * The time precision is limited by 1 second. A MaxIdle which is less than
-     * 1 second can lead to unexpected behaviour.
+     * The entry will expire and get evicted after the Max Idle time. It limits
+     * the lifetime of the entries relative to the time of the last read or write
+     * access performed on them. If the MaxIdle is 0, then the entry lives forever.
+     * If the MaxIdle is negative, then the MaxIdle from the map configuration will
+     * be used (default: forever). The time precision is limited by 1 second.
+     * The MaxIdle that less than 1 second can lead to unexpected behaviour.
      * <p>
      * <b>Warning 1:</b>
      * <p>
@@ -1378,15 +1387,18 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * Same as {@link #put(Object, Object, long, TimeUnit)} except that the map
      * store, if defined, will not be called to load/store/persist the entry.
      * <p>
-     * The entry will expire and get evicted after the TTL. If the TTL is 0,
-     * then the entry lives forever. If the TTL is negative, then the TTL
-     * from the map configuration will be used (default: forever).
+     * The entry will expire and get evicted after the TTL. It limits the
+     * lifetime of the entries relative to the time of the last write access
+     * performed on them. If the TTL is 0, then the entry lives forever.
+     * If the TTL is negative, then the TTL from the map configuration will
+     * be used (default: forever).
      * <p>
-     * The entry will expire and get evicted after the Max Idle time. If the
-     * MaxIdle is 0, then the entry lives forever. If the MaxIdle is negative,
-     * then the MaxIdle from the map configuration will be used (default: forever).
-     * The time precision is limited by 1 second. The MaxIdle that less than 1
-     * second can lead to unexpected behaviour.
+     * The entry will expire and get evicted after the Max Idle time. It limits
+     * the lifetime of the entries relative to the time of the last read or write
+     * access performed on them. If the MaxIdle is 0, then the entry lives forever.
+     * If the MaxIdle is negative, then the MaxIdle from the map configuration will
+     * be used (default: forever). The time precision is limited by 1 second.
+     * The MaxIdle that less than 1 second can lead to unexpected behaviour.
      * <p>
      * <b>Warning 1:</b>
      * <p>
@@ -1508,15 +1520,18 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * max idle time value.
      * if the specified key is not already associated with a value.
      * <p>
-     * The entry will expire and get evicted after the TTL. If the TTL is 0,
-     * then the entry lives forever. If the TTL is negative, then the TTL
-     * from the map configuration will be used (default: forever).
+     * The entry will expire and get evicted after the TTL. It limits the
+     * lifetime of the entries relative to the time of the last write access
+     * performed on them. If the TTL is 0, then the entry lives forever.
+     * If the TTL is negative, then the TTL from the map configuration will
+     * be used (default: forever).
      * <p>
-     * The entry will expire and get evicted after the Max Idle time. If the
-     * MaxIdle is 0, then the entry lives forever. If the MaxIdle is negative,
-     * then the MaxIdle from the map configuration will be used (default: forever).
-     * The time precision is limited by 1 second. The MaxIdle that less than
-     * 1 second can lead to unexpected behaviour.
+     * The entry will expire and get evicted after the Max Idle time. It limits
+     * the lifetime of the entries relative to the time of the last read or write
+     * access performed on them. If the MaxIdle is 0, then the entry lives forever.
+     * If the MaxIdle is negative, then the MaxIdle from the map configuration will
+     * be used (default: forever). The time precision is limited by 1 second.
+     * The MaxIdle that less than 1 second can lead to unexpected behaviour.
      * <p>
      * <b>Warning 1:</b>
      * <p>
@@ -1720,15 +1735,18 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * max idle time value without returning the old value (which is more
      * efficient than {@code put()}).
      * <p>
-     * The entry will expire and get evicted after the TTL. If the TTL is 0,
-     * then the entry lives forever. If the TTL is negative, then the TTL
-     * from the map configuration will be used (default: forever).
+     * The entry will expire and get evicted after the TTL. It limits the
+     * lifetime of the entries relative to the time of the last write access
+     * performed on them. If the TTL is 0, then the entry lives forever.
+     * If the TTL is negative, then the TTL from the map configuration will
+     * be used (default: forever).
      * <p>
-     * The entry will expire and get evicted after the Max Idle time. If the
-     * MaxIdle is 0, then the entry lives forever. If the MaxIdle is negative,
-     * then the MaxIdle from the map configuration will be used
-     * (default: forever). The time precision is limited by 1 second. The MaxIdle
-     * that less than 1 second can lead to unexpected behaviour.
+     * The entry will expire and get evicted after the Max Idle time. It limits
+     * the lifetime of the entries relative to the time of the last read or write
+     * access performed on them. If the MaxIdle is 0, then the entry lives forever.
+     * If the MaxIdle is negative, then the MaxIdle from the map configuration will
+     * be used (default: forever). The time precision is limited by 1 second.
+     * The MaxIdle that less than 1 second can lead to unexpected behaviour.
      * <p>
      * <b>Warning 1:</b>
      * <p>


### PR DESCRIPTION
Javadoc didn't clarify the difference between `ttl` and `maxIdle` parameters in `IMap` operations. This PR adds a short description of both.