### PR TITLE
Remove the deadlock between clientStateMutex and clusterViewMutex

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -590,20 +590,24 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
         return onAuthenticated(connection, response);
     }
 
-    private void fireConnectionAddedEvent(TcpClientConnection connection) {
-        executor.execute(() -> {
-            for (ConnectionListener connectionListener : connectionListeners) {
-                connectionListener.connectionAdded(connection);
-            }
-        });
-    }
-
-    private void fireConnectionRemovedEvent(TcpClientConnection connection) {
-        executor.execute(() -> {
-            for (ConnectionListener listener : connectionListeners) {
-                listener.connectionRemoved(connection);
-            }
-        });
+    private void fireConnectionEvent(TcpClientConnection connection, boolean isAdded) {
+        if (!isAlive()) {
+            return;
+        }
+        try {
+            executor.execute(() -> {
+                for (ConnectionListener listener : connectionListeners) {
+                    if (isAdded) {
+                        listener.connectionAdded(connection);
+                    } else {
+                        listener.connectionRemoved(connection);
+                    }
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            //RejectedExecutionException thrown when the client is shutting down
+            EmptyStatement.ignore(e);
+        }
     }
 
     private boolean useAnyOutboundPort() {
@@ -735,7 +739,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                     triggerClusterReconnection();
                 }
 
-                fireConnectionRemovedEvent(connection);
+                fireConnectionEvent(connection, false);
             } else if (logger.isFinestEnabled()) {
                 logger.finest("Destroying a connection, but there is no mapping " + endpoint + ":" + memberUuid
                         + " -> " + connection + " in the connection map.");
@@ -913,7 +917,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                     + ", server version: " + response.serverHazelcastVersion
                     + ", local address: " + connection.getLocalSocketAddress());
 
-            fireConnectionAddedEvent(connection);
+            fireConnectionEvent(connection, true);
         }
 
         // It could happen that this connection is already closed and

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -35,12 +35,10 @@ import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.MemberSelectingCollection;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
@@ -80,7 +78,6 @@ public class ClientClusterServiceImpl
     private final ConcurrentMap<UUID, MembershipListener> listeners = new ConcurrentHashMap<>();
     private final Set<String> labels;
     private final ILogger logger;
-    private final ClientConnectionManager connectionManager;
     private final Object clusterViewLock = new Object();
     private final TranslateToPublicAddressProvider translateToPublicAddress;
     //read and written under clusterViewLock
@@ -101,7 +98,6 @@ public class ClientClusterServiceImpl
         this.client = client;
         labels = unmodifiableSet(client.getClientConfig().getLabels());
         logger = client.getLoggingService().getLogger(ClientClusterService.class);
-        connectionManager = client.getConnectionManager();
         translateToPublicAddress = new TranslateToPublicAddressProvider(client.getClientConfig().getNetworkConfig(),
                 client.getProperties(), logger);
     }
@@ -281,15 +277,8 @@ public class ClientClusterServiceImpl
 
         List<MembershipEvent> events = new LinkedList<>();
 
-        // removal events should be added before added events
         for (Member member : deadMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, currentMembers));
-            Connection connection = connectionManager.getConnection(member.getUuid());
-            if (connection != null) {
-                connection.close(null,
-                        new TargetDisconnectedException("The client has closed the connection to this member,"
-                                + " after receiving a member left event from the cluster. " + connection));
-            }
         }
         for (Member member : newMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, currentMembers));


### PR DESCRIPTION
We have captured a deadlock in a failing test:
```
java.lang.Thread.State: BLOCKED, on lock=java.lang.Object@467064ec, owned by pool-1004-thread-1, id=100868, cpu=3827564 nsecs, usr=0 nsecs, blocked=121349 msecs, waited=18 msecs
    at com.hazelcast.client.impl.connection.tcp.TcpClientConnectionManager.onConnectionClose(TcpClientConnectionManager.java:711)
    at com.hazelcast.client.impl.connection.tcp.TcpClientConnection.close(TcpClientConnection.java:190)
    at com.hazelcast.client.impl.spi.impl.ClientClusterServiceImpl.detectMembershipEvents(ClientClusterServiceImpl.java:280)
    at com.hazelcast.client.impl.spi.impl.ClientClusterServiceImpl.handleMembersViewEvent(ClientClusterServiceImpl.java:338)
    at com.hazelcast.client.impl.spi.impl.listener.ClientClusterViewListenerService$ClusterViewListenerHandler.handleMembersViewEvent(ClientClusterViewListenerService.java:90)
    at com.hazelcast.client.impl.protocol.codec.ClientAddClusterViewListenerCodec$AbstractEventHandler.handle(ClientAddClusterViewListenerCodec.java:116)
    at com.hazelcast.client.impl.spi.impl.listener.ClientClusterViewListenerService$ClusterViewListenerHandler.handle(ClientClusterViewListenerService.java:64)
    at com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl.handleEventMessageOnCallingThread(ClientListenerServiceImpl.java:189)
    at com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl.lambda$handleEventMessage$2(ClientListenerServiceImpl.java:167)
    at com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl$$Lambda$1821/1960977249.run(Unknown Source)
    at com.hazelcast.internal.util.executor.StripedExecutor$Worker.process(StripedExecutor.java:245)
    at com.hazelcast.internal.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:228)

java.lang.Thread.State: BLOCKED, on lock=java.lang.Object@35eabfb3, owned by hz.client_313.event-7092, id=100854, cpu=3544732 nsecs, usr=0 nsecs, blocked=121349 msecs, waited=34 msecs
    at com.hazelcast.client.impl.spi.impl.ClientClusterServiceImpl.clearMemberListVersion(ClientClusterServiceImpl.java:203)
    at com.hazelcast.client.impl.spi.impl.listener.ClientClusterViewListenerService$ClusterViewListenerHandler.beforeListenerRegister(ClientClusterViewListenerService.java:75)
    at com.hazelcast.client.impl.spi.impl.listener.ClientClusterViewListenerService.tryRegister(ClientClusterViewListenerService.java:129)
    at com.hazelcast.client.impl.spi.impl.listener.ClientClusterViewListenerService.tryReregisterToRandomConnection(ClientClusterViewListenerService.java:116)
    at com.hazelcast.client.impl.spi.impl.listener.ClientClusterViewListenerService.connectionRemoved(ClientClusterViewListenerService.java:106)
    at com.hazelcast.client.impl.connection.tcp.TcpClientConnectionManager.fireConnectionRemovedEvent(TcpClientConnectionManager.java:600)
    at com.hazelcast.client.impl.connection.tcp.TcpClientConnectionManager.onConnectionClose(TcpClientConnectionManager.java:722)
    at com.hazelcast.client.impl.connection.tcp.TcpClientConnection.close(TcpClientConnection.java:190)
    at com.hazelcast.client.test.TestClientRegistry$MockedTcpClientConnection$4.run(TestClientRegistry.java:316)
    at com.hazelcast.client.test.TwoWayBlockableExecutor$BlockableRunnable.run(TwoWayBlockableExecutor.java:98)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```
These two threads are waiting for each other because they are trying to lock same mutexes in reverse order.

In the first stacktrace, a member REMOVED event could cause closing of a member under `clusterViewLock` which will require `clientStateMutex`
Fix: The responsibility of closing of the connection is taken from ClientCLusterService and given to TcpClientConnectioManager.

In the second stacktrace, Someone closing the connection could potentially cause a reregistration listener under `clientStateMutex` which will requre `clusterViewLock`
Fix:  fireConenctionRemovedEvent is offloaded to an executor so that it will not held the mutex when fired.

fixes https://github.com/hazelcast/hazelcast/issues/18032