### PR TITLE
Handle error on query for HD path correctly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -263,7 +263,7 @@ public class QueryOperation extends AbstractNamedOperation implements ReadonlyOp
                 Result result
                         = queryRunner.runPartitionIndexOrPartitionScanQueryOnGivenOwnedPartition(query, partitionId);
                 future.addResult(partitionId, result);
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 future.completeExceptionally(ex);
             }
         }
@@ -285,7 +285,7 @@ public class QueryOperation extends AbstractNamedOperation implements ReadonlyOp
                     Result combinedResult = queryRunner.populateEmptyResult(query, Collections.emptyList());
                     populateResult(response, combinedResult);
                     QueryOperation.this.sendResponse(combinedResult);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     QueryOperation.this.sendResponse(e);
                     throw rethrow(e);
                 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ErrorThrowingPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ErrorThrowingPredicate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.query.Predicate;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class ErrorThrowingPredicate implements Predicate, Serializable {
+    @Override
+    public boolean apply(Map.Entry mapEntry) {
+        throw new NoClassDefFoundError();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -20,7 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapStoreAdapter;
 import com.hazelcast.map.listener.EntryExpiredListener;
@@ -37,8 +39,10 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -58,6 +62,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class QueryAdvancedTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     @Override
     protected Config getConfig() {
@@ -114,7 +121,7 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
 
         String mapName = "default";
         config.getMapConfig(mapName)
-                .setTimeToLiveSeconds(3);
+              .setTimeToLiveSeconds(3);
 
         HazelcastInstance instance = createHazelcastInstance(config);
 
@@ -520,8 +527,8 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
         Config config = getConfig();
         config.getSerializationConfig().addPortableFactory(666, classId -> new PortableEmployee());
         config.getMapConfig(mapName)
-                .addIndexConfig(new IndexConfig(IndexType.HASH, "notExist"))
-                .addIndexConfig(new IndexConfig(IndexType.HASH, "n"));
+              .addIndexConfig(new IndexConfig(IndexType.HASH, "notExist"))
+              .addIndexConfig(new IndexConfig(IndexType.HASH, "n"));
 
         HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
 
@@ -532,5 +539,21 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
 
         Collection values = map.values(Predicates.sql("n = name_2 OR notExist = name_0"));
         assertEquals(1, values.size());
+    }
+
+    @Test
+    public void testClassNotFoundErrorDelegatedToCallerOnQuery() {
+        Config config = getConfig();
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        IMap<Integer, Integer> map = hazelcastInstance.getMap("map");
+
+        map.put(1, 1);
+        //A remote predicate can throw Error in case of Usercodeployment and missing sub classes
+        //See the issue for actual problem https://github.com/hazelcast/hazelcast/issues/18052
+        //We are throwing error to see if the error is delegated to the caller
+        expected.expect(HazelcastException.class);
+        expected.expectCause(new RootCauseMatcher(NoClassDefFoundError.class));
+        map.values(new ErrorThrowingPredicate());
     }
 }


### PR DESCRIPTION
HDQuery was not handling thrown Errors correctly.
The Error is not catched and therefore not delegated back to the
caller. A caller in that case hangs indefinetely.

forward port of https://github.com/hazelcast/hazelcast-enterprise/pull/3908 and https://github.com/hazelcast/hazelcast/pull/18082

fixes https://github.com/hazelcast/hazelcast/issues/18052