### PR TITLE
Add isInfiniteRows to QueryParseResult

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/index/IndexRexVisitor.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/index/IndexRexVisitor.java
@@ -29,7 +29,7 @@ import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexVisitorImpl;
 
 /**
- * Visitor that checks whether the given epression is valid for index filter creation.
+ * Visitor that checks whether the given expression is valid for index filter creation.
  * <p>
  * Consider the expression {@code a > exp}. If there is an index on the column {@code [a]}, then
  * it can be used only if the {@code exp} will produce the same result for all rows. That is, it

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParseResult.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParseResult.java
@@ -30,17 +30,20 @@ public class QueryParseResult {
     private final QueryParameterMetadata parameterMetadata;
     private final SqlValidator validator;
     private final SqlBackend sqlBackend;
+    private final boolean isInfiniteRows;
 
     public QueryParseResult(
         SqlNode node,
         QueryParameterMetadata parameterMetadata,
         SqlValidator validator,
-        SqlBackend sqlBackend
+        SqlBackend sqlBackend,
+        boolean isInfiniteRows
     ) {
         this.node = node;
         this.parameterMetadata = parameterMetadata;
         this.validator = validator;
         this.sqlBackend = sqlBackend;
+        this.isInfiniteRows = isInfiniteRows;
     }
 
     public SqlNode getNode() {
@@ -57,5 +60,9 @@ public class QueryParseResult {
 
     public SqlBackend getSqlBackend() {
         return sqlBackend;
+    }
+
+    public boolean isInfiniteRows() {
+        return isInfiniteRows;
     }
 }

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
@@ -92,10 +92,10 @@ public class QueryParser {
 
         Config config = createConfig(sqlBackend.parserFactory());
         SqlParser parser = SqlParser.create(sql, config);
+        SqlNode topNode = parser.parseStmt();
 
         HazelcastSqlValidator validator = (HazelcastSqlValidator) sqlBackend.validator(catalogReader, typeFactory, conformance);
-
-        SqlNode node = validator.validate(parser.parseStmt());
+        SqlNode node = validator.validate(topNode);
 
         SqlVisitor<Void> visitor = sqlBackend.unsupportedOperationVisitor(catalogReader);
         node.accept(visitor);
@@ -104,7 +104,8 @@ public class QueryParser {
             node,
             new QueryParameterMetadata(validator.getParameterConverters(node)),
             validator,
-            sqlBackend
+            sqlBackend,
+            validator.isInfiniteRows()
         );
     }
 

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlValidator.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlValidator.java
@@ -280,4 +280,13 @@ public class HazelcastSqlValidator extends SqlValidatorImplBridge {
 
         return Util.last(names);
     }
+
+    /**
+     * Returns whether the validated node returns an infinite number of rows.
+     *
+     * @throws IllegalStateException if called before the node is validated.
+     */
+    public boolean isInfiniteRows() {
+        return false;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ColumnExpression.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ColumnExpression.java
@@ -63,7 +63,8 @@ public final class ColumnExpression<T> implements Expression<T>, IdentifiedDataS
     }
 
     @SuppressWarnings("unchecked")
-    @Override public T eval(Row row, ExpressionEvalContext context) {
+    @Override
+    public T eval(Row row, ExpressionEvalContext context) {
         Object res = row.get(index);
 
         if (res instanceof LazyTarget) {
@@ -74,7 +75,7 @@ public final class ColumnExpression<T> implements Expression<T>, IdentifiedDataS
     }
 
     private Object unwrapLazyValue(LazyTarget lazyValue, ExpressionEvalContext context) {
-        assert type == QueryDataType.OBJECT;
+        assert type.equals(QueryDataType.OBJECT);
 
         return lazyValue.deserialize(context.getSerializationService());
     }


### PR DESCRIPTION
Jet obtains this information while parsing, it's also needed later.

Also fix the assert in `unwrapLazyValue` - QueryDataType isn't canonical after serde