### PR TITLE
Fix for query_cache_recreates_itself_after_server_restart: Wait for cache size to be 100

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheRecreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheRecreationTest.java
@@ -102,6 +102,9 @@ public class ClientQueryCacheRecreationTest extends HazelcastTestSupport {
             map.put(i, i);
         }
 
+        // Make sure that all events are processed before calling queryCache#recreate
+        assertCacheSizeEventually(queryCache, 100);
+
         InternalQueryCache internalQueryCache = (InternalQueryCache) queryCache;
         internalQueryCache.recreate();
 
@@ -157,6 +160,10 @@ public class ClientQueryCacheRecreationTest extends HazelcastTestSupport {
 
         assertTrueEventually(assertTask);
         assertTrueAllTheTime(assertTask, 3);
+    }
+
+    private static void assertCacheSizeEventually(QueryCache cache, int expectedCacheSize) {
+        assertTrueEventually(() -> assertEquals(expectedCacheSize, cache.size()));
     }
 
 }


### PR DESCRIPTION
The waiting will prevent the events originated from previous
statements to be processed in the client side while recreating
happens.

Fixes: https://github.com/hazelcast/hazelcast/issues/16328
More details: https://github.com/hazelcast/hazelcast/issues/16328#issuecomment-781224033