### PR TITLE
Fix loopback mode for the MulticastService.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -57,7 +57,7 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
      * Default flag that indicates if the loopback mode
      * is turned on or off.
      */
-    public static final boolean DEFAULT_LOOPBACK_MODE_ENABLED = false;
+    public static final boolean DEFAULT_LOOPBACK_MODE_ENABLED = true;
 
     private static final int MULTICAST_TTL_UPPER_BOUND = 255;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -120,11 +120,11 @@ public final class MulticastService implements Runnable {
             try {
                 multicastSocket.setInterface(bindAddress.getInetAddress());
                 if (bindAddress.getInetAddress().isLoopbackAddress()) {
-                    if (multicastConfig.isLoopbackModeEnabled()) {
-                        multicastSocket.setLoopbackMode(true);
-                    } else {
+                    // the parameter of the setLoopbackMode method is "disable: true to disable the LoopbackMode"!
+                    multicastSocket.setLoopbackMode(! multicastConfig.isLoopbackModeEnabled());
+                    if (multicastSocket.getLoopbackMode()) {
                         logger.warning("Hazelcast is bound to " + bindAddress.getHost() + " and loop-back mode is "
-                                + "disabled in the configuration. This could cause multicast auto-discovery issues "
+                                + "disabled. This could cause multicast auto-discovery issues "
                                 + "and render it unable to work. Check your network connectivity, try to enable the "
                                 + "loopback mode and/or force -Djava.net.preferIPv4Stack=true on your JVM.");
                     }


### PR DESCRIPTION
This PR is a follow-up for #18225. The original patch caused compatibility test failures in Hazelcast EE.

The change in this PR fixes usage (semantics) of `MulticastSocket.setLoopbackMode()` call.

Compatibility test run with the fix applied:
http://jenkins.hazelcast.com/job/tmp-josef-EE-compatibility/4/#showFailuresLink

Fixes hazelcast/hazelcast-enterprise#3949