### PR TITLE
Delete flood control mechanism to prevent launching actions in sync

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
@@ -34,7 +34,6 @@ import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.executor.LocalExecutorStats;
 import com.hazelcast.executor.impl.ExecutionCallbackAdapter;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
@@ -548,18 +547,6 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         Object response;
         try {
             response = f.get();
-        } catch (Exception e) {
-            response = e;
-        }
-        return response;
-    }
-
-    private Object retrieveResultFromMessage(ClientInvocationFuture f) {
-        Object response;
-        try {
-            SerializationService serializationService = getClient().getSerializationService();
-            Data data = ExecutorServiceSubmitToMemberCodec.decodeResponse(f.get());
-            response = serializationService.toObject(data);
         } catch (Exception e) {
             response = e;
         }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -29,7 +29,6 @@ import com.hazelcast.executor.impl.operations.MemberCallableTaskOperation;
 import com.hazelcast.executor.impl.operations.ShutdownOperation;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.internal.util.Timer;
 import com.hazelcast.logging.ILogger;
@@ -59,7 +58,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.logging.Level;
 
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
@@ -94,11 +92,6 @@ public class ExecutorServiceProxy
     private final Random random = new Random(-System.currentTimeMillis());
     private final int partitionCount;
     private final ILogger logger;
-
-    // This field is never accessed directly but by the CONSECUTIVE_SUBMITS above
-    private volatile int consecutiveSubmits;
-
-    private volatile long lastSubmitTime;
 
     public ExecutorServiceProxy(String name, NodeEngine nodeEngine, DistributedExecutorService service) {
         super(nodeEngine, service);

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -239,15 +239,6 @@ public class ExecutorServiceProxy
         Operation op = new CallableTaskOperation(name, uuid, callableData)
                 .setPartitionId(partitionId);
         InvocationFuture future = invokeOnPartition(op);
-        boolean sync = checkSync();
-        if (sync) {
-            try {
-                future.get();
-            } catch (Exception exception) {
-                logger.warning(exception);
-            }
-            return InternalCompletableFuture.newCompletedFuture(result);
-        }
         return new CancellableDelegatingFuture<>(future, result, nodeEngine, uuid, partitionId);
     }
 
@@ -262,13 +253,12 @@ public class ExecutorServiceProxy
     public <T> Future<T> submit(@Nonnull Callable<T> task) {
         checkNotNull(task, "task must not be null");
         final int partitionId = getTaskPartitionId(task);
-        return submitToPartitionOwner(task, partitionId, false);
+        return submitToPartitionOwner(task, partitionId);
     }
 
     private @Nonnull
     <T> Future<T> submitToPartitionOwner(@Nonnull Callable<T> task,
-                                         int partitionId,
-                                         boolean preventSync) {
+                                         int partitionId) {
         checkNotNull(task, "task must not be null");
         checkNotShutdown();
 
@@ -276,31 +266,10 @@ public class ExecutorServiceProxy
         Data taskData = nodeEngine.toData(task);
         UUID uuid = newUnsecureUUID();
 
-        boolean sync = !preventSync && checkSync();
         Operation op = new CallableTaskOperation(name, uuid, taskData)
                 .setPartitionId(partitionId);
         InternalCompletableFuture future = invokeOnPartition(op);
-        if (sync) {
-            return completedSynchronously(future, nodeEngine.getSerializationService());
-        }
         return new CancellableDelegatingFuture<>(future, nodeEngine, uuid, partitionId);
-    }
-
-    /**
-     * This is a hack to prevent overloading the system with unprocessed tasks. Once backpressure is added, this can
-     * be removed.
-     */
-    private boolean checkSync() {
-        boolean sync = false;
-        long last = lastSubmitTime;
-        long now = Clock.currentTimeMillis();
-        if (last + SYNC_DELAY_MS < now) {
-            CONSECUTIVE_SUBMITS.set(this, 0);
-        } else if (CONSECUTIVE_SUBMITS.incrementAndGet(this) % SYNC_FREQUENCY == 0) {
-            sync = true;
-        }
-        lastSubmitTime = now;
-        return sync;
     }
 
     private <T> int getTaskPartitionId(Callable<T> task) {
@@ -318,7 +287,7 @@ public class ExecutorServiceProxy
                                           @Nonnull Object key) {
         checkNotNull(key, "key must not be null");
         NodeEngine nodeEngine = getNodeEngine();
-        return submitToPartitionOwner(task, nodeEngine.getPartitionService().getPartitionId(key), false);
+        return submitToPartitionOwner(task, nodeEngine.getPartitionService().getPartitionId(key));
     }
 
     @Override
@@ -338,13 +307,9 @@ public class ExecutorServiceProxy
         UUID uuid = newUnsecureUUID();
         Address target = member.getAddress();
 
-        boolean sync = checkSync();
         MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, uuid, taskData);
         InternalCompletableFuture future = nodeEngine.getOperationService()
                 .invokeOnTarget(DistributedExecutorService.SERVICE_NAME, op, target);
-        if (sync) {
-            return completedSynchronously(future, nodeEngine.getSerializationService());
-        }
         return new CancellableDelegatingFuture<>(future, nodeEngine, uuid, target);
     }
 
@@ -541,7 +506,7 @@ public class ExecutorServiceProxy
             for (Callable<T> task : tasks) {
                 long startNanos = Timer.nanos();
                 int partitionId = getTaskPartitionId(task);
-                futures.add(submitToPartitionOwner(task, partitionId, true));
+                futures.add(submitToPartitionOwner(task, partitionId));
                 timeoutNanos -= Timer.nanosElapsed(startNanos);
             }
             if (timeoutNanos <= 0L) {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -73,12 +73,6 @@ public class ExecutorServiceProxy
         extends AbstractDistributedObject<DistributedExecutorService>
         implements IExecutorService {
 
-    public static final int SYNC_FREQUENCY = 100;
-    public static final int SYNC_DELAY_MS = 10;
-
-    private static final AtomicIntegerFieldUpdater<ExecutorServiceProxy> CONSECUTIVE_SUBMITS = AtomicIntegerFieldUpdater
-            .newUpdater(ExecutorServiceProxy.class, "consecutiveSubmits");
-
     private final ExceptionHandler shutdownExceptionHandler = new ExceptionHandler() {
         @Override
         public void handleException(Throwable throwable) {


### PR DESCRIPTION
This commit addresses discussion from #17587  and other referenced tasks.

For now we'll remove sync mechanism, as it causes unexpected delays.

Closes #17587, #9117, #13170