### PR TITLE
Fix cp-subsystem.sh parameters

### DIFF
--- a/hazelcast/src/main/resources/cp-subsystem.sh
+++ b/hazelcast/src/main/resources/cp-subsystem.sh
@@ -4,7 +4,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "Sends CP subsystem management operations to a Hazelcast instance."
     echo "Parameters:"
     echo "  -o, --operation   : Operation to be called."
-    echo "  -c, --group       : Name of the CP group. Must be provided for 'get-group', 'force-destroy-group', 'get-sessions', 'force-close-session'."
+    echo "  -g, --group       : Name of the CP group. Must be provided for 'get-group', 'force-destroy-group', 'get-sessions', 'force-close-session'."
     echo "  -m, --member      : UUID of the CP member. Must be provided for 'remove-member'."
     echo "  -s, --session-id  : CP Session ID. Must be provided for 'force-close-session'."
     echo "  -a, --address     : Defines which ip address hazelcast is running. Default value is '127.0.0.1'."
@@ -127,7 +127,7 @@ if [[ -z "$PORT" ]]; then
     PORT="5701"
 fi
 
-if [[ -z "CLUSTERNAME" ]]; then
+if [[ -z "$CLUSTERNAME" ]]; then
     echo "No clustername is defined, running script with default clustername: 'dev'."
     CLUSTERNAME="dev"
 fi


### PR DESCRIPTION
-c was used for two variables group and clustername.
Changed the config to -g for group to differentiate.

Cluster name parameters was not defaulting correctly.
It is also fixed.

(cherry picked from commit 7d4fc3e0d7a0f51e1dd13c6cc086096cb3c9cc37)