### PR TITLE
[4.1.z] Optimize CopyOnWriteArrayList/Set serializers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/AbstractCollectionStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/AbstractCollectionStreamSerializer.java
@@ -40,10 +40,15 @@ abstract class AbstractCollectionStreamSerializer<CollectionType extends Collect
 
     CollectionType deserializeEntries(ObjectDataInput in, int size, CollectionType collection)
             throws IOException {
+        deserializeEntriesInto(in, size, collection);
+        return collection;
+    }
+
+    void deserializeEntriesInto(ObjectDataInput in, int size, Collection<?> collection)
+            throws IOException {
         for (int i = 0; i < size; i++) {
             collection.add(in.readObject());
         }
-        return collection;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArrayListStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArrayListStreamSerializer.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.nio.ObjectDataInput;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -36,8 +37,9 @@ public class CopyOnWriteArrayListStreamSerializer<E> extends AbstractCollectionS
     public CopyOnWriteArrayList<E> read(ObjectDataInput in) throws IOException {
         int size = in.readInt();
 
-        CopyOnWriteArrayList<E> collection = new CopyOnWriteArrayList<>();
+        ArrayList<E> collection = new ArrayList<>(size);
+        deserializeEntriesInto(in, size, collection);
 
-        return deserializeEntries(in, size, collection);
+        return new CopyOnWriteArrayList<>(collection);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArraySetStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArraySetStreamSerializer.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.nio.ObjectDataInput;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -36,8 +37,9 @@ public class CopyOnWriteArraySetStreamSerializer<E> extends AbstractCollectionSt
     public CopyOnWriteArraySet<E> read(ObjectDataInput in) throws IOException {
         int size = in.readInt();
 
-        CopyOnWriteArraySet<E> collection = new CopyOnWriteArraySet<>();
+        ArrayList<E> collection = new ArrayList<>(size);
+        deserializeEntriesInto(in, size, collection);
 
-        return deserializeEntries(in, size, collection);
+        return new CopyOnWriteArraySet<>(collection);
     }
 }


### PR DESCRIPTION
As reported on https://github.com/hazelcast/hazelcast/issues/18129,
adding deserialized elements one by one to the CoW data structures
causes too many array copies.

Instead, elements are deserialized into a pre-allocated ArrayList
first. Then, the expected CoW data structure is created from
that ArrayList.