### PR TITLE
improve timestamp check in ReplicatedMapMBeanTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MapMBeanTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -41,13 +43,11 @@ public class MapMBeanTest extends HazelcastTestSupport {
     private TestHazelcastInstanceFactory hazelcastInstanceFactory = createHazelcastInstanceFactory(1);
     private MBeanDataHolder holder = new MBeanDataHolder(hazelcastInstanceFactory);
 
-    private long started;
     private IMap<String, String> map;
     private String objectName;
 
     @Before
     public void setUp() {
-        started = System.currentTimeMillis();
         map = holder.getHz().getMap("distributedMap");
         objectName = map.getName();
 
@@ -75,6 +75,7 @@ public class MapMBeanTest extends HazelcastTestSupport {
 
     @Test
     public void testAttributesAndOperations() throws Exception {
+        long started = System.currentTimeMillis();
         map.put("firstKey", "firstValue");
         map.put("secondKey", "secondValue");
         map.remove("secondKey");
@@ -124,9 +125,17 @@ public class MapMBeanTest extends HazelcastTestSupport {
         assertTrue(localOwnedEntryMemoryCost > 0);
         assertEquals(0, localBackupEntryMemoryCost);
 
-        assertTrue(localCreationTime >= started);
-        assertTrue(localLastAccessTime >= started);
-        assertTrue(localLastUpdateTime >= started);
+        long lowerBound = started - TimeUnit.SECONDS.toMillis(10);
+        long upperBound = started + TimeUnit.SECONDS.toMillis(10);
+        assertTrue(
+                "localCreationTime <" + localCreationTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localCreationTime && localCreationTime < upperBound);
+        assertTrue(
+                "localLastAccessTime <" + localLastAccessTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localLastAccessTime && localLastAccessTime < upperBound);
+        assertTrue(
+                "localLastUpdateTime <" + localLastUpdateTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localLastUpdateTime && localLastUpdateTime < upperBound);
         assertEquals(1, localHits);
         assertEquals(0, localLockedEntryCount);
         assertEquals(0, localDirtyEntryCount);

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MultiMapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MultiMapMBeanTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -41,7 +43,6 @@ public class MultiMapMBeanTest extends HazelcastTestSupport {
     private MBeanDataHolder holder;
     private MultiMap<String, String> multiMap;
     private String mapName = randomString();
-    private long startTime = System.currentTimeMillis();
 
     @Before
     public void setup() {
@@ -72,7 +73,7 @@ public class MultiMapMBeanTest extends HazelcastTestSupport {
 
     @Test
     public void testStats() throws Exception {
-
+        long started = System.currentTimeMillis();
         int iterations = 100;
         for (int i = 0; i < iterations; i++) {
             multiMap.put("Ubuntu", "Artful Aardvark");
@@ -123,9 +124,18 @@ public class MultiMapMBeanTest extends HazelcastTestSupport {
         assertEquals(0, localLockedEntryCount);
         assertEquals(0, localDirtyEntryCount);
 
-        assertTrue("Creation time should be > start time", localCreationTime > startTime);
-        assertTrue("Last access time should be > start time", localLastAccessTime > startTime);
-        assertTrue("Last update time should be > start time", localLastUpdateTime > startTime);
+        long lowerBound = started - TimeUnit.SECONDS.toMillis(10);
+        long upperBound = started + TimeUnit.SECONDS.toMillis(10);
+        assertTrue(
+                "localCreationTime <" + localCreationTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localCreationTime && localCreationTime < upperBound);
+        assertTrue(
+                "localLastAccessTime <" + localLastAccessTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localLastAccessTime && localLastAccessTime < upperBound);
+        assertTrue(
+                "localLastUpdateTime <" + localLastUpdateTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localLastUpdateTime && localLastUpdateTime < upperBound);
+
         assertTrue("Total put latency should be >= 0", localTotalPutLatency >= 0);
         assertTrue("Total get latency should be >= 0", localTotalGetLatency >= 0);
         assertTrue("Total remove latency should be >= 0", localTotalRemoveLatency >= 0);

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReplicatedMapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReplicatedMapMBeanTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -110,9 +112,17 @@ public class ReplicatedMapMBeanTest extends HazelcastTestSupport {
         assertEquals("firstValue", value);
 
         assertEquals(1, localEntryCount);
-        assertTrue(localCreationTime >= started);
-        assertTrue(localLastAccessTime >= started);
-        assertTrue(localLastUpdateTime >= started);
+        long lowerBound = started - TimeUnit.SECONDS.toMillis(10);
+        long upperBound = started + TimeUnit.SECONDS.toMillis(10);
+        assertTrue(
+                "localCreationTime <" + localCreationTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localCreationTime && localCreationTime < upperBound);
+        assertTrue(
+                "localLastAccessTime <" + localLastAccessTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localLastAccessTime && localLastAccessTime < upperBound);
+        assertTrue(
+                "localLastUpdateTime <" + localLastUpdateTime + "> has to be between [" + lowerBound + " and " + upperBound + "]",
+                lowerBound < localLastUpdateTime && localLastUpdateTime < upperBound);
         assertEquals(1, localHits);
 
         assertEquals(2, localPutOperationCount);


### PR DESCRIPTION
Fixes #18098

Weaker ReplicatedMap timestamp metrics check, test if they are in specific interval instead of strict `>=` with test start time. That should ~eliminate~ reduce friction of the test that relays on `System.currentTimeMillis()` 

example of new failing assertion message
```
java.lang.AssertionError: localCreationTime <1612347512568> has to be between [1612347583807 and 1612347603807]
```