### PR TITLE
Do not deserialize HazelcastJsonValues when the InMemoryFormat is not OBJECT

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
@@ -132,8 +132,9 @@ public final class Records {
      * otherwise return the actual value.
      * Value caching makes sense when:
      * <ul>
-     * <li>Portable serialization is not used</li>
      * <li>OBJECT InMemoryFormat is not used</li>
+     * <li>Portable serialization is not used</li>
+     * <li>HazelcastJsonValue objects are not used</li>
      * </ul>
      * <p>
      * If Record does not contain cached value and is found
@@ -223,7 +224,11 @@ public final class Records {
     }
 
     static boolean shouldCache(Object value) {
-        return value instanceof Data && !((Data) value).isPortable();
+        // For portables, we cannot extract information from the deserialized form.
+        // For HazelcastJsonValue objects, if we pass the instanceof Data check, that
+        // means the metadata is created from the Data representation of the object.
+        // If we allow using the deserialized values, the metadata might not be safe to use.
+        return value instanceof Data && !((Data) value).isPortable() && !((Data) value).isJson();
     }
 
 


### PR DESCRIPTION
When the InMemoryFormat of the map is BINARY/NATIVE, the JSON metadata
will be created Data objects. In this case, that metadata will
contain offsets created from the UTF-8 encoded bytearray representation
of the string. If the HJV string contains any characters that take
more than 1 byte in their encoded form (such as emojis or Chinese characters)
then the metadata offsets created from Data objects will not be
safe to use on deserialized HJV values.

Our query system will try to cache and use deserialized values if the
CacheDeserializedValues option of the map is set to ALWAYS or set to INDEX_ONLY
and the map has indexes. That creates the problem mentioned above on HJV
queries. When the InMemoryFormat is BINARY/NATIVE, metadata will be created
from Data objects, but when the query is run, it will use HJV values
with the metadata we have which will either produce wrong results
or produce unexpected exceptions.

The solution is to not allow HJV objects to be deserialized when we
access them via `Records.getValueOrCachedValue`.

Also, improved the `MapIndexJsonTest` a bit to use non-ascii characters
in some of their string attributes and added a test that verifies
dynamic index creation does not cause any problems.

Closes https://github.com/hazelcast/hazelcast/issues/17418