### PR TITLE
Use cached deserialized values in SQL when possible

### DIFF
--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/misc/SqlNoSerializationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/misc/SqlNoSerializationTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.misc;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.IndexConfig;
+import com.hazelcast.config.IndexType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.SqlTestInstanceFactory;
+import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that ensures that there are no unexpected serializations when executing a query on an IMap with the
+ * default {@link InMemoryFormat#BINARY} format.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlNoSerializationTest extends SqlTestSupport {
+
+    private static final String MAP_NAME = "map";
+    private static final int KEY_COUNT = 100;
+
+    @Parameterized.Parameter
+    public boolean useIndex;
+
+    private final SqlTestInstanceFactory factory = SqlTestInstanceFactory.create();
+    private HazelcastInstance member;
+
+    private static volatile boolean failOnSerialization;
+
+    @Parameterized.Parameters(name = "useIndex:{0}")
+    public static Collection<Object> parameters() {
+        return Arrays.asList(true, false);
+    }
+
+    @Before
+    public void before() {
+        member = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+
+        Map<Key, Value> localMap = new HashMap<>();
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            localMap.put(new Key(i), new Value(i));
+        }
+
+        IMap<Key, Value> map = member.getMap(MAP_NAME);
+
+        map.putAll(localMap);
+
+        // An index may change the behavior due to MapContainer.isUseCachedDeserializedValuesEnabled.
+        if (useIndex) {
+            map.addIndex(new IndexConfig().setType(IndexType.SORTED).addAttribute("val"));
+        }
+
+        failOnSerialization = true;
+    }
+
+    @After
+    public void after() {
+        failOnSerialization = false;
+
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testMapScan() {
+        check("SELECT __key, this FROM " + MAP_NAME, 100);
+    }
+
+    @Test
+    public void testIndexScan() {
+        check("SELECT __key, this FROM " + MAP_NAME + " WHERE val = 1", 1);
+    }
+
+    private void check(String sql, int expectedCount) {
+        try (SqlResult res = member.getSql().execute(sql)) {
+            int count = 0;
+
+            for (SqlRow row : res) {
+                Object key = row.getObject(0);
+                Object value = row.getObject(1);
+
+                assertTrue(key instanceof Key);
+                assertTrue(value instanceof Value);
+
+                count++;
+            }
+
+            assertEquals(expectedCount, count);
+        }
+    }
+
+    public static class Key implements Externalizable {
+
+        public int key;
+
+        public Key() {
+            // No-op
+        }
+
+        private Key(int key) {
+            this.key = key;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeInt(key);
+
+            if (failOnSerialization) {
+                throw new IOException("Key serialization must not happen.");
+            }
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            key = in.readInt();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Key that = (Key) o;
+
+            return key == that.key;
+        }
+
+        @Override
+        public int hashCode() {
+            return key;
+        }
+    }
+
+    public static class Value implements Externalizable {
+
+        public int val;
+
+        public Value() {
+            // No-op
+        }
+
+        private Value(int val) {
+            this.val = val;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeInt(val);
+
+            if (failOnSerialization) {
+                throw new IOException("Value serialization must not happen.");
+            }
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            val = in.readInt();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -469,4 +469,17 @@ public class MapContainer {
             return ss.toData(input, partitioningStrategy);
         }
     }
+
+    public boolean isUseCachedDeserializedValuesEnabled(int partitionId) {
+        CacheDeserializedValues cacheDeserializedValues = getMapConfig().getCacheDeserializedValues();
+        switch (cacheDeserializedValues) {
+            case NEVER:
+                return false;
+            case ALWAYS:
+                return true;
+            default:
+                //if index exists then cached value is already set -> let's use it
+                return getIndexes(partitionId).haveAtLeastOneIndex();
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.query;
 
-import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.iteration.IterationPointer;
@@ -82,7 +81,7 @@ public class PartitionScanRunner {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         RecordStore<Record> recordStore = partitionContainer.getRecordStore(mapName);
         boolean nativeMemory = recordStore.getInMemoryFormat() == InMemoryFormat.NATIVE;
-        boolean useCachedValues = isUseCachedDeserializedValuesEnabled(mapContainer, partitionId);
+        boolean useCachedValues = mapContainer.isUseCachedDeserializedValuesEnabled(partitionId);
         Extractors extractors = mapServiceContext.getExtractors(mapName);
         Map.Entry<Integer, Map.Entry> nearestAnchorEntry =
                 pagingPredicate == null ? null : pagingPredicate.getNearestAnchorEntry();
@@ -164,18 +163,5 @@ public class PartitionScanRunner {
             }
         }
         return new QueryableEntriesSegment(resultList, pointers);
-    }
-
-    protected boolean isUseCachedDeserializedValuesEnabled(MapContainer mapContainer, int partitionId) {
-        CacheDeserializedValues cacheDeserializedValues = mapContainer.getMapConfig().getCacheDeserializedValues();
-        switch (cacheDeserializedValues) {
-            case NEVER:
-                return false;
-            case ALWAYS:
-                return true;
-            default:
-                //if index exists then cached value is already set -> let's use it
-                return mapContainer.getIndexes(partitionId).haveAtLeastOneIndex();
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -73,6 +73,11 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
     }
 
     @Override
+    public Data getKeyData() {
+        return keyData;
+    }
+
+    @Override
     public V getValue() {
         if (valueObject == null) {
             valueObject = serializationService.toObject(valueData);
@@ -81,15 +86,30 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
     }
 
     @Override
-    public Data getKeyData() {
-        return keyData;
-    }
-
-    @Override
     public Data getValueData() {
         if (valueData == null) {
             valueData = serializationService.toData(valueObject);
         }
+        return valueData;
+    }
+
+    @Override
+    public K getKeyIfPresent() {
+        return keyObject != null ? keyObject : null;
+    }
+
+    @Override
+    public Data getKeyDataIfPresent() {
+        return keyData;
+    }
+
+    @Override
+    public V getValueIfPresent() {
+        return valueObject;
+    }
+
+    @Override
+    public Data getValueDataIfPresent() {
         return valueData;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -103,14 +103,27 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
         return keyData;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public V getValueIfPresent() {
-        return valueObject;
+        if (valueObject != null) {
+            return valueObject;
+        }
+
+        Object possiblyNotData = record.getValue();
+
+        return possiblyNotData instanceof Data ? null : (V) possiblyNotData;
     }
 
     @Override
     public Data getValueDataIfPresent() {
-        return valueData;
+        if (valueData != null) {
+            return valueData;
+        }
+
+        Object possiblyData = record.getValue();
+
+        return possiblyData instanceof Data ? (Data) possiblyData : null;
     }
 
     public Object getByPrioritizingDataValue() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -96,12 +96,24 @@ public class QueryEntry extends QueryableEntry {
 
     @Override
     public Object getValueIfPresent() {
-        return value instanceof Data ? null : value;
+        if (!(value instanceof Data)) {
+            return value;
+        }
+
+        Object possiblyNotData = record.getValue();
+
+        return possiblyNotData instanceof Data ? null : possiblyNotData;
     }
 
     @Override
     public Data getValueDataIfPresent() {
-        return value instanceof Data ? (Data) value : null;
+        if (value instanceof Data) {
+            return (Data) value;
+        }
+
+        Object possiblyData = record.getValue();
+
+        return possiblyData instanceof Data ? (Data) possiblyData : null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.getters.Extractors;
 
 /**
@@ -70,18 +70,38 @@ public class QueryEntry extends QueryableEntry {
     }
 
     @Override
-    public Object getValue() {
-        return serializationService.toObject(value);
-    }
-
-    @Override
     public Data getKeyData() {
         return key;
     }
 
     @Override
+    public Object getValue() {
+        return serializationService.toObject(value);
+    }
+
+    @Override
     public Data getValueData() {
         return serializationService.toData(value);
+    }
+
+    @Override
+    public Object getKeyIfPresent() {
+        return null;
+    }
+
+    @Override
+    public Data getKeyDataIfPresent() {
+        return key;
+    }
+
+    @Override
+    public Object getValueIfPresent() {
+        return value instanceof Data ? null : value;
+    }
+
+    @Override
+    public Data getValueDataIfPresent() {
+        return value instanceof Data ? (Data) value : null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -46,7 +46,7 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
     protected InternalSerializationService serializationService;
     protected Extractors extractors;
 
-    private Record record;
+    protected Record record;
     private transient Metadata metadata;
 
     public Record getRecord() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -62,13 +62,15 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
         return extractAttributeValue(attributeName);
     }
 
-    public abstract V getValue();
-
     public abstract K getKey();
-
     public abstract Data getKeyData();
-
+    public abstract V getValue();
     public abstract Data getValueData();
+
+    public abstract K getKeyIfPresent();
+    public abstract Data getKeyDataIfPresent();
+    public abstract V getValueIfPresent();
+    public abstract Data getValueDataIfPresent();
 
     protected abstract Object getTargetObject(boolean key);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -52,8 +52,7 @@ public abstract class AbstractMapScanExec extends AbstractExec {
     protected final List<QueryDataType> fieldTypes;
     protected final List<Integer> projects;
     protected final Expression<Boolean> filter;
-
-    private final InternalSerializationService serializationService;
+    protected final InternalSerializationService serializationService;
 
     private int migrationStamp;
     private KeyValueIterator recordIterator;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/AbstractMapScanExec.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.exec.scan;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.sql.impl.SqlErrorCode;
@@ -103,7 +104,12 @@ public abstract class AbstractMapScanExec extends AbstractExec {
         currentRows = null;
 
         while (recordIterator.tryAdvance()) {
-            Row row = prepareRow(recordIterator.getKey(), recordIterator.getValue());
+            Row row = prepareRow(
+                recordIterator.getKey(),
+                recordIterator.getKeyData(),
+                recordIterator.getValue(),
+                recordIterator.getValueData()
+            );
 
             if (row != null) {
                 if (currentRows == null) {
@@ -164,12 +170,14 @@ public abstract class AbstractMapScanExec extends AbstractExec {
      * 1) Check filter
      * 2) Extract projections
      *
-     * @param rawKey Key (data or object)
-     * @param rawValue Value (data or object)
+     * @param rawKey key as object, might be null
+     * @param rawKeyData key as data, might be null
+     * @param rawValue value as object, might be null
+     * @param rawValueData value as data, might be null
      * @return Row that is ready for processing by parent operators or {@code null} if the row hasn't passed the filter.
      */
-    protected Row prepareRow(Object rawKey, Object rawValue) {
-        row.setKeyValue(rawKey, rawValue);
+    protected Row prepareRow(Object rawKey, Data rawKeyData, Object rawValue, Data rawValueData) {
+        row.setKeyValue(rawKey, rawKeyData, rawValue, rawValueData);
 
         // Filter.
         if (filter != null && TernaryLogic.isNotTrue(filter.evalTop(row, ctx))) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/KeyValueIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/KeyValueIterator.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.sql.impl.exec.scan;
 
+import com.hazelcast.internal.serialization.Data;
+
 /**
  * Iterator over key/value pairs.
  */
@@ -36,13 +38,8 @@ public interface KeyValueIterator {
      */
     boolean done();
 
-    /**
-     * @return current key
-     */
     Object getKey();
-
-    /**
-     * @return current value
-     */
+    Data getKeyData();
     Object getValue();
+    Data getValueData();
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExec.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExec.java
@@ -70,7 +70,7 @@ public class MapScanExec extends AbstractMapScanExec {
 
     @Override
     protected KeyValueIterator createIterator() {
-        return MapScanExecUtils.createIterator(map, partitions);
+        return MapScanExecUtils.createIterator(map, partitions, serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -89,7 +89,7 @@ public class MapScanExecIterator implements KeyValueIterator {
     /**
      * Get the next key/value pair from the store.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "checkstyle:CyclomaticComplexity"})
     private void advance0(boolean first) {
         while (true) {
             // Move to the next record store if needed.

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecUtils.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.exec.scan;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.query.impl.getters.Extractors;
@@ -32,7 +33,11 @@ public final class MapScanExecUtils {
         return map.getExtractors();
     }
 
-    public static MapScanExecIterator createIterator(MapContainer map, PartitionIdSet parts) {
-        return new MapScanExecIterator(map, parts.iterator());
+    public static MapScanExecIterator createIterator(
+        MapContainer map,
+        PartitionIdSet parts,
+        InternalSerializationService serializationService
+    ) {
+        return new MapScanExecIterator(map, parts.iterator(), serializationService);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanRow.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.exec.scan;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.sql.impl.extract.QueryExtractor;
@@ -72,12 +73,14 @@ public final class MapScanRow implements Row {
     /**
      * Set current key and value.
      *
-     * @param rawKey Key (object or data).
-     * @param rawValue Value (object or data).
+     * @param rawKey key, might be null
+     * @param rawKeyData key data, might be null
+     * @param rawValue value as object, might be null
+     * @param rawValueData value as data, might be null
      */
-    public void setKeyValue(Object rawKey, Object rawValue) {
-        keyTarget.setTarget(rawKey);
-        valueTarget.setTarget(rawValue);
+    public void setKeyValue(Object rawKey, Data rawKeyData, Object rawValue, Data rawValueData) {
+        keyTarget.setTarget(rawKey, rawKeyData);
+        valueTarget.setTarget(rawValue, rawValueData);
     }
 
     @SuppressWarnings("unchecked")

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecIterator.java
@@ -85,12 +85,25 @@ public class MapIndexScanExecIterator implements KeyValueIterator {
 
     @Override
     public Object getKey() {
+        // TODO: Implement
+        return null;
+    }
+
+    @Override
+    public Data getKeyData() {
         return currentKey;
     }
 
     @Override
     public Object getValue() {
-        return currentValue;
+        // TODO: Implement
+        return currentValue instanceof Data ? null : currentValue;
+    }
+
+    @Override
+    public Data getValueData() {
+        // TODO: Implement
+        return currentValue instanceof Data ? (Data) currentValue : null;
     }
 
     private void advance0() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecIterator.java
@@ -37,10 +37,15 @@ public class MapIndexScanExecIterator implements KeyValueIterator {
 
     private final Iterator<QueryableEntry> iterator;
 
-    private Data currentKey;
+    private Object currentKey;
+    private Data currentKeyData;
     private Object currentValue;
-    private Data nextKey;
+    private Data currentValueData;
+
+    private Object nextKey;
+    private Data nextKeyData;
     private Object nextValue;
+    private Data nextValueData;
 
     public MapIndexScanExecIterator(
         String mapName,
@@ -68,7 +73,9 @@ public class MapIndexScanExecIterator implements KeyValueIterator {
     public boolean tryAdvance() {
         if (!done()) {
             currentKey = nextKey;
+            currentKeyData = nextKeyData;
             currentValue = nextValue;
+            currentValueData = nextValueData;
 
             advance0();
 
@@ -80,41 +87,42 @@ public class MapIndexScanExecIterator implements KeyValueIterator {
 
     @Override
     public boolean done() {
-        return nextKey == null;
+        return nextKeyData == null;
     }
 
     @Override
     public Object getKey() {
-        // TODO: Implement
-        return null;
-    }
-
-    @Override
-    public Data getKeyData() {
         return currentKey;
     }
 
     @Override
+    public Data getKeyData() {
+        return currentKeyData;
+    }
+
+    @Override
     public Object getValue() {
-        // TODO: Implement
-        return currentValue instanceof Data ? null : currentValue;
+        return currentValue;
     }
 
     @Override
     public Data getValueData() {
-        // TODO: Implement
-        return currentValue instanceof Data ? (Data) currentValue : null;
+        return currentValueData;
     }
 
     private void advance0() {
         if (iterator.hasNext()) {
             QueryableEntry<?, ?> entry = iterator.next();
 
-            nextKey = entry.getKeyData();
-            nextValue = entry.getValue();
+            nextKey = entry.getKeyIfPresent();
+            nextKeyData = entry.getKeyDataIfPresent();
+            nextValue = entry.getValueIfPresent();
+            nextValueData = entry.getValueDataIfPresent();
         } else {
             nextKey = null;
+            nextKeyData = null;
             nextValue = null;
+            nextValueData = null;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/GenericQueryTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/GenericQueryTarget.java
@@ -43,14 +43,9 @@ public class GenericQueryTarget implements QueryTarget, GenericTargetAccessor {
     }
 
     @Override
-    public void setTarget(Object object) {
-        if (object instanceof Data) {
-            serialized = (Data) object;
-            deserialized = null;
-        } else {
-            serialized = null;
-            deserialized = object;
-        }
+    public void setTarget(Object target, Data targetData) {
+        serialized = targetData;
+        deserialized = target;
 
         targetWithObjectTypeForDirectAccess = null;
         targetForFieldAccess = null;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/QueryTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/QueryTarget.java
@@ -16,19 +16,20 @@
 
 package com.hazelcast.sql.impl.extract;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
 /**
  * Target that is used to extract values from map entry's key or value.
  * <p>
  * Extractors are created once per query using the {@link #createExtractor(String, QueryDataType)} method. The target is then
- * updated for every map record using the {@link #setTarget(Object)} method, while extractors remain the same.
+ * updated for every map record using the {@link #setTarget(Object, Data)} method, while extractors remain the same.
  * <p>
  * The motivation for this design is to minimize the overhead on extractors creation and to avoid constant overhead associated
  * with data extraction, by maintaining the state. An example is {@code PortableGetter} that opens a reader on every get
  * operation. Instead, the reader might be opened in {@code setTarget} once and then reused for all fields.
  */
 public interface QueryTarget {
-    void setTarget(Object target);
+    void setTarget(Object target, Data targetData);
     QueryExtractor createExtractor(String path, QueryDataType type);
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/TestSamples.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/TestSamples.java
@@ -245,6 +245,26 @@ final class TestSamples {
         }
 
         @Override
+        public K getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public V getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -225,5 +225,25 @@ public class AndResultSetTest extends HazelcastTestSupport {
         public Data getValueData() {
             return null;
         }
+
+        @Override
+        public Object getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Object getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
@@ -226,6 +226,25 @@ public class ConverterResolutionTest {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public Integer getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Value getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
@@ -189,6 +189,25 @@ public class IndexFirstComponentDecoratorTest {
             return key ? this.key : value;
         }
 
+        @Override
+        public Integer getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Long getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -485,6 +485,26 @@ public class IndexTest {
         public Record toRecord() {
             return recordFactory.newRecord(attributeValue);
         }
+
+        @Override
+        public Object getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Object getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
     }
 
     private void testIt(boolean ordered) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/OrResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/OrResultSetTest.java
@@ -121,5 +121,25 @@ public class OrResultSetTest extends HazelcastTestSupport {
         public Data getValueData() {
             return null;
         }
+
+        @Override
+        public Object getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Object getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -365,6 +365,25 @@ public class PredicatesTest extends HazelcastTestSupport {
             return null;
         }
 
+        @Override
+        public Object getKeyIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getKeyDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Object getValueIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
+
+        @Override
+        public Data getValueDataIfPresent() {
+            throw new UnsupportedOperationException("Should not be called.");
+        }
     }
 
     private Entry createEntry(final Object key, final Object value) {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
@@ -65,7 +65,11 @@ public class GenericQueryTargetTest extends SqlTestSupport {
 
     private void checkTarget(GenericQueryTarget target, TestObject originalObject, Object object) {
         // Set target.
-        target.setTarget(object);
+        if (object instanceof Data) {
+            target.setTarget(null, (Data) object);
+        } else {
+            target.setTarget(object, null);
+        }
 
         // Good top-level extractor.
         QueryExtractor targetExtractor = target.createExtractor(null, QueryDataType.OBJECT);


### PR DESCRIPTION
This PR ensures that the SQL engine attempts to re-use already deserialized values stored in an index, similarly to predicate API. This substantially improves map scan operations performance when there is at least one index on an `IMap`. 

In addition to this, the PR ensures that we move both serialized and deserialized representations to the SQL engine to avoid serialization of entries that already have a `Data` representation. This improves the performance of index lookups by ~10-15%.