### PR TITLE
[BACKPORT] Fixes DelegatingCompletableFuture

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDelegatingFuture.java
@@ -19,8 +19,9 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.impl.clientside.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.impl.DelegatingCompletableFuture;
 
 import javax.annotation.Nonnull;
@@ -63,9 +64,7 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
         this.decodedResponse = VOID;
         this.clientMessageDecoder = clientMessageDecoder;
         this.deserializeResponse = deserializeResponse;
-        this.future.whenComplete((v, t) -> {
-            completeSuper(v, (Throwable) t);
-        });
+        this.future.whenComplete((v, t) -> completeSuper(v, (Throwable) t));
     }
 
     public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
@@ -101,11 +100,15 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
         // otherwise, do not cache the value returned from future.getNow
         // because it might be the default valueIfAbsent
         Object value = future.getNow(valueIfAbsent);
-        if (value instanceof ClientMessage) {
-            return resolve(value);
-        } else {
-            return (value instanceof Data && deserializeResponse)
-                    ? serializationService.toObject(value) : (V) value;
+        try {
+            if (value instanceof ClientMessage) {
+                return resolve(value);
+            } else {
+                return (value instanceof Data && deserializeResponse)
+                        ? serializationService.toObject(value) : (V) value;
+            }
+        } catch (HazelcastSerializationException exc) {
+            throw new CompletionException(exc);
         }
     }
 
@@ -188,17 +191,17 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
     @Override
     public CompletableFuture<Void> thenRun(Runnable action) {
-        return future.thenRunAsync(action, defaultExecutor());
+        return future.thenRunAsync(new DeserializingRunnable(action), defaultExecutor());
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action) {
-        return future.thenRunAsync(action, defaultExecutor());
+        return future.thenRunAsync(new DeserializingRunnable(action), defaultExecutor());
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
-        return future.thenRunAsync(action, executor);
+        return future.thenRunAsync(new DeserializingRunnable(action), executor);
     }
 
     @Override
@@ -239,17 +242,17 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
     @Override
     public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
-        return future.runAfterBothAsync(other, action, defaultExecutor());
+        return future.runAfterBothAsync(other, new DeserializingRunnable(action), defaultExecutor());
     }
 
     @Override
     public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
-        return future.runAfterBothAsync(other, action, defaultExecutor());
+        return future.runAfterBothAsync(other, new DeserializingRunnable(action), defaultExecutor());
     }
 
     @Override
     public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return future.runAfterBothAsync(other, action, executor);
+        return future.runAfterBothAsync(other, new DeserializingRunnable(action), executor);
     }
 
     @SuppressWarnings("unchecked")
@@ -289,17 +292,17 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
     @Override
     public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
-        return future.runAfterEitherAsync(other, action, defaultExecutor());
+        return future.runAfterEitherAsync(other, new DeserializingRunnable(action), defaultExecutor());
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
-        return future.runAfterEitherAsync(other, action, defaultExecutor());
+        return future.runAfterEitherAsync(other, new DeserializingRunnable(action), defaultExecutor());
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return future.runAfterEitherAsync(other, action, executor);
+        return future.runAfterEitherAsync(other, new DeserializingRunnable(action), executor);
     }
 
     @Override
@@ -334,17 +337,17 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
     @Override
     public <U> CompletableFuture<U> handle(BiFunction<? super V, Throwable, ? extends U> fn) {
-        return future.handleAsync(new DeserializingBiFunction<>(fn), defaultExecutor());
+        return future.handleAsync(new HandleBiFunction<>(fn), defaultExecutor());
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super V, Throwable, ? extends U> fn) {
-        return future.handleAsync(new DeserializingBiFunction<>(fn), defaultExecutor());
+        return future.handleAsync(new HandleBiFunction<>(fn), defaultExecutor());
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super V, Throwable, ? extends U> fn, Executor executor) {
-        return future.handleAsync(new DeserializingBiFunction<>(fn), executor);
+        return future.handleAsync(new HandleBiFunction<>(fn), executor);
     }
 
     @Override
@@ -365,11 +368,6 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
     @Override
     public boolean isCancelled() {
         return future.isCancelled();
-    }
-
-    @Override
-    public boolean isCompletedExceptionally() {
-        return future.isCompletedExceptionally();
     }
 
     @Override
@@ -438,6 +436,22 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
         }
     }
 
+    class DeserializingRunnable implements Runnable {
+        private final Runnable delegate;
+
+        DeserializingRunnable(Runnable delegate) {
+            requireNonNull(delegate);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void run() {
+            // deserialize to ensure no HazelcastSerializationException occurs
+            resolve(future.join());
+            delegate.run();
+        }
+    }
+
     class DeserializingBiFunction<U, R> implements BiFunction<ClientMessage, U, R> {
         private final BiFunction<? super V, U, ? extends R> delegate;
 
@@ -468,6 +482,26 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
         }
     }
 
+    class HandleBiFunction<U, R> implements BiFunction<ClientMessage, Throwable, R> {
+        private final BiFunction<? super V, Throwable, R> delegate;
+
+        HandleBiFunction(@Nonnull BiFunction<? super V, Throwable, R> delegate) {
+            requireNonNull(delegate);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public R apply(ClientMessage t, Throwable u) {
+            V resolved = null;
+            try {
+                resolved = t == null ? null : resolve(t);
+            } catch (HazelcastSerializationException exc) {
+                u = exc;
+            }
+            return delegate.apply(resolved, u);
+        }
+    }
+
     // adapts a BiConsumer to a BiFunction for implementation
     // of whenComplete methods
     class WhenCompleteAdapter implements BiFunction<ClientMessage, Throwable, V> {
@@ -480,8 +514,13 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
         @Override
         public V apply(ClientMessage message, Throwable t) {
-            V resolved = message == null ? null : resolve(message);
+            V resolved = null;
             Throwable delegateException = null;
+            try {
+                resolved = message == null ? null : resolve(message);
+            } catch (HazelcastSerializationException exc) {
+                t = exc;
+            }
             try {
                 delegate.accept(resolved, t);
             } catch (Throwable throwable) {
@@ -517,14 +556,16 @@ public class ClientDelegatingFuture<V> extends DelegatingCompletableFuture<V> {
 
         @Override
         public V apply(ClientMessage message, Throwable t) {
-            V resolved = message == null ? null : resolve(message);
-            if (t == null) {
-                return resolved;
-            }
-            try {
+            if (t != null) {
                 return delegate.apply(t);
-            } catch (Throwable throwable) {
-                throw throwable;
+            } else {
+                V resolved;
+                try {
+                    resolved = message == null ? null : resolve(message);
+                    return resolved;
+                } catch (HazelcastSerializationException throwable) {
+                    return delegate.apply(throwable);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
@@ -48,6 +49,15 @@ import static java.util.Objects.requireNonNull;
  * threads.
  * </li>
  * </ol>
+ *
+ * Even though the wrapped future may be completed normally, it is possible that
+ * a {@link HazelcastSerializationException} thrown when deserializing the value
+ * will result in this future being completed exceptionally. A deserialization
+ * failure makes this future being considered to complete exceptionally,
+ * therefore futures from dependent stages will be completed with a
+ * HazelcastSerializationException (unless the dependent stage transforms
+ * the outcome).
+ *
  * @param <V>
  */
 @SuppressWarnings("checkstyle:methodcount")
@@ -89,20 +99,26 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
         this.serializationService = (InternalSerializationService) serializationService;
         this.result = result;
         if (listenFutureCompletion) {
-            this.future.whenComplete((v, t) -> {
-                completeSuper(v, (Throwable) t);
-            });
+            this.future.whenComplete((v, t) -> completeSuper(v, (Throwable) t));
         }
     }
 
     @Override
     public V get() throws InterruptedException, ExecutionException {
-        return resolve(future.get());
+        try {
+            return resolve(future.get());
+        } catch (HazelcastSerializationException e) {
+            throw new ExecutionException(e);
+        }
     }
 
     @Override
     public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return resolve(future.get(timeout, unit));
+        try {
+            return resolve(future.get(timeout, unit));
+        } catch (HazelcastSerializationException e) {
+            throw new ExecutionException(e);
+        }
     }
 
     @Override
@@ -120,13 +136,21 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
         // otherwise, do not cache the value returned from future.getNow
         // because it might be the default valueIfAbsent
         Object value = future.getNow(valueIfAbsent);
-        return (value instanceof Data) ? serializationService.toObject(value)
-                : (V) value;
+        try {
+            return (value instanceof Data)
+                    ? serializationService.toObject(value) : (V) value;
+        } catch (HazelcastSerializationException e) {
+            throw new CompletionException(e);
+        }
     }
 
     @Override
     public V join() {
-        return resolve(future.join());
+        try {
+            return resolve(future.join());
+        } catch (HazelcastSerializationException e) {
+            throw new CompletionException(e);
+        }
     }
 
     @Override
@@ -164,8 +188,6 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
             // we need to deserialize.
             Data data = (Data) object;
             object = serializationService.toObject(data);
-
-            //todo do we need to call dispose data here
             serializationService.disposeData(data);
 
             object = cacheDeserializedValue(object);
@@ -242,17 +264,17 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
     @Override
     public CompletableFuture<Void> thenRun(Runnable action) {
-        return future.thenRun(action);
+        return future.thenRun(new DeserializingRunnable(serializationService, action));
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action) {
-        return future.thenRunAsync(action);
+        return future.thenRunAsync(new DeserializingRunnable(serializationService, action));
     }
 
     @Override
     public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
-        return future.thenRunAsync(action, executor);
+        return future.thenRunAsync(new DeserializingRunnable(serializationService, action), executor);
     }
 
     @Override
@@ -293,17 +315,17 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
     @Override
     public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
-        return future.runAfterBoth(other, action);
+        return future.runAfterBoth(other, new DeserializingRunnable(serializationService, action));
     }
 
     @Override
     public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
-        return future.runAfterBothAsync(other, action);
+        return future.runAfterBothAsync(other, new DeserializingRunnable(serializationService, action));
     }
 
     @Override
     public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return future.runAfterBothAsync(other, action, executor);
+        return future.runAfterBothAsync(other, new DeserializingRunnable(serializationService, action), executor);
     }
 
     @Override
@@ -340,17 +362,17 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
     @Override
     public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
-        return future.runAfterEither(other, action);
+        return future.runAfterEither(other, new DeserializingRunnable(serializationService, action));
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
-        return future.runAfterEitherAsync(other, action);
+        return future.runAfterEitherAsync(other, new DeserializingRunnable(serializationService, action));
     }
 
     @Override
     public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return future.runAfterEitherAsync(other, action, executor);
+        return future.runAfterEitherAsync(other, new DeserializingRunnable(serializationService, action), executor);
     }
 
     @Override
@@ -371,34 +393,34 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
     @Override
     public CompletableFuture<V> whenComplete(BiConsumer<? super V, ? super Throwable> action) {
         return new DelegatingCompletableFuture<>(serializationService,
-                future.whenComplete(new DeserializingBiConsumer<>(serializationService, action)));
+                future.whenComplete(new WhenCompleteBiConsumer(serializationService, action)));
     }
 
     @Override
     public CompletableFuture<V> whenCompleteAsync(BiConsumer<? super V, ? super Throwable> action) {
         return new DelegatingCompletableFuture<>(serializationService,
-                future.whenCompleteAsync(new DeserializingBiConsumer<>(serializationService, action)));
+                future.whenCompleteAsync(new WhenCompleteBiConsumer(serializationService, action)));
     }
 
     @Override
     public CompletableFuture<V> whenCompleteAsync(BiConsumer<? super V, ? super Throwable> action, Executor executor) {
         return new DelegatingCompletableFuture<>(serializationService,
-                future.whenCompleteAsync(new DeserializingBiConsumer<>(serializationService, action), executor));
+                future.whenCompleteAsync(new WhenCompleteBiConsumer(serializationService, action), executor));
     }
 
     @Override
     public <U> CompletableFuture<U> handle(BiFunction<? super V, Throwable, ? extends U> fn) {
-        return future.handle(new DeserializingBiFunction<>(serializationService, fn));
+        return future.handle(new HandleBiFunction(serializationService, fn));
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super V, Throwable, ? extends U> fn) {
-        return future.handleAsync(new DeserializingBiFunction<>(serializationService, fn));
+        return future.handleAsync(new HandleBiFunction<>(serializationService, fn));
     }
 
     @Override
     public <U> CompletableFuture<U> handleAsync(BiFunction<? super V, Throwable, ? extends U> fn, Executor executor) {
-        return future.handleAsync(new DeserializingBiFunction<>(serializationService, fn), executor);
+        return future.handleAsync(new HandleBiFunction<>(serializationService, fn), executor);
     }
 
     @Override
@@ -408,8 +430,7 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
     @Override
     public CompletableFuture<V> exceptionally(Function<Throwable, ? extends V> fn) {
-        return new DelegatingCompletableFuture<>(serializationService,
-                future.exceptionally(fn));
+        return future.handle(new ExceptionallyBiFunction(serializationService, fn));
     }
 
     @Override
@@ -424,7 +445,23 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
     @Override
     public boolean isCompletedExceptionally() {
-        return future.isCompletedExceptionally();
+        // if super is completed, then value deserialization has already happened,
+        // so we know if this future is completed exceptionally
+        if (super.isDone()) {
+            return super.isCompletedExceptionally();
+        }
+        // otherwise, check the delegate future: if that one is done, try
+        // resolve the completion value
+        if (future.isDone()) {
+            try {
+                resolve(future.join());
+                return false;
+            } catch (Throwable t) {
+                return true;
+            }
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -456,8 +493,12 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
         if (t != null) {
             super.completeExceptionally(t);
         } else {
-            V resolved = resolve(value);
-            super.complete(resolved);
+            try {
+                V resolved = resolve(value);
+                super.complete(resolved);
+            } catch (HazelcastSerializationException e) {
+                super.completeExceptionally(e);
+            }
         }
     }
 
@@ -475,6 +516,25 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
         @Override
         public R apply(E e) {
             return delegate.apply(serializationService.toObject(e));
+        }
+    }
+
+    class DeserializingRunnable implements Runnable {
+        private final SerializationService serializationService;
+        private final Runnable delegate;
+
+        DeserializingRunnable(SerializationService serializationService, Runnable delegate) {
+            requireNonNull(delegate);
+
+            this.serializationService = serializationService;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void run() {
+            // deserialize to ensure no HazelcastSerializationException occurs
+            serializationService.toObject(future.join());
+            delegate.run();
         }
     }
 
@@ -508,8 +568,32 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
         @Override
         public R apply(T t, U u) {
-            return delegate.apply(serializationService.toObject(t),
-                    serializationService.toObject(u));
+            T v1 = serializationService.toObject(t);
+            U v2 = serializationService.toObject(u);
+            return delegate.apply(v1, v2);
+        }
+    }
+
+    static class HandleBiFunction<T, U extends Throwable, R> implements BiFunction<T, U, R> {
+        private final SerializationService serializationService;
+        private final BiFunction<T, U, R> delegate;
+
+        HandleBiFunction(SerializationService serializationService, BiFunction<T, U, R> delegate) {
+            requireNonNull(delegate);
+
+            this.serializationService = serializationService;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public R apply(T t, U u) {
+            T deserialized = null;
+            try {
+                deserialized = serializationService.toObject(t);
+            } catch (HazelcastSerializationException exc) {
+                u = (U) exc;
+            }
+            return delegate.apply(deserialized, u);
         }
     }
 
@@ -526,8 +610,60 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
 
         @Override
         public void accept(T t, U u) {
-            delegate.accept(serializationService.toObject(t),
-                    serializationService.toObject(u));
+            T v1 = serializationService.toObject(t);
+            U v2 = serializationService.toObject(u);
+            delegate.accept(v1, v2);
+        }
+    }
+
+    static class WhenCompleteBiConsumer<E, T extends Throwable> implements BiConsumer<E, T> {
+        private final SerializationService serializationService;
+        private final BiConsumer<E, T> delegate;
+
+        WhenCompleteBiConsumer(SerializationService serializationService, BiConsumer<E, T> delegate) {
+            requireNonNull(delegate);
+
+            this.serializationService = serializationService;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void accept(E v, T t) {
+            E deserialized = null;
+            try {
+                deserialized = serializationService.toObject(v);
+            } catch (HazelcastSerializationException exc) {
+                t = (T) exc;
+            }
+            delegate.accept(deserialized, t);
+        }
+    }
+
+    static class ExceptionallyBiFunction<T, U extends Throwable, R> implements BiFunction<T, U, R> {
+        private final SerializationService serializationService;
+        private final Function<U, R> delegate;
+
+        ExceptionallyBiFunction(SerializationService serializationService, Function<U, R> delegate) {
+            requireNonNull(delegate);
+
+            this.serializationService = serializationService;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public R apply(T t, U u) {
+            if (u != null) {
+                return delegate.apply(u);
+            } else {
+                R deserialized;
+                try {
+                    deserialized = serializationService.toObject(t);
+                    return deserialized;
+                } catch (HazelcastSerializationException exc) {
+                    u = (U) exc;
+                    return delegate.apply(u);
+                }
+            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFuture_SerializationExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFuture_SerializationExceptionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapGetCodec;
+import com.hazelcast.client.impl.spi.impl.ClientInvocation;
+import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.DelegatingCompletableFuture_SerializationExceptionTest;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.sequence.CallIdSequence;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientDelegatingFuture_SerializationExceptionTest
+        extends DelegatingCompletableFuture_SerializationExceptionTest {
+
+    private ClientMessage request;
+    private ClientMessage response;
+    private ILogger logger;
+    private SerializationService serializationService;
+    private Data key;
+    private Data value;
+    private ClientInvocationFuture invocationFuture;
+    private ClientDelegatingFuture<Object> delegatingFuture;
+    private CallIdSequence callIdSequence;
+
+    @Before
+    public void setup() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        key = serializationService.toData("key");
+        value = invalidData;
+        logger = mock(ILogger.class);
+        request = MapGetCodec.encodeRequest("test", key, 1L);
+        response = MapGetCodec.encodeResponse(value);
+        callIdSequence = mock(CallIdSequence.class);
+        invocationFuture = new ClientInvocationFuture(mock(ClientInvocation.class),
+                request,
+                logger,
+                callIdSequence);
+        invocationFuture.complete(response);
+        delegatingFuture = new ClientDelegatingFuture<>(invocationFuture, serializationService,
+                MapGetCodec::decodeResponse, true);
+    }
+
+    @Override
+    protected InternalCompletableFuture<Object> newCompletableFuture(long completeAfterMillis) {
+        return delegatingFuture;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFuture_SerializationExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/ClientDelegatingFuture_SerializationExceptionTest.java
@@ -66,7 +66,7 @@ public class ClientDelegatingFuture_SerializationExceptionTest
                 callIdSequence);
         invocationFuture.complete(response);
         delegatingFuture = new ClientDelegatingFuture<>(invocationFuture, serializationService,
-                MapGetCodec::decodeResponse, true);
+                clientMessage -> MapGetCodec.decodeResponse(clientMessage).response, true);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFutureTest.java
@@ -54,7 +54,7 @@ public class DelegatingCompletableFutureTest {
     @Test
     public void test_get_Object() throws Exception {
         Object value = "value";
-        Future future = new DelegatingCompletableFuture(null, newCompletedFuture(value));
+        Future future = new DelegatingCompletableFuture(serializationService, newCompletedFuture(value));
         assertEquals(value, future.get());
     }
 
@@ -87,7 +87,7 @@ public class DelegatingCompletableFutureTest {
     @Test
     public void test_get_Object_withTimeout() throws Exception {
         Object value = "value";
-        Future future = new DelegatingCompletableFuture(null, newCompletedFuture(value));
+        Future future = new DelegatingCompletableFuture(serializationService, newCompletedFuture(value));
         assertEquals(value, future.get(1, TimeUnit.MILLISECONDS));
     }
 
@@ -102,20 +102,20 @@ public class DelegatingCompletableFutureTest {
     @Test(expected = ExecutionException.class)
     public void test_get_Exception() throws Exception {
         Throwable error = new Throwable();
-        Future future = new DelegatingCompletableFuture(null, completedExceptionally(error));
+        Future future = new DelegatingCompletableFuture(serializationService, completedExceptionally(error));
         future.get();
     }
 
     @Test
     public void test_cancel() {
-        Future future = new DelegatingCompletableFuture(null, newCompletedFuture(null));
+        Future future = new DelegatingCompletableFuture(serializationService, newCompletedFuture(null));
         assertFalse(future.cancel(true));
         assertFalse(future.isCancelled());
     }
 
     @Test
     public void test_isDone() {
-        Future future = new DelegatingCompletableFuture(null, newCompletedFuture("value"));
+        Future future = new DelegatingCompletableFuture(serializationService, newCompletedFuture("value"));
         assertTrue(future.isDone());
     }
 
@@ -123,7 +123,7 @@ public class DelegatingCompletableFutureTest {
     public void test_actionsTrigger_whenAlreadyCompletedFuture() {
         CountDownLatch latch = new CountDownLatch(1);
         CompletableFuture<String> future =
-                new DelegatingCompletableFuture(null, newCompletedFuture("value"));
+                new DelegatingCompletableFuture(serializationService, newCompletedFuture("value"));
         future.thenRun(latch::countDown);
         assertOpenEventually(latch);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFuture_SerializationExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingCompletableFuture_SerializationExceptionTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.test.HazelcastTestSupport.assertInstanceOf;
+import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastMillis;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test DelegatingCompletableFuture dependent actions when these fail
+ * with HazelcastSerializationException.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DelegatingCompletableFuture_SerializationExceptionTest {
+
+    protected final Data invalidData = new HeapData(new byte[] {0, 0, 0, 0, 5, 0, 0, 0, 0});
+
+    private InternalSerializationService serializationService
+            = new DefaultSerializationServiceBuilder().build();
+    private AtomicBoolean executed = new AtomicBoolean();
+
+    @Test
+    public void ensureInvalidData() {
+        assertThrows(HazelcastSerializationException.class,
+                () -> serializationService.toObject(invalidData));
+    }
+
+    @Test
+    public void test_isCompletedExceptionally() {
+        CompletableFuture<Object> future = newCompletableFuture(0L);
+
+        assertTrue(future.isDone());
+        assertTrue(future.isCompletedExceptionally());
+    }
+
+    @Test
+    public void test_get() {
+        CompletableFuture<Object> future = newCompletableFuture(0L);
+        Throwable t = assertThrows(ExecutionException.class, future::get);
+        assertInstanceOf(HazelcastSerializationException.class, t.getCause());
+    }
+
+    @Test
+    public void test_getWithTimeout() {
+        CompletableFuture<Object> future = newCompletableFuture(0L);
+        Throwable t = assertThrows(ExecutionException.class,
+                () -> future.get(1, TimeUnit.SECONDS));
+        assertInstanceOf(HazelcastSerializationException.class, t.getCause());
+    }
+
+    @Test
+    public void test_getNow() {
+        CompletableFuture<Object> future = newCompletableFuture(0L);
+        Throwable t = assertThrows(CompletionException.class,
+                () -> future.getNow(null));
+        assertInstanceOf(HazelcastSerializationException.class, t.getCause());
+    }
+
+    @Test
+    public void test_join() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0L);
+        Throwable t = assertThrows(CompletionException.class, future::join);
+        assertInstanceOf(HazelcastSerializationException.class, t.getCause());
+    }
+
+    @Test
+    public void test_joinInternal() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0L);
+        assertThrows(HazelcastSerializationException.class, future::joinInternal);
+    }
+
+    @Test
+    public void test_thenApply() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0L);
+        CompletableFuture<Object> chained = future.thenApply(v -> {
+            executed.set(true);
+            return new Object();
+        });
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_thenAccept() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(1000L);
+        CompletableFuture<Void> chained = future.thenAccept(v -> executed.set(true));
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_thenRun() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(1000L);
+        CompletableFuture<Void> chained = future.thenRun(() -> executed.set(true));
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_thenCombine() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Object> chained = future.thenCombine(newCompletableFuture(1000), (v, t) -> {
+            executed.set(true);
+            return new Object();
+        });
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_thenAcceptBoth() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Void> chained = future.thenAcceptBoth(newCompletableFuture(1000),
+                (v, t) -> executed.set(true));
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_runAfterBoth() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Void> chained = future.runAfterBoth(newCompletableFuture(1000),
+                () -> executed.set(true));
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_applyToEither() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Object> chained = future.applyToEither(newCompletableFuture(1000),
+                v -> {
+                    executed.set(true);
+                    return new Object();
+                });
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_acceptEither() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Void> chained = future.acceptEither(newCompletableFuture(1000),
+                v -> executed.set(true));
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_runAfterEither() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Void> chained = future.runAfterEither(newCompletableFuture(1000),
+                () -> executed.set(true));
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_thenCompose() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Object> chained = future.thenCompose(v -> {
+            executed.set(true);
+            return CompletableFuture.completedFuture(new Object());
+        });
+
+        assertWithCause(chained);
+        assertFalse(executed.get());
+    }
+
+    @Test
+    public void test_whenComplete() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        CompletableFuture<Object> chained = future.whenComplete((v, t) -> {
+            executed.set(true);
+            assertNull(v);
+            assertInstanceOf(HazelcastSerializationException.class, t);
+        });
+
+        assertWithCause(chained);
+        assertTrue(executed.get());
+    }
+
+    @Test
+    public void test_handle() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        Object chainedReturnValue = new Object();
+        CompletableFuture<Object> chained = future.handle((v, t) -> {
+            executed.set(true);
+            assertNull(v);
+            assertInstanceOf(HazelcastSerializationException.class, t);
+            return chainedReturnValue;
+        });
+
+        assertEquals(chainedReturnValue, chained.join());
+        assertTrue(executed.get());
+    }
+
+    @Test
+    public void test_exceptionally() {
+        InternalCompletableFuture<Object> future = newCompletableFuture(0);
+        Object chainedReturnValue = new Object();
+        CompletableFuture<Object> chained = future.exceptionally(t -> {
+            executed.set(true);
+            assertInstanceOf(HazelcastSerializationException.class, t);
+            return chainedReturnValue;
+        });
+
+        assertEquals(chainedReturnValue, chained.join());
+        assertTrue(executed.get());
+    }
+
+    protected InternalCompletableFuture<Object> newCompletableFuture(long completeAfterMillis) {
+        InternalCompletableFuture<Object> future = new InternalCompletableFuture<>();
+        Executor completionExecutor;
+        if (completeAfterMillis <= 0) {
+            completionExecutor = CALLER_RUNS;
+        } else {
+            completionExecutor = command -> new Thread(() -> {
+                sleepAtLeastMillis(completeAfterMillis);
+                command.run();
+            }, "test-completion-thread").start();
+        }
+        completionExecutor.execute(() -> future.complete(invalidData));
+        return new DelegatingCompletableFuture<>(serializationService, future);
+    }
+
+    private void assertWithCause(CompletableFuture<?> future) {
+        Throwable t = assertThrows(CompletionException.class, future::join);
+        assertInstanceOf(HazelcastSerializationException.class, t.getCause());
+    }
+}


### PR DESCRIPTION
Fixes DelegatingCompletableFuture
and subclass ClientDelegatingFuture behaviour
when HazelcastSerializationException is thrown:

- serialization exception is now properly wrapped
in (Execution|Completion)Exception when thrown
from get, getNow or join methods.
- whenComplete, handle and exceptionally
can act on the HazelcastSerializationException

(cherry picked from commit d9df32c219bc7b85542883c67ddc2f57e5770b56)

Clean 1:1 backport of #18070 to `4.0.z` branch
Fixes #18053 