### PR TITLE
Fix URLDefinition#equals

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -52,7 +52,7 @@ import static java.lang.Boolean.getBoolean;
  */
 public final class ServiceLoader {
     // kill-switch for URLDefinition#equals fix to take into account classloader
-    private static final boolean URLDEFINITION_COMPAT = getBoolean("hazelcast.compat.urldefinition");
+    private static final boolean URLDEFINITION_COMPAT = getBoolean("hazelcast.compat.classloading.urldefinition");
 
     private static final ILogger LOGGER = Logger.getLogger(ServiceLoader.class);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -79,18 +79,18 @@ public final class ServiceLoader {
     public static <T> Iterator<Class<T>> classIterator(Class<T> expectedType, String factoryId, ClassLoader classLoader)
             throws Exception {
         Set<ServiceDefinition> serviceDefinitions = getServiceDefinitions(factoryId, classLoader);
-        return new ClassIterator<T>(serviceDefinitions, expectedType);
+        return new ClassIterator<>(serviceDefinitions, expectedType);
     }
 
     private static Set<ServiceDefinition> getServiceDefinitions(String factoryId, ClassLoader classLoader) {
         List<ClassLoader> classLoaders = selectClassLoaders(classLoader);
 
-        Set<URLDefinition> factoryUrls = new HashSet<URLDefinition>();
+        Set<URLDefinition> factoryUrls = new HashSet<>();
         for (ClassLoader selectedClassLoader : classLoaders) {
             factoryUrls.addAll(collectFactoryUrls(factoryId, selectedClassLoader));
         }
 
-        Set<ServiceDefinition> serviceDefinitions = new HashSet<ServiceDefinition>();
+        Set<ServiceDefinition> serviceDefinitions = new HashSet<>();
         for (URLDefinition urlDefinition : factoryUrls) {
             serviceDefinitions.addAll(parse(urlDefinition));
         }
@@ -106,7 +106,7 @@ public final class ServiceLoader {
         try {
             Enumeration<URL> configs = classLoader.getResources(resourceName);
 
-            Set<URLDefinition> urlDefinitions = new HashSet<URLDefinition>();
+            Set<URLDefinition> urlDefinitions = new HashSet<>();
             while (configs.hasMoreElements()) {
                 URL url = configs.nextElement();
                 if (!classLoader.getClass().getName().equals(IGNORED_GLASSFISH_MAGIC_CLASSLOADER)) {
@@ -123,7 +123,7 @@ public final class ServiceLoader {
 
     private static Set<ServiceDefinition> parse(URLDefinition urlDefinition) {
         try {
-            Set<ServiceDefinition> names = new HashSet<ServiceDefinition>();
+            Set<ServiceDefinition> names = new HashSet<>();
             BufferedReader r = null;
             try {
                 URL url = urlDefinition.url;
@@ -295,13 +295,10 @@ public final class ServiceLoader {
                     constructor.setAccessible(true);
                 }
                 return constructor.newInstance();
-            } catch (InstantiationException e) {
-                throw new HazelcastException(e);
-            } catch (IllegalAccessException e) {
-                throw new HazelcastException(e);
-            } catch (NoSuchMethodException e) {
-                throw new HazelcastException(e);
-            } catch (InvocationTargetException e) {
+            } catch (InstantiationException
+                    | IllegalAccessException
+                    | NoSuchMethodException
+                    | InvocationTargetException e) {
                 throw new HazelcastException(e);
             }
         }
@@ -324,8 +321,8 @@ public final class ServiceLoader {
 
         private final Iterator<ServiceDefinition> iterator;
         private final Class<T> expectedType;
+        private final Set<Class<?>> alreadyProvidedClasses = new HashSet<>();
         private Class<T> nextClass;
-        private Set<Class<?>> alreadyProvidedClasses = new HashSet<Class<?>>();
 
         ClassIterator(Set<ServiceDefinition> serviceDefinitions, Class<T> expectedType) {
             iterator = serviceDefinitions.iterator();
@@ -412,7 +409,6 @@ public final class ServiceLoader {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public Class<T> next() {
             if (nextClass == null) {
                 advance();

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.util;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.ClassLoaderUtil;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
@@ -263,7 +264,7 @@ public final class ServiceLoader {
             if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
                 return false;
             }
-            return true;
+            return Objects.equals(classLoader, that.classLoader);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -51,8 +51,8 @@ import static java.lang.Boolean.getBoolean;
  * environments like application or OSGi servers.
  */
 public final class ServiceLoader {
-    //compatibility flag to re-introduce behaviour from 3.8.0 with classloading fallbacks
-    private static final boolean USE_CLASSLOADING_FALLBACK = getBoolean("hazelcast.compat.classloading.hooks.fallback");
+    // kill-switch for URLDefinition#equals fix to take into account classloader
+    private static final boolean URLDEFINITION_COMPAT = getBoolean("hazelcast.compat.urldefinition");
 
     private static final ILogger LOGGER = Logger.getLogger(ServiceLoader.class);
 
@@ -264,7 +264,7 @@ public final class ServiceLoader {
             if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
                 return false;
             }
-            return Objects.equals(classLoader, that.classLoader);
+            return URLDEFINITION_COMPAT || Objects.equals(classLoader, that.classLoader);
         }
 
         @Override
@@ -365,13 +365,7 @@ public final class ServiceLoader {
         }
 
         private Class<?> loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
-            Class<?> candidate;
-            if (USE_CLASSLOADING_FALLBACK) {
-                candidate = ClassLoaderUtil.loadClass(classLoader, className);
-            } else {
-                candidate = classLoader.loadClass(className);
-            }
-            return candidate;
+            return classLoader.loadClass(className);
         }
 
         private void onClassNotFoundException(String className, ClassLoader classLoader, ClassNotFoundException e) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -72,7 +72,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -135,8 +137,8 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ClassLoader parent = this.getClass().getClassLoader();
         ClassLoader childLoader = new StealingClassloader(parent);
         // ensure parent and child loader load separate Class objects for same class name
-        assertFalse(parent.loadClass(DataSerializerHook.class.getName())
-                        == childLoader.loadClass(DataSerializerHook.class.getName()));
+        assertNotSame(parent.loadClass(DataSerializerHook.class.getName()),
+                        childLoader.loadClass(DataSerializerHook.class.getName()));
 
         // request from childLoader the classes that implement DataSerializerHook, as loaded by parent
         Iterator<? extends Class<?>> iterator
@@ -148,7 +150,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         // ensure all hooks are loaded from parent classloader
         while (iterator.hasNext()) {
             Class<?> hook = iterator.next();
-            assertTrue(hook.getClassLoader() == parent);
+            assertSame(parent, hook.getClassLoader());
         }
     }
 
@@ -503,12 +505,12 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ctx.addServletMappingDecoded("/", "testServlet");
 
         tomcat.start();
-
-        assertTrueEventually(() -> assertTrue(testServlet.isInitDone()));
-        assertNull("No failure is expected from servlet init() method", testServlet.failure());
-
-        webappClassLoader = testServlet.getWebappClassLoader();
         try {
+            assertTrueEventually(() -> assertTrue(testServlet.isInitDone()));
+            assertNull("No failure is expected from servlet init() method", testServlet.failure());
+
+            webappClassLoader = testServlet.getWebappClassLoader();
+
             assertNotEquals(launchClassLoader, webappClassLoader);
             Iterator<? extends Class<?>> iterator
                     = ServiceLoader.classIterator(DataSerializerHook.class, "com.hazelcast.DataSerializerHook",

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -483,6 +483,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ClassLoader webappClassLoader;
         // setup embedded tomcat
         Tomcat tomcat = new Tomcat();
+        tomcat.setPort(13256); // 8080 may be used by some other tests
         Context ctx = tomcat.addContext("", null);
         // Map target/classes as WEB-INF/classes, so webapp classloader
         // will locate compiled production classes in the webapp classpath.

--- a/pom.xml
+++ b/pom.xml
@@ -1272,5 +1272,11 @@
             <version>1.7.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>9.0.41</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
`URLDefinition#equals` is updated to take into account classloader.

Fixes use cases where Hazelcast is deployed
as both app server and webapp lib. See use case
description in test added in `ServiceLoaderTest`.