### PR TITLE
Increase default cluster timeout to 2 minutes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ConnectionRetryConfig.java
@@ -27,7 +27,7 @@ public class ConnectionRetryConfig {
 
     private static final int INITIAL_BACKOFF_MILLIS = 1000;
     private static final int MAX_BACKOFF_MILLIS = 30000;
-    private static final long CLUSTER_CONNECT_TIMEOUT_MILLIS = 20000;
+    private static final long CLUSTER_CONNECT_TIMEOUT_MILLIS = 120000;
     private static final double JITTER = 0;
     private int initialBackoffMillis = INITIAL_BACKOFF_MILLIS;
     private int maxBackoffMillis = MAX_BACKOFF_MILLIS;
@@ -107,7 +107,7 @@ public class ConnectionRetryConfig {
     }
 
     /**
-     * Timeout value in seconds for the client to give up to connect to the current cluster
+     * Timeout value in milliseconds for the client to give up to connect to the current cluster
      * Depending on FailoverConfig, a client can shutdown or start trying on alternative cluster after reaching the timeout.
      *
      * @return clusterConnectTimeoutMillis

--- a/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -296,7 +296,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
     public void testExponentialConnectionRetryConfig_defaults() {
         ClientConnectionStrategyConfig connectionStrategyConfig = defaultClientConfig.getConnectionStrategyConfig();
         ConnectionRetryConfig exponentialRetryConfig = connectionStrategyConfig.getConnectionRetryConfig();
-        assertEquals(20000, exponentialRetryConfig.getClusterConnectTimeoutMillis());
+        assertEquals(120000, exponentialRetryConfig.getClusterConnectTimeoutMillis());
         assertEquals(0, exponentialRetryConfig.getJitter(), 0);
         assertEquals(1000, exponentialRetryConfig.getInitialBackoffMillis());
         assertEquals(30000, exponentialRetryConfig.getMaxBackoffMillis());


### PR DESCRIPTION
The old default tiemout was 20 seconds.
The change is done for environments like Kubernetes
where an Ip resolution/system restart could take
around a minute. We don't want a client to shutdown
in such cases, and we also want this to be out-of-the-box
behaviour.

Related config API

clientConfig.getConnectionStrategyConfig()
.getConnectionRetryConfig().getClusterConnectTimeoutMillis();

fixes https://github.com/hazelcast/hazelcast/issues/17904