### PR TITLE
Check whether or not client is active only if no addresses are tried …

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -495,7 +495,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                 triedAddresses.addAll(triedAddressesPerAttempt);
                 // If the address provider loads no addresses, then the above loop is not entered
                 // and the lifecycle check is missing, hence we need to repeat the same check at this point.
-                if (addresses.isEmpty()) {
+                if (triedAddressesPerAttempt.isEmpty()) {
                     checkClientActive();
                 }
             } while (waitStrategy.sleep());


### PR DESCRIPTION
…to connect

The logic of the ConnectionManager is changed a lot since the
https://github.com/hazelcast/hazelcast/pull/17855 is prepared.

The merge of this PR caused compilation problems in the master branch.

The same functionality of https://github.com/hazelcast/hazelcast/pull/17855 can be
achieved by checking the `triedAddressesPerAttempt` instead of `addresses`.