### PR TITLE
Set the logging level to TRACE for GracefulShutdownCorrectnessTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
@@ -17,9 +17,11 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,6 +33,9 @@ import java.util.Collection;
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class GracefulShutdownCorrectnessTest extends AbstractGracefulShutdownCorrectnessTest {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace-graceful-shutdown-correctness.xml");
 
     @Parameterized.Parameters(name = "backups:{0},nodes:{1},shutdown:{2}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/resources/log4j2-trace-graceful-shutdown-correctness.xml
+++ b/hazelcast/src/test/resources/log4j2-trace-graceful-shutdown-correctness.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.internal.partition.impl" level="trace"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR changes the log level of `com.hazelcast.internal.partition.impl` package to trace for GracefulShutdownCorrectnessTest to get more detailed logs for the partition migration operations in this test. 
It is necessary for a better understanding about this issue: #18163