### PR TITLE
Support OBJECT type in comparison operators

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
@@ -22,7 +22,6 @@ import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlValidator;
 import com.hazelcast.sql.impl.calcite.validate.HazelcastCallBinding;
 import com.hazelcast.sql.impl.calcite.validate.param.NumericPrecedenceParameterConverter;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDynamicParam;
 import org.apache.calcite.sql.SqlKind;

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
@@ -101,15 +101,6 @@ public final class HazelcastComparisonPredicateUtils {
         QueryDataType highHZType = HazelcastTypeUtils.toHazelcastType(highType.getSqlTypeName());
         QueryDataType lowHZType = HazelcastTypeUtils.toHazelcastType(lowType.getSqlTypeName());
 
-        if (highHZType.getTypeFamily() == QueryDataTypeFamily.OBJECT) {
-            // Disallow comparisons for temporal and OBJECT types.
-            if (throwOnFailure) {
-                throw callBinding.newValidationSignatureError();
-            } else {
-                return false;
-            }
-        }
-
         if (highHZType.getTypeFamily().isNumeric()) {
             // Set flexible parameter converter that allows TINYINT/SMALLINT/INTEGER -> BIGINT conversions
             setNumericParameterConverter(validator, high, highHZType);

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
@@ -22,6 +22,7 @@ import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlValidator;
 import com.hazelcast.sql.impl.calcite.validate.HazelcastCallBinding;
 import com.hazelcast.sql.impl.calcite.validate.param.NumericPrecedenceParameterConverter;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDynamicParam;
 import org.apache.calcite.sql.SqlKind;

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -255,26 +255,26 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
 
     @Test
     public void testComparable_to_Comparable() {
-        putBiValue(new ComparableImpl(1), new ComparableImpl(1));
+        putBiValue(new ComparableImpl(1), new ComparableImpl(1), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
         check("field1", "field2", new ComparableImpl(1).compareTo(new ComparableImpl(1)));
 
-        putBiValue(new ComparableImpl(1), new ComparableImpl(2));
+        putBiValue(new ComparableImpl(1), new ComparableImpl(2), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
         check("field1", "field2", new ComparableImpl(1).compareTo(new ComparableImpl(2)));
 
-        putBiValue(new ComparableImpl(2), new ComparableImpl(1));
+        putBiValue(new ComparableImpl(2), new ComparableImpl(1), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
         check("field1", "field2", new ComparableImpl(2).compareTo(new ComparableImpl(1)));
     }
 
     @Test
     public void testComparable_and_NonComparable() {
-        putBiValue(new ComparableImpl(1), new NonComparable());
+        putBiValue(new ComparableImpl(1), new NonComparable(), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
         checkFailure(
                 "field1", "field2", SqlErrorCode.GENERIC,
                 "Cannot compare two OBJECT values, because "
                         + "left operand has " + ComparableImpl.class + " type and "
                         + "right operand has " + NonComparable.class + " type");
 
-        putBiValue(new NonComparable(), new ComparableImpl(1));
+        putBiValue(new NonComparable(), new ComparableImpl(1), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
         checkFailure(
                 "field1", "field2", SqlErrorCode.GENERIC,
                 "Cannot compare two OBJECT values, because "
@@ -284,7 +284,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
 
     @Test
     public void testDifferentClassThatImplementsComparableInterface() {
-        putBiValue(new ComparableImpl(1), new ComparableImpl2(1));
+        putBiValue(new ComparableImpl(1), new ComparableImpl2(1), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
 
         checkFailure(
                 "field1", "field2", SqlErrorCode.GENERIC,
@@ -295,21 +295,11 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
 
     @Test
     public void testNonComparableObjects() {
-        putBiValue(new NonComparable(), new NonComparable());
+        putBiValue(new NonComparable(), new NonComparable(), ExpressionTypes.OBJECT, ExpressionTypes.OBJECT);
 
         checkFailure(
                 "field1", "field2", SqlErrorCode.GENERIC,
                 "Cannot compare OBJECT value because " + NonComparable.class + " doesn't implement Comparable interface");
-    }
-
-    private void putBiValue(Object field1, Object field2) {
-        ExpressionBiValue value = ExpressionBiValue.createBiValue(
-                ExpressionBiValue.createBiClass(ExpressionTypes.OBJECT, ExpressionTypes.OBJECT),
-                field1,
-                field2
-        );
-
-        put(value);
     }
 
     @Test

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -268,24 +268,38 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     @Test
     public void testComparable_and_NonComparable() {
         putBiValue(new ComparableImpl(1), new NonComparable());
-        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare two OBJECT values, because they have different classes");
+        checkFailure(
+                "field1", "field2", SqlErrorCode.GENERIC,
+                "Cannot compare two OBJECT values, because "
+                        + "left operand has " + ComparableImpl.class + " type and "
+                        + "right operand has " + NonComparable.class + " type");
 
         putBiValue(new NonComparable(), new ComparableImpl(1));
-        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare two OBJECT values, because they have different classes");
+        checkFailure(
+                "field1", "field2", SqlErrorCode.GENERIC,
+                "Cannot compare two OBJECT values, because "
+                        + "left operand has " + NonComparable.class + " type and "
+                        + "right operand has " + ComparableImpl.class + " type");
     }
 
     @Test
     public void testDifferentClassThatImplementsComparableInterface() {
         putBiValue(new ComparableImpl(1), new ComparableImpl2(1));
 
-        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare two OBJECT values, because they have different classes");
+        checkFailure(
+                "field1", "field2", SqlErrorCode.GENERIC,
+                "Cannot compare two OBJECT values, because "
+                        + "left operand has " + ComparableImpl.class + " type and "
+                        + "right operand has " + ComparableImpl2.class + " type");
     }
 
     @Test
     public void testNonComparableObjects() {
         putBiValue(new NonComparable(), new NonComparable());
 
-        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare OBJECT value because it doesn't implement Comparable interface");
+        checkFailure(
+                "field1", "field2", SqlErrorCode.GENERIC,
+                "Cannot compare OBJECT value because " + NonComparable.class + " doesn't implement Comparable interface");
     }
 
     private void putBiValue(Object field1, Object field2) {

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -250,6 +250,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
                         ExpressionTypes.LOCAL_TIME,
                         ExpressionTypes.LOCAL_DATE_TIME,
                         ExpressionTypes.OFFSET_DATE_TIME));
+        checkUnsupportedColumnColumn(ExpressionTypes.OBJECT, ExpressionTypes.allExcept(ExpressionTypes.OBJECT));
     }
 
     @Test
@@ -267,24 +268,24 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     @Test
     public void testComparable_and_NonComparable() {
         putBiValue(new ComparableImpl(1), new NonComparable());
-        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
+        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare two OBJECT values, because they have different classes");
 
         putBiValue(new NonComparable(), new ComparableImpl(1));
-        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
+        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare two OBJECT values, because they have different classes");
     }
 
     @Test
     public void testDifferentClassThatImplementsComparableInterface() {
         putBiValue(new ComparableImpl(1), new ComparableImpl2(1));
 
-        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
+        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare two OBJECT values, because they have different classes");
     }
 
     @Test
     public void testNonComparableObjects() {
         putBiValue(new NonComparable(), new NonComparable());
 
-        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
+        checkFailure("field1", "field2", SqlErrorCode.GENERIC, "Cannot compare OBJECT value because it doesn't implement Comparable interface");
     }
 
     private void putBiValue(Object field1, Object field2) {

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -265,9 +265,11 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testComparable_to_NonComparable() {
-        putBiValue(new NonComparable(), new NonComparable());
+    public void testComparable_and_NonComparable() {
+        putBiValue(new ComparableImpl(1), new NonComparable());
+        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
 
+        putBiValue(new NonComparable(), new ComparableImpl(1));
         checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
     }
 

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -254,41 +254,45 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
 
     @Test
     public void testComparable_to_Comparable() {
-        ExpressionBiValue value = ExpressionBiValue.createBiValue(
-                ExpressionBiValue.createBiClass(ExpressionTypes.OBJECT, ExpressionTypes.OBJECT),
-                new ComparableImpl(1),
-                new ComparableImpl(1)
-        );
-
-        put(value);
-
+        putBiValue(new ComparableImpl(1), new ComparableImpl(1));
         check("field1", "field2", new ComparableImpl(1).compareTo(new ComparableImpl(1)));
+
+        putBiValue(new ComparableImpl(1), new ComparableImpl(2));
+        check("field1", "field2", new ComparableImpl(1).compareTo(new ComparableImpl(2)));
+
+        putBiValue(new ComparableImpl(2), new ComparableImpl(1));
+        check("field1", "field2", new ComparableImpl(2).compareTo(new ComparableImpl(1)));
+    }
+
+    @Test
+    public void testComparable_to_NonComparable() {
+        putBiValue(new NonComparable(), new NonComparable());
+
+        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
     }
 
     @Test
     public void testDifferentClassThatImplementsComparableInterface() {
-        ExpressionBiValue value = ExpressionBiValue.createBiValue(
-                ExpressionBiValue.createBiClass(ExpressionTypes.OBJECT, ExpressionTypes.OBJECT),
-                new ComparableImpl(1),
-                new ComparableImpl2(1)
-        );
-
-        put(value);
+        putBiValue(new ComparableImpl(1), new ComparableImpl2(1));
 
         checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
     }
 
     @Test
     public void testNonComparableObjects() {
+        putBiValue(new NonComparable(), new NonComparable());
+
+        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
+    }
+
+    private void putBiValue(Object field1, Object field2) {
         ExpressionBiValue value = ExpressionBiValue.createBiValue(
                 ExpressionBiValue.createBiClass(ExpressionTypes.OBJECT, ExpressionTypes.OBJECT),
-                new NonComparable(),
-                new NonComparable()
+                field1,
+                field2
         );
 
         put(value);
-
-        checkFailure("field1", "field2", -1, "trying to compare two incomparable objects");
     }
 
     @Test
@@ -753,7 +757,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     static class ComparableImpl implements Comparable<ComparableImpl>, Serializable {
         int innerField;
 
-        public ComparableImpl(int innerField) {
+        ComparableImpl(int innerField) {
             this.innerField = innerField;
         }
 
@@ -766,7 +770,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     static class ComparableImpl2 implements Comparable<ComparableImpl2>, Serializable {
         int innerField;
 
-        public ComparableImpl2(int innerField) {
+        ComparableImpl2(int innerField) {
             this.innerField = innerField;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
@@ -84,11 +84,15 @@ public final class ComparisonPredicate extends BiExpression<Boolean> implements 
             Class<?> rightClass = right.getClass();
 
             if (!leftClass.equals(rightClass)) {
-                throw QueryException.error("Cannot compare two OBJECT values, because they have different classes");
+                throw QueryException.error(
+                        "Cannot compare two OBJECT values, because "
+                                + "left operand has " + leftClass + " type and "
+                                + "right operand has " + rightClass + " type");
             }
 
             if (!(left instanceof Comparable)) {
-                throw QueryException.error("Cannot compare OBJECT value because it doesn't implement Comparable interface");
+                throw QueryException.error(
+                        "Cannot compare OBJECT value because " + leftClass + " doesn't implement Comparable interface");
             }
 
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.sql.impl.expression.predicate;
 
-import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
@@ -26,6 +26,7 @@ import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -78,11 +79,18 @@ public final class ComparisonPredicate extends BiExpression<Boolean> implements 
             return null;
         }
 
-        Class<?> leftClass = left.getClass();
-        Class<?> rightClass = right.getClass();
+        if (this.operand1.getType().getTypeFamily() == QueryDataTypeFamily.OBJECT) {
+            Class<?> leftClass = left.getClass();
+            Class<?> rightClass = right.getClass();
 
-        if (!(left instanceof Comparable && leftClass.equals(rightClass))) {
-            throw QueryException.error("trying to compare two incomparable objects");
+            if (!leftClass.equals(rightClass)) {
+                throw QueryException.error("Cannot compare two OBJECT values, because they have different classes");
+            }
+
+            if (!(left instanceof Comparable)) {
+                throw QueryException.error("Cannot compare OBJECT value because it doesn't implement Comparable interface");
+            }
+
         }
 
         Comparable leftComparable = (Comparable) left;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.sql.impl.expression.predicate;
 
+import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpression;
 import com.hazelcast.sql.impl.expression.Expression;
@@ -75,6 +77,13 @@ public final class ComparisonPredicate extends BiExpression<Boolean> implements 
         Object right = operand2.eval(row, context);
         if (right == null) {
             return null;
+        }
+
+        Class<?> leftClass = left.getClass();
+        Class<?> rightClass = right.getClass();
+
+        if (!(left instanceof Comparable && leftClass.equals(rightClass))) {
+            throw QueryException.error("trying to compare two incomparable objects");
         }
 
         Comparable leftComparable = (Comparable) left;


### PR DESCRIPTION
Closes https://github.com/hazelcast/hazelcast/issues/17302

PR implements support of OBJECT type comparison. Both left and right operand have to be the same class and implements `Comparable` interface to be compared, otherwise, `QueryException` is thrown