### PR TITLE
[BACKPORT] Fix URLDefinition#equals

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.util;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.ClassLoaderUtil;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
@@ -50,8 +51,8 @@ import static java.lang.Boolean.getBoolean;
  * environments like application or OSGi servers.
  */
 public final class ServiceLoader {
-    //compatibility flag to re-introduce behaviour from 3.8.0 with classloading fallbacks
-    private static final boolean USE_CLASSLOADING_FALLBACK = getBoolean("hazelcast.compat.classloading.hooks.fallback");
+    // kill-switch for URLDefinition#equals fix to take into account classloader
+    private static final boolean URLDEFINITION_COMPAT = getBoolean("hazelcast.compat.classloading.urldefinition");
 
     private static final ILogger LOGGER = Logger.getLogger(ServiceLoader.class);
 
@@ -78,18 +79,18 @@ public final class ServiceLoader {
     public static <T> Iterator<Class<T>> classIterator(Class<T> expectedType, String factoryId, ClassLoader classLoader)
             throws Exception {
         Set<ServiceDefinition> serviceDefinitions = getServiceDefinitions(factoryId, classLoader);
-        return new ClassIterator<T>(serviceDefinitions, expectedType);
+        return new ClassIterator<>(serviceDefinitions, expectedType);
     }
 
     private static Set<ServiceDefinition> getServiceDefinitions(String factoryId, ClassLoader classLoader) {
         List<ClassLoader> classLoaders = selectClassLoaders(classLoader);
 
-        Set<URLDefinition> factoryUrls = new HashSet<URLDefinition>();
+        Set<URLDefinition> factoryUrls = new HashSet<>();
         for (ClassLoader selectedClassLoader : classLoaders) {
             factoryUrls.addAll(collectFactoryUrls(factoryId, selectedClassLoader));
         }
 
-        Set<ServiceDefinition> serviceDefinitions = new HashSet<ServiceDefinition>();
+        Set<ServiceDefinition> serviceDefinitions = new HashSet<>();
         for (URLDefinition urlDefinition : factoryUrls) {
             serviceDefinitions.addAll(parse(urlDefinition));
         }
@@ -105,7 +106,7 @@ public final class ServiceLoader {
         try {
             Enumeration<URL> configs = classLoader.getResources(resourceName);
 
-            Set<URLDefinition> urlDefinitions = new HashSet<URLDefinition>();
+            Set<URLDefinition> urlDefinitions = new HashSet<>();
             while (configs.hasMoreElements()) {
                 URL url = configs.nextElement();
                 if (!classLoader.getClass().getName().equals(IGNORED_GLASSFISH_MAGIC_CLASSLOADER)) {
@@ -122,7 +123,7 @@ public final class ServiceLoader {
 
     private static Set<ServiceDefinition> parse(URLDefinition urlDefinition) {
         try {
-            Set<ServiceDefinition> names = new HashSet<ServiceDefinition>();
+            Set<ServiceDefinition> names = new HashSet<>();
             BufferedReader r = null;
             try {
                 URL url = urlDefinition.url;
@@ -263,7 +264,7 @@ public final class ServiceLoader {
             if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
                 return false;
             }
-            return true;
+            return URLDEFINITION_COMPAT || Objects.equals(classLoader, that.classLoader);
         }
 
         @Override
@@ -294,13 +295,10 @@ public final class ServiceLoader {
                     constructor.setAccessible(true);
                 }
                 return constructor.newInstance();
-            } catch (InstantiationException e) {
-                throw new HazelcastException(e);
-            } catch (IllegalAccessException e) {
-                throw new HazelcastException(e);
-            } catch (NoSuchMethodException e) {
-                throw new HazelcastException(e);
-            } catch (InvocationTargetException e) {
+            } catch (InstantiationException
+                    | IllegalAccessException
+                    | NoSuchMethodException
+                    | InvocationTargetException e) {
                 throw new HazelcastException(e);
             }
         }
@@ -323,8 +321,8 @@ public final class ServiceLoader {
 
         private final Iterator<ServiceDefinition> iterator;
         private final Class<T> expectedType;
+        private final Set<Class<?>> alreadyProvidedClasses = new HashSet<>();
         private Class<T> nextClass;
-        private Set<Class<?>> alreadyProvidedClasses = new HashSet<Class<?>>();
 
         ClassIterator(Set<ServiceDefinition> serviceDefinitions, Class<T> expectedType) {
             iterator = serviceDefinitions.iterator();
@@ -367,13 +365,7 @@ public final class ServiceLoader {
         }
 
         private Class<?> loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
-            Class<?> candidate;
-            if (USE_CLASSLOADING_FALLBACK) {
-                candidate = ClassLoaderUtil.loadClass(classLoader, className);
-            } else {
-                candidate = classLoader.loadClass(className);
-            }
-            return candidate;
+            return classLoader.loadClass(className);
         }
 
         private void onClassNotFoundException(String className, ClassLoader classLoader, ClassNotFoundException e) {
@@ -411,7 +403,6 @@ public final class ServiceLoader {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public Class<T> next() {
             if (nextClass == null) {
                 advance();

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.util;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.portable.PortableHook;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
@@ -31,11 +31,22 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType;
+import org.apache.catalina.Context;
+import org.apache.catalina.WebResourceRoot;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.webresources.DirResourceSet;
+import org.apache.catalina.webresources.StandardRoot;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -51,13 +62,19 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -98,6 +115,42 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         while (iterator.hasNext()) {
             Class<?> hook = iterator.next();
             assertEquals(childLoader, hook.getClassLoader());
+        }
+    }
+
+    @Test
+    public void testMultipleClassloaderLoadsTheSameClass_fromParentClassLoader() throws Exception {
+        // Given: a parent & child class loaders that can load same classes
+        //        and same factoryId from same URL
+        // When:  requesting classes loaded by parent class loader from the child loader
+        // Then:  classes from parent class loader are returned
+
+        // Use case:
+        //  - Hazelcast jars in both tomcat/lib and tomcat/webapps/foo/lib
+        //  - Tomcat configured with hazelcast session manager (also in tomcat/lib)
+        //  - Session manager is being initialized for foo context: service loading
+        //    uses foo webapp classloader to locate all resources by factoryId.
+        //    It locates factoryId's both in foo/lib and tomcat/lib but returned
+        //    classes must be loaded from the parent classloader (from the
+        //    Hazelcast jar in tomcat/lib, same as the HazelcastInstance class that
+        //    is being started by the session manager).
+        ClassLoader parent = this.getClass().getClassLoader();
+        ClassLoader childLoader = new StealingClassloader(parent);
+        // ensure parent and child loader load separate Class objects for same class name
+        assertNotSame(parent.loadClass(DataSerializerHook.class.getName()),
+                        childLoader.loadClass(DataSerializerHook.class.getName()));
+
+        // request from childLoader the classes that implement DataSerializerHook, as loaded by parent
+        Iterator<? extends Class<?>> iterator
+                = ServiceLoader.classIterator(DataSerializerHook.class, "com.hazelcast.DataSerializerHook", childLoader);
+
+        //make sure hooks were found.
+        assertTrue(iterator.hasNext());
+
+        // ensure all hooks are loaded from parent classloader
+        while (iterator.hasNext()) {
+            Class<?> hook = iterator.next();
+            assertSame(parent, hook.getClassLoader());
         }
     }
 
@@ -423,6 +476,103 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         }
 
         assertEquals(1, implementations.size());
+    }
+
+    @Test
+    public void testClassIteratorInTomcat_whenClassesInBothLibs()
+            throws Exception {
+        ClassLoader launchClassLoader = this.getClass().getClassLoader();
+        ClassLoader webappClassLoader;
+        // setup embedded tomcat
+        Tomcat tomcat = new Tomcat();
+        tomcat.setPort(13256); // 8080 may be used by some other tests
+        Context ctx = tomcat.addContext("", null);
+        // Map target/classes as WEB-INF/classes, so webapp classloader
+        // will locate compiled production classes in the webapp classpath.
+        // The purpose of this setup is to make project classes available
+        // to both launch classloader and webapplication classloader,
+        // modeling a Tomcat deployment in which Hazelcast JARs are deployed
+        // in both tomcat/lib and webapp/lib
+        File webInfClasses = new File("target/classes");
+        WebResourceRoot resources = new StandardRoot(ctx);
+        resources.addPreResources(new DirResourceSet(resources, "/WEB-INF/classes",
+                webInfClasses.getAbsolutePath(), "/"));
+        ctx.setResources(resources);
+
+        TestServiceLoaderServlet testServlet = new TestServiceLoaderServlet();
+        Wrapper wrapper = tomcat.addServlet("", "testServlet", testServlet);
+        wrapper.setLoadOnStartup(1);
+        ctx.addServletMappingDecoded("/", "testServlet");
+
+        tomcat.start();
+        try {
+            assertTrueEventually(() -> assertTrue(testServlet.isInitDone()));
+            assertNull("No failure is expected from servlet init() method", testServlet.failure());
+
+            webappClassLoader = testServlet.getWebappClassLoader();
+
+            assertNotEquals(launchClassLoader, webappClassLoader);
+            Iterator<? extends Class<?>> iterator
+                    = ServiceLoader.classIterator(DataSerializerHook.class, "com.hazelcast.DataSerializerHook",
+                    webappClassLoader);
+            assertTrue(iterator.hasNext());
+            while (iterator.hasNext()) {
+                Class<?> klass = iterator.next();
+                assertEquals(launchClassLoader, klass.getClassLoader());
+            }
+        } finally {
+            tomcat.stop();
+        }
+    }
+
+    private static class TestServiceLoaderServlet extends HttpServlet {
+
+        private static final long serialVersionUID = 1L;
+        private volatile ClassLoader webappClassLoader;
+        private AtomicBoolean initDone = new AtomicBoolean();
+        private AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        @Override
+        public void init() throws ServletException {
+            super.init();
+            try {
+                webappClassLoader = Thread.currentThread().getContextClassLoader();
+                Class<?> dshKlass = webappClassLoader.loadClass(DataSerializerHook.class.getName());
+                Iterator<? extends Class<?>> iterator
+                        = ServiceLoader.classIterator(dshKlass, "com.hazelcast.DataSerializerHook",
+                        webappClassLoader);
+                // webapp classloader locates and loads classes from webapp classpath
+                assertTrue(iterator.hasNext());
+                while (iterator.hasNext()) {
+                    Class<?> klass = iterator.next();
+                    assertEquals(webappClassLoader, klass.getClassLoader());
+                }
+            } catch (Throwable t) {
+                failure.set(t);
+                throw new ServletException(t);
+            } finally {
+                initDone.set(true);
+            }
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                throws IOException {
+            resp.setContentType("text/plain");
+            resp.getWriter().print("OK");
+        }
+
+        public ClassLoader getWebappClassLoader() {
+            return webappClassLoader;
+        }
+
+        public boolean isInitDone() {
+            return initDone.get();
+        }
+
+        public Throwable failure() {
+            return failure.get();
+        }
     }
 
     public interface ServiceLoaderTestInterface {

--- a/pom.xml
+++ b/pom.xml
@@ -1271,5 +1271,11 @@
             <version>1.7.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>9.0.41</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes `URLDefinition#equals`

to also take into account classloader.
Fixes use cases where Hazelcast is deployed
as both app server and webapp lib.

(cherry picked from commit 8e692bc6d47204b9c840b9c1e90f1fd3864e15f5)

Backport of #18103 to `4.1.z`