### PR TITLE
[BACKPORT] Fixes URLDefinition#equals

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -48,6 +48,9 @@ import static java.lang.Boolean.getBoolean;
  * environments like application or OSGi servers.
  */
 public final class ServiceLoader {
+    // kill-switch for URLDefinition#equals fix to take into account classloader
+    private static final boolean URLDEFINITION_COMPAT = getBoolean("hazelcast.compat.classloading.urldefinition");
+
     //compatibility flag to re-introduce behaviour from 3.8.0 with classloading fallbacks
     private static final boolean USE_CLASSLOADING_FALLBACK = getBoolean("hazelcast.compat.classloading.hooks.fallback");
 
@@ -258,7 +261,11 @@ public final class ServiceLoader {
             if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
                 return false;
             }
-            return true;
+            if (URLDEFINITION_COMPAT) {
+                return true;
+            } else {
+                return classLoader != null ? classLoader.equals(that.classLoader) : that.classLoader == null;
+            }
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -473,7 +473,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         // modeling a Tomcat deployment in which Hazelcast JARs are deployed
         // in both tomcat/lib and webapp/lib
         File webInfClasses = new File("target/classes");
-        TestServiceLoaderServlet testServlet = new TestServiceLoaderServlet();
+        final TestServiceLoaderServlet testServlet = new TestServiceLoaderServlet();
         Wrapper wrapper = tomcat.addServlet("", "testServlet", testServlet);
         wrapper.setLoadOnStartup(1);
         ctx.addServletMapping("/", "testServlet");

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.util;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.PortableHook;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.ClassDefinition;
@@ -24,16 +25,25 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.SerializerHook;
 import com.hazelcast.spi.impl.SpiPortableHook;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType;
+import org.apache.catalina.Context;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.loader.WebappLoader;
+import org.apache.catalina.startup.Tomcat;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -44,13 +54,19 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -91,6 +107,42 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         while (iterator.hasNext()) {
             Class<?> hook = iterator.next();
             assertEquals(childLoader, hook.getClassLoader());
+        }
+    }
+
+    @Test
+    public void testMultipleClassloaderLoadsTheSameClass_fromParentClassLoader() throws Exception {
+        // Given: a parent & child class loaders that can load same classes
+        //        and same factoryId from same URL
+        // When:  requesting classes loaded by parent class loader from the child loader
+        // Then:  classes from parent class loader are returned
+
+        // Use case:
+        //  - Hazelcast jars in both tomcat/lib and tomcat/webapps/foo/lib
+        //  - Tomcat configured with hazelcast session manager (also in tomcat/lib)
+        //  - Session manager is being initialized for foo context: service loading
+        //    uses foo webapp classloader to locate all resources by factoryId.
+        //    It locates factoryId's both in foo/lib and tomcat/lib but returned
+        //    classes must be loaded from the parent classloader (from the
+        //    Hazelcast jar in tomcat/lib, same as the HazelcastInstance class that
+        //    is being started by the session manager).
+        ClassLoader parent = this.getClass().getClassLoader();
+        ClassLoader childLoader = new StealingClassloader(parent);
+        // ensure parent and child loader load separate Class objects for same class name
+        assertNotSame(parent.loadClass(DataSerializerHook.class.getName()),
+                childLoader.loadClass(DataSerializerHook.class.getName()));
+
+        // request from childLoader the classes that implement DataSerializerHook, as loaded by parent
+        Iterator<? extends Class<?>> iterator
+                = ServiceLoader.classIterator(DataSerializerHook.class, "com.hazelcast.DataSerializerHook", childLoader);
+
+        //make sure hooks were found.
+        assertTrue(iterator.hasNext());
+
+        // ensure all hooks are loaded from parent classloader
+        while (iterator.hasNext()) {
+            Class<?> hook = iterator.next();
+            assertSame(parent, hook.getClassLoader());
         }
     }
 
@@ -403,6 +455,105 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         }
 
         assertEquals(1, implementations.size());
+    }
+
+    @Test
+    public void testClassIteratorInTomcat_whenClassesInBothLibs()
+            throws Exception {
+        ClassLoader launchClassLoader = this.getClass().getClassLoader();
+        ClassLoader webappClassLoader;
+        // setup embedded tomcat
+        Tomcat tomcat = new Tomcat();
+        tomcat.setPort(13256); // 8080 may be used by some other tests
+        Context ctx = tomcat.addContext("", null);
+        // Map target/classes as WEB-INF/classes, so webapp classloader
+        // will locate compiled production classes in the webapp classpath.
+        // The purpose of this setup is to make project classes available
+        // to both launch classloader and webapplication classloader,
+        // modeling a Tomcat deployment in which Hazelcast JARs are deployed
+        // in both tomcat/lib and webapp/lib
+        File webInfClasses = new File("target/classes");
+        TestServiceLoaderServlet testServlet = new TestServiceLoaderServlet();
+        Wrapper wrapper = tomcat.addServlet("", "testServlet", testServlet);
+        wrapper.setLoadOnStartup(1);
+        ctx.addServletMapping("/", "testServlet");
+        WebappLoader loader = new WebappLoader();
+        loader.addRepository(webInfClasses.toURI().toURL().toString());
+        ctx.setLoader(loader);
+        tomcat.start();
+        try {
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() {
+                    assertTrue(testServlet.isInitDone());
+                }
+            });
+            assertNull("No failure is expected from servlet init() method", testServlet.failure());
+
+            webappClassLoader = testServlet.getWebappClassLoader();
+
+            assertNotEquals(launchClassLoader, webappClassLoader);
+            Iterator<? extends Class<?>> iterator
+                    = ServiceLoader.classIterator(DataSerializerHook.class, "com.hazelcast.DataSerializerHook",
+                    webappClassLoader);
+            assertTrue(iterator.hasNext());
+            while (iterator.hasNext()) {
+                Class<?> klass = iterator.next();
+                assertEquals(launchClassLoader, klass.getClassLoader());
+            }
+        } finally {
+            tomcat.stop();
+        }
+    }
+
+    private static class TestServiceLoaderServlet extends javax.servlet.http.HttpServlet {
+
+        private static final long serialVersionUID = 1L;
+        private volatile ClassLoader webappClassLoader;
+        private AtomicBoolean initDone = new AtomicBoolean();
+        private AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
+
+        @Override
+        public void init() throws ServletException {
+            super.init();
+            try {
+                webappClassLoader = Thread.currentThread().getContextClassLoader();
+                Class<?> dshKlass = webappClassLoader.loadClass(DataSerializerHook.class.getName());
+                Iterator<? extends Class<?>> iterator
+                        = ServiceLoader.classIterator(dshKlass, "com.hazelcast.DataSerializerHook",
+                        webappClassLoader);
+                // webapp classloader locates and loads classes from webapp classpath
+                assertTrue(iterator.hasNext());
+                while (iterator.hasNext()) {
+                    Class<?> klass = iterator.next();
+                    assertEquals(webappClassLoader, klass.getClassLoader());
+                }
+            } catch (Throwable t) {
+                failure.set(t);
+                throw new ServletException(t);
+            } finally {
+                initDone.set(true);
+            }
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                throws IOException {
+            resp.setContentType("text/plain");
+            resp.getWriter().print("OK");
+        }
+
+        public ClassLoader getWebappClassLoader() {
+            return webappClassLoader;
+        }
+
+        public boolean isInitDone() {
+            return initDone.get();
+        }
+
+        public Throwable failure() {
+            return failure.get();
+        }
     }
 
     public interface ServiceLoaderTestInterface {

--- a/pom.xml
+++ b/pom.xml
@@ -1330,5 +1330,17 @@
             <version>1.7.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>7.0.107</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-juli</artifactId>
+            <version>7.0.107</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
to also take into account classloader.
Fixes use cases where Hazelcast is deployed
as both app server and webapp lib.

Clean 1:1 cherry pick of #18119 

Some changes (from the original PR #18103 to `master`) were required in ServiceLoaderTest: due to JDK 6 support constraint, embedded Tomcat used in test is version 7.0.