### PR TITLE
Make NearcacheConfig equal before and after it is used

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -66,6 +66,8 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
      */
     public static final EvictionPolicy DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU;
 
+    private static final int UNSET = -1;
+
     /**
      * Maximum Size Policy
      */
@@ -94,45 +96,37 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
         FREE_NATIVE_MEMORY_PERCENTAGE
     }
 
-    protected int size = DEFAULT_MAX_ENTRY_COUNT;
+    protected int size = UNSET;
     protected MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
     protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
     protected String comparatorClassName;
     protected EvictionPolicyComparator comparator;
-
     protected EvictionConfig readOnly;
-
-    /**
-     * Used by the {@link NearCacheConfigAccessor} to initialize the proper default value for on-heap maps.
-     */
-    boolean sizeConfigured;
+    int defaultSize = DEFAULT_MAX_ENTRY_COUNT;
 
     public EvictionConfig() {
     }
 
     public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicy evictionPolicy) {
-        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
     }
 
     public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, String comparatorClassName) {
-        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         this.comparatorClassName = checkNotNull(comparatorClassName, "Comparator classname cannot be null!");
     }
 
     public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicyComparator comparator) {
-        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         this.comparator = checkNotNull(comparator, "Comparator cannot be null!");
     }
 
     public EvictionConfig(EvictionConfig config) {
-        this.sizeConfigured = true;
+        this.defaultSize = config.defaultSize;
         this.size = checkPositive(config.size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(config.maxSizePolicy, "Max-Size policy cannot be null!");
         if (config.evictionPolicy != null) {
@@ -169,6 +163,9 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
      * @return the size which is used by the {@link MaxSizePolicy}
      */
     public int getSize() {
+        if (size == UNSET) {
+            return defaultSize;
+        }
         return size;
     }
 
@@ -183,7 +180,6 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
      * @return this EvictionConfig instance
      */
     public EvictionConfig setSize(int size) {
-        this.sizeConfigured = true;
         this.size = checkPositive(size, "size must be positive number!");
         return this;
     }
@@ -348,7 +344,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
 
         EvictionConfig that = (EvictionConfig) o;
 
-        if (size != that.size) {
+        if (!((size == UNSET && that.size == UNSET) || getSize() == that.getSize())) {
             return false;
         }
         if (maxSizePolicy != that.maxSizePolicy) {
@@ -358,7 +354,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
             return false;
         }
         if (comparatorClassName != null
-                ? !comparatorClassName.equals(that.comparatorClassName) : that.comparatorClassName != null) {
+                    ? !comparatorClassName.equals(that.comparatorClassName) : that.comparatorClassName != null) {
             return false;
         }
         return comparator != null ? comparator.equals(that.comparator) : that.comparator == null;

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -34,8 +34,8 @@ public final class NearCacheConfigAccessor {
         }
 
         EvictionConfig evictionConfig = nearCacheConfig.getEvictionConfig();
-        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE && !evictionConfig.sizeConfigured) {
-            evictionConfig.setSize(EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP);
+        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE) {
+            evictionConfig.defaultSize = EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -40,7 +40,7 @@ public class EvictionConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(EvictionConfig.class)
-                .allFieldsShouldBeUsedExcept("readOnly", "sizeConfigured")
+                .allFieldsShouldBeUsedExcept("readOnly", "defaultSize")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .withPrefabValues(EvictionConfig.class,
                         new EvictionConfig(1000, ENTRY_COUNT, EvictionPolicy.LFU),

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
@@ -36,5 +38,25 @@ public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
     @Test
     public void testInitDefaultMaxSizeForOnHeapMaps_whenNull_thenDoNothing() {
         NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(null);
+    }
+
+    @Test
+    public void testNearCacheConfigEqual_BeforeAndAfterDefaultSizeIsInitialized() {
+        NearCacheConfig config1 = new NearCacheConfig();
+        NearCacheConfig config2 = new NearCacheConfig();
+        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(config1);
+
+        assertEquals(config1, config2);
+    }
+
+    @Test
+    public void testEvictionConfigCopy_whenDefaultSizeIsInitialized() {
+        NearCacheConfig config1 = new NearCacheConfig();
+        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(config1);
+
+        EvictionConfig evictionConfig = config1.getEvictionConfig();
+        EvictionConfig evictionConfig2 = new EvictionConfig(evictionConfig);
+
+        assertEquals(evictionConfig.getSize(), evictionConfig2.getSize());
     }
 }


### PR DESCRIPTION
HazelcastClientFailover checks equality of configs when switching clusters.
If a config is not equals to itself after it is used,
HazelcastClientFailover equality check fails where it should not.
This test is to make sure `NearCacheConfigAccessor` does not break
the equality of NearCacheConfig.

fixes https://github.com/hazelcast/hazelcast/issues/17952

(cherry picked from commit 8df8a6ebd1a43c42dd3ae86d223b0d3b5fd51606)