### PR TITLE
Prevent memory leak on queue backup.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -1215,5 +1216,14 @@ public class QueueContainer implements IdentifiedDataSerializable {
 
     void setId(long itemId) {
         idGenerator = Math.max(itemId + 1, idGenerator);
+    }
+
+    public void prepareForReplication() {
+        // Nullify backup, this is to rescue from the
+        // scenario, in which this partition successively
+        // changes ownership between primary and backup.
+        if (!getItemQueue().isEmpty() && MapUtil.isNullOrEmpty(backupMap)) {
+            backupMap = null;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -210,7 +210,6 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
             QueueContainer container = entry.getValue();
 
             if (partitionId == event.getPartitionId() && container.getConfig().getTotalBackupCount() >= event.getReplicaIndex()) {
-                container.prepareForReplication();
                 migrationData.put(name, container);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -210,6 +210,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
             QueueContainer container = entry.getValue();
 
             if (partitionId == event.getPartitionId() && container.getConfig().getTotalBackupCount() >= event.getReplicaIndex()) {
+                container.prepareForReplication();
                 migrationData.put(name, container);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -648,6 +648,37 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
         thread.assertFailsEventually(InterruptedException.class);
     }
 
+    @Test
+    public void test_continues_ownership_changes_does_not_leak_backup_memory() throws InterruptedException {
+        Config config = getConfig();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        // ownership changes happen on stable
+        // instance and it shouldn't leak memory
+        HazelcastInstance stableInstance = factory.newHazelcastInstance(config);
+
+        String queueName = "itemQueue";
+        IQueue<String> producer = stableInstance.getQueue(queueName);
+
+        // initial offer
+        producer.offer("item");
+        for (int j = 0; j < 5; j++) {
+            // start unreliable instance
+            HazelcastInstance unreliableInstance = factory.newHazelcastInstance(config);
+
+            // consume data in queue
+            IQueue<String> consumer = unreliableInstance.getQueue(queueName);
+            consumer.take();
+
+            // intentional termination, we are not testing graceful shutdown.
+            unreliableInstance.getLifecycleService().terminate();
+
+            producer.offer("item");
+
+            assertEquals("Failed at step :" + j
+                    + " (0 is first step)", 1, producer.size());
+        }
+    }
+
     private HazelcastInstance[] createHazelcastInstances() {
         String configName = randomString();
         Config config = getConfig();


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/18057

__Fixes:__
- Continues ownership changes was triggering backup memory leak
- And causing duplicate processing of items

