### PR TITLE
Do not use deprecated methods of ObjectDataInput/Output, PortableRead…

### DIFF
--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlBasicTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlBasicTest.java
@@ -786,7 +786,7 @@ public class SqlBasicTest extends SqlTestSupport {
             out.writeObject(decimalVal);
 
             out.writeChar(charVal);
-            out.writeUTF(varcharVal);
+            out.writeString(varcharVal);
 
             out.writeObject(dateVal);
             out.writeObject(timeVal);
@@ -817,7 +817,7 @@ public class SqlBasicTest extends SqlTestSupport {
             decimalVal = in.readObject();
 
             charVal = in.readChar();
-            varcharVal = in.readUTF();
+            varcharVal = in.readString();
 
             dateVal = in.readObject();
             timeVal = in.readObject();
@@ -944,11 +944,11 @@ public class SqlBasicTest extends SqlTestSupport {
             writer.writeDouble(portableFieldName("doubleVal"), doubleVal);
 
             writer.writeChar(portableFieldName("charVal"), charVal);
-            writer.writeUTF(portableFieldName("varcharVal"), varcharVal);
+            writer.writeString(portableFieldName("varcharVal"), varcharVal);
 
             writer.writePortable(portableFieldName("portableVal"), portableVal);
 
-            writer.writeUTF(portableFieldName("nullVal"), null);
+            writer.writeString(portableFieldName("nullVal"), null);
         }
 
         @Override
@@ -963,10 +963,10 @@ public class SqlBasicTest extends SqlTestSupport {
             doubleVal = reader.readDouble(portableFieldName("doubleVal"));
 
             charVal = reader.readChar(portableFieldName("charVal"));
-            varcharVal = reader.readUTF(portableFieldName("varcharVal"));
+            varcharVal = reader.readString(portableFieldName("varcharVal"));
 
             portableVal = reader.readPortable(portableFieldName("portableVal"));
-            nullVal = reader.readUTF(portableFieldName("nullVal"));
+            nullVal = reader.readString(portableFieldName("nullVal"));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
@@ -73,14 +73,14 @@ public final class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(sum);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readObject();
         this.count = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
@@ -66,13 +66,13 @@ public final class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigD
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
@@ -74,14 +74,14 @@ public final class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(sum);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readObject();
         this.count = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
@@ -65,13 +65,13 @@ public final class BigIntegerSumAggregator<I> extends AbstractAggregator<I, BigI
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
@@ -63,13 +63,13 @@ public final class CountAggregator<I> extends AbstractAggregator<I, Object, Long
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.count = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -71,7 +71,7 @@ public final class DistinctValuesAggregator<I, R>
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeInt(values.size());
         for (Object value : values) {
             out.writeObject(value);
@@ -80,7 +80,7 @@ public final class DistinctValuesAggregator<I, R>
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         int count = in.readInt();
         this.values = new CanonicalizingHashSet<R>(MapUtil.calculateInitialCapacity(count));
         for (int i = 0; i < count; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
@@ -73,14 +73,14 @@ public final class DoubleAverageAggregator<I> extends AbstractAggregator<I, Numb
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeDouble(sum);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readDouble();
         this.count = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
@@ -66,13 +66,13 @@ public final class DoubleSumAggregator<I> extends AbstractAggregator<I, Number, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeDouble(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readDouble();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
@@ -64,13 +64,13 @@ public final class FixedSumAggregator<I> extends AbstractAggregator<I, Number, L
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeLong(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
@@ -65,13 +65,13 @@ public final class FloatingPointSumAggregator<I> extends AbstractAggregator<I, N
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeDouble(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readDouble();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
@@ -73,14 +73,14 @@ public final class IntegerAverageAggregator<I> extends AbstractAggregator<I, Num
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeLong(sum);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readLong();
         this.count = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
@@ -66,13 +66,13 @@ public final class IntegerSumAggregator<I> extends AbstractAggregator<I, Number,
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeLong(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
@@ -72,14 +72,14 @@ public final class LongAverageAggregator<I> extends AbstractAggregator<I, Number
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeLong(sum);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readLong();
         this.count = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
@@ -65,13 +65,13 @@ public final class LongSumAggregator<I> extends AbstractAggregator<I, Number, Lo
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeLong(sum);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
@@ -79,13 +79,13 @@ public final class MaxAggregator<I, R extends Comparable> extends AbstractAggreg
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(max);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.max = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxByAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxByAggregator.java
@@ -81,14 +81,14 @@ public final class MaxByAggregator<I> extends AbstractAggregator<I, Comparable, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(maxValue);
         out.writeObject(maxEntry);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.maxValue = in.readObject();
         this.maxEntry = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
@@ -79,13 +79,13 @@ public final class MinAggregator<I, R extends Comparable> extends AbstractAggreg
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(min);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.min = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinByAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinByAggregator.java
@@ -81,14 +81,14 @@ public final class MinByAggregator<I> extends AbstractAggregator<I, Comparable, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeObject(minValue);
         out.writeObject(minEntry);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.minValue = in.readObject();
         this.minEntry = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
@@ -72,14 +72,14 @@ public final class NumberAverageAggregator<I> extends AbstractAggregator<I, Numb
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
         out.writeDouble(sum);
         out.writeLong(count);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.attributePath = in.readUTF();
+        this.attributePath = in.readString();
         this.sum = in.readDouble();
         this.count = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -87,7 +87,7 @@ public class CacheEventDataImpl
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(eventType.getType());
         IOUtil.writeData(out, dataKey);
         IOUtil.writeData(out, dataNewValue);
@@ -98,7 +98,7 @@ public class CacheEventDataImpl
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         eventType = CacheEventType.getByType(in.readInt());
         dataKey = IOUtil.readData(in);
         dataNewValue = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -63,15 +63,15 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements Versi
     @Override
     protected void writeKeyValueTypes(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(getKeyClassName());
-        out.writeUTF(getValueClassName());
+        out.writeString(getKeyClassName());
+        out.writeString(getValueClassName());
     }
 
     @Override
     protected void readKeyValueTypes(ObjectDataInput in)
             throws IOException {
-        setKeyClassName(in.readUTF());
-        setValueClassName(in.readUTF());
+        setKeyClassName(in.readString());
+        setValueClassName(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperationFactory.java
@@ -61,12 +61,12 @@ public class CacheClearOperationFactory
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
@@ -71,7 +71,7 @@ public class CacheGetAllOperationFactory
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(expiryPolicy);
         out.writeInt(keys.size());
         for (Data key : keys) {
@@ -82,7 +82,7 @@ public class CacheGetAllOperationFactory
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         expiryPolicy = in.readObject();
         int size = in.readInt();
         keys = createHashSet(size);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -83,14 +83,14 @@ public class CacheGetConfigOperation extends AbstractNamedOperation implements I
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(simpleName);
+        out.writeString(simpleName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        simpleName = in.readUTF();
+        simpleName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
@@ -103,7 +103,7 @@ public class CacheGetInvalidationMetaDataOperation extends Operation implements 
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(namePartitionSequenceList.size());
             for (Map.Entry<String, List<Map.Entry<Integer, Long>>> entry : namePartitionSequenceList.entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 out.writeInt(entry.getValue().size());
                 for (Map.Entry<Integer, Long> seqEntry : entry.getValue()) {
                     out.writeInt(seqEntry.getKey());
@@ -124,7 +124,7 @@ public class CacheGetInvalidationMetaDataOperation extends Operation implements 
             int size1 = in.readInt();
             namePartitionSequenceList = new HashMap<String, List<Map.Entry<Integer, Long>>>(size1);
             for (int i = 0; i < size1; i++) {
-                String name = in.readUTF();
+                String name = in.readString();
                 int size2 = in.readInt();
                 List<Map.Entry<Integer, Long>> innerList = new ArrayList<Map.Entry<Integer, Long>>(size2);
                 for (int j = 0; j < size2; j++) {
@@ -198,7 +198,7 @@ public class CacheGetInvalidationMetaDataOperation extends Operation implements 
         out.writeInt(names.size());
 
         for (String mapName : names) {
-            out.writeUTF(mapName);
+            out.writeString(mapName);
         }
     }
 
@@ -210,7 +210,7 @@ public class CacheGetInvalidationMetaDataOperation extends Operation implements 
 
         List<String> mapNames = new ArrayList<String>(size);
         for (int i = 0; i < size; i++) {
-            mapNames.add(in.readUTF());
+            mapNames.add(in.readString());
         }
 
         this.names = mapNames;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
@@ -68,7 +68,7 @@ public class CacheLoadAllOperationFactory
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeBoolean(replaceExistingValues);
         out.writeBoolean(keys != null);
         if (keys != null) {
@@ -82,7 +82,7 @@ public class CacheLoadAllOperationFactory
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         replaceExistingValues = in.readBoolean();
         boolean isKeysNotNull = in.readBoolean();
         if (isKeysNotNull) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
@@ -65,7 +65,7 @@ public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeIntArray(partitions);
         for (List<CacheMergeTypes<Object, Object>> list : mergingEntries) {
             out.writeInt(list.size());
@@ -78,7 +78,7 @@ public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitions = in.readIntArray();
         //noinspection unchecked
         mergingEntries = new List[partitions.length];

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
@@ -64,7 +64,7 @@ public class CacheRemoveAllOperationFactory implements OperationFactory, Identif
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(completionId);
         out.writeInt(keys == null ? -1 : keys.size());
         if (keys != null) {
@@ -76,7 +76,7 @@ public class CacheRemoveAllOperationFactory implements OperationFactory, Identif
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         completionId = in.readInt();
         int size = in.readInt();
         if (size == -1) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -163,7 +163,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
             Map<Data, CacheRecord> cacheMap = entry.getValue();
             int subCount = cacheMap.size();
             out.writeInt(subCount);
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             for (Map.Entry<Data, CacheRecord> e : cacheMap.entrySet()) {
                 final Data key = e.getKey();
                 final CacheRecord record = e.getValue();
@@ -198,7 +198,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
         int count = in.readInt();
         for (int i = 0; i < count; i++) {
             int subCount = in.readInt();
-            String name = in.readUTF();
+            String name = in.readString();
             Map<Data, CacheRecord> m = createHashMap(subCount);
             data.put(name, m);
             // subCount + 1 because of the DefaultData written as the last entry

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperationFactory.java
@@ -59,12 +59,12 @@ public class CacheSizeOperationFactory
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/tenantcontrol/CacheDestroyEventContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/tenantcontrol/CacheDestroyEventContext.java
@@ -57,13 +57,13 @@ public class CacheDestroyEventContext implements DestroyEventContext, Identified
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(cacheName);
+        out.writeString(cacheName);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        cacheName = in.readUTF();
+        cacheName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AbstractCardinalityEstimatorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AbstractCardinalityEstimatorOperation.java
@@ -63,12 +63,12 @@ public abstract class AbstractCardinalityEstimatorOperation
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        this.name = in.readUTF();
+        this.name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
@@ -70,7 +70,7 @@ public class ReplicationOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(migrationData.size());
         for (Map.Entry<String, CardinalityEstimatorContainer> entry : migrationData.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
     }
@@ -80,7 +80,7 @@ public class ReplicationOperation
         int mapSize = in.readInt();
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             CardinalityEstimatorContainer newCont = in.readObject();
             migrationData.put(name, newCont);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Address.java
@@ -142,14 +142,14 @@ public final class Address implements IdentifiedDataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(port);
         out.write(type);
-        out.writeUTF(host);
+        out.writeString(host);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         port = in.readInt();
         type = in.readByte();
-        host = in.readUTF();
+        host = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractMember.java
@@ -168,8 +168,8 @@ public abstract class AbstractMember implements Member {
         version = in.readObject();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            String key = in.readUTF();
-            String value = in.readUTF();
+            String key = in.readString();
+            String value = in.readString();
             attributes.put(key, value);
         }
         addressMap = readNullableMap(in);
@@ -184,8 +184,8 @@ public abstract class AbstractMember implements Member {
         Map<String, String> attributes = new HashMap<>(this.attributes);
         out.writeInt(attributes.size());
         for (Map.Entry<String, String> entry : attributes.entrySet()) {
-            out.writeUTF(entry.getKey());
-            out.writeUTF(entry.getValue());
+            out.writeString(entry.getKey());
+            out.writeString(entry.getValue());
         }
         writeNullableMap(addressMap, out);
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -349,7 +349,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         final Collection<CollectionItem> collection = getCollection();
         out.writeInt(collection.size());
         for (CollectionItem item : collection) {
@@ -363,7 +363,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         final int collectionSize = in.readInt();
         final Collection<CollectionItem> collection = getCollection();
         for (int i = 0; i < collectionSize; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEvent.java
@@ -71,7 +71,7 @@ public class CollectionEvent implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(eventType.getType());
         caller.writeData(out);
         IOUtil.writeData(out, data);
@@ -79,7 +79,7 @@ public class CollectionEvent implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         eventType = ItemEventType.getByType(in.readInt());
         caller = new Address();
         caller.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionOperation.java
@@ -117,12 +117,12 @@ public abstract class CollectionOperation extends Operation
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionReplicationOperation.java
@@ -58,7 +58,7 @@ public abstract class CollectionReplicationOperation extends Operation implement
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(migrationData.size());
         for (Map.Entry<String, CollectionContainer> entry : migrationData.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             CollectionContainer container = entry.getValue();
             out.writeObject(container);
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
@@ -45,7 +45,7 @@ public class ListReplicationOperation extends CollectionReplicationOperation {
         int mapSize = in.readInt();
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             migrationData.put(name, in.readObject());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -1171,7 +1171,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(getItemQueue().size());
         for (QueueItem item : getItemQueue()) {
             out.writeObject(item);
@@ -1184,7 +1184,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         pollWaitNotifyKey = new QueueWaitNotifyKey(name, "poll");
         offerWaitNotifyKey = new QueueWaitNotifyKey(name, "offer");
         int size = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
@@ -48,7 +48,7 @@ public class QueueEvent implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(eventType.getType());
         caller.writeData(out);
         IOUtil.writeData(out, data);
@@ -56,7 +56,7 @@ public class QueueEvent implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         eventType = ItemEventType.getByType(in.readInt());
         caller = new Address();
         caller.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
@@ -81,7 +81,7 @@ public class QueueReplicationOperation extends Operation implements IdentifiedDa
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(migrationData.size());
         for (Map.Entry<String, QueueContainer> entry : migrationData.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             QueueContainer container = entry.getValue();
             out.writeObject(container);
         }
@@ -92,7 +92,7 @@ public class QueueReplicationOperation extends Operation implements IdentifiedDa
         int mapSize = in.readInt();
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             migrationData.put(name, in.readObject());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
@@ -40,7 +40,7 @@ public class SetReplicationOperation extends CollectionReplicationOperation {
         int mapSize = in.readInt();
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             migrationData.put(name, in.readObject());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
@@ -119,18 +119,18 @@ public class CollectionTransactionLogRecord implements TransactionLogRecord {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(serviceName);
+        out.writeString(serviceName);
         UUIDSerializationUtil.writeUUID(out, transactionId);
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(partitionId);
         CollectionTxnUtil.write(out, operationList);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        serviceName = in.readUTF();
+        serviceName = in.readString();
         transactionId = UUIDSerializationUtil.readUUID(in);
-        name = in.readUTF();
+        name = in.readString();
         partitionId = in.readInt();
         operationList = CollectionTxnUtil.read(in);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractWanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractWanPublisherConfig.java
@@ -128,23 +128,23 @@ public abstract class AbstractWanPublisherConfig implements IdentifiedDataSerial
         int size = properties.size();
         out.writeInt(size);
         for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
-        out.writeUTF(className);
+        out.writeString(className);
         out.writeObject(implementation);
-        out.writeUTF(publisherId);
+        out.writeString(publisherId);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            properties.put(in.readUTF(), in.readObject());
+            properties.put(in.readString(), in.readObject());
         }
-        className = in.readUTF();
+        className = in.readString();
         implementation = in.readObject();
-        publisherId = in.readUTF();
+        publisherId = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
@@ -156,8 +156,8 @@ public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>
         out.writeBoolean(usePublicIp);
         out.writeInt(properties.size());
         for (Entry<String, String> entry : properties.entrySet()) {
-            out.writeUTF(entry.getKey());
-            out.writeUTF(entry.getValue());
+            out.writeString(entry.getKey());
+            out.writeString(entry.getValue());
         }
     }
 
@@ -167,7 +167,7 @@ public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>
         usePublicIp = in.readBoolean();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            properties.put(in.readUTF(), in.readUTF());
+            properties.put(in.readString(), in.readString());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AttributeConfig.java
@@ -156,14 +156,14 @@ public class AttributeConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(extractorClassName);
+        out.writeString(name);
+        out.writeString(extractorClassName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        extractorClassName = in.readUTF();
+        name = in.readString();
+        extractorClassName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/BitmapIndexOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/BitmapIndexOptions.java
@@ -208,13 +208,13 @@ public class BitmapIndexOptions implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(uniqueKey);
+        out.writeString(uniqueKey);
         out.writeInt(uniqueKeyTransformation.getId());
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        uniqueKey = in.readUTF();
+        uniqueKey = in.readString();
         uniqueKeyTransformation = UniqueKeyTransformation.fromId(in.readInt());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -485,13 +485,13 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(managerPrefix);
-        out.writeUTF(uriString);
+        out.writeString(name);
+        out.writeString(managerPrefix);
+        out.writeString(uriString);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
 
-        out.writeUTF(inMemoryFormat.name());
+        out.writeString(inMemoryFormat.name());
         out.writeObject(evictionConfig);
 
         out.writeObject(wanReplicationRef);
@@ -508,7 +508,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         out.writeObject(hotRestartConfig);
         out.writeObject(eventJournalConfig);
 
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
 
         out.writeBoolean(hasListenerConfiguration());
         if (hasListenerConfiguration()) {
@@ -541,13 +541,13 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        managerPrefix = in.readUTF();
-        uriString = in.readUTF();
+        name = in.readString();
+        managerPrefix = in.readString();
+        uriString = in.readString();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
 
-        String resultInMemoryFormat = in.readUTF();
+        String resultInMemoryFormat = in.readString();
         inMemoryFormat = InMemoryFormat.valueOf(resultInMemoryFormat);
         evictionConfig = in.readObject();
         wanReplicationRef = in.readObject();
@@ -564,7 +564,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         hotRestartConfig = in.readObject();
         eventJournalConfig = in.readObject();
 
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
 
         final boolean listNotEmpty = in.readBoolean();
         if (listNotEmpty) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -711,26 +711,26 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(keyType);
-        out.writeUTF(valueType);
+        out.writeString(name);
+        out.writeString(keyType);
+        out.writeString(valueType);
         out.writeBoolean(statisticsEnabled);
         out.writeBoolean(managementEnabled);
         out.writeBoolean(readThrough);
         out.writeBoolean(writeThrough);
         out.writeBoolean(disablePerEntryInvalidationEvents);
-        out.writeUTF(cacheLoaderFactory);
-        out.writeUTF(cacheWriterFactory);
-        out.writeUTF(cacheLoader);
-        out.writeUTF(cacheWriter);
+        out.writeString(cacheLoaderFactory);
+        out.writeString(cacheWriterFactory);
+        out.writeString(cacheLoader);
+        out.writeString(cacheWriter);
         out.writeObject(expiryPolicyFactoryConfig);
         writeNullableList(cacheEntryListeners, out);
         out.writeInt(asyncBackupCount);
         out.writeInt(backupCount);
-        out.writeUTF(inMemoryFormat.name());
+        out.writeString(inMemoryFormat.name());
         out.writeObject(evictionConfig);
         out.writeObject(wanReplicationRef);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         writeNullableList(partitionLostListenerConfigs, out);
         out.writeObject(mergePolicyConfig);
         out.writeObject(hotRestartConfig);
@@ -739,26 +739,26 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        keyType = in.readUTF();
-        valueType = in.readUTF();
+        name = in.readString();
+        keyType = in.readString();
+        valueType = in.readString();
         statisticsEnabled = in.readBoolean();
         managementEnabled = in.readBoolean();
         readThrough = in.readBoolean();
         writeThrough = in.readBoolean();
         disablePerEntryInvalidationEvents = in.readBoolean();
-        cacheLoaderFactory = in.readUTF();
-        cacheWriterFactory = in.readUTF();
-        cacheLoader = in.readUTF();
-        cacheWriter = in.readUTF();
+        cacheLoaderFactory = in.readString();
+        cacheWriterFactory = in.readString();
+        cacheLoader = in.readString();
+        cacheWriter = in.readString();
         expiryPolicyFactoryConfig = in.readObject();
         cacheEntryListeners = readNullableList(in);
         asyncBackupCount = in.readInt();
         backupCount = in.readInt();
-        inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
+        inMemoryFormat = InMemoryFormat.valueOf(in.readString());
         evictionConfig = in.readObject();
         wanReplicationRef = in.readObject();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         partitionLostListenerConfigs = readNullableList(in);
         mergePolicyConfig = in.readObject();
         hotRestartConfig = in.readObject();
@@ -949,13 +949,13 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(className);
+            out.writeString(className);
             out.writeObject(timedExpiryPolicyFactoryConfig);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            className = in.readUTF();
+            className = in.readString();
             timedExpiryPolicyFactoryConfig = in.readObject();
         }
 
@@ -1030,13 +1030,13 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
 
             @Override
             public void writeData(ObjectDataOutput out) throws IOException {
-                out.writeUTF(expiryPolicyType.name());
+                out.writeString(expiryPolicyType.name());
                 out.writeObject(durationConfig);
             }
 
             @Override
             public void readData(ObjectDataInput in) throws IOException {
-                expiryPolicyType = ExpiryPolicyType.valueOf(in.readUTF());
+                expiryPolicyType = ExpiryPolicyType.valueOf(in.readString());
                 durationConfig = in.readObject();
             }
 
@@ -1162,13 +1162,13 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
             @Override
             public void writeData(ObjectDataOutput out) throws IOException {
                 out.writeLong(durationAmount);
-                out.writeUTF(timeUnit.name());
+                out.writeString(timeUnit.name());
             }
 
             @Override
             public void readData(ObjectDataInput in) throws IOException {
                 durationAmount = in.readLong();
-                timeUnit = TimeUnit.valueOf(in.readUTF());
+                timeUnit = TimeUnit.valueOf(in.readString());
             }
 
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -155,8 +155,8 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(cacheEntryEventFilterFactory);
-        out.writeUTF(cacheEntryListenerFactory);
+        out.writeString(cacheEntryEventFilterFactory);
+        out.writeString(cacheEntryListenerFactory);
         out.writeBoolean(oldValueRequired);
         out.writeBoolean(synchronous);
     }
@@ -164,8 +164,8 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        cacheEntryEventFilterFactory = in.readUTF();
-        cacheEntryListenerFactory = in.readUTF();
+        cacheEntryEventFilterFactory = in.readString();
+        cacheEntryListenerFactory = in.readString();
         oldValueRequired = in.readBoolean();
         synchronous = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -242,19 +242,19 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, N
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -272,25 +272,25 @@ public abstract class CollectionConfig<T extends CollectionConfig>
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         writeNullableList(listenerConfigs, out);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
         out.writeInt(maxSize);
         out.writeBoolean(statisticsEnabled);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         listenerConfigs = readNullableList(in);
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         maxSize = in.readInt();
         statisticsEnabled = in.readBoolean();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -162,7 +162,7 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
         out.writeObject(discoveryStrategyConfigs);
         out.writeObject(discoveryServiceProvider);
         out.writeObject(nodeFilter);
-        out.writeUTF(nodeFilterClass);
+        out.writeString(nodeFilterClass);
     }
 
     @Override
@@ -170,7 +170,7 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
         discoveryStrategyConfigs = in.readObject();
         discoveryServiceProvider = in.readObject();
         nodeFilter = in.readObject();
-        nodeFilterClass = in.readUTF();
+        nodeFilterClass = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -143,21 +143,21 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(className);
+        out.writeString(className);
 
         out.writeInt(properties.size());
         for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        className = in.readUTF();
+        className = in.readString();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            properties.put(in.readUTF(), in.readObject());
+            properties.put(in.readString(), in.readObject());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
@@ -231,21 +231,21 @@ public class DurableExecutorConfig implements IdentifiedDataSerializable, NamedC
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(poolSize);
         out.writeInt(durability);
         out.writeInt(capacity);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeBoolean(statisticsEnabled);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         poolSize = in.readInt();
         durability = in.readInt();
         capacity = in.readInt();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         statisticsEnabled = in.readBoolean();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -247,18 +247,18 @@ public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSeri
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(size);
-        out.writeUTF(maxSizePolicy.toString());
-        out.writeUTF(evictionPolicy.toString());
-        out.writeUTF(comparatorClassName);
+        out.writeString(maxSizePolicy.toString());
+        out.writeString(evictionPolicy.toString());
+        out.writeString(comparatorClassName);
         out.writeObject(comparator);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         size = in.readInt();
-        maxSizePolicy = MaxSizePolicy.valueOf(in.readUTF());
-        evictionPolicy = EvictionPolicy.valueOf(in.readUTF());
-        comparatorClassName = in.readUTF();
+        maxSizePolicy = MaxSizePolicy.valueOf(in.readString());
+        evictionPolicy = EvictionPolicy.valueOf(in.readString());
+        comparatorClassName = in.readString();
         comparator = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -194,20 +194,20 @@ public class ExecutorConfig implements IdentifiedDataSerializable, NamedConfig {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(poolSize);
         out.writeInt(queueCapacity);
         out.writeBoolean(statisticsEnabled);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         poolSize = in.readInt();
         queueCapacity = in.readInt();
         statisticsEnabled = in.readBoolean();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -385,7 +385,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable, Named
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(prefetchCount);
         out.writeLong(prefetchValidityMillis);
         out.writeLong(epochStart);
@@ -398,7 +398,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable, Named
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         prefetchCount = in.readInt();
         prefetchValidityMillis = in.readLong();
         epochStart = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/config/IndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/IndexConfig.java
@@ -230,7 +230,7 @@ public class IndexConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(type.getId());
         writeNullableList(attributes, out);
         out.writeObject(bitmapIndexOptions);
@@ -238,7 +238,7 @@ public class IndexConfig implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         type = IndexType.getById(in.readInt());
         attributes = readNullableList(in);
         bitmapIndexOptions = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
@@ -150,13 +150,13 @@ public class ListenerConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(className);
+        out.writeString(className);
         out.writeObject(implementation);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        className = in.readUTF();
+        className = in.readString();
         implementation = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -913,7 +913,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
         out.writeInt(timeToLiveSeconds);
@@ -922,9 +922,9 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         out.writeObject(mapStoreConfig);
         out.writeObject(nearCacheConfig);
         out.writeBoolean(readBackupData);
-        out.writeUTF(cacheDeserializedValues.name());
+        out.writeString(cacheDeserializedValues.name());
         out.writeObject(mergePolicyConfig);
-        out.writeUTF(inMemoryFormat.name());
+        out.writeString(inMemoryFormat.name());
         out.writeObject(wanReplicationRef);
         writeNullableList(entryListenerConfigs, out);
         writeNullableList(partitionLostListenerConfigs, out);
@@ -933,7 +933,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         writeNullableList(queryCacheConfigs, out);
         out.writeBoolean(statisticsEnabled);
         out.writeObject(partitioningStrategyConfig);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(hotRestartConfig);
         out.writeObject(merkleTreeConfig);
         out.writeObject(eventJournalConfig);
@@ -946,7 +946,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         timeToLiveSeconds = in.readInt();
@@ -955,9 +955,9 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         mapStoreConfig = in.readObject();
         nearCacheConfig = in.readObject();
         readBackupData = in.readBoolean();
-        cacheDeserializedValues = CacheDeserializedValues.valueOf(in.readUTF());
+        cacheDeserializedValues = CacheDeserializedValues.valueOf(in.readString());
         mergePolicyConfig = in.readObject();
-        inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
+        inMemoryFormat = InMemoryFormat.valueOf(in.readString());
         wanReplicationRef = in.readObject();
         entryListenerConfigs = readNullableList(in);
         partitionLostListenerConfigs = readNullableList(in);
@@ -966,7 +966,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         queryCacheConfigs = readNullableList(in);
         statisticsEnabled = in.readBoolean();
         partitioningStrategyConfig = in.readObject();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         hotRestartConfig = in.readObject();
         merkleTreeConfig = in.readObject();
         eventJournalConfig = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -382,27 +382,27 @@ public class MapStoreConfig implements IdentifiedDataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(enabled);
         out.writeBoolean(writeCoalescing);
-        out.writeUTF(className);
-        out.writeUTF(factoryClassName);
+        out.writeString(className);
+        out.writeString(factoryClassName);
         out.writeInt(writeDelaySeconds);
         out.writeInt(writeBatchSize);
         out.writeObject(implementation);
         out.writeObject(factoryImplementation);
         out.writeObject(properties);
-        out.writeUTF(initialLoadMode.name());
+        out.writeString(initialLoadMode.name());
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         enabled = in.readBoolean();
         writeCoalescing = in.readBoolean();
-        className = in.readUTF();
-        factoryClassName = in.readUTF();
+        className = in.readString();
+        factoryClassName = in.readString();
         writeDelaySeconds = in.readInt();
         writeBatchSize = in.readInt();
         implementation = in.readObject();
         factoryImplementation = in.readObject();
         properties = in.readObject();
-        initialLoadMode = InitialLoadMode.valueOf(in.readUTF());
+        initialLoadMode = InitialLoadMode.valueOf(in.readString());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
@@ -126,13 +126,13 @@ public class MergePolicyConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(policy);
+        out.writeString(policy);
         out.writeInt(batchSize);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        policy = in.readUTF();
+        policy = in.readString();
         batchSize = in.readInt();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -338,8 +338,8 @@ public class MultiMapConfig implements IdentifiedDataSerializable, NamedConfig {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(valueCollectionType);
+        out.writeString(name);
+        out.writeString(valueCollectionType);
         if (listenerConfigs == null || listenerConfigs.isEmpty()) {
             out.writeBoolean(false);
         } else {
@@ -353,14 +353,14 @@ public class MultiMapConfig implements IdentifiedDataSerializable, NamedConfig {
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
         out.writeBoolean(statisticsEnabled);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        valueCollectionType = in.readUTF();
+        name = in.readString();
+        valueCollectionType = in.readString();
         boolean hasListenerConfig = in.readBoolean();
         if (hasListenerConfig) {
             int configSize = in.readInt();
@@ -374,7 +374,7 @@ public class MultiMapConfig implements IdentifiedDataSerializable, NamedConfig {
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         statisticsEnabled = in.readBoolean();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -389,7 +389,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(timeToLiveSeconds);
         out.writeInt(maxIdleSeconds);
         out.writeBoolean(invalidateOnChange);
@@ -402,7 +402,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         timeToLiveSeconds = in.readInt();
         maxIdleSeconds = in.readInt();
         invalidateOnChange = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -121,7 +121,7 @@ public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Ser
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(enabled);
-        out.writeUTF(directory);
+        out.writeString(directory);
         out.writeInt(storeInitialDelaySeconds);
         out.writeInt(storeIntervalSeconds);
     }
@@ -129,7 +129,7 @@ public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Ser
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         enabled = in.readBoolean();
-        directory = in.readUTF();
+        directory = in.readString();
         storeInitialDelaySeconds = in.readInt();
         storeIntervalSeconds = in.readInt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/PNCounterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PNCounterConfig.java
@@ -167,18 +167,18 @@ public class PNCounterConfig implements IdentifiedDataSerializable, NamedConfig 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(replicaCount);
         out.writeBoolean(statisticsEnabled);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         replicaCount = in.readInt();
         statisticsEnabled = in.readBoolean();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
@@ -87,13 +87,13 @@ public class PartitioningStrategyConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(partitioningStrategyClass);
+        out.writeString(partitioningStrategyClass);
         out.writeObject(partitioningStrategy);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        partitioningStrategyClass = in.readUTF();
+        partitioningStrategyClass = in.readString();
         partitioningStrategy = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -253,36 +253,36 @@ public class PermissionConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(type.getNodeName());
-        out.writeUTF(name);
+        out.writeString(type.getNodeName());
+        out.writeString(name);
         if (StringUtil.isNullOrEmptyAfterTrim(principal)) {
-            out.writeUTF("*");
+            out.writeString("*");
         } else {
-            out.writeUTF(principal);
+            out.writeString(principal);
         }
 
         out.writeInt(endpoints.size());
         for (String endpoint : endpoints) {
-            out.writeUTF(endpoint);
+            out.writeString(endpoint);
         }
 
         out.writeInt(actions.size());
         for (String action : actions) {
-            out.writeUTF(action);
+            out.writeString(action);
         }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        type = PermissionType.getType(in.readUTF());
-        name = in.readUTF();
-        principal = in.readUTF();
+        type = PermissionType.getType(in.readString());
+        name = in.readString();
+        principal = in.readString();
 
         int endpointsSize = in.readInt();
         if (endpointsSize != 0) {
             Set<String> endpoints = createHashSet(endpointsSize);
             for (int i = 0; i < endpointsSize; i++) {
-                endpoints.add(in.readUTF());
+                endpoints.add(in.readString());
             }
             this.endpoints = endpoints;
         }
@@ -291,7 +291,7 @@ public class PermissionConfig implements IdentifiedDataSerializable {
         if (actionsSize != 0) {
             Set<String> actions = createHashSet(actionsSize);
             for (int i = 0; i < actionsSize; i++) {
-                actions.add(in.readUTF());
+                actions.add(in.readString());
             }
             this.actions = actions;
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
@@ -202,15 +202,15 @@ public class PredicateConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(className);
-        out.writeUTF(sql);
+        out.writeString(className);
+        out.writeString(sql);
         out.writeObject(implementation);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        className = in.readUTF();
-        sql = in.readUTF();
+        className = in.readString();
+        sql = in.readString();
         implementation = in.readObject();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
@@ -458,8 +458,8 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         out.writeBoolean(includeValue);
         out.writeBoolean(populate);
         out.writeBoolean(coalesce);
-        out.writeUTF(inMemoryFormat.name());
-        out.writeUTF(name);
+        out.writeString(inMemoryFormat.name());
+        out.writeString(name);
         out.writeObject(predicateConfig);
         out.writeObject(evictionConfig);
         writeNullableList(entryListenerConfigs, out);
@@ -474,8 +474,8 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         includeValue = in.readBoolean();
         populate = in.readBoolean();
         coalesce = in.readBoolean();
-        inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
-        name = in.readUTF();
+        inMemoryFormat = InMemoryFormat.valueOf(in.readString());
+        name = in.readString();
         predicateConfig = in.readObject();
         evictionConfig = in.readObject();
         entryListenerConfigs = readNullableList(in);

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -399,7 +399,7 @@ public class QueueConfig implements IdentifiedDataSerializable, NamedConfig, Ver
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         writeNullableList(listenerConfigs, out);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
@@ -407,14 +407,14 @@ public class QueueConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         out.writeInt(emptyQueueTtl);
         out.writeObject(queueStoreConfig);
         out.writeBoolean(statisticsEnabled);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
-        out.writeUTF(priorityComparatorClassName);
+        out.writeString(priorityComparatorClassName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         listenerConfigs = readNullableList(in);
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
@@ -422,9 +422,9 @@ public class QueueConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         emptyQueueTtl = in.readInt();
         queueStoreConfig = in.readObject();
         statisticsEnabled = in.readBoolean();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
-        priorityComparatorClassName = in.readUTF();
+        priorityComparatorClassName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -281,8 +281,8 @@ public class QueueStoreConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(enabled);
-        out.writeUTF(className);
-        out.writeUTF(factoryClassName);
+        out.writeString(className);
+        out.writeString(factoryClassName);
         out.writeObject(properties);
         out.writeObject(storeImplementation);
         out.writeObject(factoryImplementation);
@@ -291,8 +291,8 @@ public class QueueStoreConfig implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         enabled = in.readBoolean();
-        className = in.readUTF();
-        factoryClassName = in.readUTF();
+        className = in.readString();
+        factoryClassName = in.readString();
         properties = in.readObject();
         storeImplementation = in.readObject();
         factoryImplementation = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -317,20 +317,20 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(executor);
         out.writeInt(readBatchSize);
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeBoolean(statisticsEnabled);
         writeNullableList(listenerConfigs, out);
-        out.writeUTF(topicOverloadPolicy.name());
+        out.writeString(topicOverloadPolicy.name());
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         executor = in.readObject();
         readBatchSize = in.readInt();
-        name = in.readUTF();
+        name = in.readString();
         statisticsEnabled = in.readBoolean();
         listenerConfigs = readNullableList(in);
-        topicOverloadPolicy = TopicOverloadPolicy.valueOf(in.readUTF());
+        topicOverloadPolicy = TopicOverloadPolicy.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -259,23 +259,23 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, NamedCon
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(inMemoryFormat.name());
+        out.writeString(name);
+        out.writeString(inMemoryFormat.name());
         out.writeBoolean(asyncFillup);
         out.writeBoolean(statisticsEnabled);
         writeNullableList(listenerConfigs, out);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
+        name = in.readString();
+        inMemoryFormat = InMemoryFormat.valueOf(in.readString());
         asyncFillup = in.readBoolean();
         statisticsEnabled = in.readBoolean();
         listenerConfigs = readNullableList(in);
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -406,27 +406,27 @@ public class RingbufferConfig implements IdentifiedDataSerializable, NamedConfig
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(capacity);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
         out.writeInt(timeToLiveSeconds);
-        out.writeUTF(inMemoryFormat.name());
+        out.writeString(inMemoryFormat.name());
         out.writeObject(ringbufferStoreConfig);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         capacity = in.readInt();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         timeToLiveSeconds = in.readInt();
-        inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
+        inMemoryFormat = InMemoryFormat.valueOf(in.readString());
         ringbufferStoreConfig = in.readObject();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
@@ -146,8 +146,8 @@ public class RingbufferStoreConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(enabled);
-        out.writeUTF(className);
-        out.writeUTF(factoryClassName);
+        out.writeString(className);
+        out.writeString(factoryClassName);
         out.writeObject(properties);
         out.writeObject(storeImplementation);
         out.writeObject(factoryImplementation);
@@ -156,8 +156,8 @@ public class RingbufferStoreConfig implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         enabled = in.readBoolean();
-        className = in.readUTF();
-        factoryClassName = in.readUTF();
+        className = in.readString();
+        factoryClassName = in.readString();
         properties = in.readObject();
         storeImplementation = in.readObject();
         factoryImplementation = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
@@ -306,11 +306,11 @@ public class ScheduledExecutorConfig implements IdentifiedDataSerializable, Name
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(durability);
         out.writeInt(capacity);
         out.writeInt(poolSize);
-        out.writeUTF(splitBrainProtectionName);
+        out.writeString(splitBrainProtectionName);
         out.writeObject(mergePolicyConfig);
         out.writeByte(capacityPolicy.getId());
         out.writeBoolean(statisticsEnabled);
@@ -318,11 +318,11 @@ public class ScheduledExecutorConfig implements IdentifiedDataSerializable, Name
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         durability = in.readInt();
         capacity = in.readInt();
         poolSize = in.readInt();
-        splitBrainProtectionName = in.readUTF();
+        splitBrainProtectionName = in.readString();
         mergePolicyConfig = in.readObject();
         capacityPolicy = getById(in.readByte());
         statisticsEnabled = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/config/SplitBrainProtectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SplitBrainProtectionConfig.java
@@ -199,24 +199,24 @@ public class SplitBrainProtectionConfig implements IdentifiedDataSerializable, N
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeBoolean(enabled);
         out.writeInt(minimumClusterSize);
         writeNullableList(listenerConfigs, out);
-        out.writeUTF(protectOn.name());
-        out.writeUTF(functionClassName);
+        out.writeString(protectOn.name());
+        out.writeString(functionClassName);
         out.writeObject(functionImplementation);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         enabled = in.readBoolean();
         minimumClusterSize = in.readInt();
         listenerConfigs = readNullableList(in);
-        protectOn = SplitBrainProtectionOn.valueOf(in.readUTF());
-        functionClassName = in.readUTF();
+        protectOn = SplitBrainProtectionOn.valueOf(in.readString());
+        functionClassName = in.readString();
         functionImplementation = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -270,7 +270,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeBoolean(globalOrderingEnabled);
         out.writeBoolean(statisticsEnabled);
         out.writeBoolean(multiThreadingEnabled);
@@ -279,7 +279,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         globalOrderingEnabled = in.readBoolean();
         statisticsEnabled = in.readBoolean();
         multiThreadingEnabled = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/config/WanBatchPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanBatchPublisherConfig.java
@@ -813,7 +813,7 @@ public class WanBatchPublisherConfig extends AbstractWanPublisherConfig {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeUTF(clusterName);
+        out.writeString(clusterName);
         out.writeBoolean(snapshotEnabled);
         out.writeByte(initialPublisherState.getId());
         out.writeInt(queueCapacity);
@@ -828,7 +828,7 @@ public class WanBatchPublisherConfig extends AbstractWanPublisherConfig {
         out.writeBoolean(useEndpointPrivateAddress);
         out.writeLong(idleMinParkNs);
         out.writeLong(idleMaxParkNs);
-        out.writeUTF(targetEndpoints);
+        out.writeString(targetEndpoints);
         out.writeObject(awsConfig);
         out.writeObject(gcpConfig);
         out.writeObject(azureConfig);
@@ -836,13 +836,13 @@ public class WanBatchPublisherConfig extends AbstractWanPublisherConfig {
         out.writeObject(eurekaConfig);
         out.writeObject(discoveryConfig);
         out.writeObject(syncConfig);
-        out.writeUTF(endpoint);
+        out.writeString(endpoint);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        clusterName = in.readUTF();
+        clusterName = in.readString();
         snapshotEnabled = in.readBoolean();
         initialPublisherState = WanPublisherState.getByType(in.readByte());
         queueCapacity = in.readInt();
@@ -857,7 +857,7 @@ public class WanBatchPublisherConfig extends AbstractWanPublisherConfig {
         useEndpointPrivateAddress = in.readBoolean();
         idleMinParkNs = in.readLong();
         idleMaxParkNs = in.readLong();
-        targetEndpoints = in.readUTF();
+        targetEndpoints = in.readString();
         awsConfig = in.readObject();
         gcpConfig = in.readObject();
         azureConfig = in.readObject();
@@ -865,7 +865,7 @@ public class WanBatchPublisherConfig extends AbstractWanPublisherConfig {
         eurekaConfig = in.readObject();
         discoveryConfig = in.readObject();
         syncConfig = in.readObject();
-        endpoint = in.readUTF();
+        endpoint = in.readString();
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -173,10 +173,10 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
         int size = properties.size();
         out.writeInt(size);
         for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
-        out.writeUTF(className);
+        out.writeString(className);
         out.writeObject(implementation);
         out.writeBoolean(persistWanReplicatedData);
     }
@@ -185,9 +185,9 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            properties.put(in.readUTF(), in.readObject());
+            properties.put(in.readString(), in.readObject());
         }
-        className = in.readUTF();
+        className = in.readString();
         implementation = in.readObject();
         persistWanReplicatedData = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -193,7 +193,7 @@ public class WanReplicationConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(consumerConfig);
         writeCollection(batchPublisherConfigs, out);
         writeCollection(customPublisherConfigs, out);
@@ -201,7 +201,7 @@ public class WanReplicationConfig implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         consumerConfig = in.readObject();
 
         batchPublisherConfigs = readList(in);

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -182,22 +182,22 @@ public class WanReplicationRef implements IdentifiedDataSerializable, Serializab
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(mergePolicyClassName);
+        out.writeString(name);
+        out.writeString(mergePolicyClassName);
         out.writeInt(filters.size());
         for (String filter : filters) {
-            out.writeUTF(filter);
+            out.writeString(filter);
         }
         out.writeBoolean(republishingEnabled);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        mergePolicyClassName = in.readUTF();
+        name = in.readString();
+        mergePolicyClassName = in.readString();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            filters.add(in.readUTF());
+            filters.add(in.readString());
         }
         republishingEnabled = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/console/Echo.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/Echo.java
@@ -52,12 +52,12 @@ public class Echo implements Callable<String>, DataSerializable, HazelcastInstan
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(input);
+        out.writeString(input);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        input = in.readUTF();
+        input = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/event/impl/CPMembershipEventImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/event/impl/CPMembershipEventImpl.java
@@ -71,13 +71,13 @@ public class CPMembershipEventImpl implements CPMembershipEvent, IdentifiedDataS
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(member);
-        out.writeUTF(type.name());
+        out.writeString(type.name());
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         member = in.readObject();
-        type = EventType.valueOf(in.readUTF());
+        type = EventType.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupInfo.java
@@ -194,7 +194,7 @@ public final class CPGroupInfo implements IdentifiedDataSerializable {
         for (RaftEndpoint member : members) {
             out.writeObject(member);
         }
-        out.writeUTF(status.toString());
+        out.writeString(status.toString());
     }
 
     @Override
@@ -215,7 +215,7 @@ public final class CPGroupInfo implements IdentifiedDataSerializable {
             members.add(member);
         }
         members = unmodifiableSet(members);
-        status = CPGroupStatus.valueOf(in.readUTF());
+        status = CPGroupStatus.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupSummary.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPGroupSummary.java
@@ -89,7 +89,7 @@ public class CPGroupSummary implements CPGroup, IdentifiedDataSerializable {
         for (CPMember member : members) {
             out.writeObject(member);
         }
-        out.writeUTF(status.toString());
+        out.writeString(status.toString());
     }
 
     @Override
@@ -110,7 +110,7 @@ public class CPGroupSummary implements CPGroup, IdentifiedDataSerializable {
             members.add(member);
         }
         members = unmodifiableSet(members);
-        status = CPGroupStatus.valueOf(in.readUTF());
+        status = CPGroupStatus.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
@@ -206,7 +206,7 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
             out.writeLong(commitIndex);
         }
         out.writeObject(member);
-        out.writeUTF(membershipChangeMode.name());
+        out.writeString(membershipChangeMode.name());
         out.writeInt(changes.size());
         for (CPGroupMembershipChange change : changes) {
             out.writeObject(change);
@@ -222,7 +222,7 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
             membershipChangeCommitIndices.add(commitIndex);
         }
         member = in.readObject();
-        membershipChangeMode = MembershipChangeMode.valueOf(in.readUTF());
+        membershipChangeMode = MembershipChangeMode.valueOf(in.readString());
         int groupCount = in.readInt();
         for (int i = 0; i < groupCount; i++) {
             CPGroupMembershipChange change = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
@@ -143,7 +143,7 @@ public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializab
         for (CPMemberInfo member : initializedCPMembers) {
             out.writeObject(member);
         }
-        out.writeUTF(initializationStatus.name());
+        out.writeString(initializationStatus.name());
         out.writeInt(initializationCommitIndices.size());
         for (long commitIndex : initializationCommitIndices) {
             out.writeLong(commitIndex);
@@ -181,7 +181,7 @@ public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializab
             initializedCPMembers.add(member);
         }
 
-        initializationStatus = MetadataRaftGroupInitStatus.valueOf(in.readUTF());
+        initializationStatus = MetadataRaftGroupInitStatus.valueOf(in.readString());
         len = in.readInt();
         for (int i = 0; i < len; i++) {
             long commitIndex = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupId.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupId.java
@@ -63,14 +63,14 @@ public final class RaftGroupId implements CPGroupId, IdentifiedDataSerializable,
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeLong(seed);
         out.writeLong(groupId);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         seed = in.readLong();
         groupId = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/operation/AbstractAtomicLongOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/operation/AbstractAtomicLongOp.java
@@ -53,12 +53,12 @@ public abstract class AbstractAtomicLongOp extends RaftOp implements IdentifiedD
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/operation/AlterOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/operation/AlterOp.java
@@ -100,14 +100,14 @@ public class AlterOp extends AbstractAtomicLongOp {
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
         out.writeObject(function);
-        out.writeUTF(alterResultType.name());
+        out.writeString(alterResultType.name());
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
         function = in.readObject();
-        alterResultType = AlterResultType.valueOf(in.readUTF());
+        alterResultType = AlterResultType.valueOf(in.readString());
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/AbstractAtomicRefOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/AbstractAtomicRefOp.java
@@ -58,12 +58,12 @@ public abstract class AbstractAtomicRefOp extends RaftOp implements IdentifiedDa
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/ApplyOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/operation/ApplyOp.java
@@ -133,7 +133,7 @@ public class ApplyOp extends AbstractAtomicRefOp implements IdentifiedDataSerial
             throws IOException {
         super.writeData(out);
         IOUtil.writeData(out, function);
-        out.writeUTF(returnValueType.name());
+        out.writeString(returnValueType.name());
         out.writeBoolean(alter);
     }
 
@@ -142,7 +142,7 @@ public class ApplyOp extends AbstractAtomicRefOp implements IdentifiedDataSerial
             throws IOException {
         super.readData(in);
         function = IOUtil.readData(in);
-        returnValueType = ReturnValueType.valueOf(in.readUTF());
+        returnValueType = ReturnValueType.valueOf(in.readString());
         alter = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/operation/AbstractCountDownLatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/operation/AbstractCountDownLatchOp.java
@@ -51,12 +51,12 @@ public abstract class AbstractCountDownLatchOp extends RaftOp implements Identif
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/operation/AbstractLockOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/operation/AbstractLockOp.java
@@ -67,7 +67,7 @@ abstract class AbstractLockOp extends RaftOp implements IdentifiedDataSerializab
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeLong(sessionId);
         out.writeLong(threadId);
         writeUUID(out, invocationUid);
@@ -75,7 +75,7 @@ abstract class AbstractLockOp extends RaftOp implements IdentifiedDataSerializab
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         sessionId = in.readLong();
         threadId = in.readLong();
         invocationUid = readUUID(in);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/operation/GetLockOwnershipStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/operation/GetLockOwnershipStateOp.java
@@ -70,12 +70,12 @@ public class GetLockOwnershipStateOp extends RaftOp implements IndeterminateOper
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/AbstractSemaphoreOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/AbstractSemaphoreOp.java
@@ -66,7 +66,7 @@ abstract class AbstractSemaphoreOp extends RaftOp implements IdentifiedDataSeria
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeLong(sessionId);
         out.writeLong(threadId);
         writeUUID(out, invocationUid);
@@ -74,7 +74,7 @@ abstract class AbstractSemaphoreOp extends RaftOp implements IdentifiedDataSeria
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         sessionId = in.readLong();
         threadId = in.readLong();
         invocationUid = readUUID(in);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/AvailablePermitsOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/AvailablePermitsOp.java
@@ -73,12 +73,12 @@ public class AvailablePermitsOp extends RaftOp implements IndeterminateOperation
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/InitSemaphoreOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/InitSemaphoreOp.java
@@ -75,13 +75,13 @@ public class InitSemaphoreOp extends RaftOp implements IndeterminateOperationSta
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(permits);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         permits = in.readInt();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/atomic/RaftAtomicValueSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/atomic/RaftAtomicValueSnapshot.java
@@ -55,13 +55,13 @@ public abstract class RaftAtomicValueSnapshot<T> implements IdentifiedDataSerial
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(values.size());
         for (Map.Entry<String, T> entry : values.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             writeValue(out, entry.getValue());
         }
 
         out.writeInt(destroyed.size());
         for (String name : destroyed) {
-            out.writeUTF(name);
+            out.writeString(name);
         }
     }
 
@@ -72,7 +72,7 @@ public abstract class RaftAtomicValueSnapshot<T> implements IdentifiedDataSerial
         int len = in.readInt();
         values = new HashMap<>(len);
         for (int i = 0; i < len; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             T value = readValue(in);
             values.put(name, value);
         }
@@ -80,7 +80,7 @@ public abstract class RaftAtomicValueSnapshot<T> implements IdentifiedDataSerial
         len = in.readInt();
         destroyed = new HashSet<>(len);
         for (int i = 0; i < len; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             destroyed.add(name);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
@@ -162,7 +162,7 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(groupId);
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(waitKeys.size());
         for (Entry<Object, WaitKeyContainer<W>> e : waitKeys.entrySet()) {
             out.writeObject(e.getKey());
@@ -173,7 +173,7 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         groupId = in.readObject();
-        name = in.readUTF();
+        name = in.readString();
         int count = in.readInt();
         for (int i = 0; i < count; i++) {
             Object key = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/ResourceRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/ResourceRegistry.java
@@ -292,17 +292,17 @@ public abstract class ResourceRegistry<W extends WaitKey, R extends BlockingReso
         out.writeObject(groupId);
         out.writeInt(resources.size());
         for (Entry<String, R> e : resources.entrySet()) {
-            out.writeUTF(e.getKey());
+            out.writeString(e.getKey());
             out.writeObject(e.getValue());
         }
         out.writeInt(destroyedNames.size());
         for (String name : destroyedNames) {
-            out.writeUTF(name);
+            out.writeString(name);
         }
         out.writeInt(waitTimeouts.size());
         for (Entry<BiTuple<String, UUID>, BiTuple<Long, Long>> e : waitTimeouts.entrySet()) {
             BiTuple<String, UUID> t = e.getKey();
-            out.writeUTF(t.element1);
+            out.writeString(t.element1);
             writeUUID(out, t.element2);
             out.writeLong(e.getValue().element1);
         }
@@ -313,19 +313,19 @@ public abstract class ResourceRegistry<W extends WaitKey, R extends BlockingReso
         groupId = in.readObject();
         int count = in.readInt();
         for (int i = 0; i < count; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             R res = in.readObject();
             resources.put(name, res);
         }
         count = in.readInt();
         for (int i = 0; i < count; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             destroyedNames.add(name);
         }
         long now = Clock.currentTimeMillis();
         count = in.readInt();
         for (int i = 0; i < count; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             UUID invocationUid = readUUID(in);
             long timeout = in.readLong();
             waitTimeouts.put(BiTuple.of(name, invocationUid), BiTuple.of(timeout, now + timeout));

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/operation/ExpireWaitKeysOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/operation/ExpireWaitKeysOp.java
@@ -76,21 +76,21 @@ public class ExpireWaitKeysOp extends RaftOp implements IdentifiedDataSerializab
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(serviceName);
+        out.writeString(serviceName);
         out.writeInt(keys.size());
         for (BiTuple<String, UUID> key : keys) {
-            out.writeUTF(key.element1);
+            out.writeString(key.element1);
             writeUUID(out, key.element2);
         }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        serviceName = in.readUTF();
+        serviceName = in.readString();
         int size = in.readInt();
         keys = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             UUID invocationUid = readUUID(in);
             keys.add(BiTuple.of(name, invocationUid));
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/operation/DestroyRaftObjectOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/operation/DestroyRaftObjectOp.java
@@ -66,14 +66,14 @@ public class DestroyRaftObjectOp extends RaftOp implements IdentifiedDataSeriali
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(serviceName);
-        out.writeUTF(objectName);
+        out.writeString(serviceName);
+        out.writeString(objectName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        serviceName = in.readUTF();
-        objectName = in.readUTF();
+        serviceName = in.readString();
+        objectName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/ChangeRaftGroupMembershipOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/ChangeRaftGroupMembershipOp.java
@@ -81,7 +81,7 @@ public class ChangeRaftGroupMembershipOp extends RaftReplicateOp implements Inde
         super.writeInternal(out);
         out.writeLong(membersCommitIndex);
         out.writeObject(member);
-        out.writeUTF(membershipChangeMode.toString());
+        out.writeString(membershipChangeMode.toString());
     }
 
     @Override
@@ -89,7 +89,7 @@ public class ChangeRaftGroupMembershipOp extends RaftReplicateOp implements Inde
         super.readInternal(in);
         membersCommitIndex = in.readLong();
         member = in.readObject();
-        membershipChangeMode = MembershipChangeMode.valueOf(in.readUTF());
+        membershipChangeMode = MembershipChangeMode.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftQueryOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftQueryOp.java
@@ -133,7 +133,7 @@ public class RaftQueryOp extends Operation implements IndeterminateOperationStat
         super.writeInternal(out);
         out.writeObject(groupId);
         out.writeObject(op);
-        out.writeUTF(queryPolicy.toString());
+        out.writeString(queryPolicy.toString());
     }
 
     @Override
@@ -141,7 +141,7 @@ public class RaftQueryOp extends Operation implements IndeterminateOperationStat
         super.readInternal(in);
         groupId = in.readObject();
         op = in.readObject();
-        queryPolicy = QueryPolicy.valueOf(in.readUTF());
+        queryPolicy = QueryPolicy.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/command/UpdateRaftGroupMembersCmd.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/command/UpdateRaftGroupMembersCmd.java
@@ -76,7 +76,7 @@ public class UpdateRaftGroupMembersCmd extends RaftGroupCmd implements Identifie
             out.writeObject(member);
         }
         out.writeObject(member);
-        out.writeUTF(mode.name());
+        out.writeString(mode.name());
     }
 
     @Override
@@ -89,7 +89,7 @@ public class UpdateRaftGroupMembersCmd extends RaftGroupCmd implements Identifie
         }
         this.members = members;
         this.member = in.readObject();
-        this.mode = MembershipChangeMode.valueOf(in.readUTF());
+        this.mode = MembershipChangeMode.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/CreateRaftGroupOp.java
@@ -84,7 +84,7 @@ public class CreateRaftGroupOp extends MetadataRaftGroupOp implements Indetermin
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(groupName);
+        out.writeString(groupName);
         out.writeInt(members.size());
         for (RaftEndpoint member : members) {
             out.writeObject(member);
@@ -94,7 +94,7 @@ public class CreateRaftGroupOp extends MetadataRaftGroupOp implements Indetermin
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        groupName = in.readUTF();
+        groupName = in.readString();
         int len = in.readInt();
         members = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/ForceDestroyRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/ForceDestroyRaftGroupOp.java
@@ -73,12 +73,12 @@ public class ForceDestroyRaftGroupOp extends MetadataRaftGroupOp implements Inde
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(groupName);
+        out.writeString(groupName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        groupName = in.readUTF();
+        groupName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/GetActiveRaftGroupByNameOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/GetActiveRaftGroupByNameOp.java
@@ -63,12 +63,12 @@ public class GetActiveRaftGroupByNameOp extends MetadataRaftGroupOp implements I
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(groupName);
+        out.writeString(groupName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        groupName = in.readUTF();
+        groupName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/snapshot/RestoreSnapshotOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/snapshot/RestoreSnapshotOp.java
@@ -61,13 +61,13 @@ public class RestoreSnapshotOp extends RaftOp implements IdentifiedDataSerializa
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(serviceName);
+        out.writeString(serviceName);
         out.writeObject(snapshot);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        serviceName = in.readUTF();
+        serviceName = in.readString();
         snapshot = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/CPSessionInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/CPSessionInfo.java
@@ -168,9 +168,9 @@ public class CPSessionInfo implements CPSession, IdentifiedDataSerializable {
         boolean containsEndpointName = (endpointName != null);
         out.writeBoolean(containsEndpointName);
         if (containsEndpointName) {
-            out.writeUTF(endpointName);
+            out.writeString(endpointName);
         }
-        out.writeUTF(endpointType.name());
+        out.writeString(endpointType.name());
     }
 
     @Override
@@ -182,8 +182,8 @@ public class CPSessionInfo implements CPSession, IdentifiedDataSerializable {
         endpoint = in.readObject();
         boolean containsEndpointName = in.readBoolean();
         if (containsEndpointName) {
-            endpointName = in.readUTF();
+            endpointName = in.readString();
         }
-        endpointType = CPSessionOwnerType.valueOf(in.readUTF());
+        endpointType = CPSessionOwnerType.valueOf(in.readString());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/operation/CreateSessionOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/operation/CreateSessionOp.java
@@ -83,9 +83,9 @@ public class CreateSessionOp extends RaftOp implements IndeterminateOperationSta
         boolean containsEndpointName = (endpointName != null);
         out.writeBoolean(containsEndpointName);
         if (containsEndpointName) {
-            out.writeUTF(endpointName);
+            out.writeString(endpointName);
         }
-        out.writeUTF(endpointType.name());
+        out.writeString(endpointType.name());
     }
 
     @Override
@@ -93,9 +93,9 @@ public class CreateSessionOp extends RaftOp implements IndeterminateOperationSta
         endpoint = in.readObject();
         boolean containsEndpointName = in.readBoolean();
         if (containsEndpointName) {
-            endpointName = in.readUTF();
+            endpointName = in.readString();
         }
-        endpointType = CPSessionOwnerType.valueOf(in.readUTF());
+        endpointType = CPSessionOwnerType.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/ReplicationOperation.java
@@ -100,12 +100,12 @@ public class ReplicationOperation extends Operation implements IdentifiedDataSer
 
 
         private void write(ObjectDataOutput out) throws IOException {
-            out.writeUTF(name);
+            out.writeString(name);
             ringBuffer.write(out);
         }
 
         private void read(ObjectDataInput in) throws IOException {
-            name = in.readUTF();
+            name = in.readString();
             ringBuffer = new TaskRingBuffer();
             ringBuffer.read(in);
         }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -68,14 +68,14 @@ abstract class AbstractCallableTaskOperation extends Operation implements NamedO
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         UUIDSerializationUtil.writeUUID(out, uuid);
         IOUtil.writeData(out, callableData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         uuid = UUIDSerializationUtil.readUUID(in);
         callableData = IOUtil.readData(in);
     }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/NewIdBatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/NewIdBatchOperation.java
@@ -78,13 +78,13 @@ class NewIdBatchOperation extends Operation implements IdentifiedDataSerializabl
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        flakeIdGenName = in.readUTF();
+        flakeIdGenName = in.readString();
         batchSize = in.readInt();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(flakeIdGenName);
+        out.writeString(flakeIdGenName);
         out.writeInt(batchSize);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/EndpointQualifier.java
@@ -109,13 +109,13 @@ public final class EndpointQualifier
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         type = ProtocolType.valueOf(in.readInt());
-        identifier = in.readUTF();
+        identifier = in.readString();
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(type.ordinal());
-        out.writeUTF(identifier);
+        out.writeString(identifier);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -129,8 +129,8 @@ public class MemberInfo implements IdentifiedDataSerializable {
             attributes = createHashMap(size);
         }
         for (int i = 0; i < size; i++) {
-            String key = in.readUTF();
-            String value = in.readUTF();
+            String key = in.readString();
+            String value = in.readString();
             attributes.put(key, value);
         }
         version = in.readObject();
@@ -146,8 +146,8 @@ public class MemberInfo implements IdentifiedDataSerializable {
         out.writeInt(attributes == null ? 0 : attributes.size());
         if (attributes != null) {
             for (Map.Entry<String, String> entry : attributes.entrySet()) {
-                out.writeUTF(entry.getKey());
-                out.writeUTF(entry.getValue());
+                out.writeString(entry.getKey());
+                out.writeString(entry.getValue());
             }
         }
         out.writeObject(version);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -157,39 +157,39 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(clusterName);
-        out.writeUTF(joinerType);
+        out.writeString(clusterName);
+        out.writeString(joinerType);
         out.writeBoolean(partitionGroupEnabled);
         if (partitionGroupEnabled) {
-            out.writeUTF(memberGroupType.toString());
+            out.writeString(memberGroupType.toString());
         }
 
         out.writeInt(properties.size());
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-            out.writeUTF(entry.getKey());
-            out.writeUTF(entry.getValue());
+            out.writeString(entry.getKey());
+            out.writeString(entry.getValue());
         }
 
         out.writeInt(maps.size());
         for (Map.Entry<String, Object> entry : maps.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
 
         out.writeInt(queues.size());
         for (Map.Entry<String, Object> entry : queues.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        clusterName = in.readUTF();
-        joinerType = in.readUTF();
+        clusterName = in.readString();
+        joinerType = in.readString();
         partitionGroupEnabled = in.readBoolean();
         if (partitionGroupEnabled) {
-            String s = in.readUTF();
+            String s = in.readString();
             try {
                 memberGroupType = PartitionGroupConfig.MemberGroupType.valueOf(s);
             } catch (IllegalArgumentException ignored) {
@@ -199,21 +199,21 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
         int propSize = in.readInt();
         properties = createHashMap(propSize);
         for (int k = 0; k < propSize; k++) {
-            String key = in.readUTF();
-            String value = in.readUTF();
+            String key = in.readString();
+            String value = in.readString();
             properties.put(key, value);
         }
 
         int mapSize = in.readInt();
         for (int k = 0; k < mapSize; k++) {
-            String key = in.readUTF();
+            String key = in.readString();
             Object value = in.readObject();
             maps.put(key, value);
         }
 
         int queueSize = in.readInt();
         for (int k = 0; k < queueSize; k++) {
-            String key = in.readUTF();
+            String key = in.readString();
             Object value = in.readObject();
             queues.put(key, value);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -95,8 +95,8 @@ public class JoinRequest extends JoinMessage {
         int size = in.readInt();
         attributes = createHashMap(size);
         for (int i = 0; i < size; i++) {
-            String key = in.readUTF();
-            String value = in.readUTF();
+            String key = in.readString();
+            String value = in.readString();
             attributes.put(key, value);
         }
         size = in.readInt();
@@ -116,8 +116,8 @@ public class JoinRequest extends JoinMessage {
         out.writeInt(tryCount);
         out.writeInt(attributes.size());
         for (Map.Entry<String, String> entry : attributes.entrySet()) {
-            out.writeUTF(entry.getKey());
-            out.writeUTF(entry.getValue());
+            out.writeString(entry.getKey());
+            out.writeString(entry.getValue());
         }
         out.writeInt(excludedMemberUuids.size());
         for (UUID uuid : excludedMemberUuids) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberHandshake.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberHandshake.java
@@ -150,8 +150,8 @@ public class MemberHandshake
         out.writeInt(optionsSize);
         if (optionsSize > 0) {
             for (Map.Entry<String, String> entry : options.entrySet()) {
-                out.writeUTF(entry.getKey());
-                out.writeUTF(entry.getValue());
+                out.writeString(entry.getKey());
+                out.writeString(entry.getValue());
             }
         }
     }
@@ -178,7 +178,7 @@ public class MemberHandshake
         if (schemaVersion > SCHEMA_VERSION_1) {
             int optionsSize = in.readInt();
             for (int k = 0; k < optionsSize; k++) {
-                options.put(in.readUTF(), in.readUTF());
+                options.put(in.readString(), in.readString());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/BeforeJoinCheckFailureOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/BeforeJoinCheckFailureOp.java
@@ -38,12 +38,12 @@ public class BeforeJoinCheckFailureOp extends AbstractClusterOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(failReasonMsg);
+        out.writeString(failReasonMsg);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        failReasonMsg = in.readUTF();
+        failReasonMsg = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
@@ -45,12 +45,12 @@ public class ConfigMismatchOp extends AbstractClusterOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(msg);
+        out.writeString(msg);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        msg = in.readUTF();
+        msg = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -158,7 +158,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         super.writeInternalImpl(out);
         UUIDSerializationUtil.writeUUID(out, clusterId);
         out.writeLong(clusterStartTime);
-        out.writeUTF(clusterState.toString());
+        out.writeString(clusterState.toString());
         out.writeObject(clusterVersion);
         out.writeObject(preJoinOp);
         out.writeObject(postJoinOp);
@@ -169,7 +169,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         super.readInternalImpl(in);
         clusterId = UUIDSerializationUtil.readUUID(in);
         clusterStartTime = in.readLong();
-        String stateName = in.readUTF();
+        String stateName = in.readString();
         clusterState = ClusterState.valueOf(stateName);
         clusterVersion = in.readObject();
         preJoinOp = readOnJoinOp(in);

--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/AbstractCRDTReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/AbstractCRDTReplicationOperation.java
@@ -80,7 +80,7 @@ public abstract class AbstractCRDTReplicationOperation<T extends IdentifiedDataS
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(replicationData.size());
         for (Entry<String, T> entry : replicationData.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeObject(entry.getValue());
         }
     }
@@ -90,7 +90,7 @@ public abstract class AbstractCRDTReplicationOperation<T extends IdentifiedDataS
         final int mapSize = in.readInt();
         replicationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            final String name = in.readUTF();
+            final String name = in.readString();
             final T crdt = in.readObject();
             replicationData.put(name, crdt);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/operations/AbstractPNCounterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/operations/AbstractPNCounterOperation.java
@@ -115,11 +115,11 @@ public abstract class AbstractPNCounterOperation extends Operation implements Id
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
@@ -54,7 +54,7 @@ public class DynamicConfigPreJoinOperation
         for (IdentifiedDataSerializable config: configs) {
             out.writeObject(config);
         }
-        out.writeUTF(configCheckMode.name());
+        out.writeString(configCheckMode.name());
     }
 
     @Override
@@ -64,7 +64,7 @@ public class DynamicConfigPreJoinOperation
         for (int i = 0; i < size; i++) {
             configs[i] = in.readObject();
         }
-        configCheckMode = ConfigCheckMode.valueOf(in.readUTF());
+        configCheckMode = ConfigCheckMode.valueOf(in.readString());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/journal/EventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/journal/EventJournalReadOperation.java
@@ -164,7 +164,7 @@ public abstract class EventJournalReadOperation<T, J> extends Operation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(minSize);
         out.writeInt(maxSize);
         out.writeLong(startSequence);
@@ -173,7 +173,7 @@ public abstract class EventJournalReadOperation<T, J> extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        name = in.readUTF();
+        name = in.readString();
         minSize = in.readInt();
         maxSize = in.readInt();
         startSequence = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/operations/AbstractLongRegisterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/operations/AbstractLongRegisterOperation.java
@@ -62,12 +62,12 @@ public abstract class AbstractLongRegisterOperation extends Operation
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/operations/LongRegisterReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/operations/LongRegisterReplicationOperation.java
@@ -72,7 +72,7 @@ public class LongRegisterReplicationOperation extends Operation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(migrationData.size());
         for (Map.Entry<String, Long> entry : migrationData.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeLong(entry.getValue());
         }
     }
@@ -82,7 +82,7 @@ public class LongRegisterReplicationOperation extends Operation
         int mapSize = in.readInt();
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             Long longContainer = in.readLong();
             migrationData.put(name, longContainer);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/SetLicenseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/SetLicenseOperation.java
@@ -53,13 +53,13 @@ public class SetLicenseOperation extends AbstractManagementOperation {
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        licenseKey = in.readUTF();
+        licenseKey = in.readString();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(licenseKey);
+        out.writeString(licenseKey);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
@@ -78,7 +78,7 @@ public class UpdateMapConfigOperation extends AbstractManagementOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeInt(timeToLiveSeconds);
         out.writeInt(maxIdleSeconds);
         out.writeInt(maxSize);
@@ -89,7 +89,7 @@ public class UpdateMapConfigOperation extends AbstractManagementOperation {
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         timeToLiveSeconds = in.readInt();
         maxIdleSeconds = in.readInt();
         maxSize = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidation.java
@@ -92,7 +92,7 @@ public abstract class Invalidation implements IMapEvent, IdentifiedDataSerializa
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(dataStructureName);
+        out.writeString(dataStructureName);
         UUIDSerializationUtil.writeUUID(out, sourceUuid);
         out.writeLong(sequence);
 
@@ -106,7 +106,7 @@ public abstract class Invalidation implements IMapEvent, IdentifiedDataSerializa
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        dataStructureName = in.readUTF();
+        dataStructureName = in.readString();
         sourceUuid = UUIDSerializationUtil.readUUID(in);
         sequence = in.readLong();
         boolean nullUuid = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -519,7 +519,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
         if (len > 0) {
             String[] values = new String[len];
             for (int i = 0; i < len; i++) {
-                values[i] = readUTF();
+                values[i] = readString();
             }
             return values;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -368,7 +368,7 @@ public class ByteArrayObjectDataOutput extends VersionedObjectDataOutput impleme
         writeInt(len);
         if (len > 0) {
             for (String s : strings) {
-                writeUTF(s);
+                writeString(s);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -147,7 +147,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
                     }
                 }
             } else {
-                className = in.readUTF();
+                className = in.readString();
                 if (null == aClass) {
                     ds = ClassLoaderUtil.newInstance(in.getClassLoader(), className);
                 }
@@ -236,9 +236,9 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
             out.writeInt(ds.getClassId());
         } else {
             if (obj instanceof TypedDataSerializable) {
-                out.writeUTF(((TypedDataSerializable) obj).getClassType().getName());
+                out.writeString(((TypedDataSerializable) obj).getClassType().getName());
             } else {
-                out.writeUTF(obj.getClass().getName());
+                out.writeString(obj.getClass().getName());
             }
         }
         obj.writeData(out);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -291,7 +291,7 @@ public class ObjectDataInputStream extends VersionedObjectDataInput
         if (len > 0) {
             String[] values = new String[len];
             for (int i = 0; i < len; i++) {
-                values[i] = readUTF();
+                values[i] = readString();
             }
             return values;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -234,7 +234,7 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput
         writeInt(len);
         if (len > 0) {
             for (String s : strings) {
-                writeUTF(s);
+                writeString(s);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -321,7 +321,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         if (isFlagSet(header, IDS_FLAG)) {
             skipBytesSafely(input, FACTORY_AND_CLASS_ID_BYTE_LENGTH);
         } else {
-            input.readUTF();
+            input.readString();
         }
 
         if (isFlagSet(header, EE_FLAG)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
@@ -151,7 +151,7 @@ public final class JavaDefaultSerializers {
 
         @Override
         public Externalizable read(final ObjectDataInput in) throws IOException {
-            String className = in.readUTF();
+            String className = in.readString();
             try {
                 if (gzipEnabled) {
                     return readGzipped(((InputStream) in), className, in.getClassLoader());
@@ -186,7 +186,7 @@ public final class JavaDefaultSerializers {
 
         @Override
         public void write(final ObjectDataOutput out, final Externalizable obj) throws IOException {
-            out.writeUTF(obj.getClass().getName());
+            out.writeString(obj.getClass().getName());
 
             if (gzipEnabled) {
                 writeGzipped(((OutputStream) out), obj);
@@ -277,7 +277,7 @@ public final class JavaDefaultSerializers {
         @Override
         public Class read(final ObjectDataInput in) throws IOException {
             try {
-                return ClassLoaderUtil.loadClass(in.getClassLoader(), in.readUTF());
+                return ClassLoaderUtil.loadClass(in.getClassLoader(), in.readString());
             } catch (ClassNotFoundException e) {
                 throw new HazelcastSerializationException(e);
             }
@@ -285,7 +285,7 @@ public final class JavaDefaultSerializers {
 
         @Override
         public void write(final ObjectDataOutput out, final Class obj) throws IOException {
-            out.writeUTF(obj.getName());
+            out.writeString(obj.getName());
         }
     }
 
@@ -321,12 +321,12 @@ public final class JavaDefaultSerializers {
 
         @Override
         public void write(ObjectDataOutput out, HazelcastJsonValue object) throws IOException {
-            out.writeUTF(object.toString());
+            out.writeString(object.toString());
         }
 
         @Override
         public HazelcastJsonValue read(ObjectDataInput in) throws IOException {
-            return new HazelcastJsonValue(in.readUTF());
+            return new HazelcastJsonValue(in.readString());
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -226,7 +226,7 @@ public class DefaultPortableReader implements PortableReader {
         try {
             int pos = readPosition(fieldName, FieldType.UTF);
             in.position(pos);
-            return in.readUTF();
+            return in.readString();
         } finally {
             in.position(currentPos);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableWriter.java
@@ -94,7 +94,7 @@ public class DefaultPortableWriter implements PortableWriter {
     @Override
     public void writeString(@Nonnull String fieldName, @Nullable String value) throws IOException {
         setPosition(fieldName, FieldType.UTF);
-        out.writeUTF(value);
+        out.writeString(value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -188,7 +188,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
         try {
             int pos = readPosition(fieldName, FieldType.UTF);
             in.position(pos);
-            return in.readUTF();
+            return in.readString();
         } catch (IOException e) {
             throw newIllegalStateException(e);
         } finally {
@@ -747,7 +747,7 @@ public class PortableInternalGenericRecord extends AbstractGenericRecord impleme
                     in.position(in.position() + itemLength);
                 }
             }
-            return in.readUTF();
+            return in.readString();
         } catch (IOException e) {
             throw newIllegalStateException(e);
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
@@ -245,7 +245,7 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                     writer.writeDouble(fieldName, record.getDouble(fieldName));
                     break;
                 case UTF:
-                    writer.writeUTF(fieldName, record.getString(fieldName));
+                    writer.writeString(fieldName, record.getString(fieldName));
                     break;
                 case DECIMAL:
                     writer.writeDecimal(fieldName, record.getDecimal(fieldName));
@@ -290,7 +290,7 @@ public final class PortableSerializer implements StreamSerializer<Object> {
                     writer.writeDoubleArray(fieldName, record.getDoubleArray(fieldName));
                     break;
                 case UTF_ARRAY:
-                    writer.writeUTFArray(fieldName, record.getStringArray(fieldName));
+                    writer.writeStringArray(fieldName, record.getStringArray(fieldName));
                     break;
                 case DECIMAL_ARRAY:
                     writer.writeDecimalArray(fieldName, record.getDecimalArray(fieldName));

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/DistributedObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/DistributedObjectNamespace.java
@@ -60,14 +60,14 @@ public final class DistributedObjectNamespace implements ObjectNamespace, Identi
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(service);
-        out.writeUTF(objectName);
+        out.writeString(service);
+        out.writeString(objectName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        service = in.readUTF();
-        objectName = in.readUTF();
+        service = in.readString();
+        objectName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassData.java
@@ -75,7 +75,7 @@ public class ClassData implements IdentifiedDataSerializable {
         out.writeByteArray(mainClassDefinition);
         out.writeInt(innerClassDefinitions.size());
         for (Map.Entry<String, byte[]> entry : innerClassDefinitions.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeByteArray(entry.getValue());
         }
     }
@@ -86,7 +86,7 @@ public class ClassData implements IdentifiedDataSerializable {
         int size = in.readInt();
         innerClassDefinitions = new HashMap<String, byte[]>();
         for (int i = 0; i < size; i++) {
-            innerClassDefinitions.put(in.readUTF(), in.readByteArray());
+            innerClassDefinitions.put(in.readString(), in.readByteArray());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/ClassDataFinderOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/ClassDataFinderOperation.java
@@ -57,12 +57,12 @@ public final class ClassDataFinderOperation extends Operation implements UrgentS
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(className);
+        out.writeString(className);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        className = in.readUTF();
+        className = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/DeployClassesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/DeployClassesOperation.java
@@ -58,7 +58,7 @@ public class DeployClassesOperation extends Operation implements IdentifiedDataS
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(classDefinitions.size());
         for (Map.Entry<String, byte[]> classDefinition : classDefinitions) {
-            out.writeUTF(classDefinition.getKey());
+            out.writeString(classDefinition.getKey());
             out.writeByteArray(classDefinition.getValue());
         }
     }
@@ -68,7 +68,7 @@ public class DeployClassesOperation extends Operation implements IdentifiedDataS
         int length = in.readInt();
         classDefinitions = new ArrayList<Map.Entry<String, byte[]>>(length);
         for (int i = 0; i < length; i++) {
-            String className = in.readUTF();
+            String className = in.readString();
             byte[] classDefinition = in.readByteArray();
             classDefinitions.add(new AbstractMap.SimpleEntry<String, byte[]>(className, classDefinition));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -66,16 +66,16 @@ abstract class AbstractEventData implements EventData {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(source);
-        out.writeUTF(mapName);
+        out.writeString(source);
+        out.writeString(mapName);
         out.writeObject(caller);
         out.writeInt(eventType);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        source = in.readUTF();
-        mapName = in.readUTF();
+        source = in.readString();
+        mapName = in.readString();
         caller = in.readObject();
         eventType = in.readInt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperationFactory.java
@@ -44,13 +44,13 @@ public class AddIndexOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(config);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         config = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -69,14 +69,14 @@ public class AddInterceptorOperation extends AbstractNamedOperation
     @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        id = in.readUTF();
+        id = in.readString();
         mapInterceptor = in.readObject();
     }
 
     @Override
     public void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(id);
+        out.writeString(id);
         out.writeObject(mapInterceptor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperationFactory.java
@@ -41,12 +41,12 @@ public class ClearOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperationFactory.java
@@ -45,13 +45,13 @@ public final class ContainsValueOperationFactory extends AbstractMapOperationFac
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, value);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         value = IOUtil.readData(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -149,7 +149,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(modificationType != null ? modificationType.name() : "");
+        out.writeString(modificationType != null ? modificationType.name() : "");
         IOUtil.writeData(out, oldValue);
         IOUtil.writeData(out, newValue);
         UUIDSerializationUtil.writeUUID(out, caller);
@@ -161,7 +161,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        String modificationTypeName = in.readUTF();
+        String modificationTypeName = in.readString();
         modificationType = modificationTypeName.equals("")
                 ? null : EntryEventType.valueOf(modificationTypeName);
         oldValue = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperationFactory.java
@@ -44,12 +44,12 @@ public class EvictAllOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -111,7 +111,7 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
 
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(expiredKeys.size());
         for (ExpiredKey expiredKey : expiredKeys) {
             IOUtil.writeData(out, expiredKey.getKey());
@@ -124,7 +124,7 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
 
-        name = in.readUTF();
+        name = in.readString();
         int size = in.readInt();
         expiredKeys = new LinkedList<>();
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsEmptyOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsEmptyOperationFactory.java
@@ -41,12 +41,12 @@ public class IsEmptyOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperationFactory.java
@@ -41,12 +41,12 @@ public class IsPartitionLoadedOperationFactory extends AbstractMapOperationFacto
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyLoadStatusOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyLoadStatusOperationFactory.java
@@ -46,13 +46,13 @@ public class KeyLoadStatusOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(exception);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         exception = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperationFactory.java
@@ -41,12 +41,12 @@ public class MapFlushOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetAllOperationFactory.java
@@ -47,7 +47,7 @@ public class MapGetAllOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(keys.size());
         for (Data key : keys) {
             IOUtil.writeData(out, key);
@@ -56,7 +56,7 @@ public class MapGetAllOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             Data data = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
@@ -106,7 +106,7 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(namePartitionSequenceList.size());
             for (Map.Entry<String, List<Map.Entry<Integer, Long>>> entry : namePartitionSequenceList.entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 out.writeInt(entry.getValue().size());
                 for (Map.Entry<Integer, Long> seqEntry : entry.getValue()) {
                     out.writeInt(seqEntry.getKey());
@@ -127,7 +127,7 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
             int size1 = in.readInt();
             namePartitionSequenceList = new HashMap<>(size1);
             for (int i = 0; i < size1; i++) {
-                String name = in.readUTF();
+                String name = in.readString();
                 int size2 = in.readInt();
                 List<Map.Entry<Integer, Long>> innerList = new ArrayList<>(size2);
                 for (int j = 0; j < size2; j++) {
@@ -202,7 +202,7 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
         out.writeInt(mapNames.size());
 
         for (String mapName : mapNames) {
-            out.writeUTF(mapName);
+            out.writeString(mapName);
         }
     }
 
@@ -214,7 +214,7 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
 
         List<String> mapNames = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            mapNames.add(in.readUTF());
+            mapNames.add(in.readString());
         }
 
         this.mapNames = mapNames;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
@@ -54,7 +54,7 @@ public class MapLoadAllOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         final int size = keys.size();
         out.writeInt(size);
         for (Data key : keys) {
@@ -65,7 +65,7 @@ public class MapLoadAllOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         final int size = in.readInt();
         if (size > 0) {
             keys = new ArrayList<>(size);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -247,7 +247,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
 
         for (Map.Entry<String, RecordStore<Record>> entry : storesByMapName.entrySet()) {
             String mapName = entry.getKey();
-            out.writeUTF(mapName);
+            out.writeString(mapName);
 
             SerializationService ss = getSerializationService(operation.getRecordStore(mapName).getMapContainer());
             RecordStore<Record> recordStore = entry.getValue();
@@ -270,7 +270,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
 
         out.writeInt(loaded.size());
         for (Map.Entry<String, Boolean> loadedEntry : loaded.entrySet()) {
-            out.writeUTF(loadedEntry.getKey());
+            out.writeString(loadedEntry.getKey());
             out.writeBoolean(loadedEntry.getValue());
         }
 
@@ -292,7 +292,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         recordStoreStatsPerMapName = createHashMap(size);
 
         for (int i = 0; i < size; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             int numOfRecords = in.readInt();
             List keyRecordExpiry = new ArrayList<>(numOfRecords * 3);
             for (int j = 0; j < numOfRecords; j++) {
@@ -315,7 +315,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         int loadedSize = in.readInt();
         loaded = createHashMap(loadedSize);
         for (int i = 0; i < loadedSize; i++) {
-            loaded.put(in.readUTF(), in.readBoolean());
+            loaded.put(in.readString(), in.readBoolean());
         }
 
         int mapIndexInfoSize = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
@@ -66,7 +66,7 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeIntArray(partitions);
         for (List<MapMergeTypes<Object, Object>> list : mergingEntries) {
             out.writeInt(list.size());
@@ -79,7 +79,7 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitions = in.readIntArray();
         //noinspection unchecked
         mergingEntries = new List[partitions.length];

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
@@ -51,7 +51,7 @@ public class MultipleEntryOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(keys.size());
         for (Data key : keys) {
             IOUtil.writeData(out, key);
@@ -61,7 +61,7 @@ public class MultipleEntryOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.name = in.readUTF();
+        this.name = in.readString();
         int size = in.readInt();
         this.keys = createHashSet(size);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperationFactory.java
@@ -44,13 +44,13 @@ public class PartitionWideEntryOperationFactory extends AbstractMapOperationFact
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(entryProcessor);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         entryProcessor = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -104,14 +104,14 @@ public class PartitionWideEntryWithPredicateOperationFactory extends PartitionAw
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(entryProcessor);
         out.writeObject(predicate);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         entryProcessor = in.readObject();
         predicate = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -90,20 +90,20 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(mapName);
+            out.writeString(mapName);
             out.writeInt(interceptors.size());
             for (Map.Entry<String, MapInterceptor> entry : interceptors) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 out.writeObject(entry.getValue());
             }
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            mapName = in.readUTF();
+            mapName = in.readString();
             int size = in.readInt();
             for (int i = 0; i < size; i++) {
-                String id = in.readUTF();
+                String id = in.readString();
                 MapInterceptor interceptor = in.readObject();
                 interceptors.add(new AbstractMap.SimpleImmutableEntry<>(id, interceptor));
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
@@ -66,7 +66,7 @@ public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperatio
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeIntArray(partitions);
         for (MapEntries entry : mapEntries) {
             entry.writeData(out);
@@ -78,7 +78,7 @@ public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperatio
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitions = in.readIntArray();
         mapEntries = new MapEntries[partitions.length];
         for (int i = 0; i < partitions.length; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -65,13 +65,13 @@ public class RemoveInterceptorOperation extends AbstractNamedOperation
     @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        id = in.readUTF();
+        id = in.readString();
     }
 
     @Override
     public void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(id);
+        out.writeString(id);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SizeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SizeOperationFactory.java
@@ -41,12 +41,12 @@ public class SizeOperationFactory extends AbstractMapOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
@@ -146,7 +146,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
 
         out.writeInt(delayedEntries.size());
         for (Map.Entry<String, List<DelayedEntry>> entry : delayedEntries.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             List<DelayedEntry> delayedEntryList = entry.getValue();
             out.writeInt(delayedEntryList.size());
 
@@ -167,7 +167,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
 
         out.writeInt(flushSequences.size());
         for (Map.Entry<String, Queue<WriteBehindStore.Sequence>> entry : flushSequences.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             Queue<WriteBehindStore.Sequence> queue = entry.getValue();
             out.writeInt(queue.size());
             for (WriteBehindStore.Sequence sequence : queue) {
@@ -178,7 +178,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
 
         out.writeInt(reservationsByTxnIdPerMap.size());
         for (Map.Entry<String, Map<UUID, Long>> entry : reservationsByTxnIdPerMap.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             Map<UUID, Long> reservationsByTxnId = entry.getValue();
             out.writeInt(reservationsByTxnId.size());
             for (Map.Entry<UUID, Long> counterByTxnId : reservationsByTxnId.entrySet()) {
@@ -195,7 +195,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
         delayedEntries = createHashMap(size);
 
         for (int i = 0; i < size; i++) {
-            String mapName = in.readUTF();
+            String mapName = in.readString();
             int listSize = in.readInt();
             List<DelayedEntry> delayedEntriesList = new ArrayList<>(listSize);
             for (int j = 0; j < listSize; j++) {
@@ -219,7 +219,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
         int expectedSize = in.readInt();
         flushSequences = createHashMap(expectedSize);
         for (int i = 0; i < expectedSize; i++) {
-            String mapName = in.readUTF();
+            String mapName = in.readString();
             int setSize = in.readInt();
             Queue<WriteBehindStore.Sequence> queue = new ArrayDeque<>(setSize);
             for (int j = 0; j < setSize; j++) {
@@ -231,7 +231,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
         int mapCount = in.readInt();
         reservationsByTxnIdPerMap = mapCount == 0 ? Collections.emptyMap() : new HashMap<>(mapCount);
         for (int i = 0; i < mapCount; i++) {
-            String mapName = in.readUTF();
+            String mapName = in.readString();
             int numOfCounters = in.readInt();
             Map<UUID, Long> counterByTxnId = createHashMap(numOfCounters);
             for (int j = 0; j < numOfCounters; j++) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
@@ -123,7 +123,7 @@ public class Query implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeObject(predicate);
         out.writeByte(iterationType.getId());
         out.writeObject(aggregator);
@@ -132,7 +132,7 @@ public class Query implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.mapName = in.readUTF();
+        this.mapName = in.readString();
         this.predicate = in.readObject();
         this.iterationType = IterationType.getById(in.readByte());
         this.aggregator = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
@@ -167,8 +167,8 @@ public class AccumulatorInfo implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
-        out.writeUTF(cacheId);
+        out.writeString(mapName);
+        out.writeString(cacheId);
         out.writeInt(batchSize);
         out.writeInt(bufferSize);
         out.writeLong(delaySeconds);
@@ -181,8 +181,8 @@ public class AccumulatorInfo implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
-        cacheId = in.readUTF();
+        mapName = in.readString();
+        cacheId = in.readString();
         batchSize = in.readInt();
         bufferSize = in.readInt();
         delaySeconds = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
@@ -106,7 +106,7 @@ public class BatchEventData implements Sequenced, EventData {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         Collection<QueryCacheEventData> events = this.events;
-        out.writeUTF(source);
+        out.writeString(source);
         out.writeInt(events.size());
         for (QueryCacheEventData eventData : events) {
             eventData.writeData(out);
@@ -115,7 +115,7 @@ public class BatchEventData implements Sequenced, EventData {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        source = in.readUTF();
+        source = in.readString();
         int size = in.readInt();
         if (size > 0) {
             this.events = new ArrayList<>(size);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
@@ -72,13 +72,13 @@ public class DestroyQueryCacheOperation extends AbstractNamedOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheId);
+        out.writeString(cacheId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheId = in.readUTF();
+        cacheId = in.readString();
     }
 
     private void deregisterLocalIMapListener() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperation.java
@@ -89,13 +89,13 @@ public class MadePublishableOperation extends AbstractNamedOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheId);
+        out.writeString(cacheId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheId = in.readUTF();
+        cacheId = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperationFactory.java
@@ -54,14 +54,14 @@ public class MadePublishableOperationFactory implements OperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
-        out.writeUTF(cacheId);
+        out.writeString(mapName);
+        out.writeString(cacheId);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
-        cacheId = in.readUTF();
+        mapName = in.readString();
+        cacheId = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/ReadAndResetAccumulatorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/ReadAndResetAccumulatorOperation.java
@@ -83,13 +83,13 @@ public class ReadAndResetAccumulatorOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheId);
+        out.writeString(cacheId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheId = in.readUTF();
+        cacheId = in.readString();
     }
 
     private QueryCacheContext getQueryCacheContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/SetReadCursorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/SetReadCursorOperation.java
@@ -68,14 +68,14 @@ public class SetReadCursorOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheId);
+        out.writeString(cacheId);
         out.writeLong(sequence);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheId = in.readUTF();
+        cacheId = in.readString();
         sequence = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
@@ -101,7 +101,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(partitionId);
         boolean isNullKey = key == null;
         out.writeBoolean(isNullKey);
@@ -116,7 +116,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitionId = in.readInt();
         boolean isNullKey = in.readBoolean();
         if (!isNullKey) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapAddOrUpdateEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapAddOrUpdateEvent.java
@@ -73,14 +73,14 @@ public class WanMapAddOrUpdateEvent implements InternalWanEvent<EntryView<Object
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeObject(mergePolicy);
         out.writeObject(entryView);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         mergePolicy = in.readObject();
         entryView = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapRemoveEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapRemoveEvent.java
@@ -100,13 +100,13 @@ public class WanMapRemoveEvent implements InternalWanEvent<Object>, IdentifiedDa
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         IOUtil.writeData(out, dataKey);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         dataKey = IOUtil.readData(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractMultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractMultiMapOperation.java
@@ -122,12 +122,12 @@ public abstract class AbstractMultiMapOperation extends Operation
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperationFactory.java
@@ -77,7 +77,7 @@ public class MultiMapOperationFactory implements OperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(operationFactoryType.type);
         out.writeLong(threadId);
         IOUtil.writeData(out, key);
@@ -86,7 +86,7 @@ public class MultiMapOperationFactory implements OperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         operationFactoryType = OperationFactoryType.getByType(in.readInt());
         threadId = in.readLong();
         key = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapPutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapPutAllOperationFactory.java
@@ -55,7 +55,7 @@ public class MultiMapPutAllOperationFactory extends PartitionAwareOperationFacto
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeIntArray(partitions);
         for (MapEntries entry : mapEntries) {
             entry.writeData(out);
@@ -64,7 +64,7 @@ public class MultiMapPutAllOperationFactory extends PartitionAwareOperationFacto
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitions = in.readIntArray();
         mapEntries = new MapEntries[partitions.length];
         for (int i = 0; i < partitions.length; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
@@ -59,7 +59,7 @@ public class MultiMapReplicationOperation extends Operation implements Identifie
         out.writeInt(map.size());
         for (Map.Entry<String, Map<Data, MultiMapValue>> entry : map.entrySet()) {
             String name = entry.getKey();
-            out.writeUTF(name);
+            out.writeString(name);
 
             Map<Data, MultiMapValue> collections = entry.getValue();
             out.writeInt(collections.size());
@@ -73,7 +73,7 @@ public class MultiMapReplicationOperation extends Operation implements Identifie
                 if (coll instanceof List) {
                     collectionType = MultiMapConfig.ValueCollectionType.LIST.name();
                 }
-                out.writeUTF(collectionType);
+                out.writeString(collectionType);
                 for (MultiMapRecord record : coll) {
                     record.writeData(out);
                 }
@@ -86,13 +86,13 @@ public class MultiMapReplicationOperation extends Operation implements Identifie
         int mapSize = in.readInt();
         map = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             int collectionSize = in.readInt();
             Map<Data, MultiMapValue> collections = createHashMap(collectionSize);
             for (int j = 0; j < collectionSize; j++) {
                 Data key = IOUtil.readData(in);
                 int collSize = in.readInt();
-                String collectionType = in.readUTF();
+                String collectionType = in.readString();
                 Collection<MultiMapRecord> coll;
                 if (collectionType.equals(MultiMapConfig.ValueCollectionType.SET.name())) {
                     coll = createHashSet(collSize);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapResponse.java
@@ -84,7 +84,7 @@ public class MultiMapResponse implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(collectionType.name());
+        out.writeString(collectionType.name());
         out.writeLong(nextRecordId);
         if (collection == null) {
             out.writeInt(-1);
@@ -98,7 +98,7 @@ public class MultiMapResponse implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        String collectionTypeName = in.readUTF();
+        String collectionTypeName = in.readString();
         collectionType = MultiMapConfig.ValueCollectionType.valueOf(collectionTypeName);
         nextRecordId = in.readLong();
         int size = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
@@ -68,7 +68,7 @@ public class MultiMapTransactionLogRecord implements TransactionLogRecord {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(partitionId);
         out.writeInt(opList.size());
         for (Operation op : opList) {
@@ -81,7 +81,7 @@ public class MultiMapTransactionLogRecord implements TransactionLogRecord {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitionId = in.readInt();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
@@ -70,12 +70,12 @@ public final class SingleAttributeProjection<I, O> implements Projection<I, O>, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributePath);
+        out.writeString(attributePath);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        attributePath = in.readUTF();
+        attributePath = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/MapIndexInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/MapIndexInfo.java
@@ -53,7 +53,7 @@ public class MapIndexInfo implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeInt(indexConfigs.size());
 
         for (IndexConfig indexConfig : indexConfigs) {
@@ -63,7 +63,7 @@ public class MapIndexInfo implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         int size = in.readInt();
 
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
@@ -128,7 +128,7 @@ public class PredicateBuilderImpl
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attribute);
+        out.writeString(attribute);
         out.writeInt(lsPredicates.size());
         for (Predicate predicate : lsPredicates) {
             out.writeObject(predicate);
@@ -137,7 +137,7 @@ public class PredicateBuilderImpl
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        attribute = in.readUTF();
+        attribute = in.readString();
         int size = in.readInt();
         lsPredicates = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -154,12 +154,12 @@ public abstract class AbstractPredicate<K, V> implements Predicate<K, V>, Identi
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attributeName);
+        out.writeString(attributeName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        attributeName = in.readUTF();
+        attributeName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
@@ -59,12 +59,12 @@ public class InstanceOfPredicate
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(klass.getName());
+        out.writeString(klass.getName());
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        String klassName = in.readUTF();
+        String klassName = in.readString();
         try {
             klass = ClassLoaderUtil.loadClass(in.getClassLoader(), klassName);
         } catch (ClassNotFoundException e) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -79,13 +79,13 @@ public class LikePredicate extends AbstractPredicate {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeUTF(expression);
+        out.writeString(expression);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        expression = in.readUTF();
+        expression = in.readString();
     }
 
     protected int getFlags() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -337,7 +337,7 @@ public class PagingPredicateImpl<K, V>
         out.writeObject(comparator);
         out.writeInt(page);
         out.writeInt(pageSize);
-        out.writeUTF(iterationType.name());
+        out.writeString(iterationType.name());
         out.writeInt(anchorList.size());
         for (Map.Entry<Integer, Map.Entry<K, V>> anchor : anchorList) {
             out.writeInt(anchor.getKey());
@@ -353,7 +353,7 @@ public class PagingPredicateImpl<K, V>
         comparator = in.readObject();
         page = in.readInt();
         pageSize = in.readInt();
-        iterationType = IterationType.valueOf(in.readUTF());
+        iterationType = IterationType.valueOf(in.readString());
         int size = in.readInt();
         anchorList = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
@@ -62,13 +62,13 @@ public class RegexPredicate extends AbstractPredicate {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeUTF(regex);
+        out.writeString(regex);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        regex = in.readUTF();
+        regex = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -105,12 +105,12 @@ public class SqlPredicate
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(sql);
+        out.writeString(sql);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        sql = in.readUTF();
+        sql = in.readString();
         predicate = createPredicate(sql);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersionOperation.java
@@ -97,7 +97,7 @@ public class CheckReplicaVersionOperation extends AbstractSerializableOperation 
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(versions.size());
         for (Map.Entry<String, Long> entry : versions.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeLong(entry.getValue());
         }
     }
@@ -107,7 +107,7 @@ public class CheckReplicaVersionOperation extends AbstractSerializableOperation 
         versions = new ConcurrentHashMap<>();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             Long version = in.readLong();
             versions.put(name, version);
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
@@ -129,7 +129,7 @@ public class ClearOperation extends AbstractNamedSerializableOperation implement
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeBoolean(replicateClear);
         out.writeLong(version);
     }
@@ -137,7 +137,7 @@ public class ClearOperation extends AbstractNamedSerializableOperation implement
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        mapName = in.readUTF();
+        mapName = in.readString();
         replicateClear = in.readBoolean();
         version = in.readLong();
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperationFactory.java
@@ -41,12 +41,12 @@ public class ClearOperationFactory implements OperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
@@ -54,13 +54,13 @@ public class ContainsKeyOperation extends AbstractNamedSerializableOperation imp
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         key = IOUtil.readData(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsValueOperation.java
@@ -60,13 +60,13 @@ public class ContainsValueOperation extends AbstractNamedSerializableOperation i
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, value);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         value = IOUtil.readData(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EntrySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EntrySetOperation.java
@@ -71,12 +71,12 @@ public class EntrySetOperation extends AbstractNamedSerializableOperation implem
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -60,13 +60,13 @@ public class GetOperation extends AbstractNamedSerializableOperation implements 
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         key = IOUtil.readData(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/IsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/IsEmptyOperation.java
@@ -58,12 +58,12 @@ public class IsEmptyOperation extends AbstractNamedSerializableOperation impleme
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/KeySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/KeySetOperation.java
@@ -66,12 +66,12 @@ public class KeySetOperation extends AbstractNamedSerializableOperation implemen
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -75,7 +75,7 @@ public class MergeOperation extends AbstractNamedSerializableOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeInt(mergingEntries.size());
         for (ReplicatedMapMergeTypes mergingEntry : mergingEntries) {
             out.writeObject(mergingEntry);
@@ -86,7 +86,7 @@ public class MergeOperation extends AbstractNamedSerializableOperation {
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        name = in.readUTF();
+        name = in.readString();
         int size = in.readInt();
         mergingEntries = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
@@ -64,7 +64,7 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeIntArray(partitions);
         for (List<ReplicatedMapMergeTypes<Object, Object>> list : mergingEntries) {
             out.writeInt(list.size());
@@ -77,7 +77,7 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         partitions = in.readIntArray();
         //noinspection unchecked
         mergingEntries = new List[partitions.length];

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -89,13 +89,13 @@ public class PutAllOperation extends AbstractNamedSerializableOperation implemen
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(entries);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         entries = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
@@ -49,13 +49,13 @@ public class PutAllOperationFactory implements OperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeObject(entries);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         entries = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
@@ -77,7 +77,7 @@ public class PutOperation extends AbstractReplicatedMapOperation implements Part
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, key);
         IOUtil.writeData(out, value);
         out.writeLong(ttl);
@@ -85,7 +85,7 @@ public class PutOperation extends AbstractReplicatedMapOperation implements Part
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         key = IOUtil.readData(in);
         value = IOUtil.readData(in);
         ttl = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -67,13 +67,13 @@ public class RemoveOperation extends AbstractReplicatedMapOperation implements P
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, key);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         key = IOUtil.readData(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -95,7 +95,7 @@ public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         response.writeData(out);
-        out.writeUTF(name);
+        out.writeString(name);
         IOUtil.writeData(out, dataKey);
         IOUtil.writeData(out, dataValue);
         out.writeLong(ttl);
@@ -107,7 +107,7 @@ public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation
     protected void readInternal(ObjectDataInput in) throws IOException {
         response = new VersionResponsePair();
         response.readData(in);
-        name = in.readUTF();
+        name = in.readString();
         dataKey = IOUtil.readData(in);
         dataValue = IOUtil.readData(in);
         ttl = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -107,7 +107,7 @@ public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperat
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeLong(callId);
         IOUtil.writeData(out, dataKey);
         IOUtil.writeData(out, dataValue);
@@ -118,7 +118,7 @@ public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperat
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         callId = in.readLong();
         dataKey = IOUtil.readData(in);
         dataValue = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
@@ -118,7 +118,7 @@ public class ReplicationOperation extends AbstractSerializableOperation {
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(data.size());
         for (Map.Entry<String, Set<RecordMigrationInfo>> entry : data.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             Set<RecordMigrationInfo> recordSet = entry.getValue();
             out.writeInt(recordSet.size());
             for (RecordMigrationInfo record : recordSet) {
@@ -127,7 +127,7 @@ public class ReplicationOperation extends AbstractSerializableOperation {
         }
         out.writeInt(versions.size());
         for (Map.Entry<String, Long> entry : versions.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeLong(entry.getValue());
         }
     }
@@ -137,7 +137,7 @@ public class ReplicationOperation extends AbstractSerializableOperation {
         int size = in.readInt();
         data = createHashMap(size);
         for (int i = 0; i < size; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             int mapSize = in.readInt();
             Set<RecordMigrationInfo> recordSet = createHashSet(mapSize);
             for (int j = 0; j < mapSize; j++) {
@@ -150,7 +150,7 @@ public class ReplicationOperation extends AbstractSerializableOperation {
         int versionsSize = in.readInt();
         versions = createHashMap(versionsSize);
         for (int i = 0; i < versionsSize; i++) {
-            String name = in.readUTF();
+            String name = in.readString();
             long version = in.readLong();
             versions.put(name, version);
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
@@ -99,12 +99,12 @@ public class RequestMapDataOperation extends AbstractSerializableOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SizeOperation.java
@@ -55,12 +55,12 @@ public class SizeOperation extends AbstractNamedSerializableOperation implements
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -88,7 +88,7 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractSerializableOp
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeLong(version);
         out.writeInt(recordSet.size());
         for (RecordMigrationInfo record : recordSet) {
@@ -98,7 +98,7 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractSerializableOp
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         version = in.readLong();
         int size = in.readInt();
         recordSet = createHashSet(size);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ValuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ValuesOperation.java
@@ -66,12 +66,12 @@ public class ValuesOperation extends AbstractNamedSerializableOperation implemen
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -108,13 +108,13 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/NamedTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/NamedTaskDecorator.java
@@ -60,9 +60,9 @@ public class NamedTaskDecorator<V> extends AbstractTaskDecorator<V>
             throws IOException {
         if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
             super.writeData(out);
-            out.writeUTF(name);
+            out.writeString(name);
         } else {
-            out.writeUTF(name);
+            out.writeString(name);
             out.writeObject(delegate);
         }
     }
@@ -72,9 +72,9 @@ public class NamedTaskDecorator<V> extends AbstractTaskDecorator<V>
             throws IOException {
         if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
             super.readData(in);
-            name = in.readUTF();
+            name = in.readString();
         } else {
-            name = in.readUTF();
+            name = in.readString();
             delegate = in.readObject();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImpl.java
@@ -98,13 +98,13 @@ public final class ScheduledTaskHandlerImpl
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(toUrn());
+        out.writeString(toUrn());
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        ScheduledTaskHandler handler = of(in.readUTF());
+        ScheduledTaskHandler handler = of(in.readString());
         this.uuid = handler.getUuid();
         this.partitionId = handler.getPartitionId();
         this.schedulerName = handler.getSchedulerName();

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskDefinition.java
@@ -125,12 +125,12 @@ public class TaskDefinition<V>
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(type.name());
-        out.writeUTF(name);
+        out.writeString(type.name());
+        out.writeString(name);
         out.writeObject(command);
         out.writeLong(initialDelay);
         out.writeLong(period);
-        out.writeUTF(unit.name());
+        out.writeString(unit.name());
         if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
             out.writeBoolean(autoDisposable);
         }
@@ -139,12 +139,12 @@ public class TaskDefinition<V>
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        type = Type.valueOf(in.readUTF());
-        name = in.readUTF();
+        type = Type.valueOf(in.readString());
+        name = in.readString();
         command = in.readObject();
         initialDelay = in.readLong();
         period = in.readLong();
-        unit = TimeUnit.valueOf(in.readUTF());
+        unit = TimeUnit.valueOf(in.readString());
         if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
             autoDisposable = in.readBoolean();
         }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractSchedulerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractSchedulerOperation.java
@@ -78,14 +78,14 @@ public abstract class AbstractSchedulerOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(schedulerName);
+        out.writeString(schedulerName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.schedulerName = in.readUTF();
+        this.schedulerName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
@@ -52,13 +52,13 @@ public class CancelTaskBackupOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskOperation.java
@@ -70,7 +70,7 @@ public class CancelTaskOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
         out.writeBoolean(mayInterruptIfRunning);
     }
 
@@ -78,7 +78,7 @@ public class CancelTaskOperation
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
         this.mayInterruptIfRunning = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
@@ -52,13 +52,13 @@ public class DisposeBackupTaskOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeTaskOperation.java
@@ -60,13 +60,13 @@ public class DisposeTaskOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnPartitionOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnPartitionOperationFactory.java
@@ -49,13 +49,13 @@ public class GetAllScheduledOnPartitionOperationFactory
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(schedulerName);
+        out.writeString(schedulerName);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        schedulerName = in.readUTF();
+        schedulerName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetDelayOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetDelayOperation.java
@@ -65,15 +65,15 @@ public class GetDelayOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
-        out.writeUTF(unit.name());
+        out.writeString(taskName);
+        out.writeString(unit.name());
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
-        this.unit = TimeUnit.valueOf(in.readUTF());
+        this.taskName = in.readString();
+        this.unit = TimeUnit.valueOf(in.readString());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetResultOperation.java
@@ -82,15 +82,15 @@ public class GetResultOperation<V>
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
-        out.writeUTF(handler.toUrn());
+        out.writeString(taskName);
+        out.writeString(handler.toUrn());
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
-        this.handler = ScheduledTaskHandler.of(in.readUTF());
+        this.taskName = in.readString();
+        this.handler = ScheduledTaskHandler.of(in.readString());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetStatisticsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetStatisticsOperation.java
@@ -62,13 +62,13 @@ public class GetStatisticsOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsCanceledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsCanceledOperation.java
@@ -61,13 +61,13 @@ public class IsCanceledOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsDoneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsDoneOperation.java
@@ -61,13 +61,13 @@ public class IsDoneOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ReplicationOperation.java
@@ -64,10 +64,10 @@ public class ReplicationOperation
             throws IOException {
         out.writeInt(map.size());
         for (Map.Entry<String, Map<String, ScheduledTaskDescriptor>> entry : map.entrySet()) {
-            out.writeUTF(entry.getKey());
+            out.writeString(entry.getKey());
             out.writeInt(entry.getValue().size());
             for (Map.Entry<String, ScheduledTaskDescriptor> subEntry : entry.getValue().entrySet()) {
-                out.writeUTF(subEntry.getKey());
+                out.writeString(subEntry.getKey());
                 out.writeObject(subEntry.getValue());
             }
         }
@@ -79,12 +79,12 @@ public class ReplicationOperation
         int size = in.readInt();
         map = createHashMap(size);
         for (int i = 0; i < size; i++) {
-            String key = in.readUTF();
+            String key = in.readString();
             int subSize = in.readInt();
             Map<String, ScheduledTaskDescriptor> subMap = createHashMap(subSize);
             map.put(key, subMap);
             for (int k = 0; k < subSize; k++) {
-                subMap.put(in.readUTF(), (ScheduledTaskDescriptor) in.readObject());
+                subMap.put(in.readString(), (ScheduledTaskDescriptor) in.readObject());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ResultReadyNotifyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ResultReadyNotifyOperation.java
@@ -65,13 +65,13 @@ public class ResultReadyNotifyOperation<V>
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(handler.toUrn());
+        out.writeString(handler.toUrn());
     }
 
     @Override
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.handler = ScheduledTaskHandler.of(in.readUTF());
+        this.handler = ScheduledTaskHandler.of(in.readString());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
@@ -92,7 +92,7 @@ public class SyncStateOperation
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);
-        out.writeUTF(taskName);
+        out.writeString(taskName);
         writeMap(state, out);
         out.writeObject(stats);
         out.writeObject(result);
@@ -102,7 +102,7 @@ public class SyncStateOperation
     protected void readInternal(ObjectDataInput in)
             throws IOException {
         super.readInternal(in);
-        this.taskName = in.readUTF();
+        this.taskName = in.readString();
         this.state = readMap(in);
         this.stats = in.readObject();
         this.result = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
@@ -88,14 +88,14 @@ public class UsernamePasswordCredentials implements PasswordCredentials, Identif
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        out.writeUTF(password);
+        out.writeString(name);
+        out.writeString(password);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        password = in.readUTF();
+        name = in.readString();
+        password = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
@@ -70,14 +70,14 @@ public final class EventEnvelope implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         UUIDSerializationUtil.writeUUID(out, id);
-        out.writeUTF(serviceName);
+        out.writeString(serviceName);
         IOUtil.writeObject(out, event);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         id = UUIDSerializationUtil.readUUID(in);
-        serviceName = in.readUTF();
+        serviceName = in.readString();
         event = IOUtil.readObject(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -107,8 +107,8 @@ public class Registration implements EventRegistration {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         UUIDSerializationUtil.writeUUID(out, id);
-        out.writeUTF(serviceName);
-        out.writeUTF(topic);
+        out.writeString(serviceName);
+        out.writeString(topic);
         out.writeObject(subscriber);
         out.writeObject(filter);
     }
@@ -116,8 +116,8 @@ public class Registration implements EventRegistration {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         id = UUIDSerializationUtil.readUUID(in);
-        serviceName = in.readUTF();
-        topic = in.readUTF();
+        serviceName = in.readString();
+        topic = in.readString();
         subscriber = in.readObject();
         filter = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperation.java
@@ -56,13 +56,13 @@ public class DeregistrationOperation extends AbstractRegistrationOperation {
 
     @Override
     protected void writeInternalImpl(ObjectDataOutput out) throws IOException {
-        out.writeUTF(topic);
+        out.writeString(topic);
         UUIDSerializationUtil.writeUUID(out, id);
     }
 
     @Override
     protected void readInternalImpl(ObjectDataInput in) throws IOException {
-        topic = in.readUTF();
+        topic = in.readString();
         id = UUIDSerializationUtil.readUUID(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/AbstractNamedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/AbstractNamedOperation.java
@@ -39,12 +39,12 @@ public abstract class AbstractNamedOperation extends Operation implements NamedO
 
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
@@ -673,7 +673,7 @@ public abstract class Operation implements DataSerializable, Tenantable {
         out.writeShort(flags);
 
         if (isFlagSet(BITMASK_SERVICE_NAME_SET)) {
-            out.writeUTF(serviceName);
+            out.writeString(serviceName);
         }
 
         if (isFlagSet(BITMASK_PARTITION_ID_32_BIT)) {
@@ -719,7 +719,7 @@ public abstract class Operation implements DataSerializable, Tenantable {
         flags = in.readShort();
 
         if (isFlagSet(BITMASK_SERVICE_NAME_SET)) {
-            serviceName = in.readUTF();
+            serviceName = in.readString();
         }
 
         if (isFlagSet(BITMASK_PARTITION_ID_32_BIT)) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -63,16 +63,16 @@ public final class DistributedObjectEventPacket implements IdentifiedDataSeriali
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(eventType == EventType.CREATED);
-        out.writeUTF(serviceName);
-        out.writeUTF(name);
+        out.writeString(serviceName);
+        out.writeString(name);
         UUIDSerializationUtil.writeUUID(out, source);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         eventType = in.readBoolean() ? EventType.CREATED : EventType.DESTROYED;
-        serviceName = in.readUTF();
-        name = in.readUTF();
+        serviceName = in.readString();
+        name = in.readString();
         source = UUIDSerializationUtil.readUUID(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
@@ -53,15 +53,15 @@ public class DistributedObjectDestroyOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(serviceName);
-        out.writeUTF(name);
+        out.writeString(serviceName);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        serviceName = in.readUTF();
-        name = in.readUTF();
+        serviceName = in.readString();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/InitializeDistributedObjectOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/InitializeDistributedObjectOperation.java
@@ -57,14 +57,14 @@ public class InitializeDistributedObjectOperation extends Operation implements I
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(serviceName);
+        out.writeString(serviceName);
         out.writeObject(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        serviceName = in.readUTF();
+        serviceName = in.readString();
         name = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -83,8 +83,8 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         out.writeInt(len);
         if (len > 0) {
             for (ProxyInfo proxy : proxies) {
-                out.writeUTF(proxy.getServiceName());
-                out.writeUTF(proxy.getObjectName());
+                out.writeString(proxy.getServiceName());
+                out.writeString(proxy.getObjectName());
                 UUIDSerializationUtil.writeUUID(out, proxy.getSource());
             }
         }
@@ -97,7 +97,7 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
         if (len > 0) {
             proxies = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
-                ProxyInfo proxy = new ProxyInfo(in.readUTF(), in.readUTF(), UUIDSerializationUtil.readUUID(in));
+                ProxyInfo proxy = new ProxyInfo(in.readString(), in.readString(), UUIDSerializationUtil.readUUID(in));
                 proxies.add(proxy);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlReplicationOperation.java
@@ -85,14 +85,14 @@ public class TenantControlReplicationOperation extends Operation implements Iden
 
         tenantControlMap = MapUtil.createConcurrentHashMap(serviceCount);
         for (int i = 0; i < serviceCount; i++) {
-            String serviceName = in.readUTF();
+            String serviceName = in.readString();
             int objectCount = in.readInt();
 
             ConcurrentMap<String, TenantControl> objectMap = MapUtil.createConcurrentHashMap(objectCount);
             tenantControlMap.put(serviceName, objectMap);
 
             for (int j = 0; j < objectCount; j++) {
-                objectMap.put(in.readUTF(), in.readObject());
+                objectMap.put(in.readString(), in.readObject());
             }
         }
     }
@@ -107,19 +107,19 @@ public class TenantControlReplicationOperation extends Operation implements Iden
                 String serviceName = serviceEntry.getKey();
                 ConcurrentMap<String, TenantControl> tenantControlPerObject = serviceEntry.getValue();
 
-                out.writeUTF(serviceName);
+                out.writeString(serviceName);
                 out.writeInt(tenantControlPerObject.size());
                 for (Entry<String, TenantControl> objectEntry : tenantControlPerObject.entrySet()) {
-                    out.writeUTF(objectEntry.getKey());
+                    out.writeString(objectEntry.getKey());
                     out.writeObject(objectEntry.getValue());
                 }
             }
         } else {
             // we are sending just one tenant control
             out.writeInt(1);
-            out.writeUTF(distributedObjectServiceName);
+            out.writeString(distributedObjectServiceName);
             out.writeInt(1);
-            out.writeUTF(distributedObjectName);
+            out.writeString(distributedObjectName);
             out.writeObject(tenantControl);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/QueryPath.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/extract/QueryPath.java
@@ -124,13 +124,13 @@ public final class QueryPath implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(key);
-        out.writeUTF(path);
+        out.writeString(path);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         key = in.readBoolean();
-        path = in.readUTF();
+        path = in.readString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryCancelOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/operation/QueryCancelOperation.java
@@ -81,14 +81,14 @@ public class QueryCancelOperation extends QueryAbstractIdAwareOperation {
     @Override
     protected void writeInternal1(ObjectDataOutput out) throws IOException {
         out.writeInt(errorCode);
-        out.writeUTF(errorMessage);
+        out.writeString(errorMessage);
         UUIDSerializationUtil.writeUUID(out, originatingMemberId);
     }
 
     @Override
     protected void readInternal1(ObjectDataInput in) throws IOException {
         errorCode = in.readInt();
-        errorMessage = in.readUTF();
+        errorMessage = in.readString();
         originatingMemberId = UUIDSerializationUtil.readUUID(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/AbstractMapScanPlanNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/AbstractMapScanPlanNode.java
@@ -108,7 +108,7 @@ public abstract class AbstractMapScanPlanNode extends ZeroInputPlanNode {
 
     @Override
     protected void writeData0(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeObject(keyDescriptor);
         out.writeObject(valueDescriptor);
         SerializationUtil.writeList(fieldPaths, out);
@@ -119,7 +119,7 @@ public abstract class AbstractMapScanPlanNode extends ZeroInputPlanNode {
 
     @Override
     protected void readData0(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         keyDescriptor = in.readObject();
         valueDescriptor = in.readObject();
         fieldPaths = SerializationUtil.readList(in);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/MapIndexScanPlanNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/node/MapIndexScanPlanNode.java
@@ -110,7 +110,7 @@ public class MapIndexScanPlanNode extends AbstractMapScanPlanNode implements Ide
     protected void writeData0(ObjectDataOutput out) throws IOException {
         super.writeData0(out);
 
-        out.writeUTF(indexName);
+        out.writeString(indexName);
         out.writeInt(indexComponentCount);
         out.writeObject(indexFilter);
         SerializationUtil.writeList(converterTypes, out);
@@ -121,7 +121,7 @@ public class MapIndexScanPlanNode extends AbstractMapScanPlanNode implements Ide
     protected void readData0(ObjectDataInput in) throws IOException {
         super.readData0(in);
 
-        indexName = in.readUTF();
+        indexName = in.readString();
         indexComponentCount = in.readInt();
         indexFilter = in.readObject();
         converterTypes = SerializationUtil.readList(in);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
@@ -55,7 +55,7 @@ class TopicEvent implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeLong(publishTime);
         out.writeObject(publisherAddress);
         IOUtil.writeData(out, data);
@@ -63,7 +63,7 @@ class TopicEvent implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         publishTime = in.readLong();
         publisherAddress = in.readObject();
         data = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventContainerReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventContainerReplicationOperation.java
@@ -115,12 +115,12 @@ public class WanEventContainerReplicationOperation extends Operation implements 
         for (Entry<String, Map<String, Object>> entry : eventContainers.entrySet()) {
             String wanReplicationScheme = entry.getKey();
             Map<String, Object> eventContainersByPublisherId = entry.getValue();
-            out.writeUTF(wanReplicationScheme);
+            out.writeString(wanReplicationScheme);
             out.writeInt(eventContainersByPublisherId.size());
             for (Entry<String, Object> publisherEventContainer : eventContainersByPublisherId.entrySet()) {
                 String publisherId = publisherEventContainer.getKey();
                 Object eventContainer = publisherEventContainer.getValue();
-                out.writeUTF(publisherId);
+                out.writeString(publisherId);
                 out.writeObject(eventContainer);
             }
         }
@@ -136,11 +136,11 @@ public class WanEventContainerReplicationOperation extends Operation implements 
         int wanReplicationSchemeCount = in.readInt();
         eventContainers = createHashMap(wanReplicationSchemeCount);
         for (int i = 0; i < wanReplicationSchemeCount; i++) {
-            String wanReplicationScheme = in.readUTF();
+            String wanReplicationScheme = in.readString();
             int publisherCount = in.readInt();
             Map<String, Object> eventContainersByPublisherId = createHashMap(publisherCount);
             for (int j = 0; j < publisherCount; j++) {
-                String publisherId = in.readUTF();
+                String publisherId = in.readString();
                 Object eventContainer = in.readObject();
                 eventContainersByPublisherId.put(publisherId, eventContainer);
             }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
@@ -195,12 +195,12 @@ public class AggregatorsPortableTest extends HazelcastTestSupport {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTFArray("wheels", wheels);
+            writer.writeStringArray("wheels", wheels);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            wheels = reader.readUTFArray("wheels");
+            wheels = reader.readStringArray("wheels");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/ValueContainer.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/ValueContainer.java
@@ -99,7 +99,7 @@ public class ValueContainer implements DataSerializable, Comparable<ValueContain
         out.writeObject(bigDecimal);
         out.writeObject(bigInteger);
         out.writeObject(numberValue);
-        out.writeUTF(stringValue);
+        out.writeString(stringValue);
     }
 
     @Override
@@ -111,7 +111,7 @@ public class ValueContainer implements DataSerializable, Comparable<ValueContain
         bigDecimal = in.readObject(BigDecimal.class);
         bigInteger = in.readObject(BigInteger.class);
         numberValue = in.readObject(Number.class);
-        stringValue = in.readUTF();
+        stringValue = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
@@ -189,7 +189,7 @@ public class CachePartitionLostListenerTest extends AbstractPartitionLostListene
                 withSettings().extraInterfaces(DataWriter.class));
         cachePartitionEventData.writeData(output);
 
-        verify(output).writeUTF("cacheName");
+        verify(output).writeString("cacheName");
         verify(output).writeInt(1);
     }
 
@@ -199,7 +199,7 @@ public class CachePartitionLostListenerTest extends AbstractPartitionLostListene
 
         ObjectDataInput input = mock(ObjectDataInput.class,
                 withSettings().extraInterfaces(DataReader.class));
-        when(input.readUTF()).thenReturn("cacheName");
+        when(input.readString()).thenReturn("cacheName");
         when(input.readInt()).thenReturn(1);
 
         cachePartitionEventData.readData(input);

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/tasks/MapPutPartitionAwareRunnable.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/tasks/MapPutPartitionAwareRunnable.java
@@ -58,12 +58,12 @@ public class MapPutPartitionAwareRunnable<P> implements Runnable, DataSerializab
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/executor/tasks/MapPutRunnable.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/tasks/MapPutRunnable.java
@@ -51,12 +51,12 @@ public class MapPutRunnable implements Runnable, DataSerializable, HazelcastInst
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
@@ -97,7 +97,7 @@ public class ClientMapProjectSerializationTest extends HazelcastTestSupport {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(value);
+            out.writeString(value);
         }
 
         @Override
@@ -105,7 +105,7 @@ public class ClientMapProjectSerializationTest extends HazelcastTestSupport {
             if (readCalled.incrementAndGet() > 2) {
                 throw new AssertionError("Read called more than twice!!!");
             }
-            value = in.readUTF();
+            value = in.readString();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/ClientBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/ClientBitmapIndexTest.java
@@ -303,14 +303,14 @@ public class ClientBitmapIndexTest extends HazelcastTestSupport {
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeLong(id);
-            out.writeUTF(stringId);
+            out.writeString(stringId);
             out.writeObject(age);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             id = in.readLong();
-            stringId = in.readUTF();
+            stringId = in.readString();
             age = in.readObject();
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/test/DistortInvalidationMetadataEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/DistortInvalidationMetadataEntryProcessor.java
@@ -179,14 +179,14 @@ public class DistortInvalidationMetadataEntryProcessor
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeInt(mapSize);
         out.writeInt(duration);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         mapSize = in.readInt();
         duration = in.readInt();
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/Employee.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/Employee.java
@@ -72,7 +72,7 @@ public class Employee implements Portable {
     }
 
     public void writePortable(PortableWriter writer) throws IOException {
-        writer.writeUTF("n", name);
+        writer.writeString("n", name);
         writer.writeInt("a", age);
 
         writer.writeByte("b", by);
@@ -83,8 +83,8 @@ public class Employee implements Portable {
         writer.writeLong("l", l);
         writer.writeFloat("f", f);
         writer.writeDouble("d", d);
-        writer.writeUTF("str", str);
-        writer.writeUTF("utfstr", utfStr);
+        writer.writeString("str", str);
+        writer.writeString("utfstr", utfStr);
 
         writer.writeByteArray("bb", byteArray);
         writer.writeCharArray("cc", charArray);
@@ -107,7 +107,7 @@ public class Employee implements Portable {
     }
 
     public void readPortable(PortableReader reader) throws IOException {
-        name = reader.readUTF("n");
+        name = reader.readString("n");
         age = reader.readInt("a");
 
         by = reader.readByte("b");
@@ -118,8 +118,8 @@ public class Employee implements Portable {
         l = reader.readLong("l");
         f = reader.readFloat("f");
         d = reader.readDouble("d");
-        str = reader.readUTF("str");
-        utfStr = reader.readUTF("utfstr");
+        str = reader.readString("str");
+        utfStr = reader.readString("utfstr");
 
         byteArray = reader.readByteArray("bb");
         charArray = reader.readCharArray("cc");

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
@@ -88,11 +88,11 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         }
 
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("n", name);
+            writer.writeString("n", name);
         }
 
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("n");
+            name = reader.readString("n");
         }
     }
 
@@ -116,11 +116,11 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         }
 
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(param);
+            out.writeString(param);
         }
 
         public void readData(ObjectDataInput in) throws IOException {
-            param = in.readUTF();
+            param = in.readString();
         }
     }
 
@@ -437,13 +437,13 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         @Override
         public void writeData(ObjectDataOutput out)
                 throws IOException {
-            out.writeUTF(prefix);
+            out.writeString(prefix);
         }
 
         @Override
         public void readData(ObjectDataInput in)
                 throws IOException {
-            prefix = in.readUTF();
+            prefix = in.readString();
         }
     }
 
@@ -524,12 +524,12 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(startSignalLatchName);
+            out.writeString(startSignalLatchName);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            startSignalLatchName = in.readUTF();
+            startSignalLatchName = in.readString();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedEntryProcessor.java
@@ -49,12 +49,12 @@ public class IdentifiedEntryProcessor implements EntryProcessor<String, String, 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(value);
+        out.writeString(value);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        value = in.readUTF();
+        value = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/test/PersonSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/PersonSerializer.java
@@ -31,7 +31,7 @@ public class PersonSerializer implements StreamSerializer<Person> {
     public void write(ObjectDataOutput out, Person object)
             throws IOException {
         out.writeInt(999);
-        out.writeUTF(object.getName());
+        out.writeString(object.getName());
         out.writeInt(999);
     }
 
@@ -42,7 +42,7 @@ public class PersonSerializer implements StreamSerializer<Person> {
             throw new IOException(" wrong value is read expected 999 ");
         }
         final Person person = new Person();
-        person.setName(in.readUTF());
+        person.setName(in.readString());
         if (in.readInt() != 999) {
             throw new IOException(" wrong value is read expected 999 ");
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/PortableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/PortableFactory.java
@@ -52,11 +52,11 @@ public class PortableFactory implements com.hazelcast.nio.serialization.Portable
         }
 
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("n", name);
+            writer.writeString("n", name);
         }
 
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("n");
+            name = reader.readString("n");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/test/PrefixFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/PrefixFilter.java
@@ -45,11 +45,11 @@ public class PrefixFilter implements IdentifiedDataSerializable, IFunction<Strin
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(prefix);
+        out.writeString(prefix);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        prefix = in.readUTF();
+        prefix = in.readString();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/executor/tasks/AppendCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/executor/tasks/AppendCallable.java
@@ -51,13 +51,13 @@ public class AppendCallable
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(msg);
+        out.writeString(msg);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        msg = in.readUTF();
+        msg = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/test/executor/tasks/MapPutPartitionAwareCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/executor/tasks/MapPutPartitionAwareCallable.java
@@ -68,14 +68,14 @@ public class MapPutPartitionAwareCallable<T, P>
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(mapName);
+        out.writeString(mapName);
         out.writeObject(partitionKey);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        mapName = in.readUTF();
+        mapName = in.readString();
         partitionKey = in.readObject();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ifunction/AppendString.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ifunction/AppendString.java
@@ -45,11 +45,11 @@ public class AppendString implements IFunction<String, String>, IdentifiedDataSe
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(suffix);
+        out.writeString(suffix);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        suffix = in.readUTF();
+        suffix = in.readString();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ringbuffer/filter/StartsWithStringFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ringbuffer/filter/StartsWithStringFilter.java
@@ -58,12 +58,12 @@ public class StartsWithStringFilter implements IFunction<String, Boolean>, Ident
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        out.writeUTF(startString);
+        out.writeString(startString);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        startString = in.readUTF();
+        startString = in.readString();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/TestRaftGroupId.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/TestRaftGroupId.java
@@ -70,11 +70,11 @@ public class TestRaftGroupId implements CPGroupId, DataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/genericrecord/AbstractGenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/genericrecord/AbstractGenericRecordTest.java
@@ -245,11 +245,11 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         createCluster();
         ClassDefinition namedPortableClassDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
 
         ClassDefinition inConsistentNamedPortableClassDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("WrongName").addIntField("myint").build();
+                        .addStringField("WrongName").addIntField("myint").build();
 
 
         GenericRecord namedRecord = GenericRecordBuilder.portable(namedPortableClassDefinition)
@@ -293,7 +293,7 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
         InnerPortable inner = expectedPortable.p;
         ClassDefinition namedPortableClassDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
         ClassDefinition innerPortableClassDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.INNER_PORTABLE)
                         .addByteArrayField("b")
@@ -320,7 +320,7 @@ public abstract class AbstractGenericRecordTest extends HazelcastTestSupport {
                         .addLongField("l")
                         .addFloatField("f")
                         .addDoubleField("d")
-                        .addUTFField("str")
+                        .addStringField("str")
                         .addPortableField("p", innerPortableClassDefinition)
                         .addDecimalField("bigDecimal")
                         .addTimeField("localTime")

--- a/hazelcast/src/test/java/com/hazelcast/genericrecord/GenericRecordBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/genericrecord/GenericRecordBuilderTest.java
@@ -48,7 +48,7 @@ public class GenericRecordBuilderTest {
     public void testWritingSameFieldMultipleTimes() {
         ClassDefinition namedPortableClassDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
 
 
         GenericRecordBuilder builder = GenericRecordBuilder.portable(namedPortableClassDefinition);
@@ -61,7 +61,7 @@ public class GenericRecordBuilderTest {
     public void testOverwritingSameFieldMultipleTimes() {
         ClassDefinition namedPortableClassDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
 
 
         GenericRecord record = GenericRecordBuilder.portable(namedPortableClassDefinition)
@@ -76,7 +76,7 @@ public class GenericRecordBuilderTest {
     public void testWritingToNonExistingField() {
         ClassDefinition classDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
 
         GenericRecordBuilder builder = GenericRecordBuilder.portable(classDefinition);
         assertThrows(HazelcastSerializationException.class, () -> builder.setString("nonExistingField", "foo3"));
@@ -86,7 +86,7 @@ public class GenericRecordBuilderTest {
     public void testWritingToFieldWithWrongType() {
         ClassDefinition classDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
 
         GenericRecordBuilder builder = GenericRecordBuilder.portable(classDefinition);
         assertThrows(HazelcastSerializationException.class, () -> builder.setInt("name", 1));
@@ -96,7 +96,7 @@ public class GenericRecordBuilderTest {
     public void testUnwrittenFieldsThrowException() {
         ClassDefinition classDefinition =
                 new ClassDefinitionBuilder(TestSerializationConstants.PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                        .addUTFField("name").addIntField("myint").build();
+                        .addStringField("name").addIntField("myint").build();
 
         GenericRecordBuilder builder = GenericRecordBuilder.portable(classDefinition);
         builder.setInt("myint", 1);
@@ -107,7 +107,7 @@ public class GenericRecordBuilderTest {
     public void testWriteReadGenericRecordToObjectDataInput() throws IOException {
         ClassDefinitionBuilder classDefinitionBuilder = new ClassDefinitionBuilder(1, 1);
         classDefinitionBuilder.addIntField("age");
-        classDefinitionBuilder.addUTFField("name");
+        classDefinitionBuilder.addStringField("name");
         ClassDefinition classDefinition = classDefinitionBuilder.build();
 
         InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestAbstractFragmentOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestAbstractFragmentOperation.java
@@ -36,12 +36,12 @@ abstract class TestAbstractFragmentOperation extends Operation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestServiceNamespace.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestServiceNamespace.java
@@ -45,12 +45,12 @@ public class TestServiceNamespace implements ObjectNamespace {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractDataStreamIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractDataStreamIntegrationTest.java
@@ -269,12 +269,12 @@ public abstract class AbstractDataStreamIntegrationTest<O extends ObjectDataOutp
     public void testUTF() throws IOException {
         String s1 = "Vim is a text editor that is upwards compatible to Vi. It can be used to edit all kinds of plain text.";
         String s2 = "簡単なものから複雑なものまで、具体的な例を使って説明しています。本のように最初から順を追って読んでください。";
-        out.writeUTF(s1);
-        out.writeUTF(s2);
+        out.writeString(s1);
+        out.writeString(s2);
 
         ObjectDataInput in = getDataInputFromOutput();
-        assertEquals(s1, in.readUTF());
-        assertEquals(s2, in.readUTF());
+        assertEquals(s1, in.readString());
+        assertEquals(s2, in.readString());
     }
 
     @Test
@@ -285,7 +285,7 @@ public abstract class AbstractDataStreamIntegrationTest<O extends ObjectDataOutp
         out.writeUTFArray(arr);
 
         ObjectDataInput in = getDataInputFromOutput();
-        assertArrayEquals(arr, in.readUTFArray());
+        assertArrayEquals(arr, in.readStringArray());
     }
 
     protected abstract byte[] getWrittenBytes();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -332,13 +332,13 @@ public class AbstractSerializationServiceTest {
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(intField);
-            out.writeUTF(stringField);
+            out.writeString(stringField);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             intField = in.readInt();
-            stringField = in.readUTF();
+            stringField = in.readString();
         }
 
         @Override
@@ -438,7 +438,7 @@ public class AbstractSerializationServiceTest {
             if (fail) {
                 throw new RuntimeException();
             } else {
-                out.writeUTF(stringBuffer.toString());
+                out.writeString(stringBuffer.toString());
             }
         }
 
@@ -447,7 +447,7 @@ public class AbstractSerializationServiceTest {
             if (fail) {
                 throw new RuntimeException();
             } else {
-                return new StringBuffer(in.readUTF());
+                return new StringBuffer(in.readString());
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
@@ -563,11 +563,11 @@ public class ByteArrayObjectDataInputTest extends HazelcastTestSupport {
         in.init((byteOrder == BIG_ENDIAN ? bytesBE : bytesLE), 0);
 
         in.position(bytesLE.length - 4);
-        String[] theNullArray = in.readUTFArray();
+        String[] theNullArray = in.readStringArray();
         in.position(0);
-        String[] theZeroLenghtArray = in.readUTFArray();
+        String[] theZeroLenghtArray = in.readStringArray();
         in.position(4);
-        String[] bytes = in.readUTFArray();
+        String[] bytes = in.readStringArray();
 
         assertNull(theNullArray);
         assertArrayEquals(new String[0], theZeroLenghtArray);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/CustomSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/CustomSerializationTest.java
@@ -162,12 +162,12 @@ public class CustomSerializationTest {
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             serializationCount.incrementAndGet();
-            out.writeUTF(foo);
+            out.writeString(foo);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            foo = in.readUTF();
+            foo = in.readString();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -155,12 +155,12 @@ public class DataSerializableSerializationTest extends HazelcastTestSupport {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(name);
+            out.writeString(name);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            name = in.readUTF();
+            name = in.readString();
         }
     }
 
@@ -177,12 +177,12 @@ public class DataSerializableSerializationTest extends HazelcastTestSupport {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(name);
+            out.writeString(name);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            name = in.readUTF();
+            name = in.readString();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -293,11 +293,11 @@ public class ObjectDataInputStreamFinalMethodsTest {
         inputStream.init((byteOrder == BIG_ENDIAN ? bytesBE : bytesLE), 0);
 
         inputStream.position(bytesLE.length - 4);
-        String[] theNullArray = in.readUTFArray();
+        String[] theNullArray = in.readStringArray();
         inputStream.position(0);
-        String[] theZeroLenghtArray = in.readUTFArray();
+        String[] theZeroLenghtArray = in.readStringArray();
         inputStream.position(4);
-        String[] bytes = in.readUTFArray();
+        String[] bytes = in.readStringArray();
 
         assertNull(theNullArray);
         assertArrayEquals(new String[0], theZeroLenghtArray);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationConcurrencyTest.java
@@ -140,13 +140,13 @@ public class SerializationConcurrencyTest {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(street);
+            out.writeString(street);
             out.writeInt(no);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            street = in.readUTF();
+            street = in.readString();
             no = in.readInt();
         }
 
@@ -208,7 +208,7 @@ public class SerializationConcurrencyTest {
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(name);
+            out.writeString(name);
             out.writeObject(address);
             out.writeInt(age);
             out.writeLong(height);
@@ -217,7 +217,7 @@ public class SerializationConcurrencyTest {
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
-            name = in.readUTF();
+            name = in.readString();
             address = in.readObject();
             age = in.readInt();
             height = in.readLong();
@@ -308,12 +308,12 @@ public class SerializationConcurrencyTest {
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
             writer.writeInt("no", no);
-            writer.writeUTF("street", street);
+            writer.writeString("street", street);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            street = reader.readUTF("street");
+            street = reader.readString("street");
             no = reader.readInt("no");
         }
 
@@ -436,13 +436,13 @@ public class SerializationConcurrencyTest {
         public void writePortable(PortableWriter writer) throws IOException {
             writer.writeLong("height", height);
             writer.writeInt("age", age);
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortable("address", address);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             address = reader.readPortable("address");
             height = reader.readLong("height");
             age = reader.readInt("age");

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationIssueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationIssueTest.java
@@ -97,7 +97,7 @@ public class SerializationIssueTest extends HazelcastTestSupport {
                             javaSerializer.write(out, v);
                         } else if (v instanceof DummyValue) {
                             out.writeBoolean(false);
-                            out.writeUTF(((DummyValue) v).s);
+                            out.writeString(((DummyValue) v).s);
                             out.writeInt(((DummyValue) v).k);
                         }
                     }
@@ -109,7 +109,7 @@ public class SerializationIssueTest extends HazelcastTestSupport {
                         if (java) {
                             return javaSerializer.read(in);
                         }
-                        return new DummyValue(in.readUTF(), in.readInt());
+                        return new DummyValue(in.readString(), in.readInt());
                     }
 
                     public int getTypeId() {
@@ -147,14 +147,14 @@ public class SerializationIssueTest extends HazelcastTestSupport {
                     @Override
                     public void write(ObjectDataOutput out, Object v) throws IOException {
                         writeCounter.incrementAndGet();
-                        out.writeUTF(((DummyValue) v).s);
+                        out.writeString(((DummyValue) v).s);
                         out.writeInt(((DummyValue) v).k);
                     }
 
                     @Override
                     public Object read(ObjectDataInput in) throws IOException {
                         readCounter.incrementAndGet();
-                        return new DummyValue(in.readUTF(), in.readInt());
+                        return new DummyValue(in.readString(), in.readInt());
                     }
 
                     public int getTypeId() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationV1DataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationV1DataSerializable.java
@@ -102,7 +102,7 @@ public class SerializationV1DataSerializable implements DataSerializable {
         out.writeLongArray(longs);
         out.writeFloatArray(floats);
         out.writeDoubleArray(doubles);
-        out.writeUTF(string);
+        out.writeString(string);
         out.writeUTFArray(strings);
 
         this.version = out.getVersion();
@@ -126,8 +126,8 @@ public class SerializationV1DataSerializable implements DataSerializable {
         this.longs = in.readLongArray();
         this.floats = in.readFloatArray();
         this.doubles = in.readDoubleArray();
-        this.string = in.readUTF();
-        this.strings = in.readUTFArray();
+        this.string = in.readString();
+        this.strings = in.readStringArray();
 
         this.version = in.getVersion();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/StringSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/StringSerializationTest.java
@@ -133,14 +133,14 @@ public class StringSerializationTest {
     @Test
     public void testNullStringEncodeDecode2() throws Exception {
         BufferObjectDataOutput objectDataOutput = serializationService.createObjectDataOutput();
-        objectDataOutput.writeUTF(null);
+        objectDataOutput.writeString(null);
 
         byte[] bytes = objectDataOutput.toByteArray();
         objectDataOutput.close();
 
         BufferObjectDataInput objectDataInput = serializationService.createObjectDataInput(bytes);
 
-        String decodedStr = objectDataInput.readUTF();
+        String decodedStr = objectDataInput.readString();
         assertNull(decodedStr);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ClassAndFieldDefinitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ClassAndFieldDefinitionTest.java
@@ -200,12 +200,12 @@ public class ClassAndFieldDefinitionTest {
     @Test(expected = HazelcastSerializationException.class)
     public void testClassDefinitionBuilder_addingSameFieldTwice() {
         new ClassDefinitionBuilder(1, 2, 1)
-                .addUTFField("name").addUTFField("name");
+                .addStringField("name").addStringField("name");
     }
 
     @Test(expected = HazelcastSerializationException.class)
     public void testClassDefinitionBuilder_addingSameFieldTwice_withDifferentType() {
         new ClassDefinitionBuilder(1, 2, 1)
-                .addUTFField("name").addIntField("name");
+                .addStringField("name").addIntField("name");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ExplicitClassDefinitionRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/ExplicitClassDefinitionRegistrationTest.java
@@ -66,12 +66,12 @@ public class ExplicitClassDefinitionRegistrationTest {
 
         @Override
         public void writePortable(final PortableWriter writer) throws IOException {
-            writer.writeUTF("stringField", stringField);
+            writer.writeString("stringField", stringField);
         }
 
         @Override
         public void readPortable(final PortableReader reader) throws IOException {
-            stringField = reader.readUTF("stringField");
+            stringField = reader.readString("stringField");
         }
 
         @Override
@@ -183,7 +183,7 @@ public class ExplicitClassDefinitionRegistrationTest {
                 .addPortableFactory(MyPortableFactory1.ID, new MyPortableFactory1())
                 .addPortableFactory(MyPortableFactory2.ID, new MyPortableFactory2())
                 .addClassDefinition(new ClassDefinitionBuilder(MyPortableFactory1.ID, MyPortable1.ID)
-                        .addUTFField("stringField")
+                        .addStringField("stringField")
                         .build())
                 .addClassDefinition(new ClassDefinitionBuilder(MyPortableFactory2.ID, MyPortable2.ID)
                         .addIntField("intField")

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/InvalidRawDataPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/InvalidRawDataPortable.java
@@ -41,7 +41,7 @@ class InvalidRawDataPortable extends RawDataPortable {
         writer.writeLong("l", l);
         final ObjectDataOutput output = writer.getRawDataOutput();
         output.writeInt(k);
-        output.writeUTF(s);
+        output.writeString(s);
         writer.writeCharArray("c", c);
         output.writeObject(sds);
         writer.writePortable("p", p);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/InvalidRawDataPortable2.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/InvalidRawDataPortable2.java
@@ -42,7 +42,7 @@ class InvalidRawDataPortable2 extends RawDataPortable {
         final ObjectDataInput input = reader.getRawDataInput();
         k = input.readInt();
         l = reader.readLong("l");
-        s = input.readUTF();
+        s = input.readString();
         p = reader.readPortable("p");
         sds = input.readObject();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MainPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MainPortable.java
@@ -85,7 +85,7 @@ public class MainPortable implements Portable {
         writer.writeLong("l", l);
         writer.writeFloat("f", f);
         writer.writeDouble("d", d);
-        writer.writeUTF("str", str);
+        writer.writeString("str", str);
         if (p != null) {
             writer.writePortable("p", p);
         } else {
@@ -109,7 +109,7 @@ public class MainPortable implements Portable {
         l = reader.readLong("l");
         f = reader.readFloat("f");
         d = reader.readDouble("d");
-        str = reader.readUTF("str");
+        str = reader.readString("str");
         p = reader.readPortable("p");
         bigDecimal = reader.readDecimal("bigDecimal");
         localTime = reader.readTime("localTime");

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MorphingBasePortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MorphingBasePortable.java
@@ -74,7 +74,7 @@ public class MorphingBasePortable implements Portable {
         writer.writeLong("long", aLong);
         writer.writeFloat("float", aFloat);
         writer.writeDouble("double", aDouble);
-        writer.writeUTF("string", aString);
+        writer.writeString("string", aString);
     }
 
     @Override
@@ -87,6 +87,6 @@ public class MorphingBasePortable implements Portable {
         this.aLong = reader.readLong("long");
         this.aFloat = reader.readFloat("float");
         this.aDouble = reader.readDouble("double");
-        this.aString = reader.readUTF("string");
+        this.aString = reader.readString("string");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/MorphingPortableReaderTest.java
@@ -114,10 +114,10 @@ public class MorphingPortableReaderTest {
 
     @Test
     public void testReadUTF() throws Exception {
-        String aString = reader.readUTF("string");
+        String aString = reader.readString("string");
 
         assertEquals("test", aString);
-        assertNull(reader.readUTF("NO SUCH FIELD"));
+        assertNull(reader.readString("NO SUCH FIELD"));
     }
 
     @Test
@@ -203,7 +203,7 @@ public class MorphingPortableReaderTest {
 
     @Test(expected = IncompatibleClassChangeError.class)
     public void testReadUTF_IncompatibleClass() throws Exception {
-        reader.readUTF("byte");
+        reader.readString("byte");
     }
 
     @Test(expected = IncompatibleClassChangeError.class)
@@ -273,7 +273,7 @@ public class MorphingPortableReaderTest {
 
     @Test
     public void testReadUTFArray() throws Exception {
-        assertNull(reader.readUTFArray("NO SUCH FIELD"));
+        assertNull(reader.readStringArray("NO SUCH FIELD"));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/NamedPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/NamedPortable.java
@@ -43,14 +43,14 @@ public class NamedPortable implements Portable {
 
     @Override
     public void writePortable(PortableWriter writer) throws IOException {
-        writer.writeUTF("name", name);
+        writer.writeString("name", name);
         writer.writeInt("myint", myint);
     }
 
     @Override
     public void readPortable(PortableReader reader) throws IOException {
         myint = reader.readInt("myint");
-        name = reader.readUTF("name");
+        name = reader.readString("name");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableTest.java
@@ -135,7 +135,7 @@ public class PortableTest {
     static ClassDefinition createNamedPortableClassDefinition(int portableVersion) {
         ClassDefinitionBuilder builder
                 = new ClassDefinitionBuilder(PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE, portableVersion);
-        builder.addUTFField("name");
+        builder.addStringField("name");
         builder.addIntField("myint");
         return builder.build();
     }
@@ -231,7 +231,7 @@ public class PortableTest {
                                 .addLongField("l").addCharArrayField("c").addPortableField("p", createNamedPortableClassDefinition(portableVersion)).build())
                 .addClassDefinition(
                         new ClassDefinitionBuilder(PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE, portableVersion)
-                                .addUTFField("name").addIntField("myint").build());
+                                .addStringField("name").addIntField("myint").build());
 
         SerializationService serializationService
                 = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
@@ -580,7 +580,7 @@ public class PortableTest {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("shortString", shortString);
+            writer.writeString("shortString", shortString);
         }
 
         @Override
@@ -819,14 +819,14 @@ public class PortableTest {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("s1", s1);
-            writer.writeUTF("s2", s2);
+            writer.writeString("s1", s1);
+            writer.writeString("s2", s2);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            s1 = reader.readUTF("s1");
-            s2 = reader.readUTF("s2");
+            s1 = reader.readString("s1");
+            s2 = reader.readString("s2");
         }
     }
 
@@ -854,12 +854,12 @@ public class PortableTest {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("s", s);
+            writer.writeString("s", s);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            s = reader.readUTF("s");
+            s = reader.readString("s");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/PortableVersionTest.java
@@ -106,12 +106,12 @@ public class PortableVersionTest {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/RawDataPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/RawDataPortable.java
@@ -59,7 +59,7 @@ class RawDataPortable implements Portable {
         writer.writePortable("p", p);
         final ObjectDataOutput output = writer.getRawDataOutput();
         output.writeInt(k);
-        output.writeUTF(s);
+        output.writeString(s);
         output.writeObject(sds);
     }
 
@@ -70,7 +70,7 @@ class RawDataPortable implements Portable {
         p = reader.readPortable("p");
         final ObjectDataInput input = reader.getRawDataInput();
         k = input.readInt();
-        s = input.readUTF();
+        s = input.readString();
         sds = input.readObject();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/SerializationV1Portable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/SerializationV1Portable.java
@@ -106,7 +106,7 @@ public class SerializationV1Portable implements Portable {
         out.writeLong("6", aLong);
         out.writeFloat("7", aFloat);
         out.writeDouble("8", aDouble);
-        out.writeUTF("9", string);
+        out.writeString("9", string);
 
         out.writeByteArray("a1", bytes);
         out.writeBooleanArray("a2", booleans);
@@ -116,7 +116,7 @@ public class SerializationV1Portable implements Portable {
         out.writeLongArray("a6", longs);
         out.writeFloatArray("a7", floats);
         out.writeDoubleArray("a8", doubles);
-        out.writeUTFArray("a9", strings);
+        out.writeStringArray("a9", strings);
 
         if (innerPortable == null) {
             out.writeNullPortable("p", INNER_PORTABLE.getFactoryId(), INNER_PORTABLE.getClassId());
@@ -144,7 +144,7 @@ public class SerializationV1Portable implements Portable {
         this.aLong = in.readLong("6");
         this.aFloat = in.readFloat("7");
         this.aDouble = in.readDouble("8");
-        this.string = in.readUTF("9");
+        this.string = in.readString("9");
 
         this.bytes = in.readByteArray("a1");
         this.booleans = in.readBooleanArray("a2");
@@ -154,7 +154,7 @@ public class SerializationV1Portable implements Portable {
         this.longs = in.readLongArray("a6");
         this.floats = in.readFloatArray("a7");
         this.doubles = in.readDoubleArray("a8");
-        this.strings = in.readUTFArray("a9");
+        this.strings = in.readStringArray("a9");
 
         this.innerPortable = in.readPortable("p");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/portablereader/DefaultPortableReaderQuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/portablereader/DefaultPortableReaderQuickTest.java
@@ -402,19 +402,19 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
             writer.writeInt("power", power);
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortable("engine", engine);
             writer.writePortableArray("wheels", wheels);
-            writer.writeUTFArray("model", model);
+            writer.writeStringArray("model", model);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
             power = reader.readInt("power");
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             engine = reader.readPortable("engine");
             wheels = reader.readPortableArray("wheels");
-            model = reader.readUTFArray("model");
+            model = reader.readStringArray("model");
         }
 
         @Override
@@ -604,7 +604,7 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortable("chip", chip);
             writer.writePortableArray("chips", chips);
             writer.writePortableArray("emptyChips", emptyChips);
@@ -614,7 +614,7 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             chip = reader.readPortable("chip");
             chips = reader.readPortableArray("chips");
             emptyChips = reader.readPortableArray("emptyChips");

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/portablereader/DefaultPortableReaderTestStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/portablereader/DefaultPortableReaderTestStructure.java
@@ -220,7 +220,7 @@ public class DefaultPortableReaderTestStructure {
             writer.writeDouble("double_", double_);
             writer.writeBoolean("boolean_", boolean_);
             writer.writeChar("char_", char_);
-            writer.writeUTF("string_", string_);
+            writer.writeString("string_", string_);
             writer.writeDecimal("bigDecimal_", bigDecimal_);
             writer.writeTime("localTime_", localTime_);
             writer.writeDate("localDate_", localDate_);
@@ -235,7 +235,7 @@ public class DefaultPortableReaderTestStructure {
             writer.writeDoubleArray("doubles", doubles);
             writer.writeBooleanArray("booleans", booleans);
             writer.writeCharArray("chars", chars);
-            writer.writeUTFArray("strings", strings);
+            writer.writeStringArray("strings", strings);
             writer.writeDecimalArray("bigDecimals", bigDecimals);
             writer.writeTimeArray("localTimes", localTimes);
             writer.writeDateArray("localDates", localDates);
@@ -253,7 +253,7 @@ public class DefaultPortableReaderTestStructure {
             double_ = reader.readDouble("double_");
             boolean_ = reader.readBoolean("boolean_");
             char_ = reader.readChar("char_");
-            string_ = reader.readUTF("string_");
+            string_ = reader.readString("string_");
             bigDecimal_ = reader.readDecimal("bigDecimal_");
             localTime_ = reader.readTime("localTime_");
             localDate_ = reader.readDate("localDate_");
@@ -268,7 +268,7 @@ public class DefaultPortableReaderTestStructure {
             doubles = reader.readDoubleArray("doubles");
             booleans = reader.readBooleanArray("booleans");
             chars = reader.readCharArray("chars");
-            strings = reader.readUTFArray("strings");
+            strings = reader.readStringArray("strings");
             bigDecimals = reader.readDecimalArray("bigDecimals");
             localTimes = reader.readTimeArray("localTimes");
             localDates = reader.readDateArray("localDates");

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
@@ -165,14 +165,14 @@ public class MapPredicateJsonMixedTypeTest extends HazelcastTestSupport {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", this.name);
+            writer.writeString("name", this.name);
             writer.writeInt("age", this.age);
             writer.writeBoolean("onDuty", this.onDuty);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            this.name = reader.readUTF("name");
+            this.name = reader.readString("name");
             this.age = reader.readInt("age");
             this.onDuty = reader.readBoolean("onDuty");
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MultiValueBitmapIndexTest.java
@@ -280,14 +280,14 @@ public class MultiValueBitmapIndexTest extends HazelcastTestSupport {
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeLong(id);
-            out.writeUTF(stringId);
+            out.writeString(stringId);
             out.writeLongArray(habits);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             id = in.readLong();
-            stringId = in.readUTF();
+            stringId = in.readString();
             habits = in.readLongArray();
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
@@ -356,14 +356,14 @@ public class SingleValueBitmapIndexTest extends HazelcastTestSupport {
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeLong(id);
-            out.writeUTF(stringId);
+            out.writeString(stringId);
             out.writeObject(age);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             id = in.readLong();
-            stringId = in.readUTF();
+            stringId = in.readString();
             age = in.readObject();
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortable.java
@@ -147,7 +147,7 @@ public class APortable implements Portable {
         writer.writeFloat("f", f);
         writer.writeInt("i", i);
         writer.writeLong("l", l);
-        writer.writeUTF("str", str);
+        writer.writeString("str", str);
         if (p != null) {
             writer.writePortable("p", p);
         } else {
@@ -161,7 +161,7 @@ public class APortable implements Portable {
         writer.writeFloatArray("fs", floats);
         writer.writeIntArray("is", ints);
         writer.writeLongArray("ls", longs);
-        writer.writeUTFArray("strs", strings);
+        writer.writeStringArray("strs", strings);
         writer.writePortableArray("ps", portables);
 
         writer.writeBooleanArray("booleansNull", booleansNull);
@@ -172,7 +172,7 @@ public class APortable implements Portable {
         writer.writeFloatArray("fsNull", floatsNull);
         writer.writeIntArray("isNull", intsNull);
         writer.writeLongArray("lsNull", longsNull);
-        writer.writeUTFArray("strsNull", stringsNull);
+        writer.writeStringArray("strsNull", stringsNull);
 
         ObjectDataOutput dataOutput = writer.getRawDataOutput();
 
@@ -184,7 +184,7 @@ public class APortable implements Portable {
         dataOutput.writeFloat(f);
         dataOutput.writeInt(i);
         dataOutput.writeLong(l);
-        dataOutput.writeUTF(str);
+        dataOutput.writeString(str);
 
         dataOutput.writeBooleanArray(booleans);
         dataOutput.writeByteArray(bytes);
@@ -233,7 +233,7 @@ public class APortable implements Portable {
         f = reader.readFloat("f");
         i = reader.readInt("i");
         l = reader.readLong("l");
-        str = reader.readUTF("str");
+        str = reader.readString("str");
         p = reader.readPortable("p");
 
         booleans = reader.readBooleanArray("booleans");
@@ -244,7 +244,7 @@ public class APortable implements Portable {
         floats = reader.readFloatArray("fs");
         ints = reader.readIntArray("is");
         longs = reader.readLongArray("ls");
-        strings = reader.readUTFArray("strs");
+        strings = reader.readStringArray("strs");
         portables = reader.readPortableArray("ps");
 
         booleansNull = reader.readBooleanArray("booleansNull");
@@ -255,7 +255,7 @@ public class APortable implements Portable {
         floatsNull = reader.readFloatArray("fsNull");
         intsNull = reader.readIntArray("isNull");
         longsNull = reader.readLongArray("lsNull");
-        stringsNull = reader.readUTFArray("strsNull");
+        stringsNull = reader.readStringArray("strsNull");
 
         ObjectDataInput dataInput = reader.getRawDataInput();
 
@@ -267,7 +267,7 @@ public class APortable implements Portable {
         f = dataInput.readFloat();
         i = dataInput.readInt();
         l = dataInput.readLong();
-        str = dataInput.readUTF();
+        str = dataInput.readString();
 
         booleans = dataInput.readBooleanArray();
         bytes = dataInput.readByteArray();
@@ -277,7 +277,7 @@ public class APortable implements Portable {
         floats = dataInput.readFloatArray();
         ints = dataInput.readIntArray();
         longs = dataInput.readLongArray();
-        strings = dataInput.readUTFArray();
+        strings = dataInput.readStringArray();
 
         booleansNull = dataInput.readBooleanArray();
         bytesNull = dataInput.readByteArray();
@@ -287,7 +287,7 @@ public class APortable implements Portable {
         floatsNull = dataInput.readFloatArray();
         intsNull = dataInput.readIntArray();
         longsNull = dataInput.readLongArray();
-        stringsNull = dataInput.readUTFArray();
+        stringsNull = dataInput.readStringArray();
 
         byteSize = dataInput.readByte();
         bytesFully = new byte[byteSize];

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnIdentifiedDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnIdentifiedDataSerializable.java
@@ -144,7 +144,7 @@ public class AnIdentifiedDataSerializable implements IdentifiedDataSerializable 
         dataOutput.writeFloat(f);
         dataOutput.writeInt(i);
         dataOutput.writeLong(l);
-        dataOutput.writeUTF(str);
+        dataOutput.writeString(str);
 
         dataOutput.writeBooleanArray(booleans);
         dataOutput.writeByteArray(bytes);
@@ -194,7 +194,7 @@ public class AnIdentifiedDataSerializable implements IdentifiedDataSerializable 
         f = dataInput.readFloat();
         i = dataInput.readInt();
         l = dataInput.readLong();
-        str = dataInput.readUTF();
+        str = dataInput.readString();
 
         booleans = dataInput.readBooleanArray();
         bytes = dataInput.readByteArray();
@@ -204,7 +204,7 @@ public class AnIdentifiedDataSerializable implements IdentifiedDataSerializable 
         floats = dataInput.readFloatArray();
         ints = dataInput.readIntArray();
         longs = dataInput.readLongArray();
-        strings = dataInput.readUTFArray();
+        strings = dataInput.readStringArray();
 
         booleansNull = dataInput.readBooleanArray();
         bytesNull = dataInput.readByteArray();
@@ -214,7 +214,7 @@ public class AnIdentifiedDataSerializable implements IdentifiedDataSerializable 
         floatsNull = dataInput.readFloatArray();
         intsNull = dataInput.readIntArray();
         longsNull = dataInput.readLongArray();
-        stringsNull = dataInput.readUTFArray();
+        stringsNull = dataInput.readStringArray();
 
         byteSize = dataInput.readByte();
         bytesFully = new byte[byteSize];

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -250,13 +250,13 @@ public class MapProjectionTest extends HazelcastTestSupport {
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeDouble(age);
-            out.writeUTF(state);
+            out.writeString(state);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             age = in.readDouble();
-            state = in.readUTF();
+            state = in.readString();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
@@ -117,7 +117,7 @@ public class PortablePredicatesTest {
                 FieldType fieldType = reader.getFieldType(fieldName);
                 switch (fieldType) {
                     case UTF:
-                        data.put(fieldName, reader.readUTF(fieldName));
+                        data.put(fieldName, reader.readString(fieldName));
                         break;
                     case LONG:
                         data.put(fieldName, reader.readLong(fieldName));
@@ -136,7 +136,7 @@ public class PortablePredicatesTest {
             for (String key : data.keySet()) {
                 Object object = data.get(key);
                 if (object instanceof String) {
-                    writer.writeUTF(key, (String) object);
+                    writer.writeString(key, (String) object);
                 } else if (object instanceof Long) {
                     writer.writeLong(key, (Long) object);
                 } else if (object instanceof Date) {

--- a/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
@@ -56,13 +56,13 @@ public final class SampleTestObjects {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("n", name);
+            writer.writeString("n", name);
             writer.writeInt("a", age);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("n");
+            name = reader.readString("n");
             age = reader.readInt("a");
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -126,11 +126,11 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
         }
 
         public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeUTF(this.id);
+            out.writeString(this.id);
         }
 
         public void readData(ObjectDataInput in) throws IOException {
-            this.id = in.readUTF();
+            this.id = in.readString();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -336,7 +336,7 @@ public class IndexTest {
             writer.writeLong("l", l);
             writer.writeFloat("f", f);
             writer.writeDouble("d", d);
-            writer.writeUTF("str", str);
+            writer.writeString("str", str);
         }
 
         public void readPortable(PortableReader reader) throws IOException {
@@ -348,7 +348,7 @@ public class IndexTest {
             l = reader.readLong("l");
             f = reader.readFloat("f");
             d = reader.readDouble("d");
-            str = reader.readUTF("str");
+            str = reader.readString("str");
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
@@ -112,7 +112,7 @@ public class ComplexTestDataStructure {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortableArray("limbs_portable", limbs_portable);
             writer.writePortable("firstLimb", firstLimb);
             writer.writePortable("secondLimb", secondLimb);
@@ -120,7 +120,7 @@ public class ComplexTestDataStructure {
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             limbs_portable = reader.readPortableArray("limbs_portable");
             firstLimb = reader.readPortable("firstLimb");
             secondLimb = reader.readPortable("secondLimb");
@@ -199,16 +199,16 @@ public class ComplexTestDataStructure {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortableArray("fingers_portable", fingers_portable);
-            writer.writeUTFArray("tattoos_portable", tattoos_portable);
+            writer.writeStringArray("tattoos_portable", tattoos_portable);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             fingers_portable = reader.readPortableArray("fingers_portable");
-            tattoos_portable = reader.readUTFArray("tattoos_portable");
+            tattoos_portable = reader.readStringArray("tattoos_portable");
         }
 
         @Override
@@ -288,12 +288,12 @@ public class ComplexTestDataStructure {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/PortableDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/PortableDataStructure.java
@@ -67,17 +67,17 @@ public class PortableDataStructure {
         }
 
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortable("engine", engine);
             writer.writePortableArray("wheels", wheels);
-            writer.writeUTFArray("model", model);
+            writer.writeStringArray("model", model);
         }
 
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             engine = reader.readPortable("engine");
             wheels = reader.readPortableArray("wheels");
-            model = reader.readUTFArray("model");
+            model = reader.readStringArray("model");
         }
 
         @Override
@@ -245,14 +245,14 @@ public class PortableDataStructure {
         }
 
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortable("chip", chip);
             writer.writePortableArray("chips", chips);
             writer.writeIntArray("serial", serial);
         }
 
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             chip = reader.readPortable("chip");
             chips = reader.readPortableArray("chips");
             serial = reader.readIntArray("serial");

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
@@ -183,13 +183,13 @@ public class NestedPredicateVersionedPortablesTest extends HazelcastTestSupport 
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writePortable("limb", limb);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             limb = reader.readPortable("limb");
         }
     }
@@ -251,12 +251,12 @@ public class NestedPredicateVersionedPortablesTest extends HazelcastTestSupport 
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            name = reader.readUTF("name");
+            name = reader.readString("name");
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
@@ -81,7 +81,7 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
         out.writeInt(syncBackupCount);
         out.writeInt(asyncBackupCount);
         out.writeBoolean(returnsResponse);
-        out.writeUTF(backupKey);
+        out.writeString(backupKey);
     }
 
     @Override
@@ -90,6 +90,6 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
         syncBackupCount = in.readInt();
         asyncBackupCount = in.readInt();
         returnsResponse = in.readBoolean();
-        backupKey = in.readUTF();
+        backupKey = in.readString();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupOperation.java
@@ -65,12 +65,12 @@ class DummyBackupOperation extends Operation implements BackupOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(backupKey);
+        out.writeString(backupKey);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        backupKey = in.readUTF();
+        backupKey = in.readString();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
@@ -174,13 +174,13 @@ public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
 
         @Override
         protected void writeInternal(ObjectDataOutput out) throws IOException {
-            out.writeUTF(backupId);
+            out.writeString(backupId);
             out.writeInt(primaryResponseDelaySeconds);
         }
 
         @Override
         protected void readInternal(ObjectDataInput in) throws IOException {
-            backupId = in.readUTF();
+            backupId = in.readString();
             primaryResponseDelaySeconds = in.readInt();
         }
     }
@@ -204,12 +204,12 @@ public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
 
         @Override
         protected void writeInternal(ObjectDataOutput out) throws IOException {
-            out.writeUTF(backupId);
+            out.writeString(backupId);
         }
 
         @Override
         protected void readInternal(ObjectDataInput in) throws IOException {
-            backupId = in.readUTF();
+            backupId = in.readString();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -262,12 +262,12 @@ public class OutboundResponseHandlerTest {
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
             writer.writeInt("no", no);
-            writer.writeUTF("street", street);
+            writer.writeString("street", street);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            street = reader.readUTF("street");
+            street = reader.readString("street");
             no = reader.readInt("no");
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
@@ -830,7 +830,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
             writer.writeLong(PORTABLE_LONG, fLong);
             writer.writeFloat(PORTABLE_FLOAT, fFloat);
             writer.writeDouble(PORTABLE_DOUBLE, fDouble);
-            writer.writeUTF(PORTABLE_STRING, fString);
+            writer.writeString(PORTABLE_STRING, fString);
             writer.writePortable(PORTABLE_OBJECT, fObject);
         }
 
@@ -844,7 +844,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
             fLong = reader.readLong(PORTABLE_LONG);
             fFloat = reader.readFloat(PORTABLE_FLOAT);
             fDouble = reader.readDouble(PORTABLE_DOUBLE);
-            fString = reader.readUTF(PORTABLE_STRING);
+            fString = reader.readString(PORTABLE_STRING);
             fObject = reader.readPortable(PORTABLE_OBJECT);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
@@ -402,13 +402,13 @@ public class TopicTest extends HazelcastTestSupport {
 
         public void writeData(ObjectDataOutput out) throws IOException {
             publisher.writeData(out);
-            out.writeUTF(data);
+            out.writeString(data);
         }
 
         public void readData(ObjectDataInput in) throws IOException {
             publisher = new MemberImpl();
             publisher.readData(in);
-            data = in.readUTF();
+            data = in.readString();
         }
 
         @Override


### PR DESCRIPTION
…er/Writer, and ClassDefinitionBuilder

We have deprecated methods containing `UTF` in their names and
introduced new methods that contain `String` instead of it in https://github.com/hazelcast/hazelcast/pull/18100.

This is a cleanup PR to use newly introduced methods instead of the
deprecated ones. The change is done automatically via IDE and
verified manually by going over the changes.

EE Counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3939