### PR TITLE
compare temporal types

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
@@ -218,6 +218,7 @@ public final class UnsupportedOperationVisitor implements SqlVisitor<Void> {
             case DATE:
             case TIME:
             case TIMESTAMP:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
             case NULL:
                 return null;
 

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
@@ -121,16 +121,14 @@ public final class HazelcastComparisonPredicateUtils {
         }
 
         if (highHZType.getTypeFamily() != lowHZType.getTypeFamily()
-            && !(highHZType.getTypeFamily().isNumeric() && lowHZType.getTypeFamily().isNumeric())) {
-
-            if (bothNotTemporal(highHZType, lowHZType) || nonConvertibleTemporalTypes(highHZType, lowHZType)) {
+            && !(highHZType.getTypeFamily().isNumeric() && lowHZType.getTypeFamily().isNumeric())
+            && (bothNotTemporal(highHZType, lowHZType) || !(lowHZType.getConverter().canConvertTo(highHZType.getTypeFamily())))) {
                 // Types cannot be converted to each other, throw.
                 if (throwOnFailure) {
                     throw callBinding.newValidationSignatureError();
                 } else {
                     return false;
                 }
-            }
         }
 
         // Types are in the same group, cast lower to higher.
@@ -139,10 +137,6 @@ public final class HazelcastComparisonPredicateUtils {
         validator.getTypeCoercion().coerceOperandType(callBinding.getScope(), callBinding.getCall(), lowIndex, newLowType);
 
         return true;
-    }
-
-    private static boolean nonConvertibleTemporalTypes(QueryDataType highHZType, QueryDataType lowHZType) {
-        return highHZType.getTypeFamily() == QueryDataTypeFamily.DATE && lowHZType.getTypeFamily() == QueryDataTypeFamily.TIME;
     }
 
     private static boolean bothNotTemporal(QueryDataType highHZType, QueryDataType lowHZType) {

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
@@ -100,7 +100,7 @@ public final class HazelcastComparisonPredicateUtils {
         QueryDataType highHZType = HazelcastTypeUtils.toHazelcastType(highType.getSqlTypeName());
         QueryDataType lowHZType = HazelcastTypeUtils.toHazelcastType(lowType.getSqlTypeName());
 
-        if (highHZType.getTypeFamily().isTemporal() || highHZType.getTypeFamily() == QueryDataTypeFamily.OBJECT) {
+        if (highHZType.getTypeFamily() == QueryDataTypeFamily.OBJECT) {
             // Disallow comparisons for temporal and OBJECT types.
             if (throwOnFailure) {
                 throw callBinding.newValidationSignatureError();
@@ -121,6 +121,7 @@ public final class HazelcastComparisonPredicateUtils {
         }
 
         if (highHZType.getTypeFamily() != lowHZType.getTypeFamily()
+            && !(highHZType.getTypeFamily().isTemporal() && lowHZType.getTypeFamily().isTemporal())
             && !(highHZType.getTypeFamily().isNumeric() && lowHZType.getTypeFamily().isNumeric())) {
             // Types cannot be converted to each other, throw.
             if (throwOnFailure) {

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -264,6 +264,14 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
+    public void testCompare_LocalDate_with_String() {
+        put(ExpressionValue.create(ExpressionValue.createClass(ExpressionTypes.LOCAL_DATE), LocalDate.of(2020, 12, 30)));
+
+        check("field1", "'2020-12-30'", LocalDate.of(2020, 12, 30).compareTo(LocalDate.of(2020, 12, 30)));
+        check("'2020-12-30'", "field1", LocalDate.of(2020, 12, 30).compareTo(LocalDate.of(2020, 12, 30)));
+    }
+
+    @Test
     public void testCompare_LocalTime_with_LocalTime() {
         putBiValue(
             LocalTime.of(14, 2, 0),
@@ -275,6 +283,14 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
+    public void testCompare_LocalTime_with_String() {
+        put(ExpressionValue.create(ExpressionValue.createClass(ExpressionTypes.LOCAL_TIME), LocalTime.of(14, 2, 0)));
+
+        check("field1", "'14:02:00'", LocalTime.of(14, 2, 0).compareTo(LocalTime.of(14, 2, 0)));
+        check("'14:02:00'", "field1", LocalTime.of(14, 2, 0).compareTo(LocalTime.of(14, 2, 0)));
+    }
+
+    @Test
     public void testCompare_LocalDateTime_with_LocalDateTime() {
         putBiValue(
             LocalDateTime.of(2020, 12, 30, 14, 2, 0),
@@ -283,6 +299,14 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
         );
 
         check("field1", "field2", LocalDateTime.of(2020, 12, 30, 14, 2, 0).compareTo(LocalDateTime.of(2020, 12, 30, 14, 2, 0)));
+    }
+
+    @Test
+    public void testCompare_LocalDateTime_with_String() {
+        put(ExpressionValue.create(ExpressionValue.createClass(ExpressionTypes.LOCAL_DATE_TIME), LocalDateTime.of(2020, 12, 30, 14, 2, 0)));
+
+        check("field1", "'2020-12-30T14:02'", LocalDateTime.of(2020, 12, 30, 14, 2, 0).compareTo(LocalDateTime.of(2020, 12, 30, 14, 2, 0)));
+        check("'2020-12-30T14:02'", "field1", LocalDateTime.of(2020, 12, 30, 14, 2, 0).compareTo(LocalDateTime.of(2020, 12, 30, 14, 2, 0)));
     }
 
 
@@ -335,6 +359,19 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
         );
 
         check("field1", "field2",
+                OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)
+                        .compareTo(OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)));
+    }
+
+    @Test
+    public void testCompare_LocalDateTimeWithTZ_with_String() {
+        put(ExpressionValue.create(ExpressionValue.createClass(
+                ExpressionTypes.OFFSET_DATE_TIME), OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)));
+
+        check("field1", "'2020-12-30T14:02Z'",
+                OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)
+                        .compareTo(OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)));
+        check("'2020-12-30T14:02Z'", "field1",
                 OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)
                         .compareTo(OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)));
     }

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -255,7 +255,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalDate_to_LocalDate() {
+    public void testCompare_LocalDate_with_LocalDate() {
         putBiValue(
             LocalDate.of(2020, 12, 30),
             LocalDate.of(2020, 12, 30),
@@ -266,7 +266,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalTime_to_LocalTime() {
+    public void testCompare_LocalTime_with_LocalTime() {
         putBiValue(
             LocalTime.of(14, 2, 0),
             LocalTime.of(14, 2, 0),
@@ -277,7 +277,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalTime_to_LocalDate() {
+    public void testCompare_LocalTime_with_LocalDate() {
         putBiValue(
             LocalTime.of(14, 2, 0),
             LocalDate.of(2020, 12, 30),
@@ -298,7 +298,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalDateTime_to_LocalDateTime() {
+    public void testCompare_LocalDateTime_with_LocalDateTime() {
         putBiValue(
             LocalDateTime.of(2020, 12, 30, 14, 2, 0),
             LocalDateTime.of(2020, 12, 30, 14, 2, 0),
@@ -310,7 +310,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
 
 
     @Test
-    public void testLocalDateTime_to_LocalDate() {
+    public void testCompare_LocalDateTime_with_LocalDate() {
         putBiValue(
             LocalDateTime.of(2020, 12, 30, 14, 2, 0),
             LocalDate.of(2020, 12, 30),
@@ -329,7 +329,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalDateTimeWithTZ_LocalDateTimeWithTZ() {
+    public void testCompare_LocalDateTimeWithTZ_with_LocalDateTimeWithTZ() {
         putBiValue(
             OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC),
             OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC),
@@ -342,7 +342,7 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalDateTimeWithTZ_to_LocalDateTime() {
+    public void testCompare_LocalDateTimeWithTZ_with_LocalDateTime() {
         putBiValue(
                 OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC),
                 LocalDateTime.of(2020, 12, 30, 14, 2, 0), ExpressionTypes.OFFSET_DATE_TIME, ExpressionTypes.LOCAL_DATE_TIME
@@ -364,15 +364,15 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
     }
 
     @Test
-    public void testLocalDateTimeWithTZ_to_LocalDate() {
+    public void testCompare_LocalDateTimeWithTZ_with_LocalDate() {
         putBiValue(
                 OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC),
                 LocalDate.of(2020, 12, 30), ExpressionTypes.OFFSET_DATE_TIME, ExpressionTypes.LOCAL_DATE
         );
 
         check("field1", "field2",
-                OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC).toLocalDateTime()
-                        .compareTo(LocalDate.of(2020, 12, 30).atStartOfDay()));
+                OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 23, 0, 0), ZoneOffset.of("-05"))
+                        .compareTo(ZonedDateTime.of(LocalDate.of(2020, 12, 30).atStartOfDay(), ZoneId.systemDefault()).toOffsetDateTime()));
 
         putBiValue(
                 LocalDate.of(2020, 12, 30),
@@ -381,8 +381,8 @@ public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
         );
 
         check("field1", "field2",
-                LocalDate.of(2020, 12, 30).atStartOfDay()
-                        .compareTo(OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC).toLocalDateTime()));
+                ZonedDateTime.of(LocalDate.of(2020, 12, 30).atStartOfDay(), ZoneId.systemDefault()).toOffsetDateTime()
+                        .compareTo(OffsetDateTime.of(LocalDateTime.of(2020, 12, 30, 14, 2, 0), ZoneOffset.UTC)));
     }
 
     private void putBiValue(Object field1, Object field2, ExpressionType<?> type1, ExpressionType<?> type2) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
@@ -19,12 +19,14 @@ package com.hazelcast.sql.impl.expression.predicate;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -75,6 +77,12 @@ public final class ComparisonPredicate extends BiExpression<Boolean> implements 
         Object right = operand2.eval(row, context);
         if (right == null) {
             return null;
+        }
+
+        QueryDataTypeFamily leftTypeFamily = this.operand1.getType().getTypeFamily();
+        QueryDataTypeFamily rightTypeFamily = this.operand2.getType().getTypeFamily();
+        if (leftTypeFamily != rightTypeFamily) {
+            throw QueryException.error(String.format("Cannot compare %s value with %s value", leftTypeFamily, rightTypeFamily));
         }
 
         Comparable leftComparable = (Comparable) left;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicate.java
@@ -19,14 +19,12 @@ package com.hazelcast.sql.impl.expression.predicate;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.BiExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -77,12 +75,6 @@ public final class ComparisonPredicate extends BiExpression<Boolean> implements 
         Object right = operand2.eval(row, context);
         if (right == null) {
             return null;
-        }
-
-        QueryDataTypeFamily leftTypeFamily = this.operand1.getType().getTypeFamily();
-        QueryDataTypeFamily rightTypeFamily = this.operand2.getType().getTypeFamily();
-        if (leftTypeFamily != rightTypeFamily) {
-            throw QueryException.error(String.format("Cannot compare %s value with %s value", leftTypeFamily, rightTypeFamily));
         }
 
         Comparable leftComparable = (Comparable) left;


### PR DESCRIPTION
Temporal type conversion is implemented according to https://github.com/hazelcast/hazelcast/blob/master/docs/design/sql/01-type-system.md#3-type-conversions and also added support of string date literal (e.g. `'2021-01-15'` as a `DATE`, `'2021-01-15T13:12:00'` as a `TIMESTAMP`)