### PR TITLE
finish cache eviction policy tests once CacheEvictionPolicyComparator was invoked

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
@@ -322,7 +322,7 @@ abstract class CacheProxySupport<K, V>
         return invoke(operation, keyData, withCompletionEvent);
     }
 
-   protected  <T> InvocationFuture<T> replaceAsyncInternal(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy,
+    protected  <T> InvocationFuture<T> replaceAsyncInternal(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy,
                                                           boolean hasOldValue, boolean isGet, boolean withCompletionEvent) {
         ensureOpen();
         if (hasOldValue) {
@@ -345,7 +345,7 @@ abstract class CacheProxySupport<K, V>
         return invoke(operation, keyData, withCompletionEvent);
     }
 
-   protected <T> InvocationFuture<T> putAsyncInternal(K key, V value, ExpiryPolicy expiryPolicy,
+    protected <T> InvocationFuture<T> putAsyncInternal(K key, V value, ExpiryPolicy expiryPolicy,
                                                       boolean isGet, boolean withCompletionEvent) {
         ensureOpen();
         validateNotNull(key, value);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
@@ -29,7 +29,7 @@ import java.util.Queue;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 
 /**
- * Default {BufferPool} implementation.
+ * Default {@link BufferPool} implementation.
  *
  * This class is designed to that a subclass can be made. This is done for the Enterprise version.
  */
@@ -39,8 +39,8 @@ public class BufferPoolImpl implements BufferPool {
     protected final InternalSerializationService serializationService;
 
     // accessible for testing.
-    final Queue<BufferObjectDataOutput> outputQueue = new ArrayDeque<BufferObjectDataOutput>(MAX_POOLED_ITEMS);
-    final Queue<BufferObjectDataInput> inputQueue = new ArrayDeque<BufferObjectDataInput>(MAX_POOLED_ITEMS);
+    final Queue<BufferObjectDataOutput> outputQueue = new ArrayDeque<>(MAX_POOLED_ITEMS);
+    final Queue<BufferObjectDataInput> inputQueue = new ArrayDeque<>(MAX_POOLED_ITEMS);
 
     public BufferPoolImpl(InternalSerializationService serializationService) {
         this.serializationService = serializationService;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
@@ -31,8 +31,8 @@ import static com.hazelcast.internal.util.ConcurrentReferenceHashMap.ReferenceTy
  * A thread-local for {@link BufferPool}.
  *
  * The BufferPoolThreadLocal is not assigned to a static field, but as a member field of the SerializationService-instance.
- * is unlike the common use of a ThreadLocal where it assigned to a static field. The reason behind this is that the BufferPool
- * instance belongs to a specific SerializationService instance (the buffer pool has buffers tied to a particular
+ * It is unlike to the common use of a ThreadLocal where it assigned to a static field. The reason behind this is that the
+ * BufferPool instance belongs to a specific SerializationService instance (the buffer pool has buffers tied to a particular
  * SerializationService instance). By creating a ThreadLocal per SerializationService-instance, we obtain 'BufferPool per thread
  * per SerializationService-instance' semantics.
  *
@@ -79,10 +79,10 @@ import static com.hazelcast.internal.util.ConcurrentReferenceHashMap.ReferenceTy
  */
 public final class BufferPoolThreadLocal {
 
-    private final ThreadLocal<WeakReference<BufferPool>> threadLocal = new ThreadLocal<WeakReference<BufferPool>>();
+    private final ThreadLocal<WeakReference<BufferPool>> threadLocal = new ThreadLocal<>();
     private final InternalSerializationService serializationService;
     private final BufferPoolFactory bufferPoolFactory;
-    private final Map<Thread, BufferPool> strongReferences = new ConcurrentReferenceHashMap<Thread, BufferPool>(WEAK, STRONG);
+    private final Map<Thread, BufferPool> strongReferences = new ConcurrentReferenceHashMap<>(WEAK, STRONG);
     private final Supplier<RuntimeException> notActiveExceptionSupplier;
 
     public BufferPoolThreadLocal(InternalSerializationService serializationService,
@@ -97,7 +97,7 @@ public final class BufferPoolThreadLocal {
         WeakReference<BufferPool> ref = threadLocal.get();
         if (ref == null) {
             BufferPool pool = bufferPoolFactory.create(serializationService);
-            ref = new WeakReference<BufferPool>(pool);
+            ref = new WeakReference<>(pool);
             strongReferences.put(Thread.currentThread(), pool);
             threadLocal.set(ref);
             return pool;

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractCacheEvictionPolicyComparatorTest extends HazelcastTestSupport {
 
@@ -53,7 +54,7 @@ public abstract class AbstractCacheEvictionPolicyComparatorTest extends Hazelcas
     }
 
     protected CacheConfig<Integer, String> createCacheConfig(String cacheName) {
-        return new CacheConfig<Integer, String>(cacheName);
+        return new CacheConfig<>(cacheName);
     }
 
     void testEvictionPolicyComparator(EvictionConfig evictionConfig, int iterationCount) {
@@ -68,10 +69,12 @@ public abstract class AbstractCacheEvictionPolicyComparatorTest extends Hazelcas
         for (int i = 0; i < iterationCount; i++) {
             icache.put(i, "Value-" + i);
             icache.setExpiryPolicy(i, new EternalExpiryPolicy());
+            AtomicLong callCounter = (AtomicLong) getUserContext(instance).get("callCounter");
+            if (callCounter != null && callCounter.get() > 0) {
+                return;
+            }
         }
-
-        AtomicLong callCounter = (AtomicLong) getUserContext(instance).get("callCounter");
-        assertTrue(callCounter.get() > 0);
+        fail("CacheEvictionPolicyComparator was not invoked");
     }
 
     public static class MyEvictionPolicyComparator


### PR DESCRIPTION
Closes https://github.com/hazelcast/hazelcast-enterprise/issues/3850

This PR adds code that finished `CacheEvictionPolicyComparator` tests earlier - once `CacheEvictionPolicyComparator#compare` invoked, instead of running all iterations and check if `callCouter` is greater then 0

Also as I navigating the code to understand the use case I changed javadoc and use diamond operator.