### PR TITLE
Improve MulticastService initialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -824,7 +824,7 @@ public class Node {
         JoinConfig join = getActiveMemberNetworkConfig(config).getJoin();
         join.verify();
 
-        if (shouldUseMulticastJoiner(join)) {
+        if (shouldUseMulticastJoiner(join) && multicastService != null) {
             logger.info("Using Multicast discovery");
             return new MulticastJoiner(this);
         } else if (join.getTcpIpConfig().isEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.MulticastConfig;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.logging.ILogger;
@@ -117,20 +118,16 @@ public final class MulticastService implements Runnable {
             multicastSocket.bind(new InetSocketAddress(multicastConfig.getMulticastPort()));
             multicastSocket.setTimeToLive(multicastConfig.getMulticastTimeToLive());
             try {
-                // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4417033
-                // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6402758
-                if (!bindAddress.getInetAddress().isLoopbackAddress()) {
-                    multicastSocket.setInterface(bindAddress.getInetAddress());
-                } else if (multicastConfig.isLoopbackModeEnabled()) {
-                    multicastSocket.setLoopbackMode(true);
-                    multicastSocket.setInterface(bindAddress.getInetAddress());
-                } else {
-                    // If LoopBack is not enabled but its the selected interface from the given
-                    // bind address, then we rely on Default Network Interface.
-                    logger.warning("Hazelcast is bound to " + bindAddress.getHost() + " and loop-back mode is disabled in "
-                            + "the configuration. This could cause multicast auto-discovery issues and render it unable to work. "
-                            + "Check your network connectivity, try to enable the loopback mode and/or "
-                            + "force -Djava.net.preferIPv4Stack=true on your JVM.");
+                multicastSocket.setInterface(bindAddress.getInetAddress());
+                if (bindAddress.getInetAddress().isLoopbackAddress()) {
+                    if (multicastConfig.isLoopbackModeEnabled()) {
+                        multicastSocket.setLoopbackMode(true);
+                    } else {
+                        logger.warning("Hazelcast is bound to " + bindAddress.getHost() + " and loop-back mode is "
+                                + "disabled in the configuration. This could cause multicast auto-discovery issues "
+                                + "and render it unable to work. Check your network connectivity, try to enable the "
+                                + "loopback mode and/or force -Djava.net.preferIPv4Stack=true on your JVM.");
+                    }
                 }
             } catch (Exception e) {
                 logger.warning(e);
@@ -148,6 +145,10 @@ public final class MulticastService implements Runnable {
             mcService.addMulticastListener(new NodeMulticastListener(node));
         } catch (Exception e) {
             logger.severe(e);
+            // fail-fast if multicast is explicitly enabled (i.e. autodiscovery is not used)
+            if (multicastConfig.isEnabled()) {
+                throw new HazelcastException("Starting the MulticastService failed", e);
+            }
         }
         return mcService;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -136,6 +136,7 @@ public class MulticastDeserializationTest {
         MulticastSocket multicastSocket = null;
         try {
             multicastSocket = new MulticastSocket(MULTICAST_PORT);
+            multicastSocket.setInterface(InetAddress.getByName("127.0.0.1"));
             multicastSocket.setTimeToLive(MULTICAST_TTL);
             InetAddress group = InetAddress.getByName(MULTICAST_GROUP);
             multicastSocket.joinGroup(group);


### PR DESCRIPTION
Resolves #17979.

This PR fixes the behavior of MulticastService. Failures during initialization led to `NullPointerException` in `MulticastJoiner`.

The fix handles the following 2 cases differently:
* default behavior where autodiscovery is used:  Errors in the `MulticastService` are logged, but Hazelcast member initialization continues (without the discovery enabled);
* multicast discovery is explicitly enabled in the config: Errors in the `MulticastService` fail the start of the member (i.e. fail fast approach)