### PR TITLE
Remove warning in PhoneHome because of CloudInfoCollector

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/CloudInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/CloudInfoCollector.java
@@ -68,6 +68,7 @@ class CloudInfoCollector implements MetricsCollector {
     public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
         if (environmentInfo != null) {
             environmentInfo.forEach(metricsConsumer);
+            return;
         }
         Map<PhoneHomeMetrics, String> info = MapUtil.createHashMap(2);
         if (MetricsCollector.fetchWebService(awsEndpoint)) {


### PR DESCRIPTION
When phonehome called second time, this was causing an
unnecessay warning log.
Added missing return statement to fix it.