### PR TITLE
Deprecated HOT_RESTART_FREE_NATIVE_MEMORY_PERCENTAGE property

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -53,7 +53,7 @@ class MapRemoteService implements RemoteService {
         SplitBrainMergePolicyProvider mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
 
         checkMapConfig(mapConfig, config.getNativeMemoryConfig(), mergePolicyProvider,
-                mapServiceContext.getNodeEngine().getProperties());
+                mapServiceContext.getNodeEngine().getProperties(), nodeEngine.getLogger(MapConfig.class));
 
         if (mapConfig.isNearCacheEnabled()) {
             initDefaultMaxSizeForOnHeapMaps(mapConfig.getNearCacheConfig());

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1503,13 +1503,6 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.shutdownhook.policy", "TERMINATE");
 
     /**
-     * XML and system property for setting the hot restart required free space.
-     * By default, hot restart requires at least 15% free HD space.
-     */
-    public static final HazelcastProperty HOT_RESTART_FREE_NATIVE_MEMORY_PERCENTAGE
-            = new HazelcastProperty("hazelcast.hotrestart.free.native.memory.percentage", 15);
-
-    /**
      * Name of logging framework type to send logging events.
      */
     public static final HazelcastProperty LOGGING_TYPE

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1503,6 +1503,16 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.shutdownhook.policy", "TERMINATE");
 
     /**
+     * Since 4.2, there is no effect of setting this property.
+     * HD Memory is automatically aligned for hot restart
+     * starting from that version.
+     * @deprecated since 4.2
+     */
+    @Deprecated
+    public static final HazelcastProperty HOT_RESTART_FREE_NATIVE_MEMORY_PERCENTAGE
+            = new HazelcastProperty("hazelcast.hotrestart.free.native.memory.percentage", 15);
+
+    /**
      * Name of logging framework type to send logging events.
      */
     public static final HazelcastProperty LOGGING_TYPE

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -54,6 +55,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
     private HazelcastProperties properties;
     private NativeMemoryConfig nativeMemoryConfig;
     private SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
+    private ILogger logger;
 
     @Before
     public void setUp() {
@@ -66,6 +68,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
         when(nodeEngine.getSplitBrainMergePolicyProvider()).thenReturn(splitBrainMergePolicyProvider);
 
         properties = nodeEngine.getProperties();
+        logger = nodeEngine.getLogger(MapConfig.class);
     }
 
     @Test
@@ -75,12 +78,12 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
 
     @Test
     public void checkMapConfig_BINARY() {
-        checkMapConfig(getMapConfig(BINARY), nativeMemoryConfig, splitBrainMergePolicyProvider, properties);
+        checkMapConfig(getMapConfig(BINARY), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
     }
 
     @Test
     public void checkMapConfig_OBJECT() {
-        checkMapConfig(getMapConfig(OBJECT), nativeMemoryConfig, splitBrainMergePolicyProvider, properties);
+        checkMapConfig(getMapConfig(OBJECT), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
     }
 
     /**
@@ -88,7 +91,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
      */
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_NATIVE() {
-        checkMapConfig(getMapConfig(NATIVE), nativeMemoryConfig, splitBrainMergePolicyProvider, properties);
+        checkMapConfig(getMapConfig(NATIVE), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
     }
 
     private MapConfig getMapConfig(InMemoryFormat inMemoryFormat) {


### PR DESCRIPTION
OS counterpart of https://github.com/hazelcast/hazelcast-enterprise/pull/3901

We don't need this property any more, we transparently manage memory spaces.