### PR TITLE
Fixed user-lib path from start.sh/bat scripts

### DIFF
--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -38,7 +38,7 @@ IF NOT "%JAVA_VERSION%" == "8" (
 	set JAVA_OPTS=%JAVA_OPTS% --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
 )
 
-set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar;%~dp0..\user-lib;%~dp0..\user-lib\*"
+set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar;%~dp0..\bin\user-lib;%~dp0..\bin\user-lib\*"
 
 ECHO ########################################
 ECHO # RUN_JAVA=%RUN_JAVA%

--- a/hazelcast/src/main/resources/start.sh
+++ b/hazelcast/src/main/resources/start.sh
@@ -43,7 +43,7 @@ if [ "$JAVA_VERSION" -gt "8" ]; then
 	JAVA_OPTS="$JAVA_OPTS --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
 fi
 
-export CLASSPATH="$HAZELCAST_HOME/lib/hazelcast-all-${project.version}.jar:$HAZELCAST_HOME/user-lib:$HAZELCAST_HOME/user-lib/*"
+export CLASSPATH="$HAZELCAST_HOME/lib/hazelcast-all-${project.version}.jar:$HAZELCAST_HOME/bin/user-lib:$HAZELCAST_HOME/bin/user-lib/*"
 
 echo "########################################"
 echo "# RUN_JAVA=$RUN_JAVA"

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFuture_SerializationExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFuture_SerializationExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFuture_SerializationExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFuture_SerializationExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Starting 4.0, we moved the `user-lib` directory into `bin` directory. This PR corrects that paths.