### PR TITLE
Micro-optimization in the QueryDataType.normalize method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
@@ -111,19 +111,19 @@ public class QueryDataType implements IdentifiedDataSerializable, Serializable {
      */
     public Object normalize(Object value) {
         if (value == null) {
-            return value;
+            return null;
         }
 
         Class<?> valueClass = value.getClass();
 
-        if (!converter.getValueClass().isAssignableFrom(valueClass)) {
-            // Expected and actual class don't match. Throw an error.
-            throw new QueryDataTypeMismatchException(converter.getValueClass(), valueClass);
-        }
-
         if (valueClass == converter.getNormalizedValueClass()) {
             // Do nothing if the value is already in the normalized form.
             return value;
+        }
+
+        if (!converter.getValueClass().isAssignableFrom(valueClass)) {
+            // Expected and actual class don't match. Throw an error.
+            throw new QueryDataTypeMismatchException(converter.getValueClass(), valueClass);
         }
 
         return converter.convertToSelf(converter, value);


### PR DESCRIPTION
This PR introduces a minor change to the `QueryDataType.normalize` that moves an `isAssignableFrom` check past a class equality check. The motivation is that the class equality check yields `true` in the majority of cases and is cheaper than `isAssignable`.