### PR TITLE
Fix double package failure and build warning

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -66,6 +66,21 @@
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <!-- We must generate a -javadoc JAR file to publish on Maven Central -->
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+                            <excludes>
+                                <exclude>.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -211,25 +226,6 @@
                                     </excludes>
                                 </filter>
                             </filters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>javadoc</classifier>
-                            <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
-                            <excludes>
-                                <exclude>.*</exclude>
-                            </excludes>
                         </configuration>
                     </execution>
                 </executions>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -175,6 +175,7 @@
                         <exclude>**/*.bat</exclude>
                         <exclude>META-INF/services/javax.annotation.processing.Processor</exclude>
                     </excludes>
+                    <forceCreation>true</forceCreation>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixes:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade (default) on project hazelcast: Error creating shaded jar: duplicate entry: META-INF/services/com.hazelcast.com.fasterxml.jackson.core.JsonFactory -> [Help 1]
```
when running package phase 2x without clean.

and

```
[WARNING] Some problems were encountered while building the effective model for com.hazelcast:hazelcast-sql:jar:4.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-jar-plugin @ line 218, column 21
```

at the beginning of the build.