### PR TITLE
Fix testOperationsContinueWhenClientDisconnected

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -35,13 +35,14 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -252,8 +253,10 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
 
         //we are closing a connection and making sure It is not established ever again
         waitFlag.set(true);
+        UUID memberUUID = instance1.getLocalEndpoint().getUuid();
         instance1.shutdown();
 
+        makeSureDisconnectedFromServer(client, memberUUID);
         //we expect these operations to run without throwing exception, since they are done on live instance.
         clientMap.put(keyOwnedBy2, 1);
         assertEquals(1, clientMap.get(keyOwnedBy2));

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -30,10 +30,12 @@ import com.hazelcast.test.HazelcastTestSupport;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ClientTestSupport extends HazelcastTestSupport {
 
@@ -80,6 +82,13 @@ public class ClientTestSupport extends HazelcastTestSupport {
     protected HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
         HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
         return clientProxy.client;
+    }
+
+    protected void makeSureDisconnectedFromServer(final HazelcastInstance client, UUID memberUUID) {
+        assertTrueEventually(() -> {
+            ClientConnectionManager connectionManager = getHazelcastClientInstanceImpl(client).getConnectionManager();
+            assertNull(connectionManager.getConnection(memberUUID));
+        });
     }
 
     protected void makeSureConnectedToServers(final HazelcastInstance client, final int numberOfServers) {


### PR DESCRIPTION
I have found one way that this test can fail.
Here the scenario:
1. Client is about to do a put after first instance is closed.
2. Partition table is not set yet. Client retries the operations
on random connections.
3. The connection to the first instance is not closed on the
client side yet.

When all the planets aligned, it is possible for this test to fail.
The logs on the failed issue does not disprove this, though
we are not sure if this is the real scenario.

I have added a fix to test to make sure the client will not fail
because of the found scenario.

fixes https://github.com/hazelcast/hazelcast/issues/17841