### PR TITLE
Fixes Client EndpointQualifier Resolution

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -2034,7 +2034,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         // construct the endpoint qualifier corresponding to an
         // endpoint-config or server-socket-endpoint-config node
         private EndpointQualifier createEndpointQualifier(ProtocolType type, Node node) {
-            return EndpointQualifier.resolve(type, getAttribute(node, "name"));
+            return EndpointQualifier.resolveForConfig(type, getAttribute(node, "name"));
         }
 
         private void handleInstanceTracking(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
@@ -107,7 +107,7 @@ public class EndpointConfig implements NamedConfig {
     }
 
     public EndpointQualifier getQualifier() {
-        return EndpointQualifier.resolve(protocolType, name);
+        return EndpointQualifier.resolveForConfig(protocolType, name);
     }
 
     public Collection<String> getOutboundPortDefinitions() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
@@ -136,6 +136,16 @@ public final class EndpointQualifier
                 + '\'' + '}';
     }
 
+    /**
+     * @return resolved endpoint qualifier when it is passed from the user via configuration
+     */
+    public static EndpointQualifier resolveForConfig(ProtocolType protocolType, String identifier) {
+        if (ProtocolType.CLIENT.equals(protocolType)) {
+            return CLIENT;
+        }
+        return resolve(protocolType, identifier);
+    }
+
     public static EndpointQualifier resolve(ProtocolType protocolType, String identifier) {
         switch (protocolType) {
             case MEMBER:

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -460,13 +460,11 @@ public class ClientServiceTest extends ClientTestSupport {
     @Test
     public void testClientListener_withShuttingDownOwnerMember() throws InterruptedException {
         Config config = new Config();
-        final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger atomicInteger = new AtomicInteger();
         ListenerConfig listenerConfig = new ListenerConfig(new ClientListener() {
             @Override
             public void clientConnected(Client client) {
                 atomicInteger.incrementAndGet();
-                latch.countDown();
             }
 
             @Override
@@ -478,12 +476,12 @@ public class ClientServiceTest extends ClientTestSupport {
         config.addListenerConfig(listenerConfig);
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         //first member is owner connection
-        hazelcastFactory.newHazelcastClient();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         config.setProperty(ClusterProperty.CLIENT_CLEANUP_TIMEOUT.getName(), String.valueOf(Integer.MAX_VALUE));
         hazelcastFactory.newHazelcastInstance(config);
         //make sure connected to second one before proceeding
-        assertOpenEventually(latch);
+        makeSureConnectedToServers(client, 2);
 
         //when first node is dead, client selects second one as owner
         instance.shutdown();


### PR DESCRIPTION
It seems our recent changes in `EndpointQualifier.equals` break some of the tests.
See
https://github.com/hazelcast/hazelcast/pull/17895/files#diff-495bae5b49f585b9fd0f6a37807cc792f7c9cbcc4c9e67d7d38fd104ccdda687L89

Failing test https://github.com/hazelcast/hazelcast/issues/17989
In this test, the ClientEngine on the server side is trying to reach to the connection manager for the client
Server server = node.getServer();
        server.getConnectionManager(CLIENT).addConnectionListener(connectionListener);

The problem is that the member is configured with following config
ServerSocketEndpointConfig clientEndpointConfig = new ServerSocketEndpointConfig();
        clientEndpointConfig.setName("CLIENT")
                            .setPort(5000)
                            .setPortAutoIncrement(true);

This leads to an EndpointQualifier created for the client with the identifier “CLIENT” along with the protocol type.
When ClientEngine tries to get the connection manager for CLIENT it fails to get that since they are no longer equal.

Solution:
We can not just revert the equals method because we need it to put `CLIENT`
protocol type with different identifiers to a map. So my solution is
to introduce another resolve method to EndpointQualifier called `resolveForConfig`
which will be used to resolve the endpoint from the config. All internal usages
will use the old one.

related to https://github.com/hazelcast/hazelcast/pull/17895

fixes https://github.com/hazelcast/hazelcast/issues/17989