### PR TITLE
Make NearcacheConfig equal before and after it is used

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -18,11 +18,11 @@ package com.hazelcast.config;
 
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.internal.eviction.EvictionConfiguration;
-import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.internal.eviction.EvictionStrategyType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -30,12 +30,12 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import static com.hazelcast.internal.util.Preconditions.checkHasText;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * Configuration for eviction.
- *
+ * <p>
  * You can set a limit for number of
  * entries or total memory cost of entries.
  * <p>
@@ -66,24 +66,19 @@ public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSeri
      */
     public static final EvictionPolicy DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU;
 
-    protected int size = DEFAULT_MAX_ENTRY_COUNT;
-    protected MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
-    protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
-
-    protected String comparatorClassName;
-    protected EvictionPolicyComparator comparator;
-
-    /**
-     * Used by the {@link NearCacheConfigAccessor} to
-     * initialize the proper default value for on-heap maps.
-     */
-    boolean sizeConfigured;
+    private static final int UNSET = -1;
+    private MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
+    private EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
+    private String comparatorClassName;
+    private EvictionPolicyComparator comparator;
+    private int size = UNSET;
+    int defaultSize = DEFAULT_MAX_ENTRY_COUNT;
 
     public EvictionConfig() {
     }
 
     public EvictionConfig(EvictionConfig config) {
-        this.sizeConfigured = true;
+        this.defaultSize = config.defaultSize;
         this.size = config.size;
         this.maxSizePolicy = config.maxSizePolicy;
         this.evictionPolicy = config.evictionPolicy;
@@ -100,6 +95,9 @@ public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSeri
      * @return the size which is used by the {@link MaxSizePolicy}
      */
     public int getSize() {
+        if (size == UNSET) {
+            return defaultSize;
+        }
         return size;
     }
 
@@ -116,7 +114,6 @@ public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSeri
      * @return this EvictionConfig instance
      */
     public EvictionConfig setSize(int size) {
-        this.sizeConfigured = true;
         this.size = checkNotNegative(size,
                 "size cannot be a negative number!");
         return this;
@@ -287,11 +284,11 @@ public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSeri
 
         EvictionConfig that = (EvictionConfig) o;
 
-        return size == that.size
-            && maxSizePolicy == that.maxSizePolicy
-            && evictionPolicy == that.evictionPolicy
-            && Objects.equals(comparatorClassName, that.comparatorClassName)
-            && Objects.equals(comparator, that.comparator);
+        return ((size == UNSET && that.size == UNSET) || getSize() == that.getSize())
+                && maxSizePolicy == that.maxSizePolicy
+                && evictionPolicy == that.evictionPolicy
+                && Objects.equals(comparatorClassName, that.comparatorClassName)
+                && Objects.equals(comparator, that.comparator);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -34,8 +34,8 @@ public final class NearCacheConfigAccessor {
         }
 
         EvictionConfig evictionConfig = nearCacheConfig.getEvictionConfig();
-        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE && !evictionConfig.sizeConfigured) {
-            evictionConfig.setSize(MapConfig.DEFAULT_MAX_SIZE);
+        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE) {
+            evictionConfig.defaultSize = MapConfig.DEFAULT_MAX_SIZE;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -42,7 +42,7 @@ public class EvictionConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(EvictionConfig.class)
-                .allFieldsShouldBeUsedExcept("sizeConfigured")
+                .allFieldsShouldBeUsedExcept("defaultSize")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .withPrefabValues(EvictionConfig.class,
                         new EvictionConfig().setSize(1000).setMaxSizePolicy(ENTRY_COUNT).setEvictionPolicy(LFU),

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
@@ -36,5 +38,25 @@ public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
     @Test
     public void testInitDefaultMaxSizeForOnHeapMaps_whenNull_thenDoNothing() {
         NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(null);
+    }
+
+    @Test
+    public void testNearCacheConfigEqual_BeforeAndAfterDefaultSizeIsInitialized() {
+        NearCacheConfig config1 = new NearCacheConfig();
+        NearCacheConfig config2 = new NearCacheConfig();
+        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(config1);
+
+        assertEquals(config1, config2);
+    }
+
+    @Test
+    public void testEvictionConfigCopy_whenDefaultSizeIsInitialized() {
+        NearCacheConfig config1 = new NearCacheConfig();
+        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(config1);
+
+        EvictionConfig evictionConfig = config1.getEvictionConfig();
+        EvictionConfig evictionConfig2 = new EvictionConfig(evictionConfig);
+
+        assertEquals(evictionConfig.getSize(), evictionConfig2.getSize());
     }
 }


### PR DESCRIPTION
HazelcastClientFailover checks equality of configs when switching clusters.
If a config is not equals to itself after it is used,
HazelcastClientFailover equality check fails where it should not.
This test is to make sure `NearCacheConfigAccessor` does not break
the equality of NearCacheConfig.

fixes https://github.com/hazelcast/hazelcast/issues/17952

(cherry picked from commit 8df8a6ebd1a43c42dd3ae86d223b0d3b5fd51606)