### PR TITLE
Workaround Calcite issues in CAST

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
@@ -114,7 +114,7 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         QueryDataType fromType = HazelcastTypeUtils.toHazelcastType(from.getSqlTypeName());
         QueryDataType toType = HazelcastTypeUtils.toHazelcastType(to.getSqlTypeName());
 
-        Literal literal = LiteralUtils.literal(operand);
+        Literal literal = LiteralUtils.literal(convertedOperand);
 
         if (literal != null && literal.getTypeName() != NULL) {
             // There is a bug in RexSimplify that incorrectly converts numeric literals from one numeric type to another.
@@ -232,6 +232,6 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
         CalciteContextException calciteContextError = validator.newValidationError(call, contextError);
 
-        throw QueryException.error(SqlErrorCode.PARSING, calciteContextError.getMessage(), calciteContextError);
+        throw QueryException.error(SqlErrorCode.PARSING, calciteContextError.getMessage(), e);
     }
 }

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/literal/Literal.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/literal/Literal.java
@@ -18,7 +18,6 @@ package com.hazelcast.sql.impl.calcite.validate.literal;
 
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastTypeFactory;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -27,12 +26,10 @@ import org.apache.calcite.sql.type.SqlTypeName;
  */
 public abstract class Literal {
 
-    protected final SqlLiteral original;
     protected final Object value;
     protected final SqlTypeName typeName;
 
-    public Literal(SqlLiteral original, Object value, SqlTypeName typeName) {
-        this.original = original;
+    public Literal(Object value, SqlTypeName typeName) {
         this.value = value;
         this.typeName = typeName;
     }
@@ -42,7 +39,7 @@ public abstract class Literal {
     }
 
     public String getStringValue() {
-        return original.toValue();
+        return value != null ? value.toString() : null;
     }
 
     public SqlTypeName getTypeName() {

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/literal/LiteralUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/literal/LiteralUtils.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
 
 import static org.apache.calcite.sql.type.SqlTypeName.CHAR_TYPES;
 
@@ -68,7 +69,11 @@ public final class LiteralUtils {
         }
 
         if (CHAR_TYPES.contains(typeName)) {
-            return new TypedLiteral(value.toString(), SqlTypeName.VARCHAR);
+            if (value instanceof NlsString) {
+                value = ((NlsString) value).getValue();
+            }
+            assert value instanceof String : value.getClass().getName();
+            return new TypedLiteral(value, SqlTypeName.VARCHAR);
         }
 
         return new TypedLiteral(value, typeName);

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/literal/TypedLiteral.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/literal/TypedLiteral.java
@@ -18,12 +18,11 @@ package com.hazelcast.sql.impl.calcite.validate.literal;
 
 import com.hazelcast.sql.impl.calcite.validate.types.HazelcastTypeFactory;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 public class TypedLiteral extends Literal {
-    public TypedLiteral(SqlLiteral original, Object value, SqlTypeName typeName) {
-        super(original, value, typeName);
+    public TypedLiteral(Object value, SqlTypeName typeName) {
+        super(value, typeName);
     }
 
     @Override

--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeUtils.java
@@ -139,7 +139,18 @@ public final class HazelcastTypeUtils {
      * DECIMAL.
      */
     public static boolean isNumericType(RelDataType type) {
-        switch (type.getSqlTypeName()) {
+        return isNumericType(type.getSqlTypeName());
+    }
+
+    /**
+     * @return {@code true} if the given type is a numeric type, {@code false}
+     * otherwise.
+     * <p>
+     * Numeric types are: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE and
+     * DECIMAL.
+     */
+    public static boolean isNumericType(SqlTypeName typeName) {
+        switch (typeName) {
             case TINYINT:
             case SMALLINT:
             case INTEGER:

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -399,6 +399,8 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         checkValue0(sql(literal(1), TINYINT), TINYINT, (byte) 1);
         checkValue0(sql(literal(Byte.MIN_VALUE), TINYINT), TINYINT, Byte.MIN_VALUE);
         checkValue0(sql(literal(Byte.MAX_VALUE), TINYINT), TINYINT, Byte.MAX_VALUE);
+        checkFailure0(sql(literal(128), TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
+        checkFailure0(sql("cast(128 as smallint)", TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
 
         checkValue0(sql(literal(1), SMALLINT), SMALLINT, (short) 1);
         checkValue0(sql(literal(1), INTEGER), INTEGER, 1);
@@ -616,9 +618,9 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
     public void testBigint_literal() {
         put(1);
 
-        checkValue0(sql(literal(Long.MAX_VALUE), VARCHAR), VARCHAR, Long.MAX_VALUE + "");
+//        checkValue0(sql(literal(Long.MAX_VALUE), VARCHAR), VARCHAR, Long.MAX_VALUE + "");
 
-        checkFailure0(sql(literal(Long.MAX_VALUE), BOOLEAN), PARSING, castError(BIGINT, BOOLEAN));
+//        checkFailure0(sql(literal(Long.MAX_VALUE), BOOLEAN), PARSING, castError(BIGINT, BOOLEAN));
 
         checkFailure0(sql(literal(Long.MAX_VALUE), TINYINT), PARSING, "CAST function cannot convert literal 9223372036854775807 to type TINYINT: Numeric overflow while converting BIGINT to TINYINT");
         checkFailure0(sql(literal(Long.MAX_VALUE), SMALLINT), PARSING, "CAST function cannot convert literal 9223372036854775807 to type SMALLINT: Numeric overflow while converting BIGINT to SMALLINT");

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -618,9 +618,9 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
     public void testBigint_literal() {
         put(1);
 
-//        checkValue0(sql(literal(Long.MAX_VALUE), VARCHAR), VARCHAR, Long.MAX_VALUE + "");
+        checkValue0(sql(literal(Long.MAX_VALUE), VARCHAR), VARCHAR, Long.MAX_VALUE + "");
 
-//        checkFailure0(sql(literal(Long.MAX_VALUE), BOOLEAN), PARSING, castError(BIGINT, BOOLEAN));
+        checkFailure0(sql(literal(Long.MAX_VALUE), BOOLEAN), PARSING, castError(BIGINT, BOOLEAN));
 
         checkFailure0(sql(literal(Long.MAX_VALUE), TINYINT), PARSING, "CAST function cannot convert literal 9223372036854775807 to type TINYINT: Numeric overflow while converting BIGINT to TINYINT");
         checkFailure0(sql(literal(Long.MAX_VALUE), SMALLINT), PARSING, "CAST function cannot convert literal 9223372036854775807 to type SMALLINT: Numeric overflow while converting BIGINT to SMALLINT");

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -400,6 +400,7 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         checkValue0(sql(literal(Byte.MIN_VALUE), TINYINT), TINYINT, Byte.MIN_VALUE);
         checkValue0(sql(literal(Byte.MAX_VALUE), TINYINT), TINYINT, Byte.MAX_VALUE);
         checkFailure0(sql(literal(128), TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
+        // test for https://github.com/hazelcast/hazelcast/issues/18155
         checkFailure0(sql("cast(128 as smallint)", TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
 
         checkValue0(sql(literal(1), SMALLINT), SMALLINT, (short) 1);

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -400,8 +400,6 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         checkValue0(sql(literal(Byte.MIN_VALUE), TINYINT), TINYINT, Byte.MIN_VALUE);
         checkValue0(sql(literal(Byte.MAX_VALUE), TINYINT), TINYINT, Byte.MAX_VALUE);
         checkFailure0(sql(literal(128), TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
-        // test for https://github.com/hazelcast/hazelcast/issues/18155
-        checkFailure0(sql("cast(128 as smallint)", TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
 
         checkValue0(sql(literal(1), SMALLINT), SMALLINT, (short) 1);
         checkValue0(sql(literal(1), INTEGER), INTEGER, 1);
@@ -1081,6 +1079,15 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         checkValue0(sql("null", TIMESTAMP), TIMESTAMP, null);
         checkValue0(sql("null", TIMESTAMP_WITH_TIME_ZONE), TIMESTAMP_WITH_TIME_ZONE, null);
         checkValue0(sql("null", OBJECT), OBJECT, null);
+    }
+
+    @Test
+    public void testNestedCastsOfLiterals() {
+        // tests for https://github.com/hazelcast/hazelcast/issues/18155
+        put(1);
+        checkFailure0(sql("CAST(128 AS INTEGER)", TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
+        checkFailure0(sql("CAST(128 AS SMALLINT)", TINYINT), PARSING, "Numeric overflow while converting SMALLINT to TINYINT");
+        checkValue0(sql("CAST(42 AS SMALLINT)", TINYINT), TINYINT, (byte) 42);
     }
 
     @Test

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -142,6 +142,7 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         Object expectedResult,
         Object... params
     ) {
+        System.out.println(sql);
         List<SqlRow> rows = execute(member, sql, params);
         assertEquals(1, rows.size());
 
@@ -177,10 +178,12 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         Object... params
     ) {
         try {
+            System.out.println(sql);
             execute(member, sql, params);
 
             fail("Must fail");
         } catch (HazelcastSqlException e) {
+            e.printStackTrace();
             assertTrue(expectedErrorMessage.length() != 0);
             assertNotNull(e.getMessage());
             assertTrue(

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -142,7 +142,6 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         Object expectedResult,
         Object... params
     ) {
-        System.out.println(sql);
         List<SqlRow> rows = execute(member, sql, params);
         assertEquals(1, rows.size());
 
@@ -178,12 +177,10 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         Object... params
     ) {
         try {
-            System.out.println(sql);
             execute(member, sql, params);
 
             fail("Must fail");
         } catch (HazelcastSqlException e) {
-            e.printStackTrace();
             assertTrue(expectedErrorMessage.length() != 0);
             assertNotNull(e.getMessage());
             assertTrue(

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/LiteralTypeResolutionTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/LiteralTypeResolutionTest.java
@@ -86,8 +86,17 @@ public class LiteralTypeResolutionTest {
         checkLiteral(exactNumeric("1.1"), new BigDecimal("1.1"), "1.1", DECIMAL, false);
         checkLiteral(exactNumeric(Long.MAX_VALUE + "0"), new BigDecimal(Long.MAX_VALUE + "0"), Long.MAX_VALUE + "0", DECIMAL, false);
         checkLiteral(exactNumeric(Long.MIN_VALUE + "0"), new BigDecimal(Long.MIN_VALUE + "0"), Long.MIN_VALUE + "0", DECIMAL, false);
+    }
 
+    @Test
+    public void testApproxNumeric() {
         checkLiteral(SqlLiteral.createApproxNumeric("1.1E1", ZERO), 1.1E1, "1.1E1", DOUBLE, false);
+    }
+
+    @Test
+    public void testDecimal() {
+        BigDecimal maxPlusOne = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+        checkLiteral(exactNumeric(maxPlusOne), maxPlusOne, maxPlusOne, DECIMAL, false);
     }
 
     private void checkLiteral(
@@ -103,7 +112,7 @@ public class LiteralTypeResolutionTest {
         assertNotNull(literal0);
 
         assertEquals(expectedValue, literal0.getValue());
-        assertEquals(expectedStringValue0, literal0.getStringValue());
+        assertEquals(expectedStringValue0, literal0.getValue() != null ? literal0.getValue().toString() : null);
         assertEquals(expectedTypeName, literal0.getTypeName());
         assertEquals(expectedTypeName, literal0.getType(HazelcastTypeFactory.INSTANCE).getSqlTypeName());
         assertEquals(expectedNullable, literal0.getType(HazelcastTypeFactory.INSTANCE).isNullable());
@@ -118,5 +127,9 @@ public class LiteralTypeResolutionTest {
 
     private static SqlLiteral exactNumeric(Object value) {
         return SqlLiteral.createExactNumeric(value.toString(), ZERO);
+    }
+
+    private static SqlLiteral inexactNumeric(double value) {
+        return SqlLiteral.createApproxNumeric(Double.toString(value), ZERO);
     }
 }

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/LiteralTypeResolutionTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/expression/LiteralTypeResolutionTest.java
@@ -112,7 +112,7 @@ public class LiteralTypeResolutionTest {
         assertNotNull(literal0);
 
         assertEquals(expectedValue, literal0.getValue());
-        assertEquals(expectedStringValue0, literal0.getValue() != null ? literal0.getValue().toString() : null);
+        assertEquals(expectedStringValue0, literal0.getStringValue());
         assertEquals(expectedTypeName, literal0.getTypeName());
         assertEquals(expectedTypeName, literal0.getType(HazelcastTypeFactory.INSTANCE).getSqlTypeName());
         assertEquals(expectedNullable, literal0.getType(HazelcastTypeFactory.INSTANCE).isNullable());
@@ -127,9 +127,5 @@ public class LiteralTypeResolutionTest {
 
     private static SqlLiteral exactNumeric(Object value) {
         return SqlLiteral.createExactNumeric(value.toString(), ZERO);
-    }
-
-    private static SqlLiteral inexactNumeric(double value) {
-        return SqlLiteral.createApproxNumeric(Double.toString(value), ZERO);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converters.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/Converters.java
@@ -162,7 +162,7 @@ public final class Converters {
             Converter oldConverter = map.put(converter.getId(), converter);
 
             if (oldConverter != null) {
-                throw new HazelcastException("Two converters has the same ID [id=" + converter.getId()
+                throw new HazelcastException("Two converters have the same ID [id=" + converter.getId()
                     + ", converter1=" + oldConverter.getClass().getSimpleName()
                     + ", converter2=" + converter.getClass().getSimpleName() + ']');
             }


### PR DESCRIPTION
In `SqlToRelConverter`, Calcite converts `CAST(x AS TYPE)`, in case `x` is a literal, directly to a `RexLiteral`. However, it doesn't correctly check for overflows, for which we had a workaround. However the workaround was insufficient: in case of `CAST(CAST(x AS TYPE))` it applied to the inner cast, but not to the outer, to which, after conversion, the parameter was also a RexLiteral. For example, `CAST(CAST(128 AS SMALLINT) AS TINYINT)` produced `-1` due to the overflow: the inner CAST is valid, but the outer CAST should throw.

The fix improves the `LiteralUtils` so that it can derive the same information from either `SqlLiteral` or from `RexLiteral`. Then in `HazelcastSqlToRelConverter.convertCast` we derive the literal information from `RexNode convertedOperand` instead of from `SqlNode operand`. The rest of the PR are changes necessitated by these changes.

Fixes #18155