### PR TITLE
Fix NPE in MapIndexScanExecIterator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -110,6 +110,10 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
             return valueObject;
         }
 
+        if (record == null) {
+            return null;
+        }
+
         Object possiblyNotData = record.getValue();
 
         return possiblyNotData instanceof Data ? null : (V) possiblyNotData;
@@ -119,6 +123,10 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
     public Data getValueDataIfPresent() {
         if (valueData != null) {
             return valueData;
+        }
+
+        if (record == null) {
+            return null;
         }
 
         Object possiblyData = record.getValue();


### PR DESCRIPTION
Caused by #18172 

Reproducible in HD SQL tests (e.g. `HDSqlIndexTest`)
```
Caused by: java.lang.NullPointerException
	at com.hazelcast.query.impl.CachedQueryEntry.getValueIfPresent(CachedQueryEntry.java:113)
	at com.hazelcast.sql.impl.exec.scan.index.MapIndexScanExecIterator.advance0(MapIndexScanExecIterator.java:119)
	at com.hazelcast.sql.impl.exec.scan.index.MapIndexScanExecIterator.<init>(MapIndexScanExecIterator.java:69)
	at com.hazelcast.sql.impl.exec.scan.index.MapIndexScanExec.createIterator(MapIndexScanExec.java:122)
	at com.hazelcast.sql.impl.exec.scan.AbstractMapScanExec.setup0(AbstractMapScanExec.java:99)
	at com.hazelcast.sql.impl.exec.AbstractExec.setup(AbstractExec.java:47)
	at com.hazelcast.sql.impl.exec.UpstreamState.setup(UpstreamState.java:96)
	at com.hazelcast.sql.impl.exec.AbstractUpstreamAwareExec.setup0(AbstractUpstreamAwareExec.java:48)
	at com.hazelcast.sql.impl.exec.AbstractExec.setup(AbstractExec.java:47)
	at com.hazelcast.sql.impl.worker.QueryFragmentExecutable.setupExecutor(QueryFragmentExecutable.java:233)
	at com.hazelcast.sql.impl.worker.QueryFragmentExecutable.run(QueryFragmentExecutable.java:113)
```