### PR TITLE
Fixes map config parsing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
+import com.hazelcast.internal.config.MergePolicyConfigReadOnly;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -48,8 +49,7 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, N
     /**
      * The default merge policy used for cardinality estimators
      */
-    public static final MergePolicyConfig DEFAULT_MERGE_POLICY_CONFIG
-            = new MergePolicyConfig(HyperLogLogMergePolicy.class.getSimpleName(), MergePolicyConfig.DEFAULT_BATCH_SIZE);
+    public static final MergePolicyConfig DEFAULT_MERGE_POLICY_CONFIG;
 
     private static final String[] ALLOWED_POLICIES = {
             "com.hazelcast.spi.merge.DiscardMergePolicy", "DiscardMergePolicy",
@@ -57,6 +57,12 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, N
             "com.hazelcast.spi.merge.PassThroughMergePolicy", "PassThroughMergePolicy",
             "com.hazelcast.spi.merge.PutIfAbsentMergePolicy", "PutIfAbsentMergePolicy",
     };
+
+    static {
+        MergePolicyConfig defaultMergePolicy = new MergePolicyConfig(HyperLogLogMergePolicy.class.getSimpleName(),
+                MergePolicyConfig.DEFAULT_BATCH_SIZE);
+        DEFAULT_MERGE_POLICY_CONFIG = new MergePolicyConfigReadOnly(defaultMergePolicy);
+    }
 
     private String name = "default";
 
@@ -66,7 +72,7 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, N
 
     private String splitBrainProtectionName;
 
-    private MergePolicyConfig mergePolicyConfig = DEFAULT_MERGE_POLICY_CONFIG;
+    private MergePolicyConfig mergePolicyConfig = new MergePolicyConfig(DEFAULT_MERGE_POLICY_CONFIG);
 
     public CardinalityEstimatorConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
@@ -24,6 +24,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
@@ -109,9 +110,7 @@ public final class ConfigUtils {
         T defConfig = configs.get("default");
         try {
             if (defConfig == null) {
-                Constructor constructor = clazz.getDeclaredConstructor();
-                constructor.setAccessible(true);
-                defConfig = (T) constructor.newInstance();
+                defConfig = (T) constructReflectively(clazz);
                 nameSetter.accept(defConfig, "default");
                 configs.put("default", defConfig);
             }
@@ -127,6 +126,41 @@ public final class ConfigUtils {
             assert false;
             return null;
         }
+    }
+
+    /**
+     * If {@code configs} contains an exact match for {@code name}, returns
+     * the matching config. Otherwise creates a new config with the given
+     * name, adds it to {@code configs} and returns it.
+     */
+    public static <T extends NamedConfig> T getByNameOrNew(Map<String, T> configs, String name,
+                                      Class<T> clazz) {
+        T config = configs.get(name);
+        if (config != null) {
+            return config;
+        } else {
+            try {
+                config = constructReflectively(clazz);
+                config.setName(name);
+                configs.put(name, config);
+                return config;
+            } catch (NoSuchMethodException | InstantiationException
+                    | IllegalAccessException | InvocationTargetException e) {
+                LOGGER.severe("Could not create class " + clazz.getName());
+                assert false;
+                return null;
+            }
+        }
+    }
+
+    @Nonnull
+    private static <T> T constructReflectively(Class<T> clazz)
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        T config;
+        Constructor constructor = clazz.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        config = (T) constructor.newInstance();
+        return config;
     }
 
     public static InvalidConfigurationException createAmbiguousConfigurationException(

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -532,8 +532,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleSplitBrainProtection(Node node) {
         String name = getAttribute(node, "name");
-        SplitBrainProtectionConfig splitBrainProtectionConfig = config.getSplitBrainProtectionConfig(name);
-        splitBrainProtectionConfig.setName(name);
+        SplitBrainProtectionConfig splitBrainProtectionConfig = ConfigUtils.getByNameOrNew(
+                config.getSplitBrainProtectionConfigs(),
+                name,
+                SplitBrainProtectionConfig.class);
         handleSplitBrainProtectionNode(node, splitBrainProtectionConfig, name);
     }
 
@@ -989,21 +991,29 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleExecutor(Node node) throws Exception {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        ExecutorConfig executorConfig = config.getExecutorConfig(name);
+        ExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(config.getExecutorConfigs(),
+                name,
+                ExecutorConfig.class);
 
         handleViaReflection(node, config, executorConfig);
     }
 
     protected void handleDurableExecutor(Node node) throws Exception {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        DurableExecutorConfig durableExecutorConfig = config.getDurableExecutorConfig(name);
+        DurableExecutorConfig durableExecutorConfig = ConfigUtils.getByNameOrNew(
+                config.getDurableExecutorConfigs(),
+                name,
+                DurableExecutorConfig.class);
 
         handleViaReflection(node, config, durableExecutorConfig);
     }
 
     protected void handleScheduledExecutor(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        ScheduledExecutorConfig scheduledExecutorConfig = config.getScheduledExecutorConfig(name);
+        ScheduledExecutorConfig scheduledExecutorConfig = ConfigUtils.getByNameOrNew(
+                config.getScheduledExecutorConfigs(),
+                name,
+                ScheduledExecutorConfig.class);
 
         handleScheduledExecutorNode(node, scheduledExecutorConfig);
     }
@@ -1034,8 +1044,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     protected void handleCardinalityEstimator(Node node) {
-        CardinalityEstimatorConfig cardinalityEstimatorConfig = config.getCardinalityEstimatorConfig(
-                getTextContent(getNamedItemNode(node, "name")));
+        CardinalityEstimatorConfig cardinalityEstimatorConfig =
+                ConfigUtils.getByNameOrNew(config.getCardinalityEstimatorConfigs(),
+                                            getTextContent(getNamedItemNode(node, "name")),
+                                            CardinalityEstimatorConfig.class);
 
         handleCardinalityEstimatorNode(node, cardinalityEstimatorConfig);
     }
@@ -1061,13 +1073,19 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handlePNCounter(Node node) throws Exception {
         String name = getAttribute(node, "name");
-        PNCounterConfig pnCounterConfig = config.getPNCounterConfig(name);
+        PNCounterConfig pnCounterConfig = ConfigUtils.getByNameOrNew(
+                config.getPNCounterConfigs(),
+                name,
+                PNCounterConfig.class);
         handleViaReflection(node, config, pnCounterConfig);
     }
 
     protected void handleFlakeIdGenerator(Node node) {
         String name = getAttribute(node, "name");
-        FlakeIdGeneratorConfig generatorConfig = config.getFlakeIdGeneratorConfig(name);
+        FlakeIdGeneratorConfig generatorConfig = ConfigUtils.getByNameOrNew(
+                config.getFlakeIdGeneratorConfigs(),
+                name,
+                FlakeIdGeneratorConfig.class);
         handleFlakeIdGeneratorNode(node, generatorConfig);
     }
 
@@ -1503,7 +1521,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleQueue(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        QueueConfig qConfig = config.getQueueConfig(name);
+        QueueConfig qConfig = ConfigUtils.getByNameOrNew(
+                config.getQueueConfigs(),
+                name,
+                QueueConfig.class);
         handleQueueNode(node, qConfig);
     }
 
@@ -1550,7 +1571,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleList(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        ListConfig lConfig = config.getListConfig(name);
+        ListConfig lConfig = ConfigUtils.getByNameOrNew(
+                config.getListConfigs(),
+                name,
+                ListConfig.class);
         handleListNode(node, lConfig);
     }
 
@@ -1580,7 +1604,9 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleSet(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        SetConfig sConfig = config.getSetConfig(name);
+        SetConfig sConfig = ConfigUtils.getByNameOrNew(config.getSetConfigs(),
+                name,
+                SetConfig.class);
         handleSetNode(node, sConfig);
     }
 
@@ -1609,7 +1635,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleMultiMap(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        MultiMapConfig multiMapConfig = config.getMultiMapConfig(name);
+        MultiMapConfig multiMapConfig = ConfigUtils.getByNameOrNew(
+                config.getMultiMapConfigs(),
+                name,
+                MultiMapConfig.class);
         handleMultiMapNode(node, multiMapConfig);
     }
 
@@ -1655,7 +1684,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleReplicatedMap(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        final ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig(name);
+        final ReplicatedMapConfig replicatedMapConfig = ConfigUtils.getByNameOrNew(
+                config.getReplicatedMapConfigs(),
+                name,
+                ReplicatedMapConfig.class);
         handleReplicatedMapNode(node, replicatedMapConfig);
     }
 
@@ -1682,11 +1714,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleMap(Node parentNode) throws Exception {
         String name = getAttribute(parentNode, "name");
-        MapConfig mapConfig = config.getMapConfigs().get(name);
-        if (mapConfig == null) {
-            mapConfig = new MapConfig(name);
-            config.addMapConfig(mapConfig);
-        }
+        MapConfig mapConfig = ConfigUtils.getByNameOrNew(config.getMapConfigs(), name, MapConfig.class);
         handleMapNode(parentNode, mapConfig);
     }
 
@@ -1804,7 +1832,11 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     protected void handleCache(Node node) throws Exception {
-        handleCacheNode(node, config.getCacheConfig(getAttribute(node, "name")));
+        CacheSimpleConfig cacheConfig =
+                ConfigUtils.getByNameOrNew(config.getCacheConfigs(),
+                        getAttribute(node, "name"),
+                        CacheSimpleConfig.class);
+        handleCacheNode(node, cacheConfig);
     }
 
     void handleCacheNode(Node node, CacheSimpleConfig cacheConfig) throws Exception {
@@ -2421,7 +2453,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleRingbuffer(Node node) {
         String name = getTextContent(getNamedItemNode(node, "name"));
-        handleRingBufferNode(node, config.getRingbufferConfig(name));
+        handleRingBufferNode(node, ConfigUtils.getByNameOrNew(
+                config.getRingbufferConfigs(),
+                name,
+                RingbufferConfig.class));
     }
 
     void handleRingBufferNode(Node node, RingbufferConfig rbConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1682,7 +1682,11 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleMap(Node parentNode) throws Exception {
         String name = getAttribute(parentNode, "name");
-        MapConfig mapConfig = config.getMapConfig(name);
+        MapConfig mapConfig = config.getMapConfigs().get(name);
+        if (mapConfig == null) {
+            mapConfig = new MapConfig(name);
+            config.addMapConfig(mapConfig);
+        }
         handleMapNode(parentNode, mapConfig);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -293,7 +293,12 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleMap(Node parentNode) throws Exception {
         for (Node mapNode : childElements(parentNode)) {
-            MapConfig mapConfig = config.getMapConfig(mapNode.getNodeName());
+            String name = mapNode.getNodeName();
+            MapConfig mapConfig = config.getMapConfigs().get(name);
+            if (mapConfig == null) {
+                mapConfig = new MapConfig(name);
+                config.addMapConfig(mapConfig);
+            }
             handleMapNode(mapNode, mapConfig);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -53,6 +53,7 @@ import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SecurityInterceptorConfig;
@@ -244,7 +245,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleQueue(Node node) {
         for (Node queueNode : childElements(node)) {
-            QueueConfig queueConfig = config.getQueueConfig(queueNode.getNodeName());
+            QueueConfig queueConfig = ConfigUtils.getByNameOrNew(
+                                config.getQueueConfigs(),
+                                queueNode.getNodeName(),
+                                QueueConfig.class);
             handleQueueNode(queueNode, queueConfig);
         }
     }
@@ -252,7 +256,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleList(Node node) {
         for (Node listNode : childElements(node)) {
-            ListConfig listConfig = config.getListConfig(listNode.getNodeName());
+            ListConfig listConfig = ConfigUtils.getByNameOrNew(
+                                config.getListConfigs(),
+                                listNode.getNodeName(),
+                                ListConfig.class);
             handleListNode(listNode, listConfig);
         }
     }
@@ -260,7 +267,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleSet(Node node) {
         for (Node setNode : childElements(node)) {
-            SetConfig setConfig = config.getSetConfig(setNode.getNodeName());
+            SetConfig setConfig = ConfigUtils.getByNameOrNew(
+                                config.getSetConfigs(),
+                                setNode.getNodeName(),
+                                SetConfig.class);
             handleSetNode(setNode, setConfig);
         }
     }
@@ -286,7 +296,11 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleRingbuffer(Node node) {
         for (Node rbNode : childElements(node)) {
-            handleRingBufferNode(rbNode, config.getRingbufferConfig(rbNode.getNodeName()));
+            handleRingBufferNode(rbNode,
+                    ConfigUtils.getByNameOrNew(
+                            config.getRingbufferConfigs(),
+                            rbNode.getNodeName(),
+                            RingbufferConfig.class));
         }
     }
 
@@ -294,11 +308,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     protected void handleMap(Node parentNode) throws Exception {
         for (Node mapNode : childElements(parentNode)) {
             String name = mapNode.getNodeName();
-            MapConfig mapConfig = config.getMapConfigs().get(name);
-            if (mapConfig == null) {
-                mapConfig = new MapConfig(name);
-                config.addMapConfig(mapConfig);
-            }
+            MapConfig mapConfig = ConfigUtils.getByNameOrNew(
+                                config.getMapConfigs(),
+                                name,
+                                MapConfig.class);
             handleMapNode(mapNode, mapConfig);
         }
     }
@@ -306,7 +319,11 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleCache(Node parentNode) throws Exception {
         for (Node cacheNode : childElements(parentNode)) {
-            handleCacheNode(cacheNode, config.getCacheConfig(cacheNode.getNodeName()));
+            handleCacheNode(cacheNode,
+                            ConfigUtils.getByNameOrNew(
+                                config.getCacheConfigs(),
+                                cacheNode.getNodeName(),
+                                CacheSimpleConfig.class));
         }
     }
 
@@ -314,7 +331,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     protected void handleSplitBrainProtection(Node node) {
         for (Node splitBrainProtectionNode : childElements(node)) {
             String name = splitBrainProtectionNode.getNodeName();
-            SplitBrainProtectionConfig splitBrainProtectionConfig = config.getSplitBrainProtectionConfig(name);
+            SplitBrainProtectionConfig splitBrainProtectionConfig = ConfigUtils.getByNameOrNew(
+                                config.getSplitBrainProtectionConfigs(),
+                                name,
+                                SplitBrainProtectionConfig.class);
             handleSplitBrainProtectionNode(splitBrainProtectionNode, splitBrainProtectionConfig, name);
         }
     }
@@ -322,8 +342,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleFlakeIdGenerator(Node node) {
         for (Node genNode : childElements(node)) {
-            FlakeIdGeneratorConfig genConfig = config
-              .getFlakeIdGeneratorConfig(genNode.getNodeName());
+            FlakeIdGeneratorConfig genConfig = ConfigUtils.getByNameOrNew(
+                                config.getFlakeIdGeneratorConfigs(),
+                                genNode.getNodeName(),
+                                FlakeIdGeneratorConfig.class);
 
             handleFlakeIdGeneratorNode(genNode, genConfig);
         }
@@ -332,7 +354,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleExecutor(Node node) throws Exception {
         for (Node executorNode : childElements(node)) {
-            ExecutorConfig executorConfig = config.getExecutorConfig(executorNode.getNodeName());
+            ExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(
+                                config.getExecutorConfigs(),
+                                executorNode.getNodeName(),
+                                ExecutorConfig.class);
             handleViaReflection(executorNode, config, executorConfig);
         }
     }
@@ -340,7 +365,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleDurableExecutor(Node node) throws Exception {
         for (Node executorNode : childElements(node)) {
-            DurableExecutorConfig executorConfig = config.getDurableExecutorConfig(executorNode.getNodeName());
+            DurableExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(
+                    config.getDurableExecutorConfigs(),
+                    executorNode.getNodeName(),
+                    DurableExecutorConfig.class);
             handleViaReflection(executorNode, config, executorConfig);
         }
     }
@@ -348,7 +376,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleScheduledExecutor(Node node) {
         for (Node executorNode : childElements(node)) {
-            ScheduledExecutorConfig executorConfig = config.getScheduledExecutorConfig(executorNode.getNodeName());
+            ScheduledExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(
+                                config.getScheduledExecutorConfigs(),
+                                executorNode.getNodeName(),
+                                ScheduledExecutorConfig.class);
             handleScheduledExecutorNode(executorNode, executorConfig);
         }
     }
@@ -356,8 +387,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleCardinalityEstimator(Node node) {
         for (Node estimatorNode : childElements(node)) {
-            CardinalityEstimatorConfig estimatorConfig = config
-              .getCardinalityEstimatorConfig(estimatorNode.getNodeName());
+            CardinalityEstimatorConfig estimatorConfig = ConfigUtils.getByNameOrNew(
+                    config.getCardinalityEstimatorConfigs(),
+                    estimatorNode.getNodeName(),
+                    CardinalityEstimatorConfig.class);
 
             handleCardinalityEstimatorNode(estimatorNode, estimatorConfig);
         }
@@ -366,8 +399,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handlePNCounter(Node node) throws Exception {
         for (Node counterNode : childElements(node)) {
-            PNCounterConfig counterConfig = config
-              .getPNCounterConfig(counterNode.getNodeName());
+            PNCounterConfig counterConfig = ConfigUtils.getByNameOrNew(
+                                config.getPNCounterConfigs(),
+                                counterNode.getNodeName(),
+                                PNCounterConfig.class);
 
             handleViaReflection(counterNode, config, counterConfig);
         }
@@ -376,7 +411,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleMultiMap(Node node) {
         for (Node multiMapNode : childElements(node)) {
-            MultiMapConfig multiMapConfig = config.getMultiMapConfig(multiMapNode.getNodeName());
+            MultiMapConfig multiMapConfig = ConfigUtils.getByNameOrNew(
+                                config.getMultiMapConfigs(),
+                                multiMapNode.getNodeName(),
+                                MultiMapConfig.class);
             handleMultiMapNode(multiMapNode, multiMapConfig);
         }
     }
@@ -384,7 +422,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleReplicatedMap(Node node) {
         for (Node replicatedMapNode : childElements(node)) {
-            ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig(replicatedMapNode.getNodeName());
+            ReplicatedMapConfig replicatedMapConfig = ConfigUtils.getByNameOrNew(
+                                config.getReplicatedMapConfigs(),
+                                replicatedMapNode.getNodeName(),
+                                ReplicatedMapConfig.class);
             handleReplicatedMapNode(replicatedMapNode, replicatedMapConfig);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -618,6 +618,22 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     @Test(expected = InvalidConfigurationException.class)
     public abstract void testPersistentMemoryDirectoryConfiguration_SystemMemoryModeThrows();
 
+    @Test
+    public void testMapWildcardConfig() {
+        Config config = buildMapWildcardConfig();
+
+        MapConfig map1 = config.getMapConfig("mapA");
+        assertEquals(1, map1.getBackupCount());
+        assertEquals(1, map1.getAttributeConfigs().size());
+
+        MapConfig mapWith2Backups = config.getMapConfig("mapBackup2A");
+        assertEquals(2, mapWith2Backups.getBackupCount());
+        assertEquals(1, map1.getAttributeConfigs().size());
+    }
+
     protected abstract Config buildAuditlogConfig();
+
+    /** Build a config with overlapping wildcard configs map* & mapBackup2* */
+    protected abstract Config buildMapWildcardConfig();
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3776,4 +3776,23 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(10, sqlConfig.getExecutorPoolSize());
         assertEquals(30L, sqlConfig.getStatementTimeoutMillis());
     }
+
+    @Override
+    protected Config buildMapWildcardConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "<map name=\"map*\">\n"
+                + "  <attributes>\n"
+                + "    <attribute extractor-class-name=\"usercodedeployment.CapitalizingFirstNameExtractor\">name</attribute>\n"
+                + "  </attributes>\n"
+                + "</map>\n"
+                + "<map name=\"mapBackup2*\">\n"
+                + "  <backup-count>2</backup-count>"
+                + "  <attributes>\n"
+                + "    <attribute extractor-class-name=\"usercodedeployment.CapitalizingFirstNameExtractor\">name</attribute>\n"
+                + "  </attributes>\n"
+                + "</map>\n"
+                + HAZELCAST_END_TAG;
+
+        return new InMemoryXmlConfig(xml);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3775,4 +3775,22 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "      type: tcp\n";
         return new InMemoryYamlConfig(yaml);
     }
+
+    @Override
+    protected Config buildMapWildcardConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    map*:\n"
+                + "      attributes:\n"
+                + "        name:\n"
+                + "          extractor-class-name: usercodedeployment.CapitalizingFirstNameExtractor\n"
+                + "    mapBackup2*:\n"
+                + "      backup-count: 2\n"
+                + "      attributes:\n"
+                + "        name:\n"
+                + "          extractor-class-name: usercodedeployment.CapitalizingFirstNameExtractor\n";
+
+        return new InMemoryYamlConfig(yaml);
+    }
 }


### PR DESCRIPTION
When overlapping wildcard configs are defined
in declarative config, then it can be the
case that the most specific one inherits
attributes from more generic one during
parsing.

The regression was introduced in #17946 because
`getMapConfig` will pattern-match on already
parsed map configs. The fix in this PR looks for
an exact match instead and creates a new
`MapConfig` if none is found.

@pivovarit @blazember if this looks ok, then 
the same logic must be applied in other
data structure configs probably.

Fixes #18039 (and probably #18041 )
