### PR TITLE
Reorder boolean flag reset in MulticastDeserializationTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -74,8 +74,8 @@ public class MulticastDeserializationTest {
 
     @AfterClass
     public static void cleanup() {
-        TestDeserialized.isDeserialized = false;
         HazelcastInstanceFactory.terminateAll();
+        TestDeserialized.isDeserialized = false;
     }
 
     /**


### PR DESCRIPTION
Reorder boolean flag reset in MulticastDeserializationTest due to side effect after `HazelcastInstanceFactory.terminateAll()` execution : it eventually reassign `TestDeserialized.isDeserialized` to positive value.
Closes #17843.