### PR TITLE
Make CachedQueryEntry to implement IDS

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -18,8 +18,14 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.impl.getters.Extractors;
+
+import java.io.IOException;
 
 /**
  * Entry of the Query.
@@ -27,7 +33,7 @@ import com.hazelcast.query.impl.getters.Extractors;
  * @param <K> key
  * @param <V> value
  */
-public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
+public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> implements IdentifiedDataSerializable {
 
     protected Data keyData;
     protected Data valueData;
@@ -196,4 +202,28 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
         return keyData.hashCode();
     }
 
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(getKey());
+        out.writeObject(getValue());
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        keyObject = in.readObject();
+        valueObject = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        // we are intentionally deserializing as LazyMapEntry
+        // which is actually a subclass of this
+        // TODO: write reasoning behind this
+        return MapDataSerializerHook.LAZY_MAP_ENTRY;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -221,9 +221,10 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> implements Iden
 
     @Override
     public int getClassId() {
-        // we are intentionally deserializing as LazyMapEntry
-        // which is actually a subclass of this
-        // TODO: write reasoning behind this
+        // We are intentionally deserializing CachedQueryEntry as LazyMapEntry
+        // LazyMapEntry is actually a subclass of CacheQueryEntry.
+        // If this sounds surprising, convoluted or just plain wrong
+        // then you are not wrong. Please see commit message for reasoning.
         return MapDataSerializerHook.LAZY_MAP_ENTRY;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.aggregation;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -69,12 +70,12 @@ public class AggregationMemberBounceTest extends HazelcastTestSupport {
                 @Override
                 public void run() {
                     String postfix = "";
-                    AggregatorsSpecTest.assertMinAggregators(map, postfix);
-                    AggregatorsSpecTest.assertMaxAggregators(map, postfix);
-                    AggregatorsSpecTest.assertSumAggregators(map, postfix);
-                    AggregatorsSpecTest.assertAverageAggregators(map, postfix);
-                    AggregatorsSpecTest.assertCountAggregators(map, postfix);
-                    AggregatorsSpecTest.assertDistinctAggregators(map, postfix);
+                    AggregatorsSpecTest.assertMinAggregators(map, postfix, Predicates.alwaysTrue());
+                    AggregatorsSpecTest.assertMaxAggregators(map, postfix, Predicates.alwaysTrue());
+                    AggregatorsSpecTest.assertSumAggregators(map, postfix, Predicates.alwaysTrue());
+                    AggregatorsSpecTest.assertAverageAggregators(map, postfix, Predicates.alwaysTrue());
+                    AggregatorsSpecTest.assertCountAggregators(map, postfix, Predicates.alwaysTrue());
+                    AggregatorsSpecTest.assertDistinctAggregators(map, postfix, Predicates.alwaysTrue());
                 }
             };
         }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
@@ -125,7 +125,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     @Test
     public void testAggregators() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex, postfix);
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex);
         populateMapWithPersons(map, postfix, PERSONS_COUNT);
 
         assertMinAggregators(map, postfix, predicate);
@@ -275,7 +275,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     @Test
     public void testAggregators_nullCornerCases() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex, postfix);
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex);
         map.put(0, postfix.contains("[any]") ? PersonAny.nulls() : new Person());
 
         if (postfix.contains("[any]")) {
@@ -302,7 +302,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     @Test
     public void testAggregators_emptyCornerCases() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex, postfix);
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex);
 
         if (postfix.contains("[any]")) {
             map.put(0, PersonAny.empty());
@@ -447,7 +447,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
         assertEquals(result, map.aggregate(Aggregators.distinct("optionalComparableValue" + p), predicate));
     }
 
-    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation, boolean useIndex, String postfix) {
+    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation, boolean useIndex) {
         if (nodeCount < 1) {
             throw new IllegalArgumentException("node count < 1");
         }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
@@ -119,8 +119,8 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        predicate = usePredicate ?
-                Predicates.greaterEqual("fieldWeCanQuery", Integer.MAX_VALUE) : Predicates.alwaysTrue();
+        predicate = usePredicate
+                ? Predicates.greaterEqual("fieldWeCanQuery", Integer.MAX_VALUE) : Predicates.alwaysTrue();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
@@ -18,15 +18,19 @@ package com.hazelcast.aggregation;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projections;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -71,252 +76,336 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
     @Parameter(2)
     public String postfix;
 
-    @Parameters(name = "{0} parallelAccumulation={1}, postfix={2}")
+    @Parameter(3)
+    public boolean useIndex;
+
+    @Parameter(4)
+    public boolean usePredicate;
+
+    private Predicate<Integer, Person> predicate;
+
+    @Parameters(name = "{0} parallelAccumulation={1}, postfix={2}, useIndex={3}, usePredicate={4}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {InMemoryFormat.BINARY, false, ""},
-                {InMemoryFormat.OBJECT, false, ""},
-                {InMemoryFormat.BINARY, true, ""},
-                {InMemoryFormat.OBJECT, true, ""},
+                {InMemoryFormat.BINARY, false, "", true, true},
+                {InMemoryFormat.OBJECT, false, "", true, true},
+                {InMemoryFormat.BINARY, true, "", true, true},
+                {InMemoryFormat.OBJECT, true, "", true, true},
+                {InMemoryFormat.BINARY, false, "[any]", true, true},
+                {InMemoryFormat.OBJECT, false, "[any]", true, true},
+                {InMemoryFormat.BINARY, true, "[any]", true, true},
+                {InMemoryFormat.OBJECT, true, "[any]", true, true},
+                {InMemoryFormat.BINARY, false, "", false, true},
+                {InMemoryFormat.OBJECT, false, "", false, true},
+                {InMemoryFormat.BINARY, true, "", false, true},
+                {InMemoryFormat.OBJECT, true, "", false, true},
+                {InMemoryFormat.BINARY, false, "[any]", false, true},
+                {InMemoryFormat.OBJECT, false, "[any]", false, true},
+                {InMemoryFormat.BINARY, true, "[any]", false, true},
+                {InMemoryFormat.OBJECT, true, "[any]", false, true},
 
-                {InMemoryFormat.BINARY, false, "[any]"},
-                {InMemoryFormat.OBJECT, false, "[any]"},
-                {InMemoryFormat.BINARY, true, "[any]"},
-                {InMemoryFormat.OBJECT, true, "[any]"},
+                // we skip combinations where (format=*, parallel=*, postfix=*, useIndex=true, usePredicate=false)
+                // because it's pointless to create an index when a predicate is not used
+                {InMemoryFormat.BINARY, false, "", false, false},
+                {InMemoryFormat.OBJECT, false, "", false, false},
+                {InMemoryFormat.BINARY, true, "", false, false},
+                {InMemoryFormat.OBJECT, true, "", false, false},
+                {InMemoryFormat.BINARY, false, "[any]", false, false},
+                {InMemoryFormat.OBJECT, false, "[any]", false, false},
+                {InMemoryFormat.BINARY, true, "[any]", false, false},
+                {InMemoryFormat.OBJECT, true, "[any]", false, false},
         });
+    }
+
+    @Before
+    public void setUp() {
+        predicate = usePredicate ?
+                Predicates.greaterEqual("fieldWeCanQuery", Integer.MAX_VALUE) : Predicates.alwaysTrue();
     }
 
     @Test
     public void testAggregators() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation);
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex, postfix);
         populateMapWithPersons(map, postfix, PERSONS_COUNT);
 
-        assertMinAggregators(map, postfix);
-        assertMaxAggregators(map, postfix);
-        assertSumAggregators(map, postfix);
-        assertAverageAggregators(map, postfix);
-        assertCountAggregators(map, postfix);
-        assertDistinctAggregators(map, postfix);
+        assertMinAggregators(map, postfix, predicate);
+        assertMaxAggregators(map, postfix, predicate);
+        assertSumAggregators(map, postfix, predicate);
+        assertAverageAggregators(map, postfix, predicate);
+        assertCountAggregators(map, postfix, predicate);
+        assertDistinctAggregators(map, postfix, predicate);
+        assertMaxByAggregators(map, postfix, predicate);
+        assertMinByAggregators(map, postfix, predicate);
     }
 
-    public static void assertMinAggregators(IMap<Integer, Person> map, String p) {
+    private static void assertMaxByAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("intValue" + p), predicate));
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("doubleValue" + p), predicate));
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("longValue" + p), predicate));
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("bigDecimalValue" + p), predicate));
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("bigIntegerValue" + p), predicate));
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("comparableValue" + p), predicate));
+        assertKeyEquals(999, map.aggregate(Aggregators.maxBy("optionalComparableValue" + p), predicate));
+    }
+
+    private static void assertMinByAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("intValue" + p), predicate));
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("doubleValue" + p), predicate));
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("longValue" + p), predicate));
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("bigDecimalValue" + p), predicate));
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("bigIntegerValue" + p), predicate));
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("comparableValue" + p), predicate));
+        assertKeyEquals(1, map.aggregate(Aggregators.minBy("optionalComparableValue" + p), predicate));
+    }
+
+    public static void assertMinAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.doubleMin("doubleValue" + p)));
-        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.longMin("longValue" + p)));
-        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.integerMin("intValue" + p)));
-        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.integerMin("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.bigDecimalMin("bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.bigIntegerMin("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.doubleMin("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.longMin("longValue" + p), predicate));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.integerMin("intValue" + p), predicate));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.integerMin("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.bigDecimalMin("bigDecimalValue" + p), predicate));
+        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.bigIntegerMin("bigIntegerValue" + p), predicate));
 
-        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.comparableMin("doubleValue" + p)));
-        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.comparableMin("longValue" + p)));
-        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.comparableMin("intValue" + p)));
-        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.comparableMin("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.comparableMin("bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.comparableMin("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.comparableMin("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.comparableMin("longValue" + p), predicate));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.comparableMin("intValue" + p), predicate));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.comparableMin("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.comparableMin("bigDecimalValue" + p), predicate));
+        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.comparableMin("bigIntegerValue" + p), predicate));
 
-        assertEquals("1", map.aggregate(Aggregators.comparableMin("comparableValue" + p)));
-        assertEquals("1", map.aggregate(Aggregators.comparableMin("optionalComparableValue" + p)));
+        assertEquals("1", map.aggregate(Aggregators.comparableMin("comparableValue" + p), predicate));
+        assertEquals("1", map.aggregate(Aggregators.comparableMin("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertMaxAggregators(IMap<Integer, Person> map, String p) {
+    public static void assertMaxAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.doubleMax("doubleValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.longMax("longValue" + p)));
-        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.integerMax("intValue" + p)));
-        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.integerMax("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.bigDecimalMax("bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.bigIntegerMax("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.doubleMax("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.longMax("longValue" + p), predicate));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.integerMax("intValue" + p), predicate));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.integerMax("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.bigDecimalMax("bigDecimalValue" + p), predicate));
+        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.bigIntegerMax("bigIntegerValue" + p), predicate));
 
-        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.comparableMax("doubleValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.comparableMax("longValue" + p)));
-        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.comparableMax("intValue" + p)));
-        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.comparableMax("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.comparableMax("bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.comparableMax("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.comparableMax("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.comparableMax("longValue" + p), predicate));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.comparableMax("intValue" + p), predicate));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.comparableMax("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.comparableMax("bigDecimalValue" + p), predicate));
+        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.comparableMax("bigIntegerValue" + p), predicate));
 
-        assertEquals("999", map.aggregate(Aggregators.comparableMax("comparableValue" + p)));
-        assertEquals("999", map.aggregate(Aggregators.comparableMax("optionalComparableValue" + p)));
+        assertEquals("999", map.aggregate(Aggregators.comparableMax("comparableValue" + p), predicate));
+        assertEquals("999", map.aggregate(Aggregators.comparableMax("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertSumAggregators(IMap<Integer, Person> map, String p) {
+    public static void assertSumAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(499500.0d), map.aggregate(Aggregators.doubleSum("doubleValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.longSum("longValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.integerSum("intValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.integerSum("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(499500), map.aggregate(Aggregators.bigDecimalSum("bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(499500), map.aggregate(Aggregators.bigIntegerSum("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(499500.0d), map.aggregate(Aggregators.doubleSum("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.longSum("longValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.integerSum("intValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.integerSum("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(499500), map.aggregate(Aggregators.bigDecimalSum("bigDecimalValue" + p), predicate));
+        assertEquals(BigInteger.valueOf(499500), map.aggregate(Aggregators.bigIntegerSum("bigIntegerValue" + p), predicate));
 
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("doubleValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("longValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("intValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("optionalIntValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("bigDecimalValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("longValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("intValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("optionalIntValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("bigIntegerValue" + p), predicate));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("bigDecimalValue" + p), predicate));
 
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("doubleValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("longValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("intValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("optionalIntValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("bigIntegerValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("bigDecimalValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("doubleValue" + p), predicate));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("longValue" + p), predicate));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("intValue" + p), predicate));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("optionalIntValue" + p), predicate));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("bigIntegerValue" + p), predicate));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("bigDecimalValue" + p), predicate));
     }
 
-    public static void assertAverageAggregators(IMap<Integer, Person> map, String p) {
+    public static void assertAverageAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.doubleAvg("doubleValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.longAvg("longValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.integerAvg("intValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.integerAvg("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.bigDecimalAvg("bigDecimalValue" + p)));
-        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.bigIntegerAvg("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.doubleAvg("doubleValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.longAvg("longValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.integerAvg("intValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.integerAvg("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.bigDecimalAvg("bigDecimalValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.bigIntegerAvg("bigIntegerValue" + p), predicate));
 
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("doubleValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("longValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("intValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("optionalIntValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("bigDecimalValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("doubleValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("longValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("intValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("optionalIntValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("bigDecimalValue" + p), predicate));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("bigIntegerValue" + p), predicate));
     }
 
-    public static void assertCountAggregators(IMap<Integer, Person> map, String p) {
+    public static void assertCountAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("doubleValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("longValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("intValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("optionalIntValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("bigDecimalValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("comparableValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("optionalComparableValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("longValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("intValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("optionalIntValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("bigDecimalValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("bigIntegerValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("comparableValue" + p), predicate));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertDistinctAggregators(IMap<Integer, Person> map, String p) {
+    public static void assertDistinctAggregators(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         // projections do not support [any] but we have one element only so here we go.
         assertNoDataMissing(map, PERSONS_COUNT);
         String projection = p.contains("[any]") ? "[0]" : "";
         assertCollectionEquals(map.project(Projections.singleAttribute("doubleValue" + projection)),
-                map.aggregate(Aggregators.distinct("doubleValue" + p)));
+                map.aggregate(Aggregators.distinct("doubleValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("longValue" + projection)),
-                map.aggregate(Aggregators.distinct("longValue" + p)));
+                map.aggregate(Aggregators.distinct("longValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("intValue" + projection)),
-                map.aggregate(Aggregators.distinct("intValue" + p)));
+                map.aggregate(Aggregators.distinct("intValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("optionalIntValue" + projection)),
-                map.aggregate(Aggregators.distinct("optionalIntValue" + p)));
+                map.aggregate(Aggregators.distinct("optionalIntValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("bigDecimalValue" + projection)),
-                map.aggregate(Aggregators.distinct("bigDecimalValue" + p)));
+                map.aggregate(Aggregators.distinct("bigDecimalValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("bigIntegerValue" + projection)),
-                map.aggregate(Aggregators.distinct("bigIntegerValue" + p)));
+                map.aggregate(Aggregators.distinct("bigIntegerValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("comparableValue" + projection)),
-                map.aggregate(Aggregators.distinct("comparableValue" + p)));
+                map.aggregate(Aggregators.distinct("comparableValue" + p), predicate));
         assertCollectionEquals(map.project(Projections.singleAttribute("optionalComparableValue" + projection)),
-                map.aggregate(Aggregators.distinct("optionalComparableValue" + p)));
+                map.aggregate(Aggregators.distinct("optionalComparableValue" + p), predicate));
     }
 
     @Test
     public void testAggregators_nullCornerCases() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation);
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex, postfix);
         map.put(0, postfix.contains("[any]") ? PersonAny.nulls() : new Person());
 
         if (postfix.contains("[any]")) {
-            assertMinAggregatorsAnyCornerCase(map, postfix);
-            assertMaxAggregatorsAnyCornerCase(map, postfix);
-            assertSumAggregatorsAnyCornerCase(map, postfix);
-            assertAverageAggregatorsAnyCornerCase(map, postfix);
-            assertCountAggregatorsAnyCornerCase(map, postfix, 0);
-            assertDistinctAggregatorsAnyCornerCase(map, postfix, emptySet());
+            assertMinAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertMaxAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertSumAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertAverageAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertCountAggregatorsAnyCornerCase(map, postfix, 0, predicate);
+            assertDistinctAggregatorsAnyCornerCase(map, postfix, emptySet(), predicate);
+            assertMinByAggregatorAnyCornerCase(map, postfix, predicate);
+            assertMaxByAggregatorAnyCornerCase(map, postfix, predicate);
         } else {
-            assertMinAggregatorsAnyCornerCase(map, postfix);
-            assertMaxAggregatorsAnyCornerCase(map, postfix);
+            assertMinAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertMaxAggregatorsAnyCornerCase(map, postfix, predicate);
             // sum and avg do not accept null values, thus skipped
-            assertCountAggregatorsAnyCornerCase(map, postfix, 1);
+            assertCountAggregatorsAnyCornerCase(map, postfix, 1, predicate);
             HashSet<?> expected = new HashSet<>();
             expected.add(null);
-            assertDistinctAggregatorsAnyCornerCase(map, postfix, expected);
+            assertDistinctAggregatorsAnyCornerCase(map, postfix, expected, predicate);
+            assertMinByAggregatorAnyCornerCase(map, postfix, predicate);
+            assertMaxByAggregatorAnyCornerCase(map, postfix, predicate);
         }
     }
 
     @Test
     public void testAggregators_emptyCornerCases() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation);
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation, useIndex, postfix);
 
         if (postfix.contains("[any]")) {
             map.put(0, PersonAny.empty());
-            assertMinAggregatorsAnyCornerCase(map, postfix);
-            assertMaxAggregatorsAnyCornerCase(map, postfix);
-            assertSumAggregatorsAnyCornerCase(map, postfix);
-            assertAverageAggregatorsAnyCornerCase(map, postfix);
-            assertCountAggregatorsAnyCornerCase(map, postfix, 0);
-            assertDistinctAggregatorsAnyCornerCase(map, postfix, emptySet());
+            assertMinAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertMaxAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertSumAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertAverageAggregatorsAnyCornerCase(map, postfix, predicate);
+            assertCountAggregatorsAnyCornerCase(map, postfix, 0, predicate);
+            assertDistinctAggregatorsAnyCornerCase(map, postfix, emptySet(), predicate);
+            assertMinByAggregatorAnyCornerCase(map, postfix, predicate);
+            assertMaxByAggregatorAnyCornerCase(map, postfix, predicate);
         }
     }
 
-    private void assertMinAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+    private static void assertMinByAggregatorAnyCornerCase(IMap<Integer, Person> map, String p,  Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, 1);
-        assertNull(map.aggregate(Aggregators.doubleMin("doubleValue" + p)));
-        assertNull(map.aggregate(Aggregators.longMin("longValue" + p)));
-        assertNull(map.aggregate(Aggregators.integerMin("intValue" + p)));
-        assertNull(map.aggregate(Aggregators.integerMin("optionalIntValue" + p)));
-        assertNull(map.aggregate(Aggregators.bigDecimalMin("bigDecimalValue" + p)));
-        assertNull(map.aggregate(Aggregators.bigIntegerMin("bigIntegerValue" + p)));
-
-        assertNull(map.aggregate(Aggregators.comparableMin("doubleValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMin("longValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMin("intValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMin("optionalIntValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMin("bigDecimalValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMin("bigIntegerValue" + p)));
-
-        assertNull(map.aggregate(Aggregators.comparableMin("comparableValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMin("optionalComparableValue" + p)));
+        assertNull(map.aggregate(Aggregators.minBy("doubleValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("longValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("intValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("optionalIntValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("bigDecimalValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("bigIntegerValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("comparableValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.minBy("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertMaxAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+    private static void assertMaxByAggregatorAnyCornerCase(IMap<Integer, Person> map, String p,  Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, 1);
-        assertNull(map.aggregate(Aggregators.doubleMax("doubleValue" + p)));
-        assertNull(map.aggregate(Aggregators.longMax("longValue" + p)));
-        assertNull(map.aggregate(Aggregators.integerMax("intValue" + p)));
-        assertNull(map.aggregate(Aggregators.integerMax("optionalIntValue" + p)));
-        assertNull(map.aggregate(Aggregators.bigDecimalMax("bigDecimalValue" + p)));
-        assertNull(map.aggregate(Aggregators.bigIntegerMax("bigIntegerValue" + p)));
-
-        assertNull(map.aggregate(Aggregators.comparableMax("doubleValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMax("longValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMax("intValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMax("optionalIntValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMax("bigDecimalValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMax("bigIntegerValue" + p)));
-
-        assertNull(map.aggregate(Aggregators.comparableMax("comparableValue" + p)));
-        assertNull(map.aggregate(Aggregators.comparableMax("optionalComparableValue" + p)));
+        assertNull(map.aggregate(Aggregators.maxBy("doubleValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("longValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("intValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("optionalIntValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("bigDecimalValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("bigIntegerValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("comparableValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.maxBy("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertSumAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+    private static void assertMinAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p,  Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, 1);
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.doubleSum("doubleValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.longSum("longValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.integerSum("intValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.integerSum("optionalIntValue" + p)));
-        assertEquals(BigDecimal.valueOf(0), map.aggregate(Aggregators.bigDecimalSum("bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(0), map.aggregate(Aggregators.bigIntegerSum("bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.doubleMin("doubleValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.longMin("longValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.integerMin("intValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.integerMin("optionalIntValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.bigDecimalMin("bigDecimalValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.bigIntegerMin("bigIntegerValue" + p), predicate));
 
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("doubleValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("longValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("intValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("optionalIntValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("doubleValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMin("longValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMin("intValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMin("optionalIntValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMin("bigDecimalValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMin("bigIntegerValue" + p), predicate));
 
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("doubleValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("longValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("intValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("optionalIntValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("bigIntegerValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("comparableValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMin("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertAverageAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+    public static void assertMaxAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
+        assertNoDataMissing(map, 1);
+        assertNull(map.aggregate(Aggregators.doubleMax("doubleValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.longMax("longValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.integerMax("intValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.integerMax("optionalIntValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.bigDecimalMax("bigDecimalValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.bigIntegerMax("bigIntegerValue" + p), predicate));
+
+        assertNull(map.aggregate(Aggregators.comparableMax("doubleValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMax("longValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMax("intValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMax("optionalIntValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMax("bigDecimalValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMax("bigIntegerValue" + p), predicate));
+
+        assertNull(map.aggregate(Aggregators.comparableMax("comparableValue" + p), predicate));
+        assertNull(map.aggregate(Aggregators.comparableMax("optionalComparableValue" + p), predicate));
+    }
+
+    public static void assertSumAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
+        assertNoDataMissing(map, 1);
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.doubleSum("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.longSum("longValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.integerSum("intValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.integerSum("optionalIntValue" + p), predicate));
+        assertEquals(BigDecimal.valueOf(0), map.aggregate(Aggregators.bigDecimalSum("bigDecimalValue" + p), predicate));
+        assertEquals(BigInteger.valueOf(0), map.aggregate(Aggregators.bigIntegerSum("bigIntegerValue" + p), predicate));
+
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("longValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("intValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("optionalIntValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("bigIntegerValue" + p), predicate));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("bigDecimalValue" + p), predicate));
+
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("doubleValue" + p), predicate));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("longValue" + p), predicate));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("intValue" + p), predicate));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("optionalIntValue" + p), predicate));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("bigIntegerValue" + p), predicate));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("bigDecimalValue" + p), predicate));
+    }
+
+    public static void assertAverageAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, 1);
         assertNull(map.aggregate(Aggregators.doubleAvg("doubleValue" + p)));
         assertNull(map.aggregate(Aggregators.longAvg("longValue" + p)));
@@ -333,31 +422,32 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
         assertNull(map.aggregate(Aggregators.numberAvg("bigIntegerValue" + p)));
     }
 
-    public static void assertCountAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, long value) {
+    public static void assertCountAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, long value,
+                                                           Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, 1);
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("doubleValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("longValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("intValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("optionalIntValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("bigDecimalValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("comparableValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("optionalComparableValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("doubleValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("longValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("intValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("optionalIntValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("bigDecimalValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("bigIntegerValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("comparableValue" + p), predicate));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("optionalComparableValue" + p), predicate));
     }
 
-    public static void assertDistinctAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Set result) {
+    public static void assertDistinctAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Set result, Predicate<Integer, Person> predicate) {
         assertNoDataMissing(map, 1);
-        assertEquals(result, map.aggregate(Aggregators.distinct("doubleValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("longValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("intValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("optionalIntValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("bigDecimalValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("bigIntegerValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("comparableValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.distinct("optionalComparableValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("doubleValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("longValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("intValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("optionalIntValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("bigDecimalValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("bigIntegerValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("comparableValue" + p), predicate));
+        assertEquals(result, map.aggregate(Aggregators.distinct("optionalComparableValue" + p), predicate));
     }
 
-    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation) {
+    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation, boolean useIndex, String postfix) {
         if (nodeCount < 1) {
             throw new IllegalArgumentException("node count < 1");
         }
@@ -365,6 +455,10 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
         MapConfig mapConfig = new MapConfig()
                 .setName("aggr")
                 .setInMemoryFormat(inMemoryFormat);
+
+        if (useIndex) {
+            mapConfig.addIndexConfig(new IndexConfig(IndexConfig.DEFAULT_TYPE, "fieldWeCanQuery"));
+        }
 
         Config config = getConfig()
                 .setProperty(PARTITION_COUNT.getName(), String.valueOf(nodeCount))
@@ -386,6 +480,11 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
         assertEquals("There is missing data in the map!", expectedSize, map.size());
     }
 
+    private static <T> void assertKeyEquals(T expectedValue, Map.Entry<T, ?> entry) {
+        T actualKeyValue = entry.getKey();
+        assertEquals(expectedValue, actualKeyValue);
+    }
+
     public static void populateMapWithPersons(IMap<Integer, Person> map, String postfix, int count) {
         for (int i = 1; i <= count; i++) {
             map.put(i, postfix.contains("[any]") ? new PersonAny(i) : new Person(i));
@@ -395,6 +494,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     @SuppressWarnings("WeakerAccess")
     public static class Person implements Serializable {
+        public int fieldWeCanQuery = Integer.MAX_VALUE;
 
         public Integer intValue;
         public Double doubleValue;

--- a/hazelcast/src/test/java/com/hazelcast/client/aggregation/ClientAggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/aggregation/ClientAggregatorsSpecTest.java
@@ -42,7 +42,7 @@ public class ClientAggregatorsSpecTest extends AggregatorsSpecTest {
     private TestHazelcastFactory factory;
 
     @Override
-    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation) {
+    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation, boolean useIndex, String postfix) {
         if (nodeCount < 1) {
             throw new IllegalArgumentException("node count < 1");
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/aggregation/ClientAggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/aggregation/ClientAggregatorsSpecTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.aggregation;
 import com.hazelcast.aggregation.AggregatorsSpecTest;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
@@ -42,7 +43,7 @@ public class ClientAggregatorsSpecTest extends AggregatorsSpecTest {
     private TestHazelcastFactory factory;
 
     @Override
-    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation, boolean useIndex, String postfix) {
+    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation, boolean useIndex) {
         if (nodeCount < 1) {
             throw new IllegalArgumentException("node count < 1");
         }
@@ -50,6 +51,10 @@ public class ClientAggregatorsSpecTest extends AggregatorsSpecTest {
         MapConfig mapConfig = new MapConfig()
                 .setName("aggr")
                 .setInMemoryFormat(inMemoryFormat);
+
+        if (useIndex) {
+            mapConfig.addIndexConfig(new IndexConfig(IndexConfig.DEFAULT_TYPE, "fieldWeCanQuery"));
+        }
 
         Config config = new Config()
                 .setProperty(PARTITION_COUNT.getName(), String.valueOf(nodeCount))

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.impl.wan.WanMapEntryView;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.predicates.BoundedRangePredicate;
 import com.hazelcast.query.impl.predicates.CompositeEqualPredicate;
 import com.hazelcast.query.impl.predicates.CompositeRangePredicate;
@@ -191,7 +192,7 @@ public class DataSerializableConventionsTest {
                     int factoryId = instance.getFactoryId();
                     int typeId = instance.getClassId();
                     if (factoryToTypeId.containsEntry(factoryId, typeId)) {
-                        fail("Factory-Type ID pair {" + factoryId + ", " + typeId + "} from " + klass.toString() + " is already"
+                        fail("Factory-Type ID pair {" + factoryId + ", " + typeId + "} from " + klass + " is already"
                                 + " registered in another type.");
                     } else {
                         factoryToTypeId.put(factoryId, typeId);
@@ -368,6 +369,7 @@ public class DataSerializableConventionsTest {
         whiteList.add(CompositeEqualPredicate.class);
         whiteList.add(EvaluatePredicate.class);
         whiteList.add(Converter.class);
+        whiteList.add(CachedQueryEntry.class);
         try {
             // these can't be accessed through the meta class since they are private
             whiteList.add(Class.forName("com.hazelcast.query.impl.predicates.CompositeIndexVisitor$Output"));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.SampleTestObjects.PortableEmployee;
 import com.hazelcast.query.impl.getters.Extractors;
@@ -207,6 +208,16 @@ public class CachedQueryEntryTest extends QueryEntryTest {
         CachedQueryEntry<Object, Object> entry = createEntry("key");
 
         entry.setValue(new Object());
+    }
+
+    @Test
+    public void testDeserialization() {
+        QueryableEntry entry = createEntry("key", "value");
+        int hashCode = entry.hashCode();
+        Data data = serializationService.toData(entry);
+        LazyMapEntry lazyMapEntry = serializationService.toObject(data);
+        assertEquals("key", lazyMapEntry.getKey());
+        assertEquals("value", lazyMapEntry.getValue());
     }
 
     private CachedQueryEntry<Object, Object> createEntry(Object key) {


### PR DESCRIPTION
Fixes #18131
CachedQueryEntry is an output of maxBy/minBy aggregations
when aggregating entries matching a predicate which was
evaluated by using an index.

The fix is not straightforward, there is some extra complexity
so recording here for future generations:

This changeset makes CachedQueryEntry to use the same Class ID
as LazyMapEntry which already is serializable. This means why you
serialize CachedQueryEntry and deserialize again you will get
an instance of LazyMapEntry. This is already confusing enough,
but it gets worst: LazyMapEntry is subclass of CachedQueryEntry!

So you might be asking: What is going on?
The explanation is not simple, but I will try anyway:

I could make the CachedQueryEntry to use a separate Class ID. But this means
all clients would have to be updated as well. As they would not know this new ID.

Still, this on its own would not justify using a class ID belonging to
a different class. This is the contract of LazyMapEntry: "When you serialize
and deserialize LazyMapEntry it loses its "lazy" properties." After deserialize
it behaves as if it was a plain SimpleMapEntry and that's exactly what we need.