### PR TITLE
Adding test for handling error on query

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ErrorThrowingPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ErrorThrowingPredicate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.query.Predicate;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class ErrorThrowingPredicate implements Predicate, Serializable {
+    @Override
+    public boolean apply(Map.Entry mapEntry) {
+        throw new NoClassDefFoundError();
+    }
+}


### PR DESCRIPTION
HDQuery was not handling thrown Errors correctly.
The Error is not caught and therefore not delegated back to the
caller. A caller in that case hangs indefinitely.

related to https://github.com/hazelcast/hazelcast/issues/18052