### PR TITLE
[IMDG-136] GenericRecord and Serialization API Improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractGenericRecord.java
@@ -87,35 +87,35 @@ public abstract class AbstractGenericRecord implements GenericRecord {
     private static int arrayHashCode(GenericRecord record, String path, FieldType type) {
         switch (type) {
             case BYTE_ARRAY:
-                return Arrays.hashCode(record.readByteArray(path));
+                return Arrays.hashCode(record.getByteArray(path));
             case SHORT_ARRAY:
-                return Arrays.hashCode(record.readShortArray(path));
+                return Arrays.hashCode(record.getShortArray(path));
             case INT_ARRAY:
-                return Arrays.hashCode(record.readIntArray(path));
+                return Arrays.hashCode(record.getIntArray(path));
             case LONG_ARRAY:
-                return Arrays.hashCode(record.readLongArray(path));
+                return Arrays.hashCode(record.getLongArray(path));
             case FLOAT_ARRAY:
-                return Arrays.hashCode(record.readFloatArray(path));
+                return Arrays.hashCode(record.getFloatArray(path));
             case DOUBLE_ARRAY:
-                return Arrays.hashCode(record.readDoubleArray(path));
+                return Arrays.hashCode(record.getDoubleArray(path));
             case BOOLEAN_ARRAY:
-                return Arrays.hashCode(record.readBooleanArray(path));
+                return Arrays.hashCode(record.getBooleanArray(path));
             case CHAR_ARRAY:
-                return Arrays.hashCode(record.readCharArray(path));
+                return Arrays.hashCode(record.getCharArray(path));
             case UTF_ARRAY:
-                return Arrays.hashCode(record.readUTFArray(path));
+                return Arrays.hashCode(record.getStringArray(path));
             case PORTABLE_ARRAY:
-                return Arrays.hashCode(record.readGenericRecordArray(path));
+                return Arrays.hashCode(record.getGenericRecordArray(path));
             case DECIMAL_ARRAY:
-                return Arrays.hashCode(record.readDecimalArray(path));
+                return Arrays.hashCode(record.getDecimalArray(path));
             case TIME_ARRAY:
-                return Arrays.hashCode(record.readTimeArray(path));
+                return Arrays.hashCode(record.getTimeArray(path));
             case DATE_ARRAY:
-                return Arrays.hashCode(record.readDateArray(path));
+                return Arrays.hashCode(record.getDateArray(path));
             case TIMESTAMP_ARRAY:
-                return Arrays.hashCode(record.readTimestampArray(path));
+                return Arrays.hashCode(record.getTimestampArray(path));
             case TIMESTAMP_WITH_TIMEZONE_ARRAY:
-                return Arrays.hashCode(record.readTimestampWithTimezoneArray(path));
+                return Arrays.hashCode(record.getTimestampWithTimezoneArray(path));
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }
@@ -125,65 +125,65 @@ public abstract class AbstractGenericRecord implements GenericRecord {
     private static Object readAny(GenericRecord record, String path, FieldType type) {
         switch (type) {
             case BYTE:
-                return record.readByte(path);
+                return record.getByte(path);
             case BYTE_ARRAY:
-                return record.readByteArray(path);
+                return record.getByteArray(path);
             case SHORT:
-                return record.readShort(path);
+                return record.getShort(path);
             case SHORT_ARRAY:
-                return record.readShortArray(path);
+                return record.getShortArray(path);
             case INT:
-                return record.readInt(path);
+                return record.getInt(path);
             case INT_ARRAY:
-                return record.readIntArray(path);
+                return record.getIntArray(path);
             case LONG:
-                return record.readLong(path);
+                return record.getLong(path);
             case LONG_ARRAY:
-                return record.readLongArray(path);
+                return record.getLongArray(path);
             case FLOAT:
-                return record.readFloat(path);
+                return record.getFloat(path);
             case FLOAT_ARRAY:
-                return record.readFloatArray(path);
+                return record.getFloatArray(path);
             case DOUBLE:
-                return record.readDouble(path);
+                return record.getDouble(path);
             case DOUBLE_ARRAY:
-                return record.readDoubleArray(path);
+                return record.getDoubleArray(path);
             case BOOLEAN:
-                return record.readBoolean(path);
+                return record.getBoolean(path);
             case BOOLEAN_ARRAY:
-                return record.readBooleanArray(path);
+                return record.getBooleanArray(path);
             case CHAR:
-                return record.readChar(path);
+                return record.getChar(path);
             case CHAR_ARRAY:
-                return record.readCharArray(path);
+                return record.getCharArray(path);
             case UTF:
-                return record.readUTF(path);
+                return record.getString(path);
             case UTF_ARRAY:
-                return record.readUTFArray(path);
+                return record.getStringArray(path);
             case PORTABLE:
-                return record.readGenericRecord(path);
+                return record.getGenericRecord(path);
             case PORTABLE_ARRAY:
-                return record.readGenericRecordArray(path);
+                return record.getGenericRecordArray(path);
             case DECIMAL:
-                return record.readDecimal(path);
+                return record.getDecimal(path);
             case DECIMAL_ARRAY:
-                return record.readDecimalArray(path);
+                return record.getDecimalArray(path);
             case TIME:
-                return record.readTime(path);
+                return record.getTime(path);
             case TIME_ARRAY:
-                return record.readTimeArray(path);
+                return record.getTimeArray(path);
             case DATE:
-                return record.readDate(path);
+                return record.getDate(path);
             case DATE_ARRAY:
-                return record.readDateArray(path);
+                return record.getDateArray(path);
             case TIMESTAMP:
-                return record.readTimestamp(path);
+                return record.getTimestamp(path);
             case TIMESTAMP_ARRAY:
-                return record.readTimestampArray(path);
+                return record.getTimestampArray(path);
             case TIMESTAMP_WITH_TIMEZONE:
-                return record.readTimestampWithTimezone(path);
+                return record.getTimestampWithTimezone(path);
             case TIMESTAMP_WITH_TIMEZONE_ARRAY:
-                return record.readTimestampWithTimezoneArray(path);
+                return record.getTimestampWithTimezoneArray(path);
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.collection.ArrayUtils;
 
+import javax.annotation.Nullable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -495,6 +496,11 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
 
     @Override
     public String[] readUTFArray() throws IOException {
+        return readStringArray();
+    }
+
+    @Override
+    public String[] readStringArray() throws IOException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
             return null;
@@ -552,6 +558,12 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
      */
     @Override
     public final String readUTF() throws IOException {
+        return readString();
+    }
+
+    @Nullable
+    @Override
+    public String readString() throws IOException {
         int numberOfBytes = readInt();
         if (numberOfBytes == NULL_ARRAY_LENGTH) {
             return null;
@@ -568,8 +580,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
-    public <T> T readObject(Class aClass)
-            throws IOException {
+    public <T> T readObject(Class aClass) throws IOException {
         return service.readObject(this, aClass);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -369,6 +369,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public byte[] readByteArray() throws IOException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -383,6 +384,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public boolean[] readBooleanArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -399,6 +401,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public char[] readCharArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -415,6 +418,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public int[] readIntArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -431,6 +435,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public long[] readLongArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -447,6 +452,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public double[] readDoubleArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -463,6 +469,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public float[] readFloatArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -479,6 +486,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public short[] readShortArray() throws EOFException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -495,11 +503,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public String[] readUTFArray() throws IOException {
         return readStringArray();
     }
 
     @Override
+    @Nullable
     public String[] readStringArray() throws IOException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
@@ -575,16 +585,19 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public final Object readObject() throws EOFException {
         return service.readObject(this);
     }
 
     @Override
+    @Nullable
     public <T> T readObject(Class aClass) throws IOException {
         return service.readObject(this, aClass);
     }
 
     @Override
+    @Nullable
     public <T> T readDataAsObject() throws IOException {
         // a future optimization would be to skip the construction of the Data object
         Data data = readData();
@@ -592,6 +605,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     @Override
+    @Nullable
     public final Data readData() throws IOException {
         byte[] bytes = readByteArray();
         return bytes == null ? null : new HeapData(bytes);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -504,6 +504,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
 
     @Override
     @Nullable
+    @Deprecated
     public String[] readUTFArray() throws IOException {
         return readStringArray();
     }
@@ -567,6 +568,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
      * @see java.io.DataInputStream#readUTF(java.io.DataInput)
      */
     @Override
+    @Deprecated
     public final String readUTF() throws IOException {
         return readString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -16,13 +16,14 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.collection.ArrayUtils;
-import com.hazelcast.internal.serialization.Data;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -252,6 +253,11 @@ public class ByteArrayObjectDataOutput extends VersionedObjectDataOutput impleme
 
     @Override
     public void writeUTF(final String str) throws IOException {
+        writeString(str);
+    }
+
+    @Override
+    public void writeString(@Nullable String str) throws IOException {
         if (str == null) {
             writeInt(NULL_ARRAY_LENGTH);
             return;
@@ -351,6 +357,11 @@ public class ByteArrayObjectDataOutput extends VersionedObjectDataOutput impleme
 
     @Override
     public void writeUTFArray(String[] strings) throws IOException {
+       writeStringArray(strings);
+    }
+
+    @Override
+    public void writeStringArray(@Nullable String[] strings) throws IOException {
         int len = strings != null ? strings.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -252,6 +252,7 @@ public class ByteArrayObjectDataOutput extends VersionedObjectDataOutput impleme
     }
 
     @Override
+    @Deprecated
     public void writeUTF(final String str) throws IOException {
         writeString(str);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -357,6 +357,7 @@ public class ByteArrayObjectDataOutput extends VersionedObjectDataOutput impleme
     }
 
     @Override
+    @Deprecated
     public void writeUTFArray(String[] strings) throws IOException {
        writeStringArray(strings);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/GenericRecordQueryReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/GenericRecordQueryReader.java
@@ -129,7 +129,7 @@ public final class GenericRecordQueryReader implements ValueReader {
                         multiResult.setNullOrEmptyTarget(true);
                         continue;
                     }
-                    InternalGenericRecord subGenericRecord = (InternalGenericRecord) record.readGenericRecord(fieldName);
+                    InternalGenericRecord subGenericRecord = (InternalGenericRecord) record.getGenericRecord(fieldName);
                     if (subGenericRecord == null) {
                         iterator.remove();
                         multiResult.setNullOrEmptyTarget(true);
@@ -146,7 +146,7 @@ public final class GenericRecordQueryReader implements ValueReader {
                         multiResult.setNullOrEmptyTarget(true);
                         continue;
                     }
-                    GenericRecord[] genericRecords = record.readGenericRecordArray(fieldName);
+                    GenericRecord[] genericRecords = record.getGenericRecordArray(fieldName);
                     if (genericRecords == null || genericRecords.length == 0) {
                         multiResult.setNullOrEmptyTarget(true);
                         continue;
@@ -285,65 +285,65 @@ public final class GenericRecordQueryReader implements ValueReader {
         FieldType type = record.getFieldType(path);
         switch (type) {
             case BYTE:
-                return record.readByte(path);
+                return record.getByte(path);
             case BYTE_ARRAY:
-                return record.readByteArray(path);
+                return record.getByteArray(path);
             case SHORT:
-                return record.readShort(path);
+                return record.getShort(path);
             case SHORT_ARRAY:
-                return record.readShortArray(path);
+                return record.getShortArray(path);
             case INT:
-                return record.readInt(path);
+                return record.getInt(path);
             case INT_ARRAY:
-                return record.readIntArray(path);
+                return record.getIntArray(path);
             case LONG:
-                return record.readLong(path);
+                return record.getLong(path);
             case LONG_ARRAY:
-                return record.readLongArray(path);
+                return record.getLongArray(path);
             case FLOAT:
-                return record.readFloat(path);
+                return record.getFloat(path);
             case FLOAT_ARRAY:
-                return record.readFloatArray(path);
+                return record.getFloatArray(path);
             case DOUBLE:
-                return record.readDouble(path);
+                return record.getDouble(path);
             case DOUBLE_ARRAY:
-                return record.readDoubleArray(path);
+                return record.getDoubleArray(path);
             case BOOLEAN:
-                return record.readBoolean(path);
+                return record.getBoolean(path);
             case BOOLEAN_ARRAY:
-                return record.readBooleanArray(path);
+                return record.getBooleanArray(path);
             case CHAR:
-                return record.readChar(path);
+                return record.getChar(path);
             case CHAR_ARRAY:
-                return record.readCharArray(path);
+                return record.getCharArray(path);
             case UTF:
-                return record.readUTF(path);
+                return record.getString(path);
             case UTF_ARRAY:
-                return record.readUTFArray(path);
+                return record.getStringArray(path);
             case PORTABLE:
                 return record.readObject(path);
             case PORTABLE_ARRAY:
                 return record.readObjectArray(path);
             case DECIMAL:
-                return record.readDecimal(path);
+                return record.getDecimal(path);
             case DECIMAL_ARRAY:
-                return record.readDecimalArray(path);
+                return record.getDecimalArray(path);
             case TIME:
-                return record.readTime(path);
+                return record.getTime(path);
             case TIME_ARRAY:
-                return record.readTimeArray(path);
+                return record.getTimeArray(path);
             case DATE:
-                return record.readDate(path);
+                return record.getDate(path);
             case DATE_ARRAY:
-                return record.readDateArray(path);
+                return record.getDateArray(path);
             case TIMESTAMP:
-                return record.readTimestamp(path);
+                return record.getTimestamp(path);
             case TIMESTAMP_ARRAY:
-                return record.readTimestampArray(path);
+                return record.getTimestampArray(path);
             case TIMESTAMP_WITH_TIMEZONE:
-                return record.readTimestampWithTimezone(path);
+                return record.getTimestampWithTimezone(path);
             case TIMESTAMP_WITH_TIMEZONE_ARRAY:
-                return record.readTimestampWithTimezoneArray(path);
+                return record.getTimestampWithTimezoneArray(path);
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/GenericRecordQueryReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/GenericRecordQueryReader.java
@@ -169,7 +169,7 @@ public final class GenericRecordQueryReader implements ValueReader {
                         multiResult.setNullOrEmptyTarget(true);
                         continue;
                     }
-                    GenericRecord genericRecord = record.readGenericRecordFromArray(fieldName, index);
+                    GenericRecord genericRecord = record.getGenericRecordFromArray(fieldName, index);
                     if (genericRecord != null) {
                         iterator.set(genericRecord);
                     } else {
@@ -244,35 +244,35 @@ public final class GenericRecordQueryReader implements ValueReader {
         FieldType type = record.getFieldType(path);
         switch (type) {
             case BYTE_ARRAY:
-                return record.readByteFromArray(path, index);
+                return record.getByteFromArray(path, index);
             case SHORT_ARRAY:
-                return record.readShortFromArray(path, index);
+                return record.getShortFromArray(path, index);
             case INT_ARRAY:
-                return record.readIntFromArray(path, index);
+                return record.getIntFromArray(path, index);
             case LONG_ARRAY:
-                return record.readLongFromArray(path, index);
+                return record.getLongFromArray(path, index);
             case FLOAT_ARRAY:
-                return record.readFloatFromArray(path, index);
+                return record.getFloatFromArray(path, index);
             case DOUBLE_ARRAY:
-                return record.readDoubleFromArray(path, index);
+                return record.getDoubleFromArray(path, index);
             case BOOLEAN_ARRAY:
-                return record.readBooleanFromArray(path, index);
+                return record.getBooleanFromArray(path, index);
             case CHAR_ARRAY:
-                return record.readCharFromArray(path, index);
+                return record.getCharFromArray(path, index);
             case UTF_ARRAY:
-                return record.readUTFFromArray(path, index);
+                return record.getStringFromArray(path, index);
             case PORTABLE_ARRAY:
-                return record.readObjectFromArray(path, index);
+                return record.getObjectFromArray(path, index);
             case DECIMAL_ARRAY:
-                return record.readDecimalFromArray(path, index);
+                return record.getDecimalFromArray(path, index);
             case TIME_ARRAY:
-                return record.readTimeFromArray(path, index);
+                return record.getTimeFromArray(path, index);
             case DATE_ARRAY:
-                return record.readDateFromArray(path, index);
+                return record.getDateFromArray(path, index);
             case TIMESTAMP_ARRAY:
-                return record.readTimestampFromArray(path, index);
+                return record.getTimestampFromArray(path, index);
             case TIMESTAMP_WITH_TIMEZONE_ARRAY:
-                return record.readTimestampWithTimezoneFromArray(path, index);
+                return record.getTimestampWithTimezoneFromArray(path, index);
             default:
                 throw new IllegalArgumentException("Unsupported type " + type);
         }
@@ -321,9 +321,9 @@ public final class GenericRecordQueryReader implements ValueReader {
             case UTF_ARRAY:
                 return record.getStringArray(path);
             case PORTABLE:
-                return record.readObject(path);
+                return record.getObject(path);
             case PORTABLE_ARRAY:
-                return record.readObjectArray(path);
+                return record.getObjectArray(path);
             case DECIMAL:
                 return record.getDecimal(path);
             case DECIMAL_ARRAY:

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
@@ -129,7 +129,7 @@ public interface InternalGenericRecord extends GenericRecord {
     GenericRecord readGenericRecordFromArray(@Nonnull String fieldName, int index);
 
     /**
-     * Reads same value {@link InternalGenericRecord#readGenericRecord(String)} }, but in deserialized form.
+     * Reads same value {@link InternalGenericRecord#getGenericRecord(String)} }, but in deserialized form.
      * This is used in query system when the object is leaf of the query.
      *
      * @param fieldName the name of the field
@@ -142,7 +142,7 @@ public interface InternalGenericRecord extends GenericRecord {
     Object readObjectFromArray(@Nonnull String fieldName, int index);
 
     /**
-     * Reads same value {@link GenericRecord#readGenericRecordArray(String)}, but in deserialized form.
+     * Reads same value {@link GenericRecord#getGenericRecordArray(String)}, but in deserialized form.
      * This is used in query system when the object is leaf of the query.
      *
      * @param fieldName the name of the field
@@ -154,7 +154,7 @@ public interface InternalGenericRecord extends GenericRecord {
     Object[] readObjectArray(@Nonnull String fieldName);
 
     /**
-     * Reads same value {@link GenericRecord#readGenericRecord(String)} }, but in deserialized form.
+     * Reads same value {@link GenericRecord#getGenericRecord(String)} }, but in deserialized form.
      * This is used in query system when the object is leaf of the query.
      *
      * @param fieldName the name of the field

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
@@ -45,7 +45,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Boolean readBooleanFromArray(@Nonnull String fieldName, int index);
+    Boolean getBooleanFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -54,7 +54,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Byte readByteFromArray(@Nonnull String fieldName, int index);
+    Byte getByteFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -63,7 +63,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Character readCharFromArray(@Nonnull String fieldName, int index);
+    Character getCharFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -72,7 +72,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Double readDoubleFromArray(@Nonnull String fieldName, int index);
+    Double getDoubleFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -81,7 +81,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Float readFloatFromArray(@Nonnull String fieldName, int index);
+    Float getFloatFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -90,7 +90,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Integer readIntFromArray(@Nonnull String fieldName, int index);
+    Integer getIntFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -99,7 +99,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Long readLongFromArray(@Nonnull String fieldName, int index);
+    Long getLongFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -108,7 +108,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Short readShortFromArray(@Nonnull String fieldName, int index);
+    Short getShortFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -117,7 +117,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    String readUTFFromArray(@Nonnull String fieldName, int index);
+    String getStringFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -126,7 +126,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    GenericRecord readGenericRecordFromArray(@Nonnull String fieldName, int index);
+    GenericRecord getGenericRecordFromArray(@Nonnull String fieldName, int index);
 
     /**
      * Reads same value {@link InternalGenericRecord#getGenericRecord(String)} }, but in deserialized form.
@@ -139,7 +139,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Object readObjectFromArray(@Nonnull String fieldName, int index);
+    Object getObjectFromArray(@Nonnull String fieldName, int index);
 
     /**
      * Reads same value {@link GenericRecord#getGenericRecordArray(String)}, but in deserialized form.
@@ -151,7 +151,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Object[] readObjectArray(@Nonnull String fieldName);
+    Object[] getObjectArray(@Nonnull String fieldName);
 
     /**
      * Reads same value {@link GenericRecord#getGenericRecord(String)} }, but in deserialized form.
@@ -163,7 +163,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    Object readObject(@Nonnull String fieldName);
+    Object getObject(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -172,7 +172,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    BigDecimal readDecimalFromArray(@Nonnull String fieldName, int index);
+    BigDecimal getDecimalFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -181,7 +181,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    LocalTime readTimeFromArray(@Nonnull String fieldName, int index);
+    LocalTime getTimeFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -190,7 +190,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    LocalDate readDateFromArray(@Nonnull String fieldName, int index);
+    LocalDate getDateFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -199,7 +199,7 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    LocalDateTime readTimestampFromArray(@Nonnull String fieldName, int index);
+    LocalDateTime getTimestampFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field
@@ -208,5 +208,5 @@ public interface InternalGenericRecord extends GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    OffsetDateTime readTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index);
+    OffsetDateTime getTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -17,10 +17,11 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.nio.DataReader;
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -275,6 +276,11 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
 
     @Override
     public String[] readUTFArray() throws IOException {
+        return readStringArray();
+    }
+
+    @Override
+    public String[] readStringArray() throws IOException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {
             return null;
@@ -296,6 +302,12 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
 
     @Override
     public String readUTF() throws IOException {
+        return readString();
+    }
+
+    @Nullable
+    @Override
+    public String readString() throws IOException {
         int numberOfBytes = readInt();
         if (numberOfBytes == NULL_ARRAY_LENGTH) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -276,6 +276,7 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
 
     @Override
     @Nullable
+    @Deprecated
     public String[] readUTFArray() throws IOException {
         return readStringArray();
     }
@@ -303,6 +304,8 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
     }
 
     @Override
+    @Nullable
+    @Deprecated
     public String readUTF() throws IOException {
         return readString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -275,11 +275,13 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
     }
 
     @Override
+    @Nullable
     public String[] readUTFArray() throws IOException {
         return readStringArray();
     }
 
     @Override
+    @Nullable
     public String[] readStringArray() throws IOException {
         int len = readInt();
         if (len == NULL_ARRAY_LENGTH) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -223,7 +223,7 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
     }
 
     @Override
-    public void writeUTFArray(String[] strings) throws IOException {
+    public void writeUTFArray(@Nullable String[] strings) throws IOException {
         writeStringArray(strings);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -223,6 +223,7 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
     }
 
     @Override
+    @Deprecated
     public void writeUTFArray(@Nullable String[] strings) throws IOException {
         writeStringArray(strings);
     }
@@ -239,7 +240,8 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
     }
 
     @Override
-    public void writeUTF(String str) throws IOException {
+    @Deprecated
+    public void writeUTF(@Nullable String str) throws IOException {
         writeString(str);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -17,12 +17,13 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.nio.DataWriter;
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -223,6 +224,11 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
 
     @Override
     public void writeUTFArray(String[] strings) throws IOException {
+        writeStringArray(strings);
+    }
+
+    @Override
+    public void writeStringArray(@Nullable String[] strings) throws IOException {
         int len = strings != null ? strings.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
@@ -234,6 +240,11 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
 
     @Override
     public void writeUTF(String str) throws IOException {
+        writeString(str);
+    }
+
+    @Override
+    public void writeString(@Nullable String str) throws IOException {
         if (str == null) {
             writeInt(NULL_ARRAY_LENGTH);
             return;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/ConstantSerializers.java
@@ -33,7 +33,6 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.C
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_CHAR_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DOUBLE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DOUBLE_ARRAY;
-import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SIMPLE_ENTRY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_FLOAT;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_FLOAT_ARRAY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_INTEGER;
@@ -43,6 +42,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.C
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_NULL;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SHORT;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SHORT_ARRAY;
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SIMPLE_ENTRY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_SIMPLE_IMMUTABLE_ENTRY;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_STRING;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_STRING_ARRAY;
@@ -220,12 +220,12 @@ public final class ConstantSerializers {
 
         @Override
         public String read(final ObjectDataInput in) throws IOException {
-            return in.readUTF();
+            return in.readString();
         }
 
         @Override
         public void write(final ObjectDataOutput out, final String obj) throws IOException {
-            out.writeUTF(obj);
+            out.writeString(obj);
         }
     }
 
@@ -386,12 +386,12 @@ public final class ConstantSerializers {
 
         @Override
         public String[] read(final ObjectDataInput in) throws IOException {
-            return in.readUTFArray();
+            return in.readStringArray();
         }
 
         @Override
         public void write(final ObjectDataOutput out, final String[] obj) throws IOException {
-            out.writeUTFArray(obj);
+            out.writeStringArray(obj);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/ClassDefinitionWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/ClassDefinitionWriter.java
@@ -60,91 +60,91 @@ final class ClassDefinitionWriter implements PortableWriter {
 
     @Override
     public void writeUTF(@Nonnull String fieldName, @Nullable String str) {
+        writeString(fieldName, str);
+    }
+
+    @Override
+    public void writeString(@Nonnull String fieldName, @Nullable String value) {
         builder.addStringField(fieldName);
     }
 
     @Override
-    public void writeString(@Nonnull String fieldName, @Nullable String value) throws IOException {
-        builder.addStringField(fieldName);
-    }
-
-    @Override
-    public void writeBoolean(@Nonnull String fieldName, boolean value) throws IOException {
+    public void writeBoolean(@Nonnull String fieldName, boolean value) {
         builder.addBooleanField(fieldName);
     }
 
     @Override
-    public void writeByte(@Nonnull String fieldName, byte value) throws IOException {
+    public void writeByte(@Nonnull String fieldName, byte value) {
         builder.addByteField(fieldName);
     }
 
     @Override
-    public void writeChar(@Nonnull String fieldName, int value) throws IOException {
+    public void writeChar(@Nonnull String fieldName, int value) {
         builder.addCharField(fieldName);
     }
 
     @Override
-    public void writeDouble(@Nonnull String fieldName, double value) throws IOException {
+    public void writeDouble(@Nonnull String fieldName, double value) {
         builder.addDoubleField(fieldName);
     }
 
     @Override
-    public void writeFloat(@Nonnull String fieldName, float value) throws IOException {
+    public void writeFloat(@Nonnull String fieldName, float value) {
         builder.addFloatField(fieldName);
     }
 
     @Override
-    public void writeShort(@Nonnull String fieldName, short value) throws IOException {
+    public void writeShort(@Nonnull String fieldName, short value) {
         builder.addShortField(fieldName);
     }
 
     @Override
-    public void writeByteArray(@Nonnull String fieldName, byte[] bytes) throws IOException {
+    public void writeByteArray(@Nonnull String fieldName, byte[] bytes) {
         builder.addByteArrayField(fieldName);
     }
 
     @Override
-    public void writeBooleanArray(@Nonnull String fieldName, boolean[] booleans) throws IOException {
+    public void writeBooleanArray(@Nonnull String fieldName, boolean[] booleans) {
         builder.addBooleanArrayField(fieldName);
     }
 
     @Override
-    public void writeCharArray(@Nonnull String fieldName, char[] chars) throws IOException {
+    public void writeCharArray(@Nonnull String fieldName, char[] chars) {
         builder.addCharArrayField(fieldName);
     }
 
     @Override
-    public void writeIntArray(@Nonnull String fieldName, int[] ints) throws IOException {
+    public void writeIntArray(@Nonnull String fieldName, int[] ints) {
         builder.addIntArrayField(fieldName);
     }
 
     @Override
-    public void writeLongArray(@Nonnull String fieldName, long[] longs) throws IOException {
+    public void writeLongArray(@Nonnull String fieldName, long[] longs) {
         builder.addLongArrayField(fieldName);
     }
 
     @Override
-    public void writeDoubleArray(@Nonnull String fieldName, double[] values) throws IOException {
+    public void writeDoubleArray(@Nonnull String fieldName, double[] values) {
         builder.addDoubleArrayField(fieldName);
     }
 
     @Override
-    public void writeFloatArray(@Nonnull String fieldName, float[] values) throws IOException {
+    public void writeFloatArray(@Nonnull String fieldName, float[] values) {
         builder.addFloatArrayField(fieldName);
     }
 
     @Override
-    public void writeShortArray(@Nonnull String fieldName, short[] values) throws IOException {
+    public void writeShortArray(@Nonnull String fieldName, short[] values) {
         builder.addShortArrayField(fieldName);
     }
 
     @Override
-    public void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
-        builder.addStringArrayField(fieldName);
+    public void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) {
+        writeStringArray(fieldName, values);
     }
 
     @Override
-    public void writeStringArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
+    public void writeStringArray(@Nonnull String fieldName, @Nullable String[] values) {
         builder.addStringArrayField(fieldName);
     }
 
@@ -161,7 +161,7 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeNullPortable(@Nonnull String fieldName, int factoryId, int classId) throws IOException {
+    public void writeNullPortable(@Nonnull String fieldName, int factoryId, int classId) {
         final ClassDefinition nestedClassDef = context.lookupClassDefinition(factoryId, classId, context.getVersion());
         if (nestedClassDef == null) {
             throw new HazelcastSerializationException("Cannot write null portable without explicitly "
@@ -171,27 +171,27 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) throws IOException {
+    public void writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) {
         builder.addDecimalField(fieldName);
     }
 
     @Override
-    public void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) throws IOException {
+    public void writeTime(@Nonnull String fieldName, @Nullable LocalTime value) {
         builder.addTimeField(fieldName);
     }
 
     @Override
-    public void writeDate(@Nonnull String fieldName, @Nullable LocalDate value) throws IOException {
+    public void writeDate(@Nonnull String fieldName, @Nullable LocalDate value) {
         builder.addDateField(fieldName);
     }
 
     @Override
-    public void writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) throws IOException {
+    public void writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) {
         builder.addTimestampField(fieldName);
     }
 
     @Override
-    public void writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) throws IOException {
+    public void writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) {
         builder.addTimestampWithTimezoneField(fieldName);
     }
 
@@ -215,27 +215,27 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] values) throws IOException {
+    public void writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] values) {
         builder.addDecimalArrayField(fieldName);
     }
 
     @Override
-    public void writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] values) throws IOException {
+    public void writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] values) {
         builder.addTimeArrayField(fieldName);
     }
 
     @Override
-    public void writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] values) throws IOException {
+    public void writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] values) {
         builder.addDateArrayField(fieldName);
     }
 
     @Override
-    public void writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] values) throws IOException {
+    public void writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] values) {
         builder.addTimestampArrayField(fieldName);
     }
 
     @Override
-    public void writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] values) throws IOException {
+    public void writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] values) {
         builder.addTimestampWithTimezoneArrayField(fieldName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/ClassDefinitionWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/ClassDefinitionWriter.java
@@ -59,8 +59,13 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeUTF(@Nonnull String fieldName, String str) {
-        builder.addUTFField(fieldName);
+    public void writeUTF(@Nonnull String fieldName, @Nullable String str) {
+        builder.addStringField(fieldName);
+    }
+
+    @Override
+    public void writeString(@Nonnull String fieldName, @Nullable String value) throws IOException {
+        builder.addStringField(fieldName);
     }
 
     @Override
@@ -134,8 +139,13 @@ final class ClassDefinitionWriter implements PortableWriter {
     }
 
     @Override
-    public void writeUTFArray(@Nonnull String fieldName, String[] values) throws IOException {
-        builder.addUTFArrayField(fieldName);
+    public void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
+        builder.addStringArrayField(fieldName);
+    }
+
+    @Override
+    public void writeStringArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
+        builder.addStringArrayField(fieldName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -216,6 +216,12 @@ public class DefaultPortableReader implements PortableReader {
     @Override
     @Nullable
     public String readUTF(@Nonnull String fieldName) throws IOException {
+        return readString(fieldName);
+    }
+
+    @Nullable
+    @Override
+    public String readString(@Nonnull String fieldName) throws IOException {
         int currentPos = in.position();
         try {
             int pos = readPosition(fieldName, FieldType.UTF);
@@ -329,7 +335,13 @@ public class DefaultPortableReader implements PortableReader {
     @Override
     @Nullable
     public String[] readUTFArray(@Nonnull String fieldName) throws IOException {
-        return readPrimitiveArrayField(fieldName, FieldType.UTF_ARRAY, ObjectDataInput::readUTFArray);
+        return readStringArray(fieldName);
+    }
+
+    @Nullable
+    @Override
+    public String[] readStringArray(@Nonnull String fieldName) throws IOException {
+        return readPrimitiveArrayField(fieldName, FieldType.UTF_ARRAY, ObjectDataInput::readStringArray);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
@@ -285,7 +285,7 @@ public class DefaultPortableWriter implements PortableWriter {
     @Override
     public void writeStringArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
         setPosition(fieldName, FieldType.UTF_ARRAY);
-        out.writeUTFArray(values);
+        out.writeStringArray(values);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
@@ -88,8 +88,13 @@ public class DefaultPortableWriter implements PortableWriter {
 
     @Override
     public void writeUTF(@Nonnull String fieldName, String str) throws IOException {
+        writeString(fieldName, str);
+    }
+
+    @Override
+    public void writeString(@Nonnull String fieldName, @Nullable String value) throws IOException {
         setPosition(fieldName, FieldType.UTF);
-        out.writeUTF(str);
+        out.writeUTF(value);
     }
 
     @Override
@@ -274,6 +279,11 @@ public class DefaultPortableWriter implements PortableWriter {
 
     @Override
     public void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
+        writeStringArray(fieldName, values);
+    }
+
+    @Override
+    public void writeStringArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException {
         setPosition(fieldName, FieldType.UTF_ARRAY);
         out.writeUTFArray(values);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/EmptyObjectDataOutput.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
@@ -95,6 +96,10 @@ final class EmptyObjectDataOutput extends VersionedObjectDataOutput
     }
 
     @Override
+    public void writeString(@Nullable String string) throws IOException {
+    }
+
+    @Override
     public void writeByteArray(byte[] value) throws IOException {
     }
 
@@ -128,6 +133,10 @@ final class EmptyObjectDataOutput extends VersionedObjectDataOutput
 
     @Override
     public void writeUTFArray(String[] values) throws IOException {
+    }
+
+    @Override
+    public void writeStringArray(@Nullable String[] values) throws IOException {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
@@ -119,7 +119,13 @@ public class MorphingPortableReader extends DefaultPortableReader {
     @Override
     @Nullable
     public String readUTF(@Nonnull String fieldName) throws IOException {
-        return readIncompatibleField(fieldName, UTF, super::readUTF);
+        return readIncompatibleField(fieldName, UTF, super::readString);
+    }
+
+    @Override
+    @Nullable
+    public String readString(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, UTF, super::readString);
     }
 
     @Override
@@ -298,6 +304,12 @@ public class MorphingPortableReader extends DefaultPortableReader {
     @Nullable
     public String[] readUTFArray(@Nonnull String fieldName) throws IOException {
         return readIncompatibleField(fieldName, UTF_ARRAY, super::readUTFArray);
+    }
+
+    @Override
+    @Nullable
+    public String[] readStringArray(@Nonnull String fieldName) throws IOException {
+        return readIncompatibleField(fieldName, UTF_ARRAY, super::readStringArray);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReader.java
@@ -119,7 +119,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     @Override
     @Nullable
     public String readUTF(@Nonnull String fieldName) throws IOException {
-        return readIncompatibleField(fieldName, UTF, super::readString);
+        return readString(fieldName);
     }
 
     @Override
@@ -303,7 +303,7 @@ public class MorphingPortableReader extends DefaultPortableReader {
     @Override
     @Nullable
     public String[] readUTFArray(@Nonnull String fieldName) throws IOException {
-        return readIncompatibleField(fieldName, UTF_ARRAY, super::readUTFArray);
+        return readStringArray(fieldName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -51,13 +52,13 @@ public class PortableGenericRecord extends AbstractGenericRecord {
 
     @Nonnull
     @Override
-    public Builder newBuilder() {
-        return Builder.portable(classDefinition);
+    public GenericRecordBuilder newBuilder() {
+        return GenericRecordBuilder.portable(classDefinition);
     }
 
     @Nonnull
     @Override
-    public Builder cloneWithBuilder() {
+    public GenericRecordBuilder cloneWithBuilder() {
         return new PortableGenericRecordBuilder(classDefinition, Arrays.copyOf(objects, objects.length));
     }
 
@@ -68,13 +69,13 @@ public class PortableGenericRecord extends AbstractGenericRecord {
     }
 
     @Override
-    public GenericRecord[] readGenericRecordArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.PORTABLE_ARRAY);
+    public GenericRecord[] getGenericRecordArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.PORTABLE_ARRAY);
     }
 
     @Override
-    public GenericRecord readGenericRecord(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.PORTABLE);
+    public GenericRecord getGenericRecord(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.PORTABLE);
     }
 
     @Override
@@ -89,166 +90,166 @@ public class PortableGenericRecord extends AbstractGenericRecord {
     }
 
     @Override
-    public boolean readBoolean(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.BOOLEAN);
+    public boolean getBoolean(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.BOOLEAN);
     }
 
     @Override
-    public byte readByte(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.BYTE);
+    public byte getByte(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.BYTE);
     }
 
     @Override
-    public char readChar(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.CHAR);
+    public char getChar(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.CHAR);
     }
 
     @Override
-    public double readDouble(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.DOUBLE);
+    public double getDouble(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.DOUBLE);
     }
 
     @Override
-    public float readFloat(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.FLOAT);
+    public float getFloat(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.FLOAT);
     }
 
     @Override
-    public int readInt(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.INT);
+    public int getInt(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.INT);
     }
 
     @Override
-    public long readLong(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.LONG);
+    public long getLong(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.LONG);
     }
 
     @Override
-    public short readShort(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.SHORT);
-    }
-
-    @Override
-    @Nullable
-    public String readUTF(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.UTF);
+    public short getShort(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.SHORT);
     }
 
     @Override
     @Nullable
-    public BigDecimal readDecimal(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.DECIMAL);
+    public String getString(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.UTF);
     }
 
     @Override
     @Nullable
-    public LocalTime readTime(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.TIME);
+    public BigDecimal getDecimal(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.DECIMAL);
     }
 
     @Override
     @Nullable
-    public LocalDate readDate(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.DATE);
+    public LocalTime getTime(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.TIME);
     }
 
     @Override
     @Nullable
-    public LocalDateTime readTimestamp(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.TIMESTAMP);
+    public LocalDate getDate(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.DATE);
     }
 
     @Override
     @Nullable
-    public OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
+    public LocalDateTime getTimestamp(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.TIMESTAMP);
     }
 
     @Override
     @Nullable
-    public boolean[] readBooleanArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.BOOLEAN_ARRAY);
+    public OffsetDateTime getTimestampWithTimezone(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
     }
 
     @Override
     @Nullable
-    public byte[] readByteArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.BYTE_ARRAY);
+    public boolean[] getBooleanArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.BOOLEAN_ARRAY);
     }
 
     @Override
     @Nullable
-    public char[] readCharArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.CHAR_ARRAY);
+    public byte[] getByteArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.BYTE_ARRAY);
     }
 
     @Override
     @Nullable
-    public double[] readDoubleArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.DOUBLE_ARRAY);
+    public char[] getCharArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.CHAR_ARRAY);
     }
 
     @Override
     @Nullable
-    public float[] readFloatArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.FLOAT_ARRAY);
+    public double[] getDoubleArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.DOUBLE_ARRAY);
     }
 
     @Override
     @Nullable
-    public int[] readIntArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.INT_ARRAY);
+    public float[] getFloatArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.FLOAT_ARRAY);
     }
 
     @Override
     @Nullable
-    public long[] readLongArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.LONG_ARRAY);
+    public int[] getIntArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.INT_ARRAY);
     }
 
     @Override
     @Nullable
-    public short[] readShortArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.SHORT_ARRAY);
+    public long[] getLongArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.LONG_ARRAY);
     }
 
     @Override
     @Nullable
-    public String[] readUTFArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.UTF_ARRAY);
+    public short[] getShortArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.SHORT_ARRAY);
     }
 
     @Override
     @Nullable
-    public BigDecimal[] readDecimalArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.DECIMAL_ARRAY);
+    public String[] getStringArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.UTF_ARRAY);
     }
 
     @Override
     @Nullable
-    public LocalTime[] readTimeArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.TIME_ARRAY);
+    public BigDecimal[] getDecimalArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.DECIMAL_ARRAY);
     }
 
     @Override
     @Nullable
-    public LocalDate[] readDateArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.DATE_ARRAY);
+    public LocalTime[] getTimeArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.TIME_ARRAY);
     }
 
     @Override
     @Nullable
-    public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.TIMESTAMP_ARRAY);
+    public LocalDate[] getDateArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.DATE_ARRAY);
     }
 
     @Override
     @Nullable
-    public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) {
-        return read(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
+    public LocalDateTime[] getTimestampArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.TIMESTAMP_ARRAY);
     }
 
-    private <T> T read(@Nonnull String fieldName, FieldType fieldType) {
+    @Override
+    @Nullable
+    public OffsetDateTime[] getTimestampWithTimezoneArray(@Nonnull String fieldName) {
+        return get(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
+    }
+
+    private <T> T get(@Nonnull String fieldName, FieldType fieldType) {
         FieldDefinition fd = check(fieldName, fieldType);
         return (T) objects[fd.getIndex()];
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 
 import javax.annotation.Nonnull;
@@ -30,39 +31,39 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
-public class PortableGenericRecordBuilder implements GenericRecord.Builder {
+public class PortableGenericRecordBuilder implements GenericRecordBuilder {
 
     private final ClassDefinition classDefinition;
     private final Object[] objects;
-    private final boolean[] isWritten;
+    private final boolean[] isSet;
     private final boolean isClone;
 
     public PortableGenericRecordBuilder(ClassDefinition classDefinition) {
         this.classDefinition = classDefinition;
         this.objects = new Object[classDefinition.getFieldCount()];
         this.isClone = false;
-        this.isWritten = new boolean[objects.length];
+        this.isSet = new boolean[objects.length];
     }
 
     PortableGenericRecordBuilder(ClassDefinition classDefinition, Object[] objects) {
         this.classDefinition = classDefinition;
         this.objects = objects;
         this.isClone = true;
-        this.isWritten = new boolean[objects.length];
+        this.isSet = new boolean[objects.length];
     }
 
     /**
      * @return newly created GenericRecord
      * @throws HazelcastSerializationException if a field is not written when building with builder from
-     *                                         {@link GenericRecord.Builder#portable(ClassDefinition)} and
+     *                                         {@link GenericRecordBuilder#portable(ClassDefinition)} and
      *                                         {@link GenericRecord#newBuilder()}
      */
     @Nonnull
     @Override
     public GenericRecord build() {
         if (!isClone) {
-            for (int i = 0; i < isWritten.length; i++) {
-                if (!isWritten[i]) {
+            for (int i = 0; i < isSet.length; i++) {
+                if (!isSet[i]) {
                     throw new HazelcastSerializationException("All fields must be written when building"
                             + " a GenericRecord for portable, unwritten field :" + classDefinition.getField(i));
                 }
@@ -71,191 +72,190 @@ public class PortableGenericRecordBuilder implements GenericRecord.Builder {
         return new PortableGenericRecord(classDefinition, objects);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeInt(@Nonnull String fieldName, int value) {
-        return write(fieldName, value, FieldType.INT);
+    @Override
+    public GenericRecordBuilder setInt(@Nonnull String fieldName, int value) {
+        return set(fieldName, value, FieldType.INT);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeLong(@Nonnull String fieldName, long value) {
-        return write(fieldName, value, FieldType.LONG);
+    @Override
+    public GenericRecordBuilder setLong(@Nonnull String fieldName, long value) {
+        return set(fieldName, value, FieldType.LONG);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeUTF(@Nonnull String fieldName, String value) {
-        return write(fieldName, value, FieldType.UTF);
+    @Override
+    public GenericRecordBuilder setString(@Nonnull String fieldName, String value) {
+        return set(fieldName, value, FieldType.UTF);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeBoolean(@Nonnull String fieldName, boolean value) {
-        return write(fieldName, value, FieldType.BOOLEAN);
+    @Override
+    public GenericRecordBuilder setBoolean(@Nonnull String fieldName, boolean value) {
+        return set(fieldName, value, FieldType.BOOLEAN);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeByte(@Nonnull String fieldName, byte value) {
-        return write(fieldName, value, FieldType.BYTE);
+    @Override
+    public GenericRecordBuilder setByte(@Nonnull String fieldName, byte value) {
+        return set(fieldName, value, FieldType.BYTE);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeChar(@Nonnull String fieldName, char value) {
-        return write(fieldName, value, FieldType.CHAR);
+    @Override
+    public GenericRecordBuilder setChar(@Nonnull String fieldName, char value) {
+        return set(fieldName, value, FieldType.CHAR);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeDouble(@Nonnull String fieldName, double value) {
-        return write(fieldName, value, FieldType.DOUBLE);
+    @Override
+    public GenericRecordBuilder setDouble(@Nonnull String fieldName, double value) {
+        return set(fieldName, value, FieldType.DOUBLE);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeFloat(@Nonnull String fieldName, float value) {
-        return write(fieldName, value, FieldType.FLOAT);
+    @Override
+    public GenericRecordBuilder setFloat(@Nonnull String fieldName, float value) {
+        return set(fieldName, value, FieldType.FLOAT);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeShort(@Nonnull String fieldName, short value) {
-        return write(fieldName, value, FieldType.SHORT);
+    @Override
+    public GenericRecordBuilder setShort(@Nonnull String fieldName, short value) {
+        return set(fieldName, value, FieldType.SHORT);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
-        return write(fieldName, value, FieldType.PORTABLE);
+    @Override
+    public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
+        return set(fieldName, value, FieldType.PORTABLE);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) {
-        return write(fieldName, value, FieldType.DECIMAL);
+    @Override
+    public GenericRecordBuilder setDecimal(@Nonnull String fieldName, @Nullable BigDecimal value) {
+        return set(fieldName, value, FieldType.DECIMAL);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value) {
-        return write(fieldName, value, FieldType.TIME);
+    @Override
+    public GenericRecordBuilder setTime(@Nonnull String fieldName, @Nullable LocalTime value) {
+        return set(fieldName, value, FieldType.TIME);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeDate(@Nonnull String fieldName, @Nullable LocalDate value) {
-        return write(fieldName, value, FieldType.DATE);
+    @Override
+    public GenericRecordBuilder setDate(@Nonnull String fieldName, @Nullable LocalDate value) {
+        return set(fieldName, value, FieldType.DATE);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) {
-        return write(fieldName, value, FieldType.TIMESTAMP);
+    @Override
+    public GenericRecordBuilder setTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value) {
+        return set(fieldName, value, FieldType.TIMESTAMP);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) {
-        return write(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE);
+    @Override
+    public GenericRecordBuilder setTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value) {
+        return set(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
-        return write(fieldName, value, FieldType.PORTABLE_ARRAY);
+    @Override
+    public GenericRecordBuilder setGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
+        return set(fieldName, value, FieldType.PORTABLE_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeByteArray(@Nonnull String fieldName, byte[] value) {
-        return write(fieldName, value, FieldType.BYTE_ARRAY);
+    @Override
+    public GenericRecordBuilder setByteArray(@Nonnull String fieldName, byte[] value) {
+        return set(fieldName, value, FieldType.BYTE_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeBooleanArray(@Nonnull String fieldName, boolean[] value) {
-        return write(fieldName, value, FieldType.BOOLEAN_ARRAY);
+    @Override
+    public GenericRecordBuilder setBooleanArray(@Nonnull String fieldName, boolean[] value) {
+        return set(fieldName, value, FieldType.BOOLEAN_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeCharArray(@Nonnull String fieldName, char[] value) {
-        return write(fieldName, value, FieldType.CHAR_ARRAY);
+    @Override
+    public GenericRecordBuilder setCharArray(@Nonnull String fieldName, char[] value) {
+        return set(fieldName, value, FieldType.CHAR_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeIntArray(@Nonnull String fieldName, int[] value) {
-        return write(fieldName, value, FieldType.INT_ARRAY);
+    @Override
+    public GenericRecordBuilder setIntArray(@Nonnull String fieldName, int[] value) {
+        return set(fieldName, value, FieldType.INT_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeLongArray(@Nonnull String fieldName, long[] value) {
-        return write(fieldName, value, FieldType.LONG_ARRAY);
+    @Override
+    public GenericRecordBuilder setLongArray(@Nonnull String fieldName, long[] value) {
+        return set(fieldName, value, FieldType.LONG_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeDoubleArray(@Nonnull String fieldName, double[] value) {
-        return write(fieldName, value, FieldType.DOUBLE_ARRAY);
+    @Override
+    public GenericRecordBuilder setDoubleArray(@Nonnull String fieldName, double[] value) {
+        return set(fieldName, value, FieldType.DOUBLE_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeFloatArray(@Nonnull String fieldName, float[] value) {
-        return write(fieldName, value, FieldType.FLOAT_ARRAY);
+    @Override
+    public GenericRecordBuilder setFloatArray(@Nonnull String fieldName, float[] value) {
+        return set(fieldName, value, FieldType.FLOAT_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeShortArray(@Nonnull String fieldName, short[] value) {
-        return write(fieldName, value, FieldType.SHORT_ARRAY);
+    @Override
+    public GenericRecordBuilder setShortArray(@Nonnull String fieldName, short[] value) {
+        return set(fieldName, value, FieldType.SHORT_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeUTFArray(@Nonnull String fieldName, String[] value) {
-        return write(fieldName, value, FieldType.UTF_ARRAY);
+    @Override
+    public GenericRecordBuilder setStringArray(@Nonnull String fieldName, String[] value) {
+        return set(fieldName, value, FieldType.UTF_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeDecimalArray(@Nonnull String fieldName, BigDecimal[] value) {
-        return write(fieldName, value, FieldType.DECIMAL_ARRAY);
+    @Override
+    public GenericRecordBuilder setDecimalArray(@Nonnull String fieldName, BigDecimal[] value) {
+        return set(fieldName, value, FieldType.DECIMAL_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeTimeArray(@Nonnull String fieldName, LocalTime[] value) {
-        return write(fieldName, value, FieldType.TIME_ARRAY);
+    @Override
+    public GenericRecordBuilder setTimeArray(@Nonnull String fieldName, LocalTime[] value) {
+        return set(fieldName, value, FieldType.TIME_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeDateArray(@Nonnull String fieldName, LocalDate[] value) {
-        return write(fieldName, value, FieldType.DATE_ARRAY);
+    @Override
+    public GenericRecordBuilder setDateArray(@Nonnull String fieldName, LocalDate[] value) {
+        return set(fieldName, value, FieldType.DATE_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeTimestampArray(@Nonnull String fieldName, LocalDateTime[] value) {
-        return write(fieldName, value, FieldType.TIMESTAMP_ARRAY);
+    @Override
+    public GenericRecordBuilder setTimestampArray(@Nonnull String fieldName, LocalDateTime[] value) {
+        return set(fieldName, value, FieldType.TIMESTAMP_ARRAY);
     }
 
-    @Override
     @Nonnull
-    public GenericRecord.Builder writeTimestampWithTimezoneArray(@Nonnull String fieldName, OffsetDateTime[] value) {
-        return write(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
+    @Override
+    public GenericRecordBuilder setTimestampWithTimezoneArray(@Nonnull String fieldName, OffsetDateTime[] value) {
+        return set(fieldName, value, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
     }
 
-
-    private GenericRecord.Builder write(@Nonnull String fieldName, Object value, FieldType fieldType) {
+    private GenericRecordBuilder set(@Nonnull String fieldName, Object value, FieldType fieldType) {
         FieldDefinition fd = check(fieldName, fieldType);
         int index = fd.getIndex();
-        if (isWritten[index]) {
+        if (isSet[index]) {
             if (!isClone) {
                 throw new HazelcastSerializationException("It is illegal to the overwrite the field");
             } else {
@@ -263,7 +263,7 @@ public class PortableGenericRecordBuilder implements GenericRecord.Builder {
             }
         }
         objects[index] = value;
-        isWritten[index] = true;
+        isSet[index] = true;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -110,7 +111,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public boolean readBoolean(@Nonnull String fieldName) {
+    public boolean getBoolean(@Nonnull String fieldName) {
         try {
             return in.readBoolean(readPosition(fieldName, FieldType.BOOLEAN));
         } catch (IOException e) {
@@ -119,7 +120,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public byte readByte(@Nonnull String fieldName) {
+    public byte getByte(@Nonnull String fieldName) {
         try {
             return in.readByte(readPosition(fieldName, FieldType.BYTE));
         } catch (IOException e) {
@@ -128,7 +129,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public char readChar(@Nonnull String fieldName) {
+    public char getChar(@Nonnull String fieldName) {
         try {
             return in.readChar(readPosition(fieldName, FieldType.CHAR));
         } catch (IOException e) {
@@ -137,7 +138,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public double readDouble(@Nonnull String fieldName) {
+    public double getDouble(@Nonnull String fieldName) {
         try {
             return in.readDouble(readPosition(fieldName, FieldType.DOUBLE));
         } catch (IOException e) {
@@ -146,7 +147,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public float readFloat(@Nonnull String fieldName) {
+    public float getFloat(@Nonnull String fieldName) {
         try {
             return in.readFloat(readPosition(fieldName, FieldType.FLOAT));
         } catch (IOException e) {
@@ -155,7 +156,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public int readInt(@Nonnull String fieldName) {
+    public int getInt(@Nonnull String fieldName) {
         try {
             return in.readInt(readPosition(fieldName, FieldType.INT));
         } catch (IOException e) {
@@ -164,7 +165,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public long readLong(@Nonnull String fieldName) {
+    public long getLong(@Nonnull String fieldName) {
         try {
             return in.readLong(readPosition(fieldName, FieldType.LONG));
         } catch (IOException e) {
@@ -173,7 +174,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public short readShort(@Nonnull String fieldName) {
+    public short getShort(@Nonnull String fieldName) {
         try {
             return in.readShort(readPosition(fieldName, FieldType.SHORT));
         } catch (IOException e) {
@@ -182,7 +183,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public String readUTF(@Nonnull String fieldName) {
+    public String getString(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int pos = readPosition(fieldName, FieldType.UTF);
@@ -219,27 +220,27 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public BigDecimal readDecimal(@Nonnull String fieldName) {
+    public BigDecimal getDecimal(@Nonnull String fieldName) {
         return readNullableField(fieldName, FieldType.DECIMAL, IOUtil::readBigDecimal);
     }
 
     @Override
-    public LocalTime readTime(@Nonnull String fieldName) {
+    public LocalTime getTime(@Nonnull String fieldName) {
         return readNullableField(fieldName, FieldType.TIME, IOUtil::readLocalTime);
     }
 
     @Override
-    public LocalDate readDate(@Nonnull String fieldName) {
+    public LocalDate getDate(@Nonnull String fieldName) {
         return readNullableField(fieldName, FieldType.DATE, IOUtil::readLocalDate);
     }
 
     @Override
-    public LocalDateTime readTimestamp(@Nonnull String fieldName) {
+    public LocalDateTime getTimestamp(@Nonnull String fieldName) {
         return readNullableField(fieldName, FieldType.TIMESTAMP, IOUtil::readLocalDateTime);
     }
 
     @Override
-    public OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName) {
+    public OffsetDateTime getTimestampWithTimezone(@Nonnull String fieldName) {
         return readNullableField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE, IOUtil::readOffsetDateTime);
     }
 
@@ -248,7 +249,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public boolean[] readBooleanArray(@Nonnull String fieldName) {
+    public boolean[] getBooleanArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.BOOLEAN_ARRAY);
@@ -265,7 +266,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public byte[] readByteArray(@Nonnull String fieldName) {
+    public byte[] getByteArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.BYTE_ARRAY);
@@ -283,7 +284,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public char[] readCharArray(@Nonnull String fieldName) {
+    public char[] getCharArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.CHAR_ARRAY);
@@ -300,7 +301,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public double[] readDoubleArray(@Nonnull String fieldName) {
+    public double[] getDoubleArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.DOUBLE_ARRAY);
@@ -317,7 +318,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public float[] readFloatArray(@Nonnull String fieldName) {
+    public float[] getFloatArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.FLOAT_ARRAY);
@@ -334,7 +335,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public int[] readIntArray(@Nonnull String fieldName) {
+    public int[] getIntArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.INT_ARRAY);
@@ -351,7 +352,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public long[] readLongArray(@Nonnull String fieldName) {
+    public long[] getLongArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.LONG_ARRAY);
@@ -368,7 +369,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public short[] readShortArray(@Nonnull String fieldName) {
+    public short[] getShortArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.SHORT_ARRAY);
@@ -385,7 +386,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public String[] readUTFArray(@Nonnull String fieldName) {
+    public String[] getStringArray(@Nonnull String fieldName) {
         int currentPos = in.position();
         try {
             int position = readPosition(fieldName, FieldType.UTF_ARRAY);
@@ -393,7 +394,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
                 return null;
             }
             in.position(position);
-            return in.readUTFArray();
+            return in.readStringArray();
         } catch (IOException e) {
             throw newIllegalStateException(e);
         } finally {
@@ -435,27 +436,27 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public BigDecimal[] readDecimalArray(@Nonnull String fieldName) {
+    public BigDecimal[] getDecimalArray(@Nonnull String fieldName) {
         return readObjectArrayField(fieldName, DECIMAL_ARRAY, BigDecimal[]::new, IOUtil::readBigDecimal);
     }
 
     @Override
-    public LocalTime[] readTimeArray(@Nonnull String fieldName) {
+    public LocalTime[] getTimeArray(@Nonnull String fieldName) {
         return readObjectArrayField(fieldName, TIME_ARRAY, LocalTime[]::new, IOUtil::readLocalTime);
     }
 
     @Override
-    public LocalDate[] readDateArray(@Nonnull String fieldName) {
+    public LocalDate[] getDateArray(@Nonnull String fieldName) {
         return readObjectArrayField(fieldName, DATE_ARRAY, LocalDate[]::new, IOUtil::readLocalDate);
     }
 
     @Override
-    public LocalDateTime[] readTimestampArray(@Nonnull String fieldName) {
+    public LocalDateTime[] getTimestampArray(@Nonnull String fieldName) {
         return readObjectArrayField(fieldName, TIMESTAMP_ARRAY, LocalDateTime[]::new, IOUtil::readLocalDateTime);
     }
 
     @Override
-    public OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName) {
+    public OffsetDateTime[] getTimestampWithTimezoneArray(@Nonnull String fieldName) {
         return readObjectArrayField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, OffsetDateTime[]::new, IOUtil::readOffsetDateTime);
     }
 
@@ -504,13 +505,13 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
 
     @Nonnull
     @Override
-    public Builder newBuilder() {
+    public GenericRecordBuilder newBuilder() {
         throw new UnsupportedOperationException();
     }
 
     @Nonnull
     @Override
-    public Builder cloneWithBuilder() {
+    public GenericRecordBuilder cloneWithBuilder() {
         throw new UnsupportedOperationException();
     }
 
@@ -521,7 +522,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public GenericRecord[] readGenericRecordArray(@Nonnull String fieldName) {
+    public GenericRecord[] getGenericRecordArray(@Nonnull String fieldName) {
         return readNestedArray(fieldName, GenericRecord[]::new, false);
     }
 
@@ -573,7 +574,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public GenericRecord readGenericRecord(@Nonnull String fieldName) {
+    public GenericRecord getGenericRecord(@Nonnull String fieldName) {
         return readNested(fieldName, false);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -624,7 +624,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Byte readByteFromArray(@Nonnull String fieldName, int index) {
+    public Byte getByteFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.BYTE_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -638,7 +638,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
 
     @SuppressFBWarnings({"NP_BOOLEAN_RETURN_NULL"})
     @Override
-    public Boolean readBooleanFromArray(@Nonnull String fieldName, int index) {
+    public Boolean getBooleanFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.BOOLEAN_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -651,7 +651,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Character readCharFromArray(@Nonnull String fieldName, int index) {
+    public Character getCharFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.CHAR_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -664,7 +664,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Double readDoubleFromArray(@Nonnull String fieldName, int index) {
+    public Double getDoubleFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.DOUBLE_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -677,7 +677,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Float readFloatFromArray(@Nonnull String fieldName, int index) {
+    public Float getFloatFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.FLOAT_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -690,7 +690,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Integer readIntFromArray(@Nonnull String fieldName, int index) {
+    public Integer getIntFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.INT_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -703,7 +703,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Long readLongFromArray(@Nonnull String fieldName, int index) {
+    public Long getLongFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.LONG_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -716,7 +716,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public Short readShortFromArray(@Nonnull String fieldName, int index) {
+    public Short getShortFromArray(@Nonnull String fieldName, int index) {
         int position = readPosition(fieldName, FieldType.SHORT_ARRAY);
         if (isNullOrEmpty(position) || doesNotHaveIndex(position, index)) {
             return null;
@@ -729,7 +729,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public String readUTFFromArray(@Nonnull String fieldName, int index) {
+    public String getStringFromArray(@Nonnull String fieldName, int index) {
         int currentPos = in.position();
         try {
             int pos = readPosition(fieldName, FieldType.UTF_ARRAY);
@@ -756,12 +756,12 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public GenericRecord readGenericRecordFromArray(@Nonnull String fieldName, int index) {
+    public GenericRecord getGenericRecordFromArray(@Nonnull String fieldName, int index) {
         return readNestedFromArray(fieldName, index, false);
     }
 
     @Override
-    public Object readObjectFromArray(@Nonnull String fieldName, int index) {
+    public Object getObjectFromArray(@Nonnull String fieldName, int index) {
         return readNestedFromArray(fieldName, index, true);
     }
 
@@ -832,37 +832,37 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
     }
 
     @Override
-    public BigDecimal readDecimalFromArray(@Nonnull String fieldName, int index) {
+    public BigDecimal getDecimalFromArray(@Nonnull String fieldName, int index) {
         return readObjectFromArrayField(fieldName, DECIMAL_ARRAY, IOUtil::readBigDecimal, index);
     }
 
     @Override
-    public LocalTime readTimeFromArray(@Nonnull String fieldName, int index) {
+    public LocalTime getTimeFromArray(@Nonnull String fieldName, int index) {
         return readObjectFromArrayField(fieldName, TIME_ARRAY, IOUtil::readLocalTime, index);
     }
 
     @Override
-    public LocalDate readDateFromArray(@Nonnull String fieldName, int index) {
+    public LocalDate getDateFromArray(@Nonnull String fieldName, int index) {
         return readObjectFromArrayField(fieldName, DATE_ARRAY, IOUtil::readLocalDate, index);
     }
 
     @Override
-    public LocalDateTime readTimestampFromArray(@Nonnull String fieldName, int index) {
+    public LocalDateTime getTimestampFromArray(@Nonnull String fieldName, int index) {
         return readObjectFromArrayField(fieldName, TIMESTAMP_ARRAY, IOUtil::readLocalDateTime, index);
     }
 
     @Override
-    public OffsetDateTime readTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
+    public OffsetDateTime getTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
         return readObjectFromArrayField(fieldName, TIMESTAMP_WITH_TIMEZONE_ARRAY, IOUtil::readOffsetDateTime, index);
     }
 
     @Override
-    public Object[] readObjectArray(@Nonnull String fieldName) {
+    public Object[] getObjectArray(@Nonnull String fieldName) {
         return readNestedArray(fieldName, Portable[]::new, true);
     }
 
     @Override
-    public Object readObject(@Nonnull String fieldName) {
+    public Object getObject(@Nonnull String fieldName) {
         return readNested(fieldName, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
@@ -217,94 +218,94 @@ public final class PortableSerializer implements StreamSerializer<Object> {
         for (String fieldName : fieldNames) {
             switch (cd.getFieldType(fieldName)) {
                 case PORTABLE:
-                    writer.writeGenericRecord(fieldName, record.readGenericRecord(fieldName));
+                    writer.writeGenericRecord(fieldName, record.getGenericRecord(fieldName));
                     break;
                 case BYTE:
-                    writer.writeByte(fieldName, record.readByte(fieldName));
+                    writer.writeByte(fieldName, record.getByte(fieldName));
                     break;
                 case BOOLEAN:
-                    writer.writeBoolean(fieldName, record.readBoolean(fieldName));
+                    writer.writeBoolean(fieldName, record.getBoolean(fieldName));
                     break;
                 case CHAR:
-                    writer.writeChar(fieldName, record.readChar(fieldName));
+                    writer.writeChar(fieldName, record.getChar(fieldName));
                     break;
                 case SHORT:
-                    writer.writeShort(fieldName, record.readShort(fieldName));
+                    writer.writeShort(fieldName, record.getShort(fieldName));
                     break;
                 case INT:
-                    writer.writeInt(fieldName, record.readInt(fieldName));
+                    writer.writeInt(fieldName, record.getInt(fieldName));
                     break;
                 case LONG:
-                    writer.writeLong(fieldName, record.readLong(fieldName));
+                    writer.writeLong(fieldName, record.getLong(fieldName));
                     break;
                 case FLOAT:
-                    writer.writeFloat(fieldName, record.readFloat(fieldName));
+                    writer.writeFloat(fieldName, record.getFloat(fieldName));
                     break;
                 case DOUBLE:
-                    writer.writeDouble(fieldName, record.readDouble(fieldName));
+                    writer.writeDouble(fieldName, record.getDouble(fieldName));
                     break;
                 case UTF:
-                    writer.writeUTF(fieldName, record.readUTF(fieldName));
+                    writer.writeUTF(fieldName, record.getString(fieldName));
                     break;
                 case DECIMAL:
-                    writer.writeDecimal(fieldName, record.readDecimal(fieldName));
+                    writer.writeDecimal(fieldName, record.getDecimal(fieldName));
                     break;
                 case TIME:
-                    writer.writeTime(fieldName, record.readTime(fieldName));
+                    writer.writeTime(fieldName, record.getTime(fieldName));
                     break;
                 case DATE:
-                    writer.writeDate(fieldName, record.readDate(fieldName));
+                    writer.writeDate(fieldName, record.getDate(fieldName));
                     break;
                 case TIMESTAMP:
-                    writer.writeTimestamp(fieldName, record.readTimestamp(fieldName));
+                    writer.writeTimestamp(fieldName, record.getTimestamp(fieldName));
                     break;
                 case TIMESTAMP_WITH_TIMEZONE:
-                    writer.writeTimestampWithTimezone(fieldName, record.readTimestampWithTimezone(fieldName));
+                    writer.writeTimestampWithTimezone(fieldName, record.getTimestampWithTimezone(fieldName));
                     break;
                 case PORTABLE_ARRAY:
-                    writer.writeGenericRecordArray(fieldName, record.readGenericRecordArray(fieldName));
+                    writer.writeGenericRecordArray(fieldName, record.getGenericRecordArray(fieldName));
                     break;
                 case BYTE_ARRAY:
-                    writer.writeByteArray(fieldName, record.readByteArray(fieldName));
+                    writer.writeByteArray(fieldName, record.getByteArray(fieldName));
                     break;
                 case BOOLEAN_ARRAY:
-                    writer.writeBooleanArray(fieldName, record.readBooleanArray(fieldName));
+                    writer.writeBooleanArray(fieldName, record.getBooleanArray(fieldName));
                     break;
                 case CHAR_ARRAY:
-                    writer.writeCharArray(fieldName, record.readCharArray(fieldName));
+                    writer.writeCharArray(fieldName, record.getCharArray(fieldName));
                     break;
                 case SHORT_ARRAY:
-                    writer.writeShortArray(fieldName, record.readShortArray(fieldName));
+                    writer.writeShortArray(fieldName, record.getShortArray(fieldName));
                     break;
                 case INT_ARRAY:
-                    writer.writeIntArray(fieldName, record.readIntArray(fieldName));
+                    writer.writeIntArray(fieldName, record.getIntArray(fieldName));
                     break;
                 case LONG_ARRAY:
-                    writer.writeLongArray(fieldName, record.readLongArray(fieldName));
+                    writer.writeLongArray(fieldName, record.getLongArray(fieldName));
                     break;
                 case FLOAT_ARRAY:
-                    writer.writeFloatArray(fieldName, record.readFloatArray(fieldName));
+                    writer.writeFloatArray(fieldName, record.getFloatArray(fieldName));
                     break;
                 case DOUBLE_ARRAY:
-                    writer.writeDoubleArray(fieldName, record.readDoubleArray(fieldName));
+                    writer.writeDoubleArray(fieldName, record.getDoubleArray(fieldName));
                     break;
                 case UTF_ARRAY:
-                    writer.writeUTFArray(fieldName, record.readUTFArray(fieldName));
+                    writer.writeUTFArray(fieldName, record.getStringArray(fieldName));
                     break;
                 case DECIMAL_ARRAY:
-                    writer.writeDecimalArray(fieldName, record.readDecimalArray(fieldName));
+                    writer.writeDecimalArray(fieldName, record.getDecimalArray(fieldName));
                     break;
                 case TIME_ARRAY:
-                    writer.writeTimeArray(fieldName, record.readTimeArray(fieldName));
+                    writer.writeTimeArray(fieldName, record.getTimeArray(fieldName));
                     break;
                 case DATE_ARRAY:
-                    writer.writeDateArray(fieldName, record.readDateArray(fieldName));
+                    writer.writeDateArray(fieldName, record.getDateArray(fieldName));
                     break;
                 case TIMESTAMP_ARRAY:
-                    writer.writeTimestampArray(fieldName, record.readTimestampArray(fieldName));
+                    writer.writeTimestampArray(fieldName, record.getTimestampArray(fieldName));
                     break;
                 case TIMESTAMP_WITH_TIMEZONE_ARRAY:
-                    writer.writeTimestampWithTimezoneArray(fieldName, record.readTimestampWithTimezoneArray(fieldName));
+                    writer.writeTimestampWithTimezoneArray(fieldName, record.getTimestampWithTimezoneArray(fieldName));
                     break;
                 default:
                     throw new IllegalStateException("Unexpected field type: " + cd.getFieldType(fieldName));
@@ -340,99 +341,99 @@ public final class PortableSerializer implements StreamSerializer<Object> {
         int version = in.readInt();
         ClassDefinition cd = setupPositionAndDefinition(in, factoryId, classId, version);
         PortableInternalGenericRecord reader = new PortableInternalGenericRecord(this, in, cd, false);
-        GenericRecord.Builder genericRecordBuilder = GenericRecord.Builder.portable(cd);
+        GenericRecordBuilder genericRecordBuilder = GenericRecordBuilder.portable(cd);
         for (String fieldName : cd.getFieldNames()) {
             switch (cd.getFieldType(fieldName)) {
                 case PORTABLE:
-                    genericRecordBuilder.writeGenericRecord(fieldName, reader.readGenericRecord(fieldName));
+                    genericRecordBuilder.setGenericRecord(fieldName, reader.getGenericRecord(fieldName));
                     break;
                 case BYTE:
-                    genericRecordBuilder.writeByte(fieldName, reader.readByte(fieldName));
+                    genericRecordBuilder.setByte(fieldName, reader.getByte(fieldName));
                     break;
                 case BOOLEAN:
-                    genericRecordBuilder.writeBoolean(fieldName, reader.readBoolean(fieldName));
+                    genericRecordBuilder.setBoolean(fieldName, reader.getBoolean(fieldName));
                     break;
                 case CHAR:
-                    genericRecordBuilder.writeChar(fieldName, reader.readChar(fieldName));
+                    genericRecordBuilder.setChar(fieldName, reader.getChar(fieldName));
                     break;
                 case SHORT:
-                    genericRecordBuilder.writeShort(fieldName, reader.readShort(fieldName));
+                    genericRecordBuilder.setShort(fieldName, reader.getShort(fieldName));
                     break;
                 case INT:
-                    genericRecordBuilder.writeInt(fieldName, reader.readInt(fieldName));
+                    genericRecordBuilder.setInt(fieldName, reader.getInt(fieldName));
                     break;
                 case LONG:
-                    genericRecordBuilder.writeLong(fieldName, reader.readLong(fieldName));
+                    genericRecordBuilder.setLong(fieldName, reader.getLong(fieldName));
                     break;
                 case FLOAT:
-                    genericRecordBuilder.writeFloat(fieldName, reader.readFloat(fieldName));
+                    genericRecordBuilder.setFloat(fieldName, reader.getFloat(fieldName));
                     break;
                 case DOUBLE:
-                    genericRecordBuilder.writeDouble(fieldName, reader.readDouble(fieldName));
+                    genericRecordBuilder.setDouble(fieldName, reader.getDouble(fieldName));
                     break;
                 case UTF:
-                    genericRecordBuilder.writeUTF(fieldName, reader.readUTF(fieldName));
+                    genericRecordBuilder.setString(fieldName, reader.getString(fieldName));
                     break;
                 case DECIMAL:
-                    genericRecordBuilder.writeDecimal(fieldName, reader.readDecimal(fieldName));
+                    genericRecordBuilder.setDecimal(fieldName, reader.getDecimal(fieldName));
                     break;
                 case TIME:
-                    genericRecordBuilder.writeTime(fieldName, reader.readTime(fieldName));
+                    genericRecordBuilder.setTime(fieldName, reader.getTime(fieldName));
                     break;
                 case DATE:
-                    genericRecordBuilder.writeDate(fieldName, reader.readDate(fieldName));
+                    genericRecordBuilder.setDate(fieldName, reader.getDate(fieldName));
                     break;
                 case TIMESTAMP:
-                    genericRecordBuilder.writeTimestamp(fieldName, reader.readTimestamp(fieldName));
+                    genericRecordBuilder.setTimestamp(fieldName, reader.getTimestamp(fieldName));
                     break;
                 case TIMESTAMP_WITH_TIMEZONE:
-                    genericRecordBuilder.writeTimestampWithTimezone(fieldName, reader.readTimestampWithTimezone(fieldName));
+                    genericRecordBuilder.setTimestampWithTimezone(fieldName, reader.getTimestampWithTimezone(fieldName));
                     break;
                 case PORTABLE_ARRAY:
-                    genericRecordBuilder.writeGenericRecordArray(fieldName, reader.readGenericRecordArray(fieldName));
+                    genericRecordBuilder.setGenericRecordArray(fieldName, reader.getGenericRecordArray(fieldName));
                     break;
                 case BYTE_ARRAY:
-                    genericRecordBuilder.writeByteArray(fieldName, reader.readByteArray(fieldName));
+                    genericRecordBuilder.setByteArray(fieldName, reader.getByteArray(fieldName));
                     break;
                 case BOOLEAN_ARRAY:
-                    genericRecordBuilder.writeBooleanArray(fieldName, reader.readBooleanArray(fieldName));
+                    genericRecordBuilder.setBooleanArray(fieldName, reader.getBooleanArray(fieldName));
                     break;
                 case CHAR_ARRAY:
-                    genericRecordBuilder.writeCharArray(fieldName, reader.readCharArray(fieldName));
+                    genericRecordBuilder.setCharArray(fieldName, reader.getCharArray(fieldName));
                     break;
                 case SHORT_ARRAY:
-                    genericRecordBuilder.writeShortArray(fieldName, reader.readShortArray(fieldName));
+                    genericRecordBuilder.setShortArray(fieldName, reader.getShortArray(fieldName));
                     break;
                 case INT_ARRAY:
-                    genericRecordBuilder.writeIntArray(fieldName, reader.readIntArray(fieldName));
+                    genericRecordBuilder.setIntArray(fieldName, reader.getIntArray(fieldName));
                     break;
                 case LONG_ARRAY:
-                    genericRecordBuilder.writeLongArray(fieldName, reader.readLongArray(fieldName));
+                    genericRecordBuilder.setLongArray(fieldName, reader.getLongArray(fieldName));
                     break;
                 case FLOAT_ARRAY:
-                    genericRecordBuilder.writeFloatArray(fieldName, reader.readFloatArray(fieldName));
+                    genericRecordBuilder.setFloatArray(fieldName, reader.getFloatArray(fieldName));
                     break;
                 case DOUBLE_ARRAY:
-                    genericRecordBuilder.writeDoubleArray(fieldName, reader.readDoubleArray(fieldName));
+                    genericRecordBuilder.setDoubleArray(fieldName, reader.getDoubleArray(fieldName));
                     break;
                 case UTF_ARRAY:
-                    genericRecordBuilder.writeUTFArray(fieldName, reader.readUTFArray(fieldName));
+                    genericRecordBuilder.setStringArray(fieldName, reader.getStringArray(fieldName));
                     break;
                 case DECIMAL_ARRAY:
-                    genericRecordBuilder.writeDecimalArray(fieldName, reader.readDecimalArray(fieldName));
+                    genericRecordBuilder.setDecimalArray(fieldName, reader.getDecimalArray(fieldName));
                     break;
                 case TIME_ARRAY:
-                    genericRecordBuilder.writeTimeArray(fieldName, reader.readTimeArray(fieldName));
+                    genericRecordBuilder.setTimeArray(fieldName, reader.getTimeArray(fieldName));
                     break;
                 case DATE_ARRAY:
-                    genericRecordBuilder.writeDateArray(fieldName, reader.readDateArray(fieldName));
+                    genericRecordBuilder.setDateArray(fieldName, reader.getDateArray(fieldName));
                     break;
                 case TIMESTAMP_ARRAY:
-                    genericRecordBuilder.writeTimestampArray(fieldName, reader.readTimestampArray(fieldName));
+                    genericRecordBuilder.setTimestampArray(fieldName, reader.getTimestampArray(fieldName));
                     break;
                 case TIMESTAMP_WITH_TIMEZONE_ARRAY:
-                    genericRecordBuilder.writeTimestampWithTimezoneArray(fieldName,
-                            reader.readTimestampWithTimezoneArray(fieldName));
+                    genericRecordBuilder.setTimestampWithTimezoneArray(fieldName,
+                            reader.getTimestampWithTimezoneArray(fieldName));
                     break;
                 default:
                     throw new IllegalStateException("Unexpected value: " + cd.getFieldType(fieldName));

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio;
 
+import javax.annotation.Nullable;
 import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -24,6 +25,18 @@ import java.nio.ByteOrder;
  * Provides serialization methods for arrays of primitive types.
  */
 public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVersionAware {
+
+    /**
+     * @deprecated for the sake of better naming. Use {@link #readString()} instead
+     */
+    String readUTF() throws IOException;
+
+    /**
+     * @return the string read
+     * @throws IOException if it reaches end of file before finish reading
+     */
+    @Nullable
+    String readString() throws IOException;
 
     /**
      * @return the byte array read
@@ -76,8 +89,15 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
     /**
      * @return String array read
      * @throws IOException if it reaches end of file before finish reading
+     * @deprecated for the sake of better naming. Use {@link #readStringArray()} instead
      */
     String[] readUTFArray() throws IOException;
+
+    /**
+     * @return String array read
+     * @throws IOException if it reaches end of file before finish reading
+     */
+    String[] readStringArray() throws IOException;
 
     /**
      * @param <T> type of the object to be read

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -29,6 +29,8 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
     /**
      * @deprecated for the sake of better naming. Use {@link #readString()} instead
      */
+    @Deprecated
+    @Nullable
     String readUTF() throws IOException;
 
     /**
@@ -42,48 +44,56 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
      * @return the byte array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     byte[] readByteArray() throws IOException;
 
     /**
      * @return the boolean array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     boolean[] readBooleanArray() throws IOException;
 
     /**
      * @return the char array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     char[] readCharArray() throws IOException;
 
     /**
      * @return int array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     int[] readIntArray() throws IOException;
 
     /**
      * @return long array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     long[] readLongArray() throws IOException;
 
     /**
      * @return double array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     double[] readDoubleArray() throws IOException;
 
     /**
      * @return float array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     float[] readFloatArray() throws IOException;
 
     /**
      * @return short array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     short[] readShortArray() throws IOException;
 
     /**
@@ -91,12 +101,15 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
      * @throws IOException if it reaches end of file before finish reading
      * @deprecated for the sake of better naming. Use {@link #readStringArray()} instead
      */
+    @Nullable
+    @Deprecated
     String[] readUTFArray() throws IOException;
 
     /**
      * @return String array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     String[] readStringArray() throws IOException;
 
     /**
@@ -104,6 +117,7 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
      * @return object array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     <T> T readObject() throws IOException;
 
     /**
@@ -112,6 +126,7 @@ public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVer
      * @return object array read
      * @throws IOException if it reaches end of file before finish reading
      */
+    @Nullable
     <T> T readObject(Class aClass) throws IOException;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio;
 
+import javax.annotation.Nullable;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -24,6 +25,17 @@ import java.nio.ByteOrder;
  * Provides serialization methods for arrays by extending DataOutput
  */
 public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolVersionAware {
+
+    /**
+     * @deprecated for the sake of better naming. Use {@link #writeString(String)} instead
+     */
+    void writeUTF(String string) throws IOException;
+
+    /**
+     * @param string string to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeString(@Nullable String string) throws IOException;
 
     /**
      * @param bytes byte array to be written
@@ -76,8 +88,15 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
     /**
      * @param values String array to be written
      * @throws IOException in case of any exceptional case
+     * @deprecated for the sake of better naming. Use {@link #writeStringArray(String[])} instead
      */
     void writeUTFArray(String[] values) throws IOException;
+
+    /**
+     * @param values String array to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeStringArray(@Nullable String[] values) throws IOException;
 
     /**
      * @param object object to be written

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -29,7 +29,8 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
     /**
      * @deprecated for the sake of better naming. Use {@link #writeString(String)} instead
      */
-    void writeUTF(String string) throws IOException;
+    @Deprecated
+    void writeUTF(@Nullable String string) throws IOException;
 
     /**
      * @param string string to be written
@@ -41,56 +42,57 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
      * @param bytes byte array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeByteArray(byte[] bytes) throws IOException;
+    void writeByteArray(@Nullable byte[] bytes) throws IOException;
 
     /**
      * @param booleans boolean array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeBooleanArray(boolean[] booleans) throws IOException;
+    void writeBooleanArray(@Nullable boolean[] booleans) throws IOException;
 
     /**
      * @param chars char array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeCharArray(char[] chars) throws IOException;
+    void writeCharArray(@Nullable char[] chars) throws IOException;
 
     /**
      * @param ints int array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeIntArray(int[] ints) throws IOException;
+    void writeIntArray(@Nullable int[] ints) throws IOException;
 
     /**
      * @param longs long array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeLongArray(long[] longs) throws IOException;
+    void writeLongArray(@Nullable long[] longs) throws IOException;
 
     /**
      * @param values double array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeDoubleArray(double[] values) throws IOException;
+    void writeDoubleArray(@Nullable double[] values) throws IOException;
 
     /**
      * @param values float array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeFloatArray(float[] values) throws IOException;
+    void writeFloatArray(@Nullable float[] values) throws IOException;
 
     /**
      * @param values short array to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeShortArray(short[] values) throws IOException;
+    void writeShortArray(@Nullable short[] values) throws IOException;
 
     /**
      * @param values String array to be written
      * @throws IOException in case of any exceptional case
      * @deprecated for the sake of better naming. Use {@link #writeStringArray(String[])} instead
      */
-    void writeUTFArray(String[] values) throws IOException;
+    @Deprecated
+    void writeUTFArray(@Nullable String[] values) throws IOException;
 
     /**
      * @param values String array to be written
@@ -102,7 +104,7 @@ public interface ObjectDataOutput extends DataOutput, VersionAware, WanProtocolV
      * @param object object to be written
      * @throws IOException in case of any exceptional case
      */
-    void writeObject(Object object) throws IOException;
+    void writeObject(@Nullable Object object) throws IOException;
 
     /**
      * @return copy of internal byte array

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -95,8 +95,19 @@ public final class ClassDefinitionBuilder {
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @deprecated for the sake of better naming. Use {@link #addStringField(String)} instead.
      */
     public ClassDefinitionBuilder addUTFField(@Nonnull String fieldName) {
+        return addField(fieldName, FieldType.UTF);
+    }
+
+    /**
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addStringField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.UTF);
     }
 
@@ -308,8 +319,20 @@ public final class ClassDefinitionBuilder {
      * @return itself for chaining
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     * @deprecated for the sake of better naming. Use {@link #addStringArrayField(String)} instead.
      */
+    @Deprecated
     public ClassDefinitionBuilder addUTFArrayField(@Nonnull String fieldName) {
+        return addField(fieldName, FieldType.UTF_ARRAY);
+    }
+
+    /**
+     * @param fieldName name of the field that will be added to this class definition
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if a field with same name already exists or
+     *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
+     */
+    public ClassDefinitionBuilder addStringArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.UTF_ARRAY);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -76,6 +76,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addIntField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.INT);
     }
@@ -86,6 +87,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addLongField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.LONG);
     }
@@ -97,8 +99,10 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @deprecated for the sake of better naming. Use {@link #addStringField(String)} instead.
      */
+    @Nonnull
+    @Deprecated
     public ClassDefinitionBuilder addUTFField(@Nonnull String fieldName) {
-        return addField(fieldName, FieldType.UTF);
+        return addStringField(fieldName);
     }
 
     /**
@@ -107,6 +111,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addStringField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.UTF);
     }
@@ -117,6 +122,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addBooleanField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.BOOLEAN);
     }
@@ -127,6 +133,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addByteField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.BYTE);
     }
@@ -137,6 +144,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addBooleanArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.BOOLEAN_ARRAY);
     }
@@ -147,6 +155,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addCharField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.CHAR);
     }
@@ -157,6 +166,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addDoubleField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.DOUBLE);
     }
@@ -167,6 +177,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addFloatField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.FLOAT);
     }
@@ -177,6 +188,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addShortField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.SHORT);
     }
@@ -189,6 +201,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addDecimalField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.DECIMAL);
     }
@@ -201,6 +214,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addTimeField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.TIME);
     }
@@ -213,6 +227,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addDateField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.DATE);
     }
@@ -226,6 +241,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addTimestampField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.TIMESTAMP);
     }
@@ -240,6 +256,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addTimestampWithTimezoneField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE);
     }
@@ -250,6 +267,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addByteArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.BYTE_ARRAY);
     }
@@ -260,6 +278,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addCharArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.CHAR_ARRAY);
     }
@@ -270,6 +289,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addIntArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.INT_ARRAY);
     }
@@ -280,6 +300,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addLongArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.LONG_ARRAY);
     }
@@ -290,6 +311,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addDoubleArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.DOUBLE_ARRAY);
     }
@@ -300,6 +322,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addFloatArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.FLOAT_ARRAY);
     }
@@ -310,6 +333,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addShortArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.SHORT_ARRAY);
     }
@@ -321,9 +345,10 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @deprecated for the sake of better naming. Use {@link #addStringArrayField(String)} instead.
      */
+    @Nonnull
     @Deprecated
     public ClassDefinitionBuilder addUTFArrayField(@Nonnull String fieldName) {
-        return addField(fieldName, FieldType.UTF_ARRAY);
+        return addStringArrayField(fieldName);
     }
 
     /**
@@ -332,6 +357,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addStringArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.UTF_ARRAY);
     }
@@ -342,6 +368,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addPortableField(@Nonnull String fieldName, ClassDefinition def) {
         if (def.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
@@ -359,6 +386,7 @@ public final class ClassDefinitionBuilder {
      * @throws HazelcastSerializationException if a field with same name already exists or
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      */
+    @Nonnull
     public ClassDefinitionBuilder addPortableArrayField(@Nonnull String fieldName, ClassDefinition classDefinition) {
         if (classDefinition.getClassId() == 0) {
             throw new IllegalArgumentException("Portable class ID cannot be zero!");
@@ -378,6 +406,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @see #addDecimalField(String)
      */
+    @Nonnull
     public ClassDefinitionBuilder addDecimalArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.DECIMAL_ARRAY);
     }
@@ -391,6 +420,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @see #addTimeField(String)
      */
+    @Nonnull
     public ClassDefinitionBuilder addTimeArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.TIME_ARRAY);
     }
@@ -404,6 +434,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @see #addDateField(String)
      */
+    @Nonnull
     public ClassDefinitionBuilder addDateArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.DATE_ARRAY);
     }
@@ -417,6 +448,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @see #addTimestampField(String)
      */
+    @Nonnull
     public ClassDefinitionBuilder addTimestampArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.TIMESTAMP_ARRAY);
     }
@@ -430,6 +462,7 @@ public final class ClassDefinitionBuilder {
      *                                         if this method is called after {@link ClassDefinitionBuilder#build()}
      * @see #addTimestampWithTimezoneField(String)
      */
+    @Nonnull
     public ClassDefinitionBuilder addTimestampWithTimezoneArrayField(@Nonnull String fieldName) {
         return addField(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
     }
@@ -453,6 +486,7 @@ public final class ClassDefinitionBuilder {
     /**
      * @return creates and returns a new ClassDefinition
      */
+    @Nonnull
     public ClassDefinition build() {
         done = true;
         final ClassDefinitionImpl cd = new ClassDefinitionImpl(factoryId, classId, version);

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.nio.serialization;
 
-import com.hazelcast.internal.serialization.impl.portable.PortableGenericRecordBuilder;
 import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
@@ -40,7 +39,7 @@ import java.util.Set;
  *             Object value = entry.getValue();
  *             GenericRecord genericRecord = (GenericRecord) value;
  *
- *             int id = genericRecord.readInt("id");
+ *             int id = genericRecord.getInt("id");
  *
  *             return null;
  *         });
@@ -50,7 +49,7 @@ import java.util.Set;
  * map.executeOnKey("key", (EntryProcessor<Object, Object, Object>) entry -> {
  *             GenericRecord genericRecord = (GenericRecord) entry.getValue();
  *             GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder()
- *                     .writeInt("age",22).build();
+ *                     .setInt("age",22).build();
  *             entry.setValue(modifiedGenericRecord);
  *             return null;
  *         });
@@ -59,7 +58,7 @@ import java.util.Set;
  * GenericRecord also allows to read from a cluster without having the classes on the client side.
  * For {@link Portable}, when {@link PortableFactory} is not provided in the config at the start,
  * a {@link HazelcastSerializationException} was thrown stating that a factory could not be found. Starting from 4.1,
- * the objects will be returned as {@link GenericRecord}. This way, the clients can be  read and write the objects back to
+ * the objects will be returned as {@link GenericRecord}. This way, the clients can read and write the objects back to
  * the cluster without needing the classes of the domain objects on the classpath.
  * <p>
  * Currently this is valid for {@link Portable} objects.
@@ -70,46 +69,46 @@ import java.util.Set;
 public interface GenericRecord {
 
     /**
-     * Creates a {@link Builder} allows to create a new object. This method is a convenience method to get a builder,
+     * Creates a {@link GenericRecordBuilder} allows to create a new object. This method is a convenience method to get a builder,
      * without creating the class definition for this type. Here you can see  a  new object is constructed from an existing
      * GenericRecord with its class definition:
      *
      * <pre>
      *
      * GenericRecord newGenericRecord = genericRecord.newBuilder()
-     *      .writeUTF("name", "bar")
-     *      .writeInt("id", 4).build();
+     *      .setString("name", "bar")
+     *      .setInt("id", 4).build();
      *
      * </pre>
      * <p>
-     * see {@link Builder#portable(ClassDefinition)} to create a GenericRecord in Portable format
+     * see {@link GenericRecordBuilder#portable(ClassDefinition)} to create a GenericRecord in Portable format
      * with a different class definition.
      *
      * @return an empty generic record builder with same class definition as this one
      */
     @Nonnull
-    Builder newBuilder();
+    GenericRecordBuilder newBuilder();
 
     /**
-     * Returned {@link Builder} can be used to have exact copy and also just to update a couple of fields. By default,
-     * it will copy all the fields.
+     * Returned {@link GenericRecordBuilder} can be used to have exact copy and also just to update a couple of fields.
+     * By default, it will copy all the fields.
      * So instead of following where only the `id` field is updated,
      * <pre>
      *     GenericRecord modifiedGenericRecord = genericRecord.newBuilder()
-     *                         .writeUTF("name", genericRecord.readUTF("name"))
-     *                         .writeLong("id", 4)
-     *                         .writeUTF("surname", genericRecord.readUTF("surname"))
-     *                         .writeInt("age", genericRecord.readInt("age")).build();
+     *                         .setString("name", genericRecord.getString("name"))
+     *                         .setLong("id", 4)
+     *                         .setString("surname", genericRecord.getString("surname"))
+     *                         .setInt("age", genericRecord.getInt("age")).build();
      * </pre>
      * `cloneWithBuilder` used as follows:
      * <pre>
-     *     GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder().writeInt("id", 4).build();
+     *     GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder().setInt("id", 4).build();
      * </pre>
      *
      * @return a generic record builder with same class definition as this one and populated with same values.
      */
     @Nonnull
-    Builder cloneWithBuilder();
+    GenericRecordBuilder cloneWithBuilder();
 
     /**
      * @return set of field names of this GenericRecord
@@ -137,7 +136,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    boolean readBoolean(@Nonnull String fieldName);
+    boolean getBoolean(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -145,7 +144,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    byte readByte(@Nonnull String fieldName);
+    byte getByte(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -153,7 +152,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    char readChar(@Nonnull String fieldName);
+    char getChar(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -161,7 +160,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    double readDouble(@Nonnull String fieldName);
+    double getDouble(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -169,7 +168,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    float readFloat(@Nonnull String fieldName);
+    float getFloat(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -177,7 +176,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    int readInt(@Nonnull String fieldName);
+    int getInt(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -185,7 +184,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    long readLong(@Nonnull String fieldName);
+    long getLong(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -193,74 +192,7 @@ public interface GenericRecord {
      * @throws HazelcastSerializationException if the field name does not exist in the class definition or
      *                                         the type of the field does not match the one in the class definition.
      */
-    short readShort(@Nonnull String fieldName);
-
-    /**
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     */
-    @Nullable
-    String readUTF(@Nonnull String fieldName);
-
-    /**
-     * Reads a decimal which is arbitrary precision and scale floating-point number to BigDecimal
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     */
-    @Nullable
-    BigDecimal readDecimal(@Nonnull String fieldName);
-
-    /**
-     * Reads a time field consisting of hour, minute, seconds and nanos parts to LocalTime
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     */
-    @Nullable
-    LocalTime readTime(@Nonnull String fieldName);
-
-    /**
-     * Reads a date field consisting of year, month of the year and day of the month to LocalDate
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     */
-    @Nullable
-    LocalDate readDate(@Nonnull String fieldName);
-
-    /**
-     * Reads a timestamp field consisting of
-     * year, month of the year, day of the month, hour, minute, seconds, nanos parts to LocalDateTime
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     */
-    @Nullable
-    LocalDateTime readTimestamp(@Nonnull String fieldName);
-
-    /**
-     * Reads a timestamp with timezone field consisting of
-     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
-     * to OffsetDateTime
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     */
-    @Nullable
-    OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName);
+    short getShort(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -269,7 +201,54 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    GenericRecord readGenericRecord(@Nonnull String fieldName);
+    String getString(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return decimal which is arbitrary precision and scale floating-point number as BigDecimal
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    BigDecimal getDecimal(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return time field consisting of hour, minute, seconds and nanos parts as LocalTime
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalTime getTime(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return date field consisting of year, month of the year and day of the month as LocalDate
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalDate getDate(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return timestamp field consisting of year, month of the year, day of the month, hour, minute, seconds,
+     * nanos parts as LocalDateTime
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    LocalDateTime getTimestamp(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return timestamp with timezone field consisting of
+     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts as OffsetDateTime
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    OffsetDateTime getTimestampWithTimezone(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -278,7 +257,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    boolean[] readBooleanArray(@Nonnull String fieldName);
+    GenericRecord getGenericRecord(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -287,7 +266,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    byte[] readByteArray(@Nonnull String fieldName);
+    boolean[] getBooleanArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -296,7 +275,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    char[] readCharArray(@Nonnull String fieldName);
+    byte[] getByteArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -305,7 +284,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    double[] readDoubleArray(@Nonnull String fieldName);
+    char[] getCharArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -314,7 +293,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    float[] readFloatArray(@Nonnull String fieldName);
+    double[] getDoubleArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -323,7 +302,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    int[] readIntArray(@Nonnull String fieldName);
+    float[] getFloatArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -332,7 +311,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    long[] readLongArray(@Nonnull String fieldName);
+    int[] getIntArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -341,7 +320,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    short[] readShortArray(@Nonnull String fieldName);
+    long[] getLongArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -350,67 +329,7 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    String[] readUTFArray(@Nonnull String fieldName);
-
-    /**
-     * Reads an array of Decimal's to BigDecimal[]
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     * @see #readDecimal(String)
-     */
-    @Nullable
-    BigDecimal[] readDecimalArray(@Nonnull String fieldName);
-
-    /**
-     * Reads an array of Time's to LocalTime[]
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     * @see #readTime(String)
-     */
-    @Nullable
-    LocalTime[] readTimeArray(@Nonnull String fieldName);
-
-    /**
-     * Reads an array of Date's to LocalDate[]
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     * @see #readDate(String)
-     */
-    @Nullable
-    LocalDate[] readDateArray(@Nonnull String fieldName);
-
-    /**
-     * Reads an array of Timestamp's to LocalDateTime[]
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     * @see #readTimestamp(String)
-     */
-    @Nullable
-    LocalDateTime[] readTimestampArray(@Nonnull String fieldName);
-
-    /**
-     * Reads an array of TimestampWithTimezone's to OffsetDateTime[]
-     *
-     * @param fieldName the name of the field
-     * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
-     * @see #readTimestampWithTimezone(String)
-     */
-    @Nullable
-    OffsetDateTime[] readTimestampWithTimezoneArray(@Nonnull String fieldName);
+    short[] getShortArray(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
@@ -419,519 +338,64 @@ public interface GenericRecord {
      *                                         the type of the field does not match the one in the class definition.
      */
     @Nullable
-    GenericRecord[] readGenericRecordArray(@Nonnull String fieldName);
+    String[] getStringArray(@Nonnull String fieldName);
 
     /**
-     * Interface for creating {@link GenericRecord} instances.
+     * @param fieldName the name of the field
+     * @return array of Decimal's as BigDecimal[]
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #getDecimal(String)
      */
-    @Beta
-    interface Builder {
+    @Nullable
+    BigDecimal[] getDecimalArray(@Nonnull String fieldName);
 
-        /**
-         * Creates a Builder that will build a {@link GenericRecord} in {@link Portable} format with a new class definition:
-         * <pre>
-         *     ClassDefinition classDefinition =
-         *                 new ClassDefinitionBuilder(FACTORY_ID, CLASS_ID)
-         *                         .addUTFField("name").addIntField("id").build();
-         *
-         *     GenericRecord genericRecord = GenericRecord.Builder.portable(classDefinition)
-         *           .writeUTF("name", "foo")
-         *           .writeInt("id", 123).build();
-         * </pre>
-         *
-         * @param classDefinition of the portable that we will create
-         * @return GenericRecordBuilder for Portable format
-         */
-        @Nonnull
-        static Builder portable(@Nonnull ClassDefinition classDefinition) {
-            return new PortableGenericRecordBuilder(classDefinition);
-        }
+    /**
+     * @param fieldName the name of the field
+     * @return array of Time's as LocalTime[]
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #getTime(String)
+     */
+    @Nullable
+    LocalTime[] getTimeArray(@Nonnull String fieldName);
 
-        /**
-         * @return a new constructed GenericRecord
-         * @throws HazelcastSerializationException when the GenericRecord cannot be build.
-         */
-        @Nonnull
-        GenericRecord build();
+    /**
+     * @param fieldName the name of the field
+     * @return array of Date's to LocalDate[]
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #getDate(String)
+     */
+    @Nullable
+    LocalDate[] getDateArray(@Nonnull String fieldName);
 
-        /**
-         * It is legal to overwrite the field once only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-         * Otherwise, it is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  It should be composed of only alpha-numeric characters.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeBoolean(@Nonnull String fieldName, boolean value);
+    /**
+     * @param fieldName the name of the field
+     * @return array of Timestamp's as LocalDateTime[]
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #getTimestamp(String)
+     */
+    @Nullable
+    LocalDateTime[] getTimestampArray(@Nonnull String fieldName);
 
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  It should be composed of only alpha-numeric characters.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeByte(@Nonnull String fieldName, byte value);
+    /**
+     * @param fieldName the name of the field
+     * @return array of TimestampWithTimezone's as OffsetDateTime[]
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     * @see #getTimestampWithTimezone(String)
+     */
+    @Nullable
+    OffsetDateTime[] getTimestampWithTimezoneArray(@Nonnull String fieldName);
 
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeChar(@Nonnull String fieldName, char value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeDouble(@Nonnull String fieldName, double value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeFloat(@Nonnull String fieldName, float value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeInt(@Nonnull String fieldName, int value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeLong(@Nonnull String fieldName, long value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeShort(@Nonnull String fieldName, short value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeUTF(@Nonnull String fieldName, @Nullable String value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         * This method allows nested structures. Subclass should also created as `GenericRecord`
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value);
-
-        /**
-         * Writes a decimal which is arbitrary precision and scale floating-point number
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeDecimal(@Nonnull String fieldName, @Nullable BigDecimal value);
-
-        /**
-         * Write a time field consisting of hour, minute, seconds and nanos parts
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeTime(@Nonnull String fieldName, @Nullable LocalTime value);
-
-        /**
-         * Writes a date field consisting of year, month of the year and day of the month
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeDate(@Nonnull String fieldName, @Nullable LocalDate value);
-
-        /**
-         * Writes a timestamp field consisting of
-         * year, month of the year, day of the month, hour, minute, seconds, nanos parts
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value);
-
-        /**
-         * Writes a timestamp with timezone field consisting of
-         * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeBooleanArray(@Nonnull String fieldName, @Nullable boolean[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeByteArray(@Nonnull String fieldName, @Nullable byte[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeCharArray(@Nonnull String fieldName, @Nullable char[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeFloatArray(@Nonnull String fieldName, @Nullable float[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeIntArray(@Nonnull String fieldName, @Nullable int[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeDoubleArray(@Nonnull String fieldName, @Nullable double[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeLongArray(@Nonnull String fieldName, @Nullable long[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeShortArray(@Nonnull String fieldName, @Nullable short[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord String[] to write
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeUTFArray(@Nonnull String fieldName, @Nullable String[] value);
-
-        /**
-         * Writes an array of Decimals
-         * It is illegal to write to the same field twice.
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         * @see #writeDecimal(String, BigDecimal)
-         */
-        @Nonnull
-        Builder writeDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] value);
-
-        /**
-         * Writes an array of Time's
-         * It is illegal to write to the same field twice.
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         * @see #writeTime(String, LocalTime)
-         */
-        @Nonnull
-        Builder writeTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] value);
-
-        /**
-         * Writes an array of Date's
-         * It is illegal to write to the same field twice.
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         * @see #writeDate(String, LocalDate)
-         */
-        @Nonnull
-        Builder writeDateArray(@Nonnull String fieldName, @Nullable LocalDate[] value);
-
-        /**
-         * Writes an array of Timestamp's
-         * It is illegal to write to the same field twice.
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         * @see #writeTimestamp(String, LocalDateTime)
-         */
-        @Nonnull
-        Builder writeTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] value);
-
-        /**
-         * Writes an array of TimestampWithTimezone's
-         * It is illegal to write to the same field twice.
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         * @see #writeTimestampWithTimezone(String, OffsetDateTime)
-         */
-        @Nonnull
-        Builder writeTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] value);
-
-        /**
-         * It is illegal to write to the same field twice.
-         * This method allows nested structures. Subclasses should also created as `GenericRecord`
-         * <p>
-         * Array items can not be null
-         *
-         * @param fieldName name of the field as it is defined in its class definition.
-         *                  See {@link ClassDefinition} for {@link Portable}
-         * @param value     to set to GenericRecord
-         * @return itself for chaining
-         * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-         *                                         the type of the field does not match the one in the class definition or
-         *                                         Same field is trying to be overwritten without using
-         *                                         {@link GenericRecord#cloneWithBuilder()}.
-         */
-        @Nonnull
-        Builder writeGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value);
-    }
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition.
+     */
+    @Nullable
+    GenericRecord[] getGenericRecordArray(@Nonnull String fieldName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
+
+import com.hazelcast.internal.serialization.impl.portable.PortableGenericRecordBuilder;
+import com.hazelcast.spi.annotation.Beta;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+/**
+ * Interface for creating {@link GenericRecord} instances.
+ */
+@Beta
+public
+interface GenericRecordBuilder {
+
+    /**
+     * Creates a Builder that will build a {@link GenericRecord} in {@link Portable} format with a new class definition:
+     * <pre>
+     *     ClassDefinition classDefinition =
+     *                 new ClassDefinitionBuilder(FACTORY_ID, CLASS_ID)
+     *                         .addStringField("name").addIntField("id").build();
+     *
+     *     GenericRecord genericRecord = GenericRecord.Builder.portable(classDefinition)
+     *           .setString("name", "foo")
+     *           .setInt("id", 123).build();
+     * </pre>
+     *
+     * @param classDefinition of the portable that we will create
+     * @return GenericRecordBuilder for Portable format
+     */
+    @Nonnull
+    static GenericRecordBuilder portable(@Nonnull ClassDefinition classDefinition) {
+        return new PortableGenericRecordBuilder(classDefinition);
+    }
+
+    /**
+     * @return a new constructed GenericRecord
+     * @throws HazelcastSerializationException when the GenericRecord cannot be build.
+     */
+    @Nonnull
+    GenericRecord build();
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  It should be composed of only alpha-numeric characters.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setBoolean(@Nonnull String fieldName, boolean value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  It should be composed of only alpha-numeric characters.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setByte(@Nonnull String fieldName, byte value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setChar(@Nonnull String fieldName, char value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setDouble(@Nonnull String fieldName, double value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setFloat(@Nonnull String fieldName, float value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setInt(@Nonnull String fieldName, int value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setLong(@Nonnull String fieldName, long value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setShort(@Nonnull String fieldName, short value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setString(@Nonnull String fieldName, @Nullable String value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * This method allows nested structures. Subclass should also created as `GenericRecord`.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value);
+
+    /**
+     * Sets a decimal which is arbitrary precision and scale floating-point number
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setDecimal(@Nonnull String fieldName, @Nullable BigDecimal value);
+
+    /**
+     * Sets a time field consisting of hour, minute, seconds and nanos parts
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setTime(@Nonnull String fieldName, @Nullable LocalTime value);
+
+    /**
+     * Sets a date field consisting of year , month of the year and day of the month
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setDate(@Nonnull String fieldName, @Nullable LocalDate value);
+
+    /**
+     * Sets a timestamp field consisting of
+     * year , month of the year and day of the month, hour, minute, seconds, nanos parts
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value);
+
+    /**
+     * Sets a timestamp with timezone field consisting of
+     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setBooleanArray(@Nonnull String fieldName, @Nullable boolean[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setByteArray(@Nonnull String fieldName, @Nullable byte[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setCharArray(@Nonnull String fieldName, @Nullable char[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setFloatArray(@Nonnull String fieldName, @Nullable float[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setIntArray(@Nonnull String fieldName, @Nullable int[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setDoubleArray(@Nonnull String fieldName, @Nullable double[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setLongArray(@Nonnull String fieldName, @Nullable long[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setShortArray(@Nonnull String fieldName, @Nullable short[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setStringArray(@Nonnull String fieldName, @Nullable String[] value);
+
+    /**
+     * Sets an array of Decimals
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @see #setDecimal(String, BigDecimal)
+     */
+    @Nonnull
+    GenericRecordBuilder setDecimalArray(@Nonnull String fieldName, @Nullable BigDecimal[] value);
+
+    /**
+     * Sets an array of Time's
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @see #setTime(String, LocalTime)
+     */
+    @Nonnull
+    GenericRecordBuilder setTimeArray(@Nonnull String fieldName, @Nullable LocalTime[] value);
+
+    /**
+     * Sets an array of Date's
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @see #setDate(String, LocalDate)
+     */
+    @Nonnull
+    GenericRecordBuilder setDateArray(@Nonnull String fieldName, @Nullable LocalDate[] value);
+
+    /**
+     * Sets an array of Timestamp's
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @see #setTimestamp(String, LocalDateTime)
+     */
+    @Nonnull
+    GenericRecordBuilder setTimestampArray(@Nonnull String fieldName, @Nullable LocalDateTime[] value);
+
+    /**
+     * Sets an array of TimestampWithTimezone's
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @see #setTimestampWithTimezone(String, OffsetDateTime)
+     */
+    @Nonnull
+    GenericRecordBuilder setTimestampWithTimezoneArray(@Nonnull String fieldName, @Nullable OffsetDateTime[] value);
+
+    /**
+     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
+     * Otherwise, it is illegal to set to the same field twice.
+     * This method allows nested structures. Subclasses should also created as `GenericRecord`.
+     * <p>
+     * Array items can not be null.
+     *
+     * @param fieldName name of the field as it is defined in its class definition.
+     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param value     to set to GenericRecord
+     * @return itself for chaining
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
+     *                                         the type of the field does not match the one in the class definition or
+     *                                         Same field is trying to be set without using
+     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     */
+    @Nonnull
+    GenericRecordBuilder setGenericRecordArray(@Nonnull String fieldName, @Nullable GenericRecord[] value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -83,9 +83,18 @@ public interface PortableReader {
      * @param fieldName name of the field
      * @return the utf string value read
      * @throws IOException in case of any exceptional case
+     * @deprecated for the sake of better naming. Use {@link #readString(String)} instead
      */
     @Nullable
     String readUTF(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * @param fieldName name of the field
+     * @return the string value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    String readString(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field
@@ -258,9 +267,18 @@ public interface PortableReader {
      * @param fieldName name of the field
      * @return the String array value read
      * @throws IOException in case of any exceptional case
+     * @deprecated for the sake of better naming. Use {@link #readStringArray(String)} instead
      */
     @Nullable
     String[] readUTFArray(@Nonnull String fieldName) throws IOException;
+
+    /**
+     * @param fieldName name of the field
+     * @return the String array value read
+     * @throws IOException in case of any exceptional case
+     */
+    @Nullable
+    String[] readStringArray(@Nonnull String fieldName) throws IOException;
 
     /**
      * @param fieldName name of the field

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -86,6 +86,7 @@ public interface PortableReader {
      * @deprecated for the sake of better naming. Use {@link #readString(String)} instead
      */
     @Nullable
+    @Deprecated
     String readUTF(@Nonnull String fieldName) throws IOException;
 
     /**
@@ -270,6 +271,7 @@ public interface PortableReader {
      * @deprecated for the sake of better naming. Use {@link #readStringArray(String)} instead
      */
     @Nullable
+    @Deprecated
     String[] readUTFArray(@Nonnull String fieldName) throws IOException;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
@@ -57,8 +57,18 @@ public interface PortableWriter {
      * @param fieldName name of the field
      * @param value     utf string value to be written
      * @throws IOException in case of any exceptional case
+     * @deprecated for the sake of better naming. Use {@link #writeString(String, String)} instead.
      */
     void writeUTF(@Nonnull String fieldName, @Nullable String value) throws IOException;
+
+    /**
+     * Writes an UTF string.
+     *
+     * @param fieldName name of the field
+     * @param value     utf string value to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeString(@Nonnull String fieldName, @Nullable String value) throws IOException;
 
     /**
      * Writes a primitive boolean.
@@ -259,8 +269,18 @@ public interface PortableWriter {
      * @param fieldName name of the field
      * @param values    String array to be written
      * @throws IOException in case of any exceptional case
+     * @deprecated for the sake of better naming. Use {@link #writeStringArray(String, String[])} instead.
      */
     void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException;
+
+    /**
+     * Writes a String-array.
+     *
+     * @param fieldName name of the field
+     * @param values    String array to be written
+     * @throws IOException in case of any exceptional case
+     */
+    void writeStringArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException;
 
     /**
      * Writes a an array of Portables.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
@@ -68,6 +68,7 @@ public interface PortableWriter {
      * @param value     utf string value to be written
      * @throws IOException in case of any exceptional case
      */
+    @Deprecated
     void writeString(@Nonnull String fieldName, @Nullable String value) throws IOException;
 
     /**
@@ -271,6 +272,7 @@ public interface PortableWriter {
      * @throws IOException in case of any exceptional case
      * @deprecated for the sake of better naming. Use {@link #writeStringArray(String, String[])} instead.
      */
+    @Deprecated
     void writeUTFArray(@Nonnull String fieldName, @Nullable String[] values) throws IOException;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
@@ -80,12 +80,12 @@ public final class MultiAttributeProjection<I> implements Projection<I, Object[]
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTFArray(attributePaths);
+        out.writeStringArray(attributePaths);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePaths = in.readUTFArray();
+        this.attributePaths = in.readStringArray();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/genericrecord/AbstractGenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/genericrecord/AbstractGenericRecordTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.jetbrains.annotations.NotNull;
@@ -67,8 +68,8 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         MainPortable expectedPortable = createMainPortable();
         GenericRecord expected = createGenericRecord(expectedPortable);
 
-        assertEquals(expectedPortable.c, expected.readChar("c"));
-        assertEquals(expectedPortable.f, expected.readFloat("f"), 0.1);
+        assertEquals(expectedPortable.c, expected.getChar("c"));
+        assertEquals(expectedPortable.f, expected.getFloat("f"), 0.1);
         HazelcastInstance[] instances = createCluster();
         IMap<Object, Object> clusterMap = instances[0].getMap("test");
         clusterMap.put(1, expected);
@@ -84,8 +85,8 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         MainPortable expectedPortable = createMainPortable();
         GenericRecord expected = createGenericRecord(expectedPortable);
 
-        assertEquals(expectedPortable.c, expected.readChar("c"));
-        assertEquals(expectedPortable.f, expected.readFloat("f"), 0.1);
+        assertEquals(expectedPortable.c, expected.getChar("c"));
+        assertEquals(expectedPortable.f, expected.getFloat("f"), 0.1);
         HazelcastInstance[] instances = createCluster();
         IMap<Object, Object> clusterMap = instances[0].getMap("test");
         clusterMap.put(1, expected);
@@ -117,8 +118,8 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         assertTrue(actualRecord.hasField("name"));
         assertTrue(actualRecord.hasField("myint"));
 
-        assertEquals(expected.name, actualRecord.readUTF("name"));
-        assertEquals(expected.myint, actualRecord.readInt("myint"));
+        assertEquals(expected.name, actualRecord.getString("name"));
+        assertEquals(expected.myint, actualRecord.getInt("myint"));
 
 
         //read from the instance with serialization config
@@ -142,8 +143,8 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         assertTrue(actual.hasField("name"));
         assertTrue(actual.hasField("myint"));
 
-        assertEquals(expected.name, actual.readUTF("name"));
-        assertEquals(expected.myint, actual.readInt("myint"));
+        assertEquals(expected.name, actual.getString("name"));
+        assertEquals(expected.myint, actual.getInt("myint"));
     }
 
     @Test
@@ -162,12 +163,12 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
             GenericRecord genericRecord = (GenericRecord) value;
 
             GenericRecord modifiedGenericRecord = genericRecord.newBuilder()
-                                                               .writeUTF("name", "bar")
-                                                               .writeInt("myint", 4).build();
+                                                               .setString("name", "bar")
+                                                               .setInt("myint", 4).build();
 
             entry.setValue(modifiedGenericRecord);
 
-            return genericRecord.readInt("myint");
+            return genericRecord.getInt("myint");
         });
         assertEquals(expected.myint, returnValue);
 
@@ -192,11 +193,11 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
             GenericRecord genericRecord = (GenericRecord) value;
 
             GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder()
-                                                               .writeInt("myint", 4).build();
+                                                               .setInt("myint", 4).build();
 
             entry.setValue(modifiedGenericRecord);
 
-            return genericRecord.readInt("myint");
+            return genericRecord.getInt("myint");
         });
         assertEquals(expected.myint, returnValue);
 
@@ -218,7 +219,7 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         public Integer call() throws Exception {
             IMap<Object, Object> map = instance.getMap("test");
             GenericRecord genericRecord = (GenericRecord) map.get(1);
-            return genericRecord.readInt("myint");
+            return genericRecord.getInt("myint");
         }
     }
 
@@ -251,14 +252,14 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
                         .addUTFField("WrongName").addIntField("myint").build();
 
 
-        GenericRecord namedRecord = GenericRecord.Builder.portable(namedPortableClassDefinition)
-                                                         .writeUTF("name", "foo")
-                                                         .writeInt("myint", 123).build();
+        GenericRecord namedRecord = GenericRecordBuilder.portable(namedPortableClassDefinition)
+                                                        .setString("name", "foo")
+                                                        .setInt("myint", 123).build();
 
 
-        GenericRecord inConsistentNamedRecord = GenericRecord.Builder.portable(inConsistentNamedPortableClassDefinition)
-                                                                     .writeUTF("WrongName", "foo")
-                                                                     .writeInt("myint", 123).build();
+        GenericRecord inConsistentNamedRecord = GenericRecordBuilder.portable(inConsistentNamedPortableClassDefinition)
+                                                                    .setString("WrongName", "foo")
+                                                                    .setInt("myint", 123).build();
 
 
         HazelcastInstance instance = createAccessorInstance(serializationConfig);
@@ -331,45 +332,45 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         GenericRecord[] namedRecords = new GenericRecord[inner.nn.length];
         int i = 0;
         for (NamedPortable namedPortable : inner.nn) {
-            GenericRecord namedRecord = GenericRecord.Builder.portable(namedPortableClassDefinition)
-                                                             .writeUTF("name", inner.nn[i].name)
-                                                             .writeInt("myint", inner.nn[i].myint).build();
+            GenericRecord namedRecord = GenericRecordBuilder.portable(namedPortableClassDefinition)
+                                                            .setString("name", inner.nn[i].name)
+                                                            .setInt("myint", inner.nn[i].myint).build();
             namedRecords[i++] = namedRecord;
         }
 
-        GenericRecord innerRecord = GenericRecord.Builder.portable(innerPortableClassDefinition)
-                                                         .writeByteArray("b", inner.bb)
-                                                         .writeCharArray("c", inner.cc)
-                                                         .writeShortArray("s", inner.ss)
-                                                         .writeIntArray("i", inner.ii)
-                                                         .writeLongArray("l", inner.ll)
-                                                         .writeFloatArray("f", inner.ff)
-                                                         .writeDoubleArray("d", inner.dd)
-                                                         .writeGenericRecordArray("nn", namedRecords)
-                                                         .writeDecimalArray("bigDecimals", inner.bigDecimals)
-                                                         .writeTimeArray("localTimes", inner.localTimes)
-                                                         .writeDateArray("localDates", inner.localDates)
-                                                         .writeTimestampArray("localDateTimes", inner.localDateTimes)
-                                                         .writeTimestampWithTimezoneArray("offsetDateTimes", inner.offsetDateTimes)
-                                                         .build();
+        GenericRecord innerRecord = GenericRecordBuilder.portable(innerPortableClassDefinition)
+                                                        .setByteArray("b", inner.bb)
+                                                        .setCharArray("c", inner.cc)
+                                                        .setShortArray("s", inner.ss)
+                                                        .setIntArray("i", inner.ii)
+                                                        .setLongArray("l", inner.ll)
+                                                        .setFloatArray("f", inner.ff)
+                                                        .setDoubleArray("d", inner.dd)
+                                                        .setGenericRecordArray("nn", namedRecords)
+                                                        .setDecimalArray("bigDecimals", inner.bigDecimals)
+                                                        .setTimeArray("localTimes", inner.localTimes)
+                                                        .setDateArray("localDates", inner.localDates)
+                                                        .setTimestampArray("localDateTimes", inner.localDateTimes)
+                                                        .setTimestampWithTimezoneArray("offsetDateTimes", inner.offsetDateTimes)
+                                                        .build();
 
-        return GenericRecord.Builder.portable(mainPortableClassDefinition)
-                                    .writeByte("b", expectedPortable.b)
-                                    .writeBoolean("bool", expectedPortable.bool)
-                                    .writeChar("c", expectedPortable.c)
-                                    .writeShort("s", expectedPortable.s)
-                                    .writeInt("i", expectedPortable.i)
-                                    .writeLong("l", expectedPortable.l)
-                                    .writeFloat("f", expectedPortable.f)
-                                    .writeDouble("d", expectedPortable.d)
-                                    .writeUTF("str", expectedPortable.str)
-                                    .writeGenericRecord("p", innerRecord)
-                                    .writeDecimal("bigDecimal", expectedPortable.bigDecimal)
-                                    .writeTime("localTime", expectedPortable.localTime)
-                                    .writeDate("localDate", expectedPortable.localDate)
-                                    .writeTimestamp("localDateTime", expectedPortable.localDateTime)
-                                    .writeTimestampWithTimezone("offsetDateTime", expectedPortable.offsetDateTime)
-                                    .build();
+        return GenericRecordBuilder.portable(mainPortableClassDefinition)
+                                   .setByte("b", expectedPortable.b)
+                                   .setBoolean("bool", expectedPortable.bool)
+                                   .setChar("c", expectedPortable.c)
+                                   .setShort("s", expectedPortable.s)
+                                   .setInt("i", expectedPortable.i)
+                                   .setLong("l", expectedPortable.l)
+                                   .setFloat("f", expectedPortable.f)
+                                   .setDouble("d", expectedPortable.d)
+                                   .setString("str", expectedPortable.str)
+                                   .setGenericRecord("p", innerRecord)
+                                   .setDecimal("bigDecimal", expectedPortable.bigDecimal)
+                                   .setTime("localTime", expectedPortable.localTime)
+                                   .setDate("localDate", expectedPortable.localDate)
+                                   .setTimestamp("localDateTime", expectedPortable.localDateTime)
+                                   .setTimestampWithTimezone("offsetDateTime", expectedPortable.offsetDateTime)
+                                   .build();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/genericrecord/GenericRecordBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/genericrecord/GenericRecordBuilderTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.serialization.impl.TestSerializationConstants;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -50,10 +51,10 @@ public class GenericRecordBuilderTest {
                         .addUTFField("name").addIntField("myint").build();
 
 
-        GenericRecord.Builder builder = GenericRecord.Builder.portable(namedPortableClassDefinition);
-        builder.writeUTF("name", "foo");
-        builder.writeInt("myint", 123);
-        assertThrows(HazelcastSerializationException.class, () -> builder.writeUTF("name", "foo2"));
+        GenericRecordBuilder builder = GenericRecordBuilder.portable(namedPortableClassDefinition);
+        builder.setString("name", "foo");
+        builder.setInt("myint", 123);
+        assertThrows(HazelcastSerializationException.class, () -> builder.setString("name", "foo2"));
     }
 
     @Test
@@ -63,12 +64,12 @@ public class GenericRecordBuilderTest {
                         .addUTFField("name").addIntField("myint").build();
 
 
-        GenericRecord record = GenericRecord.Builder.portable(namedPortableClassDefinition)
-                .writeUTF("name", "foo")
-                .writeInt("myint", 123).build();
+        GenericRecord record = GenericRecordBuilder.portable(namedPortableClassDefinition)
+                                                   .setString("name", "foo")
+                                                   .setInt("myint", 123).build();
 
-        GenericRecord.Builder builder = record.cloneWithBuilder().writeUTF("name", "foo2");
-        assertThrows(HazelcastSerializationException.class, () -> builder.writeUTF("name", "foo3"));
+        GenericRecordBuilder builder = record.cloneWithBuilder().setString("name", "foo2");
+        assertThrows(HazelcastSerializationException.class, () -> builder.setString("name", "foo3"));
     }
 
     @Test
@@ -77,8 +78,8 @@ public class GenericRecordBuilderTest {
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
                         .addUTFField("name").addIntField("myint").build();
 
-        GenericRecord.Builder builder = GenericRecord.Builder.portable(classDefinition);
-        assertThrows(HazelcastSerializationException.class, () -> builder.writeUTF("nonExistingField", "foo3"));
+        GenericRecordBuilder builder = GenericRecordBuilder.portable(classDefinition);
+        assertThrows(HazelcastSerializationException.class, () -> builder.setString("nonExistingField", "foo3"));
     }
 
     @Test
@@ -87,8 +88,8 @@ public class GenericRecordBuilderTest {
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
                         .addUTFField("name").addIntField("myint").build();
 
-        GenericRecord.Builder builder = GenericRecord.Builder.portable(classDefinition);
-        assertThrows(HazelcastSerializationException.class, () -> builder.writeInt("name", 1));
+        GenericRecordBuilder builder = GenericRecordBuilder.portable(classDefinition);
+        assertThrows(HazelcastSerializationException.class, () -> builder.setInt("name", 1));
     }
 
     @Test
@@ -97,8 +98,8 @@ public class GenericRecordBuilderTest {
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
                         .addUTFField("name").addIntField("myint").build();
 
-        GenericRecord.Builder builder = GenericRecord.Builder.portable(classDefinition);
-        builder.writeInt("myint", 1);
+        GenericRecordBuilder builder = GenericRecordBuilder.portable(classDefinition);
+        builder.setInt("myint", 1);
         assertThrows(HazelcastSerializationException.class, builder::build);
     }
 
@@ -114,9 +115,9 @@ public class GenericRecordBuilderTest {
 
         List<GenericRecord> list = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            GenericRecord record = GenericRecord.Builder.portable(classDefinition)
-                    .writeInt("age", i)
-                    .writeUTF("name", " " + i).build();
+            GenericRecord record = GenericRecordBuilder.portable(classDefinition)
+                                                       .setInt("age", i)
+                                                       .setString("name", " " + i).build();
             objectDataOutput.writeObject(record);
             list.add(record);
         }


### PR DESCRIPTION
GenericRecord#read methods renamed to get
GenericRecord.Builder#write methods are renamed to set
GenericRecord.Builder moved to its own class as GenericRecordBuilder

UTF renamed to String in following API's. Old API's are deprecated

ClassDefinitionBuilder.addUTFField()
ClassDefinitionBuilder.addUTFArrayField()
PortableWriter.writeUTF()
PortableWriter.writeUTFArray()
PortableReader.readUTF()
PortableReader.readUTFArray()
ObjectDataOutput.writeUTF()
ObjectDataOutput.writeUTFArray()
ObjectDataInput.readUTF()
ObjectDataInput.readUTFArray()

UTF renamed to String without deprecation on following API's

GenericRecord.readUTF()
GenericRecord.readUTFArray()

GenericRecordBuilder.writeUTF()
GenericRecordBuilder.writeUTFArray()

FieldType.UTF could not be changed because of backward compatibility.
FieldType.String could not be added because of same reason.