### PR TITLE
Support the new client SqlPage serialization protocol for Short, Float, Double, LocalDate, LocalTime, LocalDateTime, OffsetDateTime and BigDecimal types

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/BigDecimalCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/BigDecimalCodec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static com.hazelcast.client.impl.protocol.ClientMessage.NULL_FRAME;
+import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.nextFrameIsNullEndFrame;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.INT_SIZE_IN_BYTES;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.decodeInt;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.encodeInt;
+
+public final class BigDecimalCodec {
+
+    private BigDecimalCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, BigDecimal value) {
+        byte[] body = value.unscaledValue().toByteArray();
+
+        byte[] buffer = new byte[INT_SIZE_IN_BYTES + body.length + INT_SIZE_IN_BYTES];
+        encodeInt(buffer, 0, body.length);
+        System.arraycopy(body, 0, buffer, INT_SIZE_IN_BYTES, body.length);
+        encodeInt(buffer, INT_SIZE_IN_BYTES + body.length, value.scale());
+
+        clientMessage.add(new ClientMessage.Frame(buffer));
+    }
+
+    public static void encodeNullable(ClientMessage clientMessage, BigDecimal value) {
+        if (value == null) {
+            clientMessage.add(NULL_FRAME.copy());
+        } else {
+            encode(clientMessage, value);
+        }
+    }
+
+    public static BigDecimal decode(ClientMessage.ForwardFrameIterator iterator) {
+        byte[] buffer = iterator.next().content;
+
+        int contentSize = decodeInt(buffer, 0);
+        byte[] body = new byte[contentSize];
+        System.arraycopy(buffer, INT_SIZE_IN_BYTES, body, 0, contentSize);
+        int scale = decodeInt(buffer, INT_SIZE_IN_BYTES + contentSize);
+
+        return new BigDecimal(new BigInteger(body), scale);
+    }
+
+    public static BigDecimal decodeNullable(ClientMessage.ForwardFrameIterator iterator) {
+        return nextFrameIsNullEndFrame(iterator) ? null : decode(iterator);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
@@ -25,16 +25,29 @@ import com.hazelcast.internal.management.dto.ClientBwListEntryDTO;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.sql.SqlColumnType;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public final class FixedSizeTypesCodec {
 
     public static final int BYTE_SIZE_IN_BYTES = Bits.BYTE_SIZE_IN_BYTES;
-    public static final int LONG_SIZE_IN_BYTES = Bits.LONG_SIZE_IN_BYTES;
+    public static final int SHORT_SIZE_IN_BYTES = Bits.SHORT_SIZE_IN_BYTES;
     public static final int INT_SIZE_IN_BYTES = Bits.INT_SIZE_IN_BYTES;
+    public static final int LONG_SIZE_IN_BYTES = Bits.LONG_SIZE_IN_BYTES;
+    public static final int FLOAT_SIZE_IN_BYTES = Bits.FLOAT_SIZE_IN_BYTES;
+    public static final int DOUBLE_SIZE_IN_BYTES = Bits.DOUBLE_SIZE_IN_BYTES;
     public static final int BOOLEAN_SIZE_IN_BYTES = Bits.BOOLEAN_SIZE_IN_BYTES;
-    public static final int UUID_SIZE_IN_BYTES = Bits.BOOLEAN_SIZE_IN_BYTES + Bits.LONG_SIZE_IN_BYTES * 2;
+    public static final int UUID_SIZE_IN_BYTES = BOOLEAN_SIZE_IN_BYTES + LONG_SIZE_IN_BYTES * 2;
+
+    public static final int LOCAL_DATE_SIZE_IN_BYTES = SHORT_SIZE_IN_BYTES + BYTE_SIZE_IN_BYTES * 2;
+    public static final int LOCAL_TIME_SIZE_IN_BYTES = BYTE_SIZE_IN_BYTES * 3 + INT_SIZE_IN_BYTES;
+    public static final int LOCAL_DATE_TIME_SIZE_IN_BYTES = LOCAL_DATE_SIZE_IN_BYTES + LOCAL_TIME_SIZE_IN_BYTES;
+    public static final int OFFSET_DATE_TIME_SIZE_IN_BYTES = LOCAL_DATE_TIME_SIZE_IN_BYTES + INT_SIZE_IN_BYTES;
 
     private FixedSizeTypesCodec() {
     }
@@ -97,12 +110,36 @@ public final class FixedSizeTypesCodec {
         encodeInt(buffer, pos, columnType.getId());
     }
 
+    public static void encodeShort(byte[] buffer, int pos, short value) {
+        Bits.writeShortL(buffer, pos, value);
+    }
+
+    public static short decodeShort(byte[] buffer, int pos) {
+        return Bits.readShortL(buffer, pos);
+    }
+
     public static void encodeLong(byte[] buffer, int pos, long value) {
         Bits.writeLongL(buffer, pos, value);
     }
 
     public static long decodeLong(byte[] buffer, int pos) {
         return Bits.readLongL(buffer, pos);
+    }
+
+    public static void encodeFloat(byte[] buffer, int pos, float value) {
+        encodeInt(buffer, pos, Float.floatToIntBits(value));
+    }
+
+    public static float decodeFloat(byte[] buffer, int pos) {
+        return Float.intBitsToFloat(decodeInt(buffer, pos));
+    }
+
+    public static void encodeDouble(byte[] buffer, int pos, double value) {
+        encodeLong(buffer, pos, Double.doubleToLongBits(value));
+    }
+
+    public static double decodeDouble(byte[] buffer, int pos) {
+        return Double.longBitsToDouble(decodeLong(buffer, pos));
     }
 
     public static void encodeBoolean(byte[] buffer, int pos, boolean value) {
@@ -143,4 +180,57 @@ public final class FixedSizeTypesCodec {
         return new UUID(mostSigBits, leastSigBits);
     }
 
+    public static void encodeLocalDate(byte[] buffer, int pos, LocalDate value) {
+        encodeShort(buffer, pos, (short) value.getYear());
+        encodeByte(buffer, pos + SHORT_SIZE_IN_BYTES, (byte) value.getMonthValue());
+        encodeByte(buffer, pos + SHORT_SIZE_IN_BYTES + BYTE_SIZE_IN_BYTES, (byte) value.getDayOfMonth());
+    }
+
+    public static LocalDate decodeLocalDate(byte[] buffer, int pos) {
+        int year = decodeShort(buffer, pos);
+        int month = decodeByte(buffer, pos + SHORT_SIZE_IN_BYTES);
+        int dayOfMonth = decodeByte(buffer, pos + SHORT_SIZE_IN_BYTES + BYTE_SIZE_IN_BYTES);
+
+        return LocalDate.of(year, month, dayOfMonth);
+    }
+
+    public static void encodeLocalTime(byte[] buffer, int pos, LocalTime value) {
+        encodeByte(buffer, pos, (byte) value.getHour());
+        encodeByte(buffer, pos + BYTE_SIZE_IN_BYTES, (byte) value.getMinute());
+        encodeByte(buffer, pos + BYTE_SIZE_IN_BYTES * 2, (byte) value.getSecond());
+        encodeInt(buffer, pos + BYTE_SIZE_IN_BYTES * 3, value.getNano());
+    }
+
+    public static LocalTime decodeLocalTime(byte[] buffer, int pos) {
+        int hour = decodeByte(buffer, pos);
+        int minute = decodeByte(buffer, pos + BYTE_SIZE_IN_BYTES);
+        int second = decodeByte(buffer, pos + BYTE_SIZE_IN_BYTES * 2);
+        int nano = decodeInt(buffer, pos + BYTE_SIZE_IN_BYTES * 3);
+
+        return LocalTime.of(hour, minute, second, nano);
+    }
+
+    public static void encodeLocalDateTime(byte[] buffer, int pos, LocalDateTime value) {
+        encodeLocalDate(buffer, pos, value.toLocalDate());
+        encodeLocalTime(buffer, pos + LOCAL_DATE_SIZE_IN_BYTES, value.toLocalTime());
+    }
+
+    public static LocalDateTime decodeLocalDateTime(byte[] buffer, int pos) {
+        LocalDate date = decodeLocalDate(buffer, pos);
+        LocalTime time = decodeLocalTime(buffer, pos + LOCAL_DATE_SIZE_IN_BYTES);
+
+        return LocalDateTime.of(date, time);
+    }
+
+    public static void encodeOffsetDateTime(byte[] buffer, int pos, OffsetDateTime value) {
+        encodeLocalDateTime(buffer, pos, value.toLocalDateTime());
+        encodeInt(buffer, pos + LOCAL_DATE_TIME_SIZE_IN_BYTES, value.getOffset().getTotalSeconds());
+    }
+
+    public static OffsetDateTime decodeOffsetDateTime(byte[] buffer, int pos) {
+        LocalDateTime dateTime = decodeLocalDateTime(buffer, pos);
+        int offsetSeconds = decodeInt(buffer, pos + LOCAL_DATE_TIME_SIZE_IN_BYTES);
+
+        return OffsetDateTime.of(dateTime, ZoneOffset.ofTotalSeconds(offsetSeconds));
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/FixedSizeTypesCodec.java
@@ -33,6 +33,7 @@ import java.time.ZoneOffset;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("checkstyle:MethodCount")
 public final class FixedSizeTypesCodec {
 
     public static final int BYTE_SIZE_IN_BYTES = Bits.BYTE_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNDoubleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNDoubleCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.DOUBLE_SIZE_IN_BYTES;
+
+public final class ListCNDoubleCodec {
+
+    private ListCNDoubleCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<Double> items) {
+        ListCNFixedSizeCodec.encode(clientMessage, items, DOUBLE_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeDouble);
+    }
+
+    public static List<Double> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<Double> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, DOUBLE_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeDouble);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNFloatCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNFloatCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.FLOAT_SIZE_IN_BYTES;
+
+public final class ListCNFloatCodec {
+
+    private ListCNFloatCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<Float> items) {
+        ListCNFixedSizeCodec.encode(clientMessage, items, FLOAT_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeFloat);
+    }
+
+    public static List<Float> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<Float> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, FLOAT_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeFloat);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNLocalDateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNLocalDateCodec.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.LOCAL_DATE_SIZE_IN_BYTES;
+
+public final class ListCNLocalDateCodec {
+
+    private ListCNLocalDateCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<LocalDate> items) {
+        ListCNFixedSizeCodec.encode(clientMessage, items, LOCAL_DATE_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeLocalDate);
+    }
+
+    public static List<LocalDate> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<LocalDate> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, LOCAL_DATE_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeLocalDate);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNLocalDateTimeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNLocalDateTimeCodec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.LOCAL_DATE_TIME_SIZE_IN_BYTES;
+
+public final class ListCNLocalDateTimeCodec {
+
+    private ListCNLocalDateTimeCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<LocalDateTime> items) {
+        ListCNFixedSizeCodec.encode(
+            clientMessage, items, LOCAL_DATE_TIME_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeLocalDateTime
+        );
+    }
+
+    public static List<LocalDateTime> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<LocalDateTime> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, LOCAL_DATE_TIME_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeLocalDateTime);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNLocalTimeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNLocalTimeCodec.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.LOCAL_TIME_SIZE_IN_BYTES;
+
+public final class ListCNLocalTimeCodec {
+
+    private ListCNLocalTimeCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<LocalTime> items) {
+        ListCNFixedSizeCodec.encode(clientMessage, items, LOCAL_TIME_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeLocalTime);
+    }
+
+    public static List<LocalTime> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<LocalTime> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, LOCAL_TIME_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeLocalTime);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNOffsetDateTimeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNOffsetDateTimeCodec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.OFFSET_DATE_TIME_SIZE_IN_BYTES;
+
+public final class ListCNOffsetDateTimeCodec {
+
+    private ListCNOffsetDateTimeCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<OffsetDateTime> items) {
+        ListCNFixedSizeCodec.encode(
+            clientMessage, items, OFFSET_DATE_TIME_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeOffsetDateTime
+        );
+    }
+
+    public static List<OffsetDateTime> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<OffsetDateTime> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, OFFSET_DATE_TIME_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeOffsetDateTime);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNShortCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListCNShortCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec.builtin;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+
+import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.SHORT_SIZE_IN_BYTES;
+
+public final class ListCNShortCodec {
+
+    private ListCNShortCodec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, Iterable<Short> items) {
+        ListCNFixedSizeCodec.encode(clientMessage, items, SHORT_SIZE_IN_BYTES, FixedSizeTypesCodec::encodeShort);
+    }
+
+    public static List<Short> decode(ClientMessage.ForwardFrameIterator iterator) {
+        return decode(iterator.next());
+    }
+
+    public static List<Short> decode(ClientMessage.Frame frame) {
+        return ListCNFixedSizeCodec.decode(frame, SHORT_SIZE_IN_BYTES, FixedSizeTypesCodec::decodeShort);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/SqlPageCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/SqlPageCodec.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.impl.client.SqlPage;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -37,7 +38,7 @@ public final class SqlPageCodec {
     private SqlPageCodec() {
     }
 
-    @SuppressWarnings({"unchecked", "checkstyle:CyclomaticComplexity"})
+    @SuppressWarnings({"unchecked", "checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
     public static void encode(ClientMessage clientMessage, SqlPage sqlPage) {
         clientMessage.add(BEGIN_FRAME.copy());
 
@@ -122,9 +123,12 @@ public final class SqlPageCodec {
                     break;
 
                 case DECIMAL:
+                    ListMultiFrameCodec.encode(clientMessage, (Iterable<BigDecimal>) column, BigDecimalCodec::encodeNullable);
+
+                    break;
+
                 case NULL:
                 case OBJECT:
-                    // TODO: All types except for NULL and OBJECT should be serialized with a custom codecs before 4.2
                     assert SqlPage.convertToData(columnType);
 
                     ListMultiFrameCodec.encode(clientMessage, (Iterable<Data>) column, DataCodec::encodeNullable);
@@ -139,7 +143,7 @@ public final class SqlPageCodec {
         clientMessage.add(END_FRAME.copy());
     }
 
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
     public static SqlPage decode(ClientMessage.ForwardFrameIterator iterator) {
         // begin frame
         iterator.next();
@@ -222,9 +226,12 @@ public final class SqlPageCodec {
                     break;
 
                 case DECIMAL:
+                    columns.add(ListMultiFrameCodec.decode(iterator, BigDecimalCodec::decodeNullable));
+
+                    break;
+
                 case NULL:
                 case OBJECT:
-                    // TODO: All types except for NULL and OBJECT should be serialized with a custom codecs before 4.2
                     assert SqlPage.convertToData(columnType);
 
                     columns.add(ListMultiFrameCodec.decode(iterator, DataCodec::decodeNullable));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/SqlPageCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/SqlPageCodec.java
@@ -21,6 +21,10 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.impl.client.SqlPage;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -72,6 +76,11 @@ public final class SqlPageCodec {
 
                     break;
 
+                case SMALLINT:
+                    ListCNShortCodec.encode(clientMessage, (Iterable<Short>) column);
+
+                    break;
+
                 case INTEGER:
                     ListCNIntegerCodec.encode(clientMessage, (Iterable<Integer>) column);
 
@@ -82,14 +91,37 @@ public final class SqlPageCodec {
 
                     break;
 
-                case SMALLINT:
-                case DECIMAL:
                 case REAL:
+                    ListCNFloatCodec.encode(clientMessage, (Iterable<Float>) column);
+
+                    break;
+
                 case DOUBLE:
+                    ListCNDoubleCodec.encode(clientMessage, (Iterable<Double>) column);
+
+                    break;
+
                 case DATE:
+                    ListCNLocalDateCodec.encode(clientMessage, (Iterable<LocalDate>) column);
+
+                    break;
+
                 case TIME:
+                    ListCNLocalTimeCodec.encode(clientMessage, (Iterable<LocalTime>) column);
+
+                    break;
+
                 case TIMESTAMP:
+                    ListCNLocalDateTimeCodec.encode(clientMessage, (Iterable<LocalDateTime>) column);
+
+                    break;
+
                 case TIMESTAMP_WITH_TIME_ZONE:
+                    ListCNOffsetDateTimeCodec.encode(clientMessage, (Iterable<OffsetDateTime>) column);
+
+                    break;
+
+                case DECIMAL:
                 case NULL:
                 case OBJECT:
                     // TODO: All types except for NULL and OBJECT should be serialized with a custom codecs before 4.2
@@ -144,6 +176,11 @@ public final class SqlPageCodec {
 
                     break;
 
+                case SMALLINT:
+                    columns.add(ListCNShortCodec.decode(iterator));
+
+                    break;
+
                 case INTEGER:
                     columns.add(ListCNIntegerCodec.decode(iterator));
 
@@ -154,14 +191,37 @@ public final class SqlPageCodec {
 
                     break;
 
-                case SMALLINT:
-                case DECIMAL:
                 case REAL:
+                    columns.add(ListCNFloatCodec.decode(iterator));
+
+                    break;
+
                 case DOUBLE:
+                    columns.add(ListCNDoubleCodec.decode(iterator));
+
+                    break;
+
                 case DATE:
+                    columns.add(ListCNLocalDateCodec.decode(iterator));
+
+                    break;
+
                 case TIME:
+                    columns.add(ListCNLocalTimeCodec.decode(iterator));
+
+                    break;
+
                 case TIMESTAMP:
+                    columns.add(ListCNLocalDateTimeCodec.decode(iterator));
+
+                    break;
+
                 case TIMESTAMP_WITH_TIME_ZONE:
+                    columns.add(ListCNOffsetDateTimeCodec.decode(iterator));
+
+                    break;
+
+                case DECIMAL:
                 case NULL:
                 case OBJECT:
                     // TODO: All types except for NULL and OBJECT should be serialized with a custom codecs before 4.2

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/SqlPageCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/SqlPageCodec.java
@@ -128,6 +128,18 @@ public final class SqlPageCodec {
                     break;
 
                 case NULL:
+                    int size = 0;
+
+                    for (Object ignore : column) {
+                        size++;
+                    }
+
+                    byte[] sizeBuffer = new byte[FixedSizeTypesCodec.INT_SIZE_IN_BYTES];
+                    FixedSizeTypesCodec.encodeInt(sizeBuffer, 0, size);
+                    clientMessage.add(new ClientMessage.Frame(sizeBuffer));
+
+                    break;
+
                 case OBJECT:
                     assert SqlPage.convertToData(columnType);
 
@@ -231,6 +243,20 @@ public final class SqlPageCodec {
                     break;
 
                 case NULL:
+                    ClientMessage.Frame frame = iterator.next();
+
+                    int size = FixedSizeTypesCodec.decodeInt(frame.content, 0);
+
+                    List<Object> column = new ArrayList<>(size);
+
+                    for (int i = 0; i < size; i++) {
+                        column.add(null);
+                    }
+
+                    columns.add(column);
+
+                    break;
+
                 case OBJECT:
                     assert SqlPage.convertToData(columnType);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlPage.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlPage.java
@@ -312,9 +312,7 @@ public final class SqlPage {
     }
 
     public static boolean convertToData(SqlColumnType type) {
-        // TODO: All types except for NULL and OBJECT should be serialized with a custom codecs before 4.2
         switch (type) {
-            case DECIMAL:
             case NULL:
             case OBJECT:
                 return true;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlPage.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlPage.java
@@ -314,14 +314,7 @@ public final class SqlPage {
     public static boolean convertToData(SqlColumnType type) {
         // TODO: All types except for NULL and OBJECT should be serialized with a custom codecs before 4.2
         switch (type) {
-            case SMALLINT:
             case DECIMAL:
-            case REAL:
-            case DOUBLE:
-            case DATE:
-            case TIME:
-            case TIMESTAMP:
-            case TIMESTAMP_WITH_TIME_ZONE:
             case NULL:
             case OBJECT:
                 return true;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlPage.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlPage.java
@@ -312,13 +312,6 @@ public final class SqlPage {
     }
 
     public static boolean convertToData(SqlColumnType type) {
-        switch (type) {
-            case NULL:
-            case OBJECT:
-                return true;
-
-            default:
-                return false;
-        }
+        return type == SqlColumnType.OBJECT;
     }
 }


### PR DESCRIPTION
This is the follow-up PR for https://github.com/hazelcast/hazelcast/pull/18089, that adds the proper client serialization support for the following types:
1. Short
2. Float
3. Double
4. LocalDate
5. LocalTime
6. LocalDateTime
7. OffsetDateTime
8. BigDecimal

Codecs for these types are designed to be compatible with the new portable format introduced in #17257