### PR TITLE
Add metrics binary generator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -127,8 +127,8 @@ public class MetricsCompressor {
 
     // temporary buffer to avoid DeflaterOutputStream's extra byte[] allocations
     // when writing primitive fields
-    private DataOutputStream tmpDos;
-    private MorePublicByteArrayOutputStream tmpBaos = new MorePublicByteArrayOutputStream(INITIAL_BUFFER_SIZE_DESCRIPTION);
+    private final DataOutputStream tmpDos;
+    private final MorePublicByteArrayOutputStream tmpBaos = new MorePublicByteArrayOutputStream(INITIAL_BUFFER_SIZE_DESCRIPTION);
 
     private int count;
     private MetricDescriptor lastDescriptor;
@@ -303,7 +303,6 @@ public class MetricsCompressor {
     public int count() {
         return count;
     }
-
 
     private void reset(int estimatedBytesDictionary, int estimatedBytesMetrics) {
         dictionaryCompressor = new Deflater();

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompatibilityFileGenerator.java
@@ -74,7 +74,7 @@ final class MetricsCompatibilityFileGenerator {
                                   .collect(Collectors.joining());
         MetricDescriptor metric3 = supplier.get()
                                            .withPrefix(longPrefix)
-                                           .withMetric("differentMetric")
+                                           .withMetric("longPrefixMetric")
                                            .withUnit(BYTES);
         compressor.addLong(metric3, Integer.MAX_VALUE);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompatibilityFileGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.MetricDescriptor;
+
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
+import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
+
+/**
+ * This class is used for generating the binary file to be used in non-Java clients
+ * to validate metrics binary format compatibility.
+ *
+ * Run this class once. Then move the created file to resources directory.
+ *
+ * mv *binary src/test/resources/
+ */
+final class MetricsCompatibilityFileGenerator {
+
+    private MetricsCompatibilityFileGenerator() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        OutputStream out = new FileOutputStream(createFileName());
+        DataOutputStream outputStream = new DataOutputStream(out);
+        byte[] blob = generateBlob();
+        outputStream.write(blob);
+        outputStream.close();
+    }
+
+    private static String createFileName() {
+        return "metrics.compatibility.binary";
+    }
+
+    private static byte[] generateBlob() {
+        DefaultMetricDescriptorSupplier supplier = new DefaultMetricDescriptorSupplier();
+        MetricsCompressor compressor = new MetricsCompressor();
+
+        MetricDescriptor metric1 = supplier.get()
+                                           .withPrefix("prefix")
+                                           .withMetric("deltaMetric1")
+                                           .withDiscriminator("ds", "dsName1")
+                                           .withUnit(COUNT);
+        compressor.addLong(metric1, 42);
+
+        MetricDescriptor metric2 = metric1.copy()
+                                          .withMetric("deltaMetric2");
+        compressor.addDouble(metric2, -4.2);
+
+        MetricDescriptor metric3 = supplier.get()
+                                           .withMetric("differentMetric1")
+                                           .withUnit(BYTES);
+        compressor.addLong(metric3, Integer.MAX_VALUE);
+
+        return compressor.getBlobAndReset();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsCompatibilityFileGenerator.java
@@ -22,6 +22,8 @@ import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
@@ -66,8 +68,13 @@ final class MetricsCompatibilityFileGenerator {
                                           .withMetric("deltaMetric2");
         compressor.addDouble(metric2, -4.2);
 
+        // use a 254 byte string to test long words in the dictionary
+        String longPrefix = Stream.generate(() -> "a")
+                                  .limit(MetricsDictionary.MAX_WORD_LENGTH - 1)
+                                  .collect(Collectors.joining());
         MetricDescriptor metric3 = supplier.get()
-                                           .withMetric("differentMetric1")
+                                           .withPrefix(longPrefix)
+                                           .withMetric("differentMetric")
                                            .withUnit(BYTES);
         compressor.addLong(metric3, Integer.MAX_VALUE);
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityFileGenerator.java
@@ -37,7 +37,7 @@ import java.nio.ByteOrder;
  *
  * mv *binary src/test/resources/
  */
-public final class BinaryCompatibilityFileGenerator {
+final class BinaryCompatibilityFileGenerator {
 
     // DON'T FORGET TO CHANGE VERSION ACCORDINGLY
     public static final byte VERSION = 1;
@@ -55,7 +55,6 @@ public final class BinaryCompatibilityFileGenerator {
         for (Object object : objects) {
             for (ByteOrder byteOrder : byteOrders) {
                 generateBinaryFile(outputStream, object, byteOrder);
-
             }
         }
         outputStream.close();
@@ -97,7 +96,8 @@ public final class BinaryCompatibilityFileGenerator {
                 .build();
     }
 
-    public static void generateBinaryFile(DataOutputStream outputStream, Object object, ByteOrder byteOrder) throws IOException {
+    private static void generateBinaryFile(DataOutputStream outputStream,
+                                           Object object, ByteOrder byteOrder) throws IOException {
         SerializationService serializationService = createSerializationService(byteOrder);
         Data data = serializationService.toData(object);
         outputStream.writeUTF(createObjectKey(object, byteOrder));


### PR DESCRIPTION
* Adds metrics binary generator to be used for testing of non-Java clients
* Also includes minor code style improvements

Corresponding Node.js client PR: https://github.com/hazelcast/hazelcast-nodejs-client/pull/751