### PR TITLE
Fixes mbean leak after test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicBlockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicBlockTest.java
@@ -16,13 +16,11 @@
 
 package com.hazelcast.client.topic;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientReliableTopicConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -67,8 +65,7 @@ public class ClientReliableTopicBlockTest extends HazelcastTestSupport {
 
     @After
     public void teardown() {
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+        hazelcastFactory.terminateAll();
     }
 
     @Test


### PR DESCRIPTION
HazelcastClient is not aware of client instances
started by TestHazelcastFactory -> leftovers
were not cleaned up after test execution.

Fixes #16206