### PR TITLE
Add PLACEMENT_AWARE partition group strategy.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -27,8 +27,8 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
  * With PartitionGroupConfig, you can control how primary and backup partitions are mapped to physical Members.
  * <p>
  * Hazelcast will always place partitions on different partition groups so as to provide redundancy.
- * There are three partition group schemes defined in {@link MemberGroupType}: PER_MEMBER, HOST_AWARE
- * CUSTOM, ZONE_AWARE, SPI.
+ * There are seven partition group schemes defined in {@link MemberGroupType}: PER_MEMBER, HOST_AWARE
+ * CUSTOM, ZONE_AWARE, NODE_AWARE, PLACEMENT_AWARE, SPI.
  * <p>
  * In all cases a partition will never be created on the same group. If there are more partitions defined than
  * there are partition groups, then only those partitions, up to the number of partition groups, will be created.
@@ -78,8 +78,8 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
  * You can define as many <code>member-group</code>s as you want. Hazelcast will always store backups in a different
  * member-group to the primary partition.
  *
- * <h1>Zone Aware Partition Groups</h1>
- * In this scheme, groups are allocated according to the metadata provided by Discovery SPI
+ * <h1>ZONE_AWARE Partition Groups</h1>
+ * In this scheme, groups are allocated according to the metadata provided by Discovery SPI.
  * These metadata are availability zone, rack and host. The backups of the partitions are not
  * placed on the same group so this is very useful for ensuring partitions are placed on
  * different availability zones without providing the IP addresses to the config ahead.
@@ -89,7 +89,7 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
  * </pre>
  * </code>
  *
- * <h1>Node Aware Partition Groups</h1>
+ * <h1>NODE_AWARE Partition Groups</h1>
  * In this scheme, groups are allocated according to node name metadata provided by Discovery SPI.
  * For container orchestration tools like Kubernetes and Docker Swarm, node is the term used to refer
  * machine that containers/pods run on. A node may be a virtual or physical machine.
@@ -99,6 +99,19 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
  * <code>
  * <pre>
  * &lt;partition-group enabled="true" group-type="NODE_AWARE"/&gt;
+ * </pre>
+ * </code>
+ *
+ * <h1>PLACEMENT_AWARE Partition Groups</h1>
+ * In this scheme, groups are allocated according to the placement metadata provided by Discovery
+ * SPI. Depending on the cloud provider, this metadata indicates the placement information (rack,
+ * fault domain, etc.) of a VM in a zone. This scheme provides a finer granularity than ZONE_AWARE
+ * for partition groups and is useful to provide good redundancy when running members within a
+ * single availability zone.
+ *
+ * <code>
+ * <pre>
+ * &lt;partition-group enabled="true" group-type="PLACEMENT_AWARE"/&gt;
  * </pre>
  * </code>
  *
@@ -161,6 +174,11 @@ public class PartitionGroupConfig {
          * If only one node is available, backups will be created in the same node.
          */
         NODE_AWARE,
+        /**
+         * Placement Aware. Backups will be created in other placement groups.
+         * If only one placement group is available, backups will be created in the same group.
+         */
+        PLACEMENT_AWARE,
         /**
          * MemberGroup implementation will be provided by the user via Discovery SPI.
          */

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryFactory.java
@@ -45,6 +45,8 @@ public final class MemberGroupFactoryFactory {
                 return new ZoneAwareMemberGroupFactory();
             case NODE_AWARE:
                 return new NodeAwareMemberGroupFactory();
+            case PLACEMENT_AWARE:
+                return new PlacementAwareMemberGroupFactory();
             case SPI:
                 return new SPIAwareMemberGroupFactory(discoveryService);
             default:

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/PlacementAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/PlacementAwareMemberGroupFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.partition.membergroup;
 
 import com.hazelcast.cluster.Member;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/PlacementAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/PlacementAwareMemberGroupFactory.java
@@ -43,16 +43,16 @@ public class PlacementAwareMemberGroupFactory extends BackupSafeMemberGroupFacto
     protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
         Map<String, MemberGroup> groups = createHashMap(allMembers.size());
         for (Member member : allMembers) {
-            final String nodeInfo = member.getAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT);
-            if (nodeInfo == null) {
+            String placementInfo = member.getAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT);
+            if (placementInfo == null) {
                 throw new IllegalArgumentException("Not enough metadata information is provided. "
                         + "A group name indicating the placement group must be provided with "
                         + "PLACEMENT_AWARE partition group.");
             }
-            MemberGroup group = groups.get(nodeInfo);
+            MemberGroup group = groups.get(placementInfo);
             if (group == null) {
                 group = new DefaultMemberGroup();
-                groups.put(nodeInfo, group);
+                groups.put(placementInfo, group);
             }
             group.addMember(member);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/PlacementAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/PlacementAwareMemberGroupFactory.java
@@ -1,0 +1,46 @@
+package com.hazelcast.internal.partition.membergroup;
+
+import com.hazelcast.cluster.Member;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.partitiongroup.MemberGroup;
+import com.hazelcast.spi.partitiongroup.PartitionGroupMetaData;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.internal.util.MapUtil.createHashMap;
+
+/**
+ * PlacementAwareMemberGroupFactory is responsible for MemberGroups
+ * creation according to placement group metadata. Placement groups are
+ * logical or physical groups of VMs based on their racks, power sources,
+ * network, resources, etc. assigned by cloud providers. It provides good
+ * redundancy when running members within a single availability zone.
+ * Member groups are formed based on the metadata provided by
+ * {@link DiscoveryStrategy#discoverLocalMetadata()}
+ */
+public class PlacementAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
+
+    @Override
+    protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
+        Map<String, MemberGroup> groups = createHashMap(allMembers.size());
+        for (Member member : allMembers) {
+            final String nodeInfo = member.getAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT);
+            if (nodeInfo == null) {
+                throw new IllegalArgumentException("Not enough metadata information is provided. "
+                        + "A group name indicating the placement group must be provided with "
+                        + "PLACEMENT_AWARE partition group.");
+            }
+            MemberGroup group = groups.get(nodeInfo);
+            if (group == null) {
+                group = new DefaultMemberGroup();
+                groups.put(nodeInfo, group);
+            }
+            group.addMember(member);
+        }
+        return new HashSet<>(groups.values());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -31,6 +31,10 @@ package com.hazelcast.spi.partitiongroup;
  * Node aware backup strategy is based on name of the node which is provided by container orchestration tool.
  * like Kubernetes, Docker Swarm and ECS. A node is the term used to refer machine that containers/pods run on.
  * A node may be a virtual or physical machine.
+ *
+ * Placement aware backup strategy is based on the placement strategies of the virtual machines on
+ * which Hazelcast members run. Unlike zone aware, this strategy can group members within a single
+ * availability zone based on their racks, power sources, network, etc.
  */
 public enum PartitionGroupMetaData {
     ;
@@ -59,4 +63,10 @@ public enum PartitionGroupMetaData {
      * in case of container orchestration tools being used.
      */
     public static final String PARTITION_GROUP_NODE = "hazelcast.partition.group.node";
+
+    /**
+     * Metadata key definition for the placement group to which VMs belong if a placement strategy is
+     * applied by cloud providers.
+     */
+    public static final String PARTITION_GROUP_PLACEMENT = "hazelcast.partition.group.placement";
 }

--- a/hazelcast/src/main/resources/hazelcast-config-4.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.2.xsd
@@ -2575,6 +2575,7 @@
                     <xs:enumeration value="PER_MEMBER"/>
                     <xs:enumeration value="ZONE_AWARE"/>
                     <xs:enumeration value="NODE_AWARE"/>
+                    <xs:enumeration value="PLACEMENT_AWARE"/>
                     <xs:enumeration value="SPI"/>
                 </xs:restriction>
             </xs:simpleType>

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -190,6 +190,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testPartitionGroupNodeAware();
 
     @Test
+    public abstract void testPartitionGroupPlacementAware();
+
+    @Test
     public abstract void testPartitionGroupSPI();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1189,6 +1189,19 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testPartitionGroupPlacementAware() {
+        String xml = HAZELCAST_START_TAG
+                + "<partition-group enabled=\"true\" group-type=\"PLACEMENT_AWARE\" />"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
+        assertTrue(partitionGroupConfig.isEnabled());
+        assertEquals(PartitionGroupConfig.MemberGroupType.PLACEMENT_AWARE, partitionGroupConfig.getGroupType());
+    }
+
+    @Override
+    @Test
     public void testPartitionGroupSPI() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"SPI\" />"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1192,6 +1192,21 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testPartitionGroupPlacementAware() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  partition-group:\n"
+                + "    enabled: true\n"
+                + "    group-type: PLACEMENT_AWARE\n";
+
+        Config config = buildConfig(yaml);
+        PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
+        assertTrue(partitionGroupConfig.isEnabled());
+        assertEquals(PartitionGroupConfig.MemberGroupType.PLACEMENT_AWARE, partitionGroupConfig.getGroupType());
+    }
+
+    @Override
+    @Test
     public void testPartitionGroupSPI() {
         String yaml = ""
                 + "hazelcast:\n"

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryTest.java
@@ -66,12 +66,7 @@ public class MemberGroupFactoryTest {
     public void testZoneAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
         MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithNoMetadata();
-        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
-
-        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
-        for (MemberGroup memberGroup : memberGroups) {
-            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
-        }
+        groupFactory.createMemberGroups(members);
     }
 
     private Collection<Member> createMembersWithNoMetadata() {
@@ -202,12 +197,43 @@ public class MemberGroupFactoryTest {
     public void testNodeAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
         MemberGroupFactory groupFactory = new NodeAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithNoMetadata();
+        groupFactory.createMemberGroups(members);
+    }
+
+    @Test
+    public void testPlacementMetadataAwareMemberGroupFactoryCreateMemberGroups() {
+        MemberGroupFactory groupFactory = new PlacementAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithPlacementAwareMetadata();
         Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
 
-        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        assertEquals("Member Groups: " + memberGroups, 3, memberGroups.size());
         for (MemberGroup memberGroup : memberGroups) {
-            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
+            assertEquals("Member Group: " + memberGroup, 1, memberGroup.size());
         }
+    }
+
+    private Collection<Member> createMembersWithPlacementAwareMetadata() {
+        Collection<Member> members = new HashSet<>();
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
+        member1.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement@1");
+
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
+        member2.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement@2");
+
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
+        member3.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement@3");
+
+        members.add(member1);
+        members.add(member2);
+        members.add(member3);
+        return members;
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPlacementAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
+        MemberGroupFactory groupFactory = new PlacementAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithNoMetadata();
+        groupFactory.createMemberGroups(members);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryTest.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -62,11 +63,11 @@ public class MemberGroupFactoryTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testZoneAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
         MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithNoMetadata();
-        groupFactory.createMemberGroups(members);
+        assertThrows(IllegalArgumentException.class, () -> groupFactory.createMemberGroups(members));
     }
 
     private Collection<Member> createMembersWithNoMetadata() {
@@ -193,11 +194,11 @@ public class MemberGroupFactoryTest {
         return members;
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNodeAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
         MemberGroupFactory groupFactory = new NodeAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithNoMetadata();
-        groupFactory.createMemberGroups(members);
+        assertThrows(IllegalArgumentException.class, () -> groupFactory.createMemberGroups(members));
     }
 
     @Test
@@ -215,13 +216,13 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithPlacementAwareMetadata() {
         Collection<Member> members = new HashSet<>();
         MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
-        member1.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement@1");
+        member1.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement-1");
 
         MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement@2");
+        member2.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement-2");
 
         MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement@3");
+        member3.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_PLACEMENT, "us-east-1a-placement-3");
 
         members.add(member1);
         members.add(member2);
@@ -229,11 +230,11 @@ public class MemberGroupFactoryTest {
         return members;
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPlacementAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() {
         MemberGroupFactory groupFactory = new PlacementAwareMemberGroupFactory();
         Collection<Member> members = createMembersWithNoMetadata();
-        groupFactory.createMemberGroups(members);
+        assertThrows(IllegalArgumentException.class, () -> groupFactory.createMemberGroups(members));
     }
 
     /**


### PR DESCRIPTION
Adds placement aware partition group strategy to form partition groups based on the placement metadata of VMs assigned by cloud providers. Unlike zone aware (which is useful for multi-zone setups), this strategy provides availability within a single zone as high as possible by spreading partitions and their replicas across different racks. 

- Related [PRD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1110868589/Support+for+AWS+Placement+Groups) 
- Related [TDD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/2954363031/Support+for+AWS+Placement+Groups+-+TDD) 