### PR TITLE
Provide temporal types support for indexes

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/SortPhysicalRel.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/SortPhysicalRel.java
@@ -39,12 +39,12 @@ public class SortPhysicalRel extends Sort implements PhysicalRel {
         RelTraitSet traits,
         RelNode child,
         RelCollation collation,
-        boolean preSortedInput,
+        boolean requiresSort,
         RexNode offset,
         RexNode fetch
     ) {
         super(cluster, traits, child, collation, offset, fetch);
-        this.requiresSort = preSortedInput;
+        this.requiresSort = requiresSort;
     }
 
     public boolean requiresSort() {

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
@@ -37,6 +37,10 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -223,6 +227,21 @@ public class SqlOrderByTest extends SqlTestSupport {
             "decimalVal",
             "charVal",
             "varcharVal");
+
+        List<Boolean> orderDirections = new ArrayList<>(fields.size());
+        fields.forEach(entry -> orderDirections.add(true));
+
+        checkSelectWithOrderBy(fields, fields, orderDirections);
+    }
+
+    @Test
+    public void testSelectWithOrderByDefaultTemporalTypes() {
+        List<String> fields = Arrays.asList(
+                "dateVal",
+                "timeVal",
+                "timestampVal",
+                "tsTzOffsetDateTimeVal"
+        );
 
         List<Boolean> orderDirections = new ArrayList<>(fields.size());
         fields.forEach(entry -> orderDirections.add(true));
@@ -751,6 +770,14 @@ public class SqlOrderByTest extends SqlTestSupport {
                     cmp = ((Short) prevFieldValue).compareTo((Short) fieldValue);
                 } else if (fieldValue instanceof BigDecimal) {
                     cmp = ((BigDecimal) prevFieldValue).compareTo((BigDecimal) fieldValue);
+                } else if (fieldValue instanceof LocalTime) {
+                    cmp = ((LocalTime) prevFieldValue).compareTo((LocalTime) fieldValue);
+                } else if (fieldValue instanceof LocalDate) {
+                    cmp = ((LocalDate) prevFieldValue).compareTo((LocalDate) fieldValue);
+                } else if (fieldValue instanceof LocalDateTime) {
+                    cmp = ((LocalDateTime) prevFieldValue).compareTo((LocalDateTime) fieldValue);
+                } else if (fieldValue instanceof OffsetDateTime) {
+                    cmp = ((OffsetDateTime) prevFieldValue).compareTo((OffsetDateTime) fieldValue);
                 } else {
                     fail("Not supported field type " + fieldValue.getClass());
                 }

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
@@ -237,10 +237,10 @@ public class SqlOrderByTest extends SqlTestSupport {
     @Test
     public void testSelectWithOrderByDefaultTemporalTypes() {
         List<String> fields = Arrays.asList(
-                "dateVal",
-                "timeVal",
-                "timestampVal",
-                "tsTzOffsetDateTimeVal"
+            "dateVal",
+            "timeVal",
+            "timestampVal",
+            "tsTzOffsetDateTimeVal"
         );
 
         List<Boolean> orderDirections = new ArrayList<>(fields.size());

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
@@ -89,7 +89,23 @@ public enum AttributeType {
     /**
      * Portable
      */
-    PORTABLE(TypeConverters.PORTABLE_CONVERTER);
+    PORTABLE(TypeConverters.PORTABLE_CONVERTER),
+    /**
+     * Local Time
+     */
+    SQL_LOCAL_TIME(TypeConverters.LOCAL_TIME_CONVERTER),
+    /**
+     * Local Date
+     */
+    SQL_LOCAL_DATE(TypeConverters.LOCAL_DATE_CONVERTER),
+    /**
+     * Local Date Time
+     */
+    SQL_LOCAL_DATE_TIME(TypeConverters.LOCAL_DATE_TIME_CONVERTER),
+    /**
+     * Offset Date Time
+     */
+    SQL_OFFSET_DATE_TIME(TypeConverters.OFFSET_DATE_TIME_CONVERTER);
 
     private final TypeConverter converter;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -22,8 +22,13 @@ import com.hazelcast.nio.serialization.Portable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Date;
-
+import java.util.TimeZone;
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 
 public final class TypeConverters {
@@ -47,6 +52,10 @@ public final class TypeConverters {
     public static final TypeConverter NULL_CONVERTER = new IdentityConverter();
     public static final TypeConverter UUID_CONVERTER = new UUIDConverter();
     public static final TypeConverter PORTABLE_CONVERTER = new PortableConverter();
+    public static final TypeConverter LOCAL_TIME_CONVERTER = new SqlLocalTimeConverter();
+    public static final TypeConverter LOCAL_DATE_CONVERTER = new SqlLocalDateConverter();
+    public static final TypeConverter LOCAL_DATE_TIME_CONVERTER = new SqlLocalDateTimeConverter();
+    public static final TypeConverter OFFSET_DATE_TIME_CONVERTER = new SqlOffsetDateTimeConverter();
 
     private TypeConverters() {
     }
@@ -602,6 +611,113 @@ public final class TypeConverters {
                 return value;
             }
             throw new IllegalArgumentException("Cannot convert [" + value + "]");
+        }
+
+    }
+
+    /**
+     * @see com.hazelcast.sql.SqlColumnType TIME
+     */
+    static class SqlLocalTimeConverter extends BaseTypeConverter {
+
+        @Override
+        Comparable convertInternal(Comparable value) {
+            if (value instanceof LocalTime) {
+                return value;
+            }
+            if (value instanceof String) {
+                return LocalTime.parse((String) value);
+            }
+            if (value instanceof Number) {
+                Number number = (Number) value;
+                return convertNumberToLocalTime(number);
+            }
+            throw new IllegalArgumentException("Cannot convert [" + value + "] to java.time.LocalTime");
+        }
+
+        private LocalTime convertNumberToLocalTime(Number number) {
+            LocalDateTime ldTime = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(number.longValue()), TimeZone.getDefault().toZoneId());
+            return ldTime.toLocalTime();
+        }
+    }
+
+    /**
+     * @see com.hazelcast.sql.SqlColumnType DATE
+     */
+    static class SqlLocalDateConverter extends BaseTypeConverter {
+
+        @Override
+        Comparable convertInternal(Comparable value) {
+            if (value instanceof LocalDate) {
+                return value;
+            }
+            if (value instanceof String) {
+                return LocalDate.parse((String) value);
+            }
+            if (value instanceof Number) {
+                Number number = (Number) value;
+                return convertNumberToLocalTime(number);
+            }
+            throw new IllegalArgumentException("Cannot convert [" + value + "] to java.time.LocalTime");
+        }
+
+        private LocalDate convertNumberToLocalTime(Number number) {
+            LocalDateTime ldTime = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(number.longValue()), TimeZone.getDefault().toZoneId());
+            return ldTime.toLocalDate();
+        }
+    }
+
+    /**
+     * @see com.hazelcast.sql.SqlColumnType TIMESTAMP
+     */
+    static class SqlLocalDateTimeConverter extends BaseTypeConverter {
+
+        @Override
+        Comparable convertInternal(Comparable value) {
+            if (value instanceof LocalDateTime) {
+                return value;
+            }
+            if (value instanceof String) {
+                return LocalDateTime.parse((String) value);
+            }
+            if (value instanceof Number) {
+                Number number = (Number) value;
+                return convertNumberToLocalDateTime(number);
+            }
+            throw new IllegalArgumentException("Cannot convert [" + value + "] to java.time.LocalDateTime");
+        }
+
+        private LocalDateTime convertNumberToLocalDateTime(Number number) {
+            return LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(number.longValue()), TimeZone.getDefault().toZoneId());
+        }
+    }
+
+    /**
+     * @see com.hazelcast.sql.SqlColumnType TIMESTAMP_WITH_TIME_ZONE
+     */
+    static class SqlOffsetDateTimeConverter extends BaseTypeConverter {
+
+        @Override
+        Comparable convertInternal(Comparable value) {
+            if (value instanceof OffsetDateTime) {
+                return value;
+            }
+            if (value instanceof String) {
+                return OffsetDateTime.parse((String) value);
+            }
+            if (value instanceof Number) {
+                Number number = (Number) value;
+                return convertNumberToOffsetDateTime(number);
+            }
+            throw new IllegalArgumentException("Cannot convert [" + value + "] to java.time.LocalTime");
+        }
+
+        private OffsetDateTime convertNumberToOffsetDateTime(Number number) {
+            return OffsetDateTime.ofInstant(
+                    Instant.ofEpochMilli(number.longValue()), TimeZone.getDefault().toZoneId());
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -712,7 +712,7 @@ public final class TypeConverters {
                 Number number = (Number) value;
                 return convertNumberToOffsetDateTime(number);
             }
-            throw new IllegalArgumentException("Cannot convert [" + value + "] to java.time.LocalTime");
+            throw new IllegalArgumentException("Cannot convert [" + value + "] to java.time.OffsetDateTime");
         }
 
         private OffsetDateTime convertNumberToOffsetDateTime(Number number) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -25,6 +25,10 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -77,6 +81,14 @@ public final class ReflectionHelper {
             return AttributeType.SQL_DATE;
         } else if (klass == Date.class) {
             return AttributeType.DATE;
+        } else if (klass == LocalTime.class) {
+            return AttributeType.SQL_LOCAL_TIME;
+        } else if (klass == LocalDate.class) {
+            return AttributeType.SQL_LOCAL_DATE;
+        } else if (klass == LocalDateTime.class) {
+            return AttributeType.SQL_LOCAL_DATE_TIME;
+        } else if (klass == OffsetDateTime.class) {
+            return AttributeType.SQL_OFFSET_DATE_TIME;
         } else if (klass.isEnum()) {
             return AttributeType.ENUM;
         } else if (klass == UUID.class) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
@@ -214,6 +214,14 @@ public final class MapTableUtils {
             return QueryDataType.VARCHAR;
         } else if (converter == TypeConverters.CHAR_CONVERTER) {
             return QueryDataType.VARCHAR_CHARACTER;
+        } else if (converter == TypeConverters.LOCAL_TIME_CONVERTER) {
+            return QueryDataType.TIME;
+        } else if (converter == TypeConverters.LOCAL_DATE_CONVERTER) {
+            return QueryDataType.DATE;
+        } else if (converter == TypeConverters.LOCAL_DATE_TIME_CONVERTER) {
+            return QueryDataType.TIMESTAMP;
+        } else if (converter == TypeConverters.OFFSET_DATE_TIME_CONVERTER) {
+            return QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME;
         } else if (converter == TypeConverters.ENUM_CONVERTER) {
             return QueryDataType.OBJECT;
         } else if (converter == TypeConverters.IDENTITY_CONVERTER) {


### PR DESCRIPTION
This PR provides temporal types support for indexes by adding converters for missing types (`LocalTime`, `LocalDate`, `LocalDateTime` and `OffsetDateTime`)
Closes #18109.