### PR TITLE
implementation of IMap.valuesAsync() and IMap.valuesAsync(Predicate)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -2342,6 +2342,27 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V>, Iterable
     Collection<V> values();
 
     /**
+     * Returns a {@link CompletionStage} of an immutable collection clone of the values
+     * contained in this map.
+     * <p>
+     * <b>Warning:</b>
+     * <p>
+     * The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection.
+     * <p>
+     * This method is always executed by a distributed query,
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link ClusterProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
+     *
+     * @return a CompletionStage an immutable collection clone of the values contained
+     * in this map
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @see ClusterProperty#QUERY_RESULT_SIZE_LIMIT
+     */
+    @Nonnull
+    CompletionStage<Collection<V>> valuesAsync();
+
+    /**
      * Returns an immutable {@link Set} clone of the mappings contained in this map.
      * <p>
      * <b>Warning:</b>
@@ -2426,7 +2447,33 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V>, Iterable
      * @throws NullPointerException             if the predicate is {@code null}
      * @see ClusterProperty#QUERY_RESULT_SIZE_LIMIT
      */
+    @Nonnull
     Collection<V> values(@Nonnull Predicate<K, V> predicate);
+
+    /**
+     * Queries the map based on the specified predicate and returns a
+     * {@link CompletionStage} of an immutable collection of the values
+     * of matching entries.
+     * <p>
+     * Specified predicate runs on all members in parallel.
+     * <p>
+     * <b>Warning:</b>
+     * <p>
+     * The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection.
+     * <p>
+     * This method is always executed by a distributed query,
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link ClusterProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
+     *
+     * @param predicate specified query criteria
+     * @return a CompletionStage of the result value collection of the query
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @throws NullPointerException             if the predicate is {@code null}
+     * @see ClusterProperty#QUERY_RESULT_SIZE_LIMIT
+     */
+    @Nonnull
+    CompletionStage<Collection<V>> valuesAsync(@Nonnull Predicate<K, V> predicate);
 
     /**
      * Returns the locally owned immutable set of keys.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1354,11 +1354,21 @@ abstract class MapProxySupport<K, V>
     }
 
     protected <T extends Result> T executeQueryInternal(Predicate predicate, IterationType iterationType, Target target) {
-        return executeQueryInternal(predicate, null, null, iterationType, target);
+        return (T) executeQueryInternalAsync(predicate, iterationType, target).join();
+    }
+
+    protected <T extends Result> CompletableFuture<T> executeQueryInternalAsync(
+            Predicate predicate, IterationType iterationType, Target target) {
+        return executeQueryInternalAsync(predicate, null, null, iterationType, target);
     }
 
     protected <T extends Result> T executeQueryInternal(Predicate predicate, Aggregator aggregator, Projection projection,
                                                         IterationType iterationType, Target target) {
+        return (T) executeQueryInternalAsync(predicate, aggregator, projection, iterationType, target).join();
+    }
+
+    protected <T extends Result> CompletableFuture<T> executeQueryInternalAsync(
+            Predicate predicate, Aggregator aggregator, Projection projection, IterationType iterationType, Target target) {
         QueryEngine queryEngine = getMapQueryEngine();
         final Predicate userPredicate;
 
@@ -1386,7 +1396,7 @@ abstract class MapProxySupport<K, V>
                 .aggregator(aggregator)
                 .projection(projection)
                 .build();
-        return queryEngine.execute(query, target);
+        return queryEngine.executeAsync(query, target);
     }
 
     protected void handleHazelcastInstanceAwareParams(Object... objects) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngine.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.query;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Responsible for executing queries on the IMap.
  */
@@ -30,4 +32,6 @@ public interface QueryEngine {
      * @return Result of the specific type
      */
     <T extends Result> T execute(Query query, Target target);
+
+    <T extends Result> CompletableFuture<T> executeAsync(Query query, Target target);
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -26,6 +26,8 @@ import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.impl.TestSerializationConstants;
+import com.hazelcast.internal.serialization.impl.portable.NamedPortable;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.LocalMapStats;
@@ -37,9 +39,7 @@ import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.internal.serialization.impl.portable.NamedPortable;
 import com.hazelcast.nio.serialization.Portable;
-import com.hazelcast.internal.serialization.impl.TestSerializationConstants;
 import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
@@ -50,12 +50,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -67,6 +61,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
@@ -536,12 +535,31 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testAsyncValuesWithPredicate() throws Exception {
+        IMap<String, String> map = createMap();
+        fillMap(map);
+
+        Future<Collection<String>> futureValues = map.valuesAsync(Predicates.sql("this == value1")).toCompletableFuture();
+        assertEquals(1, futureValues.get().size());
+        assertEquals("value1", futureValues.get().iterator().next());
+    }
+
+    @Test
     public void testValues() {
         IMap<String, String> map = createMap();
         fillMap(map);
 
         Collection values = map.values();
         assertEquals(10, values.size());
+    }
+
+    @Test
+    public void testAsyncValues() throws Exception {
+        IMap<String, String> map = createMap();
+        fillMap(map);
+
+        Future<Collection<String>> futureValues = map.valuesAsync().toCompletableFuture();
+        assertEquals(10, futureValues.get().size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
@@ -18,19 +18,20 @@ package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
+import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -69,6 +70,23 @@ public class AsyncTest extends HazelcastTestSupport {
         Future<String> f2 = map.putAsync(key, value2).toCompletableFuture();
         String f2Val = f2.get();
         assertEquals(value1, f2Val);
+    }
+
+    @Test
+    public void testValuesAsync() throws Exception {
+        IMap<String, String> map = instance.getMap(randomString());
+        map.put(key, value1);
+        Future<Collection<String>> futureValues = map.valuesAsync().toCompletableFuture();
+        assertEquals(1, futureValues.get().size());
+        assertEquals(value1, futureValues.get().iterator().next());
+    }
+
+    @Test
+    public void testValuesAsyncWithPredicate() throws Exception {
+        IMap<String, String> map = instance.getMap(randomString());
+        map.put(key, value1);
+        Future<Collection<String>> futureValues = map.valuesAsync(Predicates.alwaysFalse()).toCompletableFuture();
+        assertEquals(0, futureValues.get().size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
@@ -205,4 +205,6 @@ public class MapValuesTest extends HazelcastTestSupport {
             return mapEntry.getValue().startsWith("good");
         }
     }
+
+    //valuesAsync tests can be found from com/hazelcast/map/AsyncTest.java
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngine_DispatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngine_DispatchTest.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.hazelcast.internal.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
@@ -94,7 +95,8 @@ public class QueryEngine_DispatchTest extends HazelcastTestSupport {
                 .partitionIdSet(queryEngine.getAllPartitionIds())
                 .iterationType(IterationType.ENTRY).build();
         List<Future<Result>> futures = queryEngine
-                .dispatchFullQueryOnQueryThread(query, target);
+                .dispatchFullQueryOnQueryThread(query, target)
+                .stream().map(cf -> (Future<Result>) cf).collect(Collectors.toList());
         Collection<Result> results = returnWithDeadline(futures, 1, TimeUnit.MINUTES);
         QueryResult result = (QueryResult) results.iterator().next();
 


### PR DESCRIPTION
attempt to resolve  #17370 .

currently, QueryEngine.execute invokes executeAsync which I have implemented.

Tests passed (MapAggregateTest, MapValuesTest, QueryEngineImplTest)

Please provide a feedback whether I am on the right track.

Also, the original design is to used partitionIdSet as a shared state to keep the ids that need re-dispatching. (within addResultsOfPredicate)

I thought I could remove that and make it more async, but was not sure if there will be any benefit from it, so I kept it.


