### PR TITLE
Set client connection timeout to prevent test timeouts

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
@@ -42,6 +42,7 @@ import static classloading.ThreadLeakTestUtils.getThreads;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class ThreadLeakClientTest {
+    private static int TIMEOUT_MS = 5 * 1000;
 
     @After
     public void shutdownInstances() {
@@ -76,8 +77,14 @@ public class ThreadLeakClientTest {
     @Test(expected = IllegalStateException.class)
     public void testThreadLeakWhenClientCanNotStart() {
         Set<Thread> testStartThreads = getThreads();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig()
+                .getConnectionRetryConfig()
+                .setClusterConnectTimeoutMillis(TIMEOUT_MS);
+
         try {
-            HazelcastClient.newHazelcastClient();
+            HazelcastClient.newHazelcastClient(clientConfig);
         } finally {
             assertHazelcastThreadShutdown(testStartThreads);
         }
@@ -88,6 +95,7 @@ public class ThreadLeakClientTest {
         Hazelcast.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
         config.setClusterName("invalid cluster");
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(TIMEOUT_MS);
         Set<Thread> testStartThreads = getThreads();
         try {
             HazelcastClient.newHazelcastClient(config);
@@ -103,6 +111,7 @@ public class ThreadLeakClientTest {
         config.getNetworkConfig().getDiscoveryConfig().addDiscoveryStrategyConfig(
                 new DiscoveryStrategyConfig(new ClientDiscoverySpiTest.NoMemberDiscoveryStrategyFactory(),
                         Collections.<String, Comparable>emptyMap()));
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(TIMEOUT_MS);
         Set<Thread> testStartThreads = getThreads();
         try {
             HazelcastClient.newHazelcastClient(config);

--- a/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakClientTest.java
@@ -42,7 +42,7 @@ import static classloading.ThreadLeakTestUtils.getThreads;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class ThreadLeakClientTest {
-    private static int TIMEOUT_MS = 5 * 1000;
+    private int zeroTimeout = 0;
 
     @After
     public void shutdownInstances() {
@@ -81,7 +81,7 @@ public class ThreadLeakClientTest {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig()
                 .getConnectionRetryConfig()
-                .setClusterConnectTimeoutMillis(TIMEOUT_MS);
+                .setClusterConnectTimeoutMillis(zeroTimeout);
 
         try {
             HazelcastClient.newHazelcastClient(clientConfig);
@@ -95,7 +95,7 @@ public class ThreadLeakClientTest {
         Hazelcast.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
         config.setClusterName("invalid cluster");
-        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(TIMEOUT_MS);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(zeroTimeout);
         Set<Thread> testStartThreads = getThreads();
         try {
             HazelcastClient.newHazelcastClient(config);
@@ -111,7 +111,7 @@ public class ThreadLeakClientTest {
         config.getNetworkConfig().getDiscoveryConfig().addDiscoveryStrategyConfig(
                 new DiscoveryStrategyConfig(new ClientDiscoverySpiTest.NoMemberDiscoveryStrategyFactory(),
                         Collections.<String, Comparable>emptyMap()));
-        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(TIMEOUT_MS);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(zeroTimeout);
         Set<Thread> testStartThreads = getThreads();
         try {
             HazelcastClient.newHazelcastClient(config);


### PR DESCRIPTION
Some tests are failing because they hit test timeouts.
The reason is that the clients are trying to connect in impossible
conditions since the test checks these impossible
conditions. The clients continuously try to establish connections
which leads to test timeouts.

Fixes: https://github.com/hazelcast/hazelcast/issues/18227