### PR TITLE
Improve MapIndexScanExecTest (#18030)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecTest.java
@@ -53,14 +53,14 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import static java.util.Arrays.asList;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -77,13 +77,13 @@ public class MapIndexScanExecTest extends SqlTestSupport {
     private static final String MAP_NAME = "map";
     private static final String INDEX_NAME = "index";
 
-    @Parameterized.Parameters(name = "descendingDirection:{0}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{{true}, {false}});
+    @Parameterized.Parameters(name = "ascending:{0}")
+    public static Object[] parameters() {
+        return new Object[] { true, false };
     }
 
     @Parameterized.Parameter
-    public boolean descendingDirection;
+    public boolean ascending;
 
     private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(2);
 
@@ -91,7 +91,7 @@ public class MapIndexScanExecTest extends SqlTestSupport {
     private HazelcastInstance instance2;
 
     @Before
-    public void beforeClass() {
+    public void before() {
         instance1 = factory.newHazelcastInstance(getInstanceConfig());
         instance2 = factory.newHazelcastInstance(getInstanceConfig());
 
@@ -106,35 +106,48 @@ public class MapIndexScanExecTest extends SqlTestSupport {
 
     @Test
     public void testScan() {
-        checkScan(
+        List<Integer> entriesForEmptyMap = executeScan(
                 instance1,
-                0,
                 getLocalPartitions(instance1),
                 null,
                 null,
                 Collections.emptyList(),
-                1,
-                new int[0]
+                1
         );
+
+        assertTrue(entriesForEmptyMap.isEmpty());
 
         int entryCount = BATCH_SIZE * 5 / 2;
 
-        checkScan(
+        populate(instance1, entryCount);
+
+        List<Integer> entries1 = executeScan(
                 instance1,
-                entryCount,
                 getLocalPartitions(instance1),
                 null,
                 null,
                 Collections.emptyList(),
-                1,
-                IntStream.range(0, entryCount).toArray()
+                1
         );
+
+        List<Integer> entries2 = executeScan(
+            instance2,
+            getLocalPartitions(instance2),
+            null,
+            null,
+            Collections.emptyList(),
+            1
+        );
+
+        checkValues(IntStream.range(0, entryCount).toArray(), entries1, entries2);
     }
 
     @Test
     public void testIndexFilter() {
         int entryCount = 100;
         int from = 50;
+
+        populate(instance1, entryCount);
 
         IndexFilterValue fromValue = new IndexFilterValue(
                 Collections.singletonList(ConstantExpression.create(from, QueryDataType.INT)),
@@ -143,16 +156,25 @@ public class MapIndexScanExecTest extends SqlTestSupport {
 
         IndexFilter indexFilter = new IndexRangeFilter(fromValue, true, null, false);
 
-        checkScan(
+        List<Integer> entries1 = executeScan(
                 instance1,
-                entryCount,
                 getLocalPartitions(instance1),
                 indexFilter,
                 null,
                 Collections.emptyList(),
-                1,
-                IntStream.range(from, entryCount).toArray()
+                1
         );
+
+        List<Integer> entries2 = executeScan(
+            instance2,
+            getLocalPartitions(instance2),
+            indexFilter,
+            null,
+            Collections.emptyList(),
+            1
+        );
+
+        checkValues(IntStream.range(from, entryCount).toArray(), entries1, entries2);
     }
 
     @Test
@@ -160,6 +182,8 @@ public class MapIndexScanExecTest extends SqlTestSupport {
         int entryCount = 100;
         int from = 50;
         int to = 75;
+
+        populate(instance1, entryCount);
 
         IndexFilterValue fromValue = new IndexFilterValue(
                 Collections.singletonList(ConstantExpression.create(from, QueryDataType.INT)),
@@ -174,20 +198,75 @@ public class MapIndexScanExecTest extends SqlTestSupport {
                 ComparisonMode.LESS_THAN
         );
 
-        checkScan(
+        List<Integer> entries1 = executeScan(
                 instance1,
-                entryCount,
                 getLocalPartitions(instance1),
                 indexFilter,
                 remainderFilter,
                 Collections.emptyList(),
-                1,
-                IntStream.range(from, to).toArray()
+                1
         );
+
+        List<Integer> entries2 = executeScan(
+            instance2,
+            getLocalPartitions(instance2),
+            indexFilter,
+            remainderFilter,
+            Collections.emptyList(),
+            1
+        );
+
+        checkValues(IntStream.range(from, to).toArray(), entries1, entries2);
+    }
+
+    private void checkValues(int[] expectedValues, List<Integer> entriesLeft, List<Integer> entriesRight) {
+        assertEquals(expectedValues.length, entriesLeft.size() + entriesRight.size());
+
+        if (!ascending) {
+            int[] expectedValuesReversed = new int[expectedValues.length];
+
+            for (int i = 0; i < expectedValues.length; i++) {
+                expectedValuesReversed[expectedValues.length - i - 1] = expectedValues[i];
+            }
+
+            expectedValues = expectedValuesReversed;
+        }
+
+        int[] actualValues = new int[expectedValues.length];
+
+        int leftPos = 0;
+        int rightPos = 0;
+
+        for (int i = 0; i < actualValues.length; i++) {
+            boolean takeLeft;
+
+            if (entriesRight.size() == rightPos) {
+                // Right input is over.
+                takeLeft = true;
+            } else if (entriesLeft.size() == leftPos) {
+                // Left input is over.
+                takeLeft = false;
+            } else {
+                int left = entriesLeft.get(leftPos);
+                int right = entriesRight.get(rightPos);
+
+                takeLeft = ascending ? left < right : left > right;
+            }
+
+            if (takeLeft) {
+                actualValues[i] = entriesLeft.get(leftPos++);
+            } else {
+                actualValues[i] = entriesRight.get(rightPos++);
+            }
+        }
+
+        assertArrayEquals(expectedValues, actualValues);
     }
 
     @Test
     public void testInvalidComponentCount() {
+        populate(instance1, 100);
+
         IndexEqualsFilter indexFilter = new IndexEqualsFilter(
                 new IndexFilterValue(
                         Collections.singletonList(ConstantExpression.create(1, QueryDataType.INT)),
@@ -196,15 +275,13 @@ public class MapIndexScanExecTest extends SqlTestSupport {
         );
 
         try {
-            checkScan(
+            executeScan(
                     instance1,
-                    0,
                     getLocalPartitions(instance1),
                     indexFilter,
                     null,
                     Arrays.asList(QueryDataType.INT, QueryDataType.INT),
-                    2,
-                    new int[0]
+                    2
             );
 
             fail("Must fail");
@@ -216,38 +293,37 @@ public class MapIndexScanExecTest extends SqlTestSupport {
     }
 
     @Test
-    public void testConverterProblems() {
-        // Converters are not checked for scans.
-        checkScan(
+    public void testNoConverterCheckOnScan() {
+        populate(instance1, 100);
+
+        executeScan(
                 instance1,
-                0,
                 getLocalPartitions(instance1),
                 null,
                 null,
                 Collections.singletonList(QueryDataType.VARCHAR),
-                1,
-                new int[0]
+                1
         );
+    }
 
-        // Converted must be checked for lookups
+    @Test
+    public void testConverterErrorOnEmptyMap() {
         IndexEqualsFilter indexFilter = new IndexEqualsFilter(
-                new IndexFilterValue(
-                        Collections.singletonList(ConstantExpression.create(1, QueryDataType.INT)),
-                        Collections.singletonList(true)
-                )
+            new IndexFilterValue(
+                Collections.singletonList(ConstantExpression.create(1, QueryDataType.INT)),
+                Collections.singletonList(true)
+            )
         );
 
         // Check missing converter (i.e. no data).
         try {
-            checkScan(
-                    instance1,
-                    0,
-                    getLocalPartitions(instance1),
-                    indexFilter,
-                    null,
-                    Collections.singletonList(QueryDataType.INT),
-                    1,
-                    new int[0]
+            executeScan(
+                instance1,
+                getLocalPartitions(instance1),
+                indexFilter,
+                null,
+                Collections.singletonList(QueryDataType.INT),
+                1
             );
 
             fail("Must fail");
@@ -256,18 +332,28 @@ public class MapIndexScanExecTest extends SqlTestSupport {
             assertEquals("Cannot use the index \"index\" of the IMap \"map\" because it does not have suitable converter for component \"this\" (expected INTEGER)", e.getMessage());
             assertTrue(e.isInvalidatePlan());
         }
+    }
+
+    @Test
+    public void testConverterMismatch() {
+        populate(instance1, 100);
+
+        IndexEqualsFilter indexFilter = new IndexEqualsFilter(
+            new IndexFilterValue(
+                Collections.singletonList(ConstantExpression.create(1, QueryDataType.INT)),
+                Collections.singletonList(true)
+            )
+        );
 
         // Check converter mismatch (i.e. data differs!).
         try {
-            checkScan(
-                    instance1,
-                    1,
-                    getLocalPartitions(instance1),
-                    indexFilter,
-                    null,
-                    Collections.singletonList(QueryDataType.VARCHAR),
-                    1,
-                    new int[0]
+            executeScan(
+                instance1,
+                getLocalPartitions(instance1),
+                indexFilter,
+                null,
+                Collections.singletonList(QueryDataType.VARCHAR),
+                1
             );
 
             fail("Must fail");
@@ -281,15 +367,15 @@ public class MapIndexScanExecTest extends SqlTestSupport {
     @Test
     public void testPartition_setup() {
         try {
-            checkScan(
+            populate(instance1, 100);
+
+            executeScan(
                     instance1,
-                    1,
                     getLocalPartitions(instance2),
                     null,
                     null,
                     Collections.singletonList(QueryDataType.INT),
-                    1,
-                    new int[0]
+                    1
             );
 
             fail("Must fail");
@@ -330,15 +416,15 @@ public class MapIndexScanExecTest extends SqlTestSupport {
         };
 
         try {
-            checkScan(
+            populate(instance1, 100);
+
+            executeScan(
                     instance1,
-                    1,
                     expectedPartitions,
                     indexFilter,
                     null,
                     Collections.singletonList(QueryDataType.INT),
-                    1,
-                    new int[0]
+                    1
             );
 
             fail("Must fail");
@@ -352,16 +438,14 @@ public class MapIndexScanExecTest extends SqlTestSupport {
     @Test
     public void testNoIndex() {
         try {
-            checkScan(
+            executeScan(
                     instance1,
                     "bad_index",
-                    0,
                     getLocalPartitions(instance1),
                     null,
                     null,
                     Arrays.asList(QueryDataType.INT, QueryDataType.INT),
-                    2,
-                    new int[0]
+                    2
             );
 
             fail("Must fail");
@@ -372,54 +456,43 @@ public class MapIndexScanExecTest extends SqlTestSupport {
         }
     }
 
-    private void checkScan(
+    private List<Integer> executeScan(
             HazelcastInstance member,
-            int entryCount,
             PartitionIdSet partitions,
             IndexFilter indexFilter,
             Expression<Boolean> remainderFilter,
             List<QueryDataType> converterTypes,
-            int expectedComponentCount,
-            int[] expectedResults
+            int expectedComponentCount
     ) {
-        checkScan(
+        return executeScan(
                 member,
                 INDEX_NAME,
-                entryCount,
                 partitions,
                 indexFilter,
                 remainderFilter,
                 converterTypes,
-                expectedComponentCount,
-                expectedResults
+                expectedComponentCount
         );
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
-    private void checkScan(
+    private List<Integer> executeScan(
             HazelcastInstance member,
             String indexName,
-            int entryCount,
             PartitionIdSet partitions,
             IndexFilter indexFilter,
             Expression<Boolean> remainderFilter,
             List<QueryDataType> converterTypes,
-            int expectedComponentCount,
-            int[] expectedResults
+            int expectedComponentCount
     ) {
-        IMap<Integer, Integer> map = member.getMap(MAP_NAME);
-
-        Map<Integer, Integer> localEntries = getLocalEntries(member, entryCount, i -> i, i -> i);
-        map.putAll(localEntries);
-
         List<QueryPath> fieldPaths = Collections.singletonList(valuePath(null));
         List<QueryDataType> fieldTypes = Collections.singletonList(QueryDataType.INT);
         List<Integer> projects = Collections.singletonList(0);
-        List<Boolean> ascs = Collections.singletonList(descendingDirection);
+        List<Boolean> ascs = Collections.singletonList(ascending);
 
         MapIndexScanExec exec = new MapIndexScanExec(
                 1,
-                getMapContainer(map),
+                getMapContainer(member.getMap(MAP_NAME)),
                 partitions,
                 GenericQueryTargetDescriptor.DEFAULT,
                 GenericQueryTargetDescriptor.DEFAULT,
@@ -455,14 +528,17 @@ public class MapIndexScanExecTest extends SqlTestSupport {
             }
         }
 
-        List<Integer> expectedResults0 = new ArrayList<>(expectedResults.length);
+        return results;
+    }
 
-        for (int expectedResult : expectedResults) {
-            expectedResults0.add(expectedResult);
+    private void populate(HazelcastInstance member, int entryCount) {
+        Map<Integer, Integer> entries = new HashMap<>();
+
+        for (int i = 0; i < entryCount; i++) {
+            entries.put(i ,i);
         }
 
-        results.sort(Integer::compareTo);
-        expectedResults0.sort(Integer::compareTo);
+        member.getMap(MAP_NAME).putAll(entries);
     }
 
     private static Config getInstanceConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecTest.java
@@ -535,7 +535,7 @@ public class MapIndexScanExecTest extends SqlTestSupport {
         Map<Integer, Integer> entries = new HashMap<>();
 
         for (int i = 0; i < entryCount; i++) {
-            entries.put(i ,i);
+            entries.put(i, i);
         }
 
         member.getMap(MAP_NAME).putAll(entries);


### PR DESCRIPTION
This PR improves `MapIndexScanExecTest` so that now it checks the actual and expected entries returned from the index scan operator.

Closes #18030