### PR TITLE
Fix HazelcastStarter for versions without  InternalLogger

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
@@ -20,7 +20,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Log4j2Factory;
 import com.hazelcast.logging.LogEvent;
 import com.hazelcast.logging.LoggerFactorySupport;
-import com.hazelcast.logging.impl.InternalLogger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.LoggerContext;
 
@@ -106,7 +105,7 @@ public class TestLoggerFactory extends LoggerFactorySupport {
         return legacyLog4j2Factory.get();
     }
 
-    private static class DelegatingTestLogger implements ILogger, InternalLogger {
+    private static class DelegatingTestLogger implements ILogger {
 
         private static final long WARNING_THRESHOLD_NANOS = MILLISECONDS.toNanos(500);
 
@@ -114,11 +113,6 @@ public class TestLoggerFactory extends LoggerFactorySupport {
 
         private DelegatingTestLogger(ILogger delegate) {
             this.delegate = delegate;
-        }
-
-        @Override
-        public void setLevel(Level level) {
-            ((InternalLogger) delegate).setLevel(level);
         }
 
         @Override


### PR DESCRIPTION
Remove InternalLogger usage from TestLoggerFactory
This way we can still use HazelcastStarter with older 4.x
versions which does not have InternalLogger.

The downside is we can not set LogLevel tests dynamically by default
with new method. TestLoggerFactory has its own method of changing the
log level on the fly if necessary.

The new tests for changing the loglevel are passing because they
are not using TestLoggerFactory in the first place.
They are overriding the system property which is set by our
test initilization.

fixes https://github.com/hazelcast/hazelcast/issues/18228