### PR TITLE
Fire membership events when persistence enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -844,8 +844,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         logger.info("Clearing local state of the client, because of a cluster restart.");
 
         dispose(onClusterChangeDisposables);
-        //clear the member list version
-        clusterService.clearMemberListVersion();
+        clusterService.clearMemberList();
     }
 
     public void waitForInitialMembershipEvents() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static java.util.Collections.EMPTY_SET;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableSet;
 
@@ -215,6 +216,22 @@ public class ClientClusterServiceImpl
                 memberListSnapshot.set(new MemberListSnapshot(0, clusterViewSnapshot.members));
             }
         }
+    }
+
+    /**
+     * Clears the member list and fires member removed event for members in the list.
+     */
+    public void clearMemberList() {
+        List<MembershipEvent> events;
+        synchronized (clusterViewLock) {
+            if (logger.isFineEnabled()) {
+                logger.fine("Resetting the member list ");
+            }
+            Collection<Member> prevMembers = memberListSnapshot.get().members.values();
+            memberListSnapshot.set(new MemberListSnapshot(0, new LinkedHashMap<>()));
+            events = detectMembershipEvents(prevMembers, EMPTY_SET);
+        }
+        fireEvents(events);
     }
 
     public void reset() {

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -98,6 +98,8 @@ public class ClientClusterRestartEventTest {
         });
 
         instance.shutdown();
+        //Allow same addresses to be used to test hot restart correctly
+        hazelcastFactory.cleanup();
         instance = hazelcastFactory.newHazelcastInstance(newConfig());
         Member newMember = instance.getCluster().getLocalMember();
 
@@ -147,7 +149,8 @@ public class ClientClusterRestartEventTest {
                 throw new AssertionError(e);
             }
         });
-
+        //Allow same addresses to be used to test hot restart correctly
+        hazelcastFactory.cleanup();
         Future<HazelcastInstance> f1 = spawn(() -> hazelcastFactory.newHazelcastInstance(newConfig()));
         Future<HazelcastInstance> f2 = spawn(() -> hazelcastFactory.newHazelcastInstance(newConfig()));
 

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -73,7 +73,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastClient(ClientConfig config, String sourceIp) {
         if (!mockNetwork) {
             HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
-            registerJvmNameAndPidMetric((HazelcastClientInstanceImpl) client);
+            registerJvmNameAndPidMetric(((HazelcastClientProxy) client).client);
             return client;
         }
 


### PR DESCRIPTION
When persistence enabled, client does not fire membership
events because members starts with same uuid's.

With this pr, we make sure that when cluster restarted,
we always update the local memberlist with empty member list
first.
This way, we will be able to fire member removed/added events
even if member uuid's does not change.

Note that if cluster uuid does not change, we will not fire
any event. This happens client disconnected and connected
back to the same cluster.
Note that cluster uuid is not preserved on hotrestart with
presistence.

There was already a test to verify this behaviour but it
was working wrong.
"ClientHotRestartTest extends ClientClusterRestartEventTest"
In this pr, we make sure that the test uses same address
for the restarted member to test this correctly.

fixes https://github.com/hazelcast/hazelcast/issues/18234