### PR TITLE
Fail fast when using IndexType#BITMAP on HD

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddIndexMessageTask.java
@@ -19,10 +19,12 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddIndexCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractAllPartitionsMessageTask;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.IndexType;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.AddIndexOperationFactory;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.impl.operationservice.OperationFactory;
@@ -77,6 +79,14 @@ public class MapAddIndexMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.indexConfig};
+        return new Object[] {parameters.indexConfig};
+    }
+
+    @Override
+    protected void beforeProcess() {
+        if (nodeEngine.getConfig().getMapConfig(parameters.name).getInMemoryFormat() == InMemoryFormat.NATIVE &&
+                parameters.indexConfig.getType() == IndexType.BITMAP) {
+            throw new IllegalArgumentException("BITMAP indexes are not supported by NATIVE storage");
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddIndexMessageTask.java
@@ -84,8 +84,8 @@ public class MapAddIndexMessageTask
 
     @Override
     protected void beforeProcess() {
-        if (nodeEngine.getConfig().getMapConfig(parameters.name).getInMemoryFormat() == InMemoryFormat.NATIVE &&
-                parameters.indexConfig.getType() == IndexType.BITMAP) {
+        if (nodeEngine.getConfig().getMapConfig(parameters.name).getInMemoryFormat() == InMemoryFormat.NATIVE
+                && parameters.indexConfig.getType() == IndexType.BITMAP) {
             throw new IllegalArgumentException("BITMAP indexes are not supported by NATIVE storage");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -641,7 +641,6 @@ public final class ConfigValidator {
                 if (indexConfig.getType() == IndexType.BITMAP) {
                     throw new InvalidConfigurationException("BITMAP indexes are not supported by NATIVE storage");
                 }
-                ;
             }
         }
     }


### PR DESCRIPTION
Usage of bitmap index in HD memory fast fails now. Tests are here https://github.com/hazelcast/hazelcast-enterprise/pull/3922.

Fixes #17032 