### PR TITLE
Fixed another stability issue with Tenant Control tests, and fixed typo in API comments

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
@@ -827,7 +827,7 @@ public abstract class Operation implements DataSerializable, Tenantable {
     /**
      * Cleans up all of the thread context. This method should clear all potential
      * context items, not just the ones set up in {@link #pushThreadContext()}
-     * This acts as a catch-all for any potential class class loader and thread-local
+     * This acts as a catch-all for any potential class loader and thread-local
      * leaks.
      */
     public void clearThreadContext() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/tenantcontrol/TenantControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/tenantcontrol/TenantControl.java
@@ -110,7 +110,7 @@ public interface TenantControl extends DataSerializable {
      * Cleans up all of the thread context to avoid potential class loader leaks
      * This method should clear all potential context items,
      * not just the ones set up in {@link #setTenant()}
-     * This acts as a catch-all for any potential class class loader and thread-local leaks.
+     * This acts as a catch-all for any potential class loader and thread-local leaks.
      */
     void clearThreadContext();
 


### PR DESCRIPTION
Fixes #17990

- fixed TenantControlTest.testTenantControl_executionBeforeAfterOps() stability,
  when structure gets destroyed before opration completes, the number of thread clearing calls
  legitimately may be two or three, but mostly three
- removed typos from comments (duplicate word class) in the API and Operation