### PR TITLE
Make sure files are closed before deleting

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -666,9 +666,13 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
     private void sendTerminateRaftNodeOpsForDestroyedGroup(CPGroupInfo group) {
         Map<UUID, CPMemberInfo> activeMembersMap = getActiveMembersMap();
-        RaftEndpoint localEndpoint = getLocalCPMember().toRaftEndpoint();
+        CPMemberInfo localCPMember = getLocalCPMember();
+        if (localCPMember == null) {
+            return;
+        }
+        RaftEndpoint localEndpoint = localCPMember.toRaftEndpoint();
         OperationService operationService = nodeEngine.getOperationService();
-        for (RaftEndpoint endpoint : group.members())  {
+        for (RaftEndpoint endpoint : group.members()) {
             if (endpoint.equals(localEndpoint)) {
                 terminateRaftNodeAsync(group.id());
             } else {


### PR DESCRIPTION
The problem is specific to windows, if you delete a file before
close, you get a `FileSystemException`

The bug was around `RaftNodeImpl.forceSetTerminatedStatus`.
It checks if the status is `Terminated` or `SteppedDown`,
and if it is deletes the file right away.
The problem was the one that sets this `status`, closes the file
after setting the `status`. In this pr, we make sure we close
the file than set the `status`.

Also found a NullPointerException when using `getLocalCPMember`.
It can return null on the startup/reset situations. All the
usages are guarded by null check except one
See MetaDataRaftGroupManager.sendTerminateRaftNodeOpsForDestroyedGroup
That is also guarded by null check in this pr.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3570

backport of https://github.com/hazelcast/hazelcast/pull/18218
(cherry picked from commit e608701a0862d5816ec46cda990f4230d11efe48)