### PR TITLE
Add test to CPMemberAddRemoveTest and increase log level of cp classes

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -39,7 +39,6 @@ import com.hazelcast.instance.impl.NodeState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -80,7 +79,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({ SlowTest.class, ParallelJVMTest.class })
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
     @Test
@@ -164,7 +163,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         factory.getInstance(crashedMember.getAddress()).getLifecycleService().terminate();
 
         CPSubsystemManagementService cpSubsystemManagementService = runningInstance.getCPSubsystem()
-                                                                                         .getCPSubsystemManagementService();
+                                                                                   .getCPSubsystemManagementService();
         cpSubsystemManagementService.forceDestroyCPGroup(groupId.getName())
                                     .toCompletableFuture().get();
         cpSubsystemManagementService.removeCPMember(crashedMember.getUuid())
@@ -740,7 +739,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         int commitIndexAdvanceCountToSnapshot = 50;
         Config config = createConfig(nodeCount, nodeCount);
         config.getCPSubsystemConfig().getRaftAlgorithmConfig()
-                .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+              .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
 
         HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
         for (int i = 0; i < nodeCount; i++) {
@@ -764,9 +763,9 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().toCompletableFuture().join();
 
         List<CPMember> cpMembers = new ArrayList<>(newInstance.getCPSubsystem()
-                .getCPSubsystemManagementService()
-                .getCPMembers()
-                .toCompletableFuture().join());
+                                                              .getCPSubsystemManagementService()
+                                                              .getCPMembers()
+                                                              .toCompletableFuture().join());
 
         assertTrueEventually(() -> {
             RaftService service = getRaftService(newInstance);
@@ -774,6 +773,46 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
             assertEquals(cpMembers, activeMembers);
         });
     }
+
+    @Test
+    public void when_snapshotIsTakenWhileRemovingCPLeader_newMemberInstallsSnapshot() throws Exception {
+        int nodeCount = 3;
+        int commitIndexAdvanceCountToSnapshot = 50;
+        Config config = createConfig(nodeCount, nodeCount);
+        config.getCPSubsystemConfig().getRaftAlgorithmConfig().setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+
+        HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
+        for (int i = 0; i < nodeCount; i++) {
+            instances[i] = factory.newHazelcastInstance(config);
+        }
+
+        assertClusterSizeEventually(nodeCount, instances);
+        waitUntilCPDiscoveryCompleted(instances);
+
+        HazelcastInstance leaderInstance = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
+
+        // `commitIndexAdvanceCountToSnapshot - 5` is selected on purpose to partially include removal of CP member in snapshot.
+        // Specifically, RemoveCPMemberOp will be in snapshot but CompleteRaftGroupMembershipChangesOp will not.
+        for (int i = 0; i < commitIndexAdvanceCountToSnapshot - 5; i++) {
+            getRaftInvocationManager(leaderInstance).invoke(getMetadataGroupId(instances[0]), new GetActiveCPMembersOp()).get();
+        }
+
+        // This will add 3 entries, RemoveCPMemberOp, ChangeRaftGroupMembersCmd and CompleteRaftGroupMembershipChangesOp.
+        // RemoveCPMemberOp will be in snapshot but CompleteRaftGroupMembershipChangesOp will not be included.
+        leaderInstance.shutdown();
+
+        HazelcastInstance newInstance = factory.newHazelcastInstance(config);
+        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().toCompletableFuture().join();
+
+        List<CPMember> cpMembers = new ArrayList<>(newInstance.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().toCompletableFuture().join());
+
+        assertTrueEventually(() -> {
+            RaftService service = getRaftService(newInstance);
+            List<CPMemberInfo> activeMembers = new ArrayList<>(service.getMetadataGroupManager().getActiveMembers());
+            assertEquals(cpMembers, activeMembers);
+        });
+    }
+
 
     @Test
     public void when_newCPMemberIsAddedToTheMetadataGroupAfterRestart_newMemberCommitsMetadataGroupLogEntries() throws ExecutionException, InterruptedException {

--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -34,7 +34,7 @@
         <Logger name="com.hazelcast.client.impl.protocol.task" level="debug"/>
         <Logger name="com.hazelcast.client.impl.operations" level="debug"/>
         <Logger name="com.hazelcast.client.impl.spi.ClientListenerService" level="trace"/>
-        <!--<Logger name="com.hazelcast.client.impl.spi.ClientClusterService" level="trace"/>-->
+        <Logger name="com.hazelcast.cp.internal" level="trace"/>
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientInvocationService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.connection.ClientConnectionManager" level="trace"/>-->
     </Loggers>


### PR DESCRIPTION
Adding a test which is more likely to fail
for the issue https://github.com/hazelcast/hazelcast/issues/16574

I have realized that in the failing test the leader is closed
which is not the main intention of the test. Looks related so
I have added a variant of failing test where we close the leader
always.

Also increased the cp classes log level on the tests.