### PR TITLE
Add getter to attribute extraction in FieldsUtil

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/FieldsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/FieldsUtil.java
@@ -89,6 +89,13 @@ public final class FieldsUtil {
 
         String fieldNameWithWrongCase;
 
+        // If field name is same as method name simply return that
+        try {
+            clazz.getDeclaredField(methodName);
+            return methodName;
+        } catch (NoSuchFieldException ignored) {
+            // No (private) field has the same name as the method name, so continue
+        }
         if (methodName.startsWith(METHOD_PREFIX_GET) && methodName.length() > METHOD_PREFIX_GET.length()) {
             fieldNameWithWrongCase = methodName.substring(METHOD_PREFIX_GET.length());
         } else if (methodName.startsWith(METHOD_PREFIX_IS) && methodName.length() > METHOD_PREFIX_IS.length()) {


### PR DESCRIPTION
This PR fixes #18045.

The PR improves the attribute extractor in the `FieldsUtil` class in the sql package. I specifically added the ability to extract fields that have a getter method with the same name. So if you have `private String myString;`, and `public String myString();` `myString` is successfully extracted as an attribute.