### PR TITLE
Add RBAC support for MC executed actions

### DIFF
--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -875,6 +875,7 @@
                             <hz:action>all</hz:action>
                         </hz:actions>
                     </hz:replicatedmap-permission>
+                    <hz:management-permission principal="mcadmin"/>
                 </hz:client-permissions>
                 <hz:client-block-unmapped-actions>false</hz:client-block-unmapped-actions>
             </hz:security>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1921,10 +1921,10 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             permissionConfigBuilder.addPropertyValue("type", type);
             NamedNodeMap attributes = node.getAttributes();
             Node nameNode = attributes.getNamedItem("name");
-            String name = nameNode != null ? getTextContent(nameNode) : "*";
+            String name = nameNode != null ? getTextContent(nameNode) : null;
             permissionConfigBuilder.addPropertyValue("name", name);
             Node principalNode = attributes.getNamedItem("principal");
-            String principal = principalNode != null ? getTextContent(principalNode) : "*";
+            String principal = principalNode != null ? getTextContent(principalNode) : null;
             permissionConfigBuilder.addPropertyValue("principal", principal);
             List<String> endpoints = new ManagedList<>();
             List<String> actions = new ManagedList<>();

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.2.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.2.xsd
@@ -2857,6 +2857,10 @@
                                     maxOccurs="unbounded"/>
                         <xs:element name="replicatedmap-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
+                        <xs:element name="replicatedmap-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="management-permission" type="management-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
                     </xs:choice>
                     <xs:attribute name="on-join-operation" type="permission-on-join-operation" default="RECEIVE"/>
                 </xs:complexType>
@@ -2934,6 +2938,20 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="management-permission">
+        <xs:complexContent>
+            <xs:extension base="base-permission">
+                <xs:attribute name="name" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Optional name of the permission. Simple wildcard (*) or prefixes (prefix.*) can be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="instance-permission">

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -526,7 +526,7 @@ import com.hazelcast.client.impl.protocol.task.list.ListSetMessageTask;
 import com.hazelcast.client.impl.protocol.task.list.ListSizeMessageTask;
 import com.hazelcast.client.impl.protocol.task.list.ListSubMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.AddWanBatchPublisherConfigMessageTask;
-import com.hazelcast.client.impl.protocol.task.management.ApplyMCConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.management.ApplyClientFilteringConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.ChangeClusterStateMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.ChangeClusterVersionMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.ChangeWanReplicationStateMessageTask;
@@ -543,7 +543,7 @@ import com.hazelcast.client.impl.protocol.task.management.HotRestartInterruptBac
 import com.hazelcast.client.impl.protocol.task.management.HotRestartTriggerBackupMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.HotRestartTriggerForceStartMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.HotRestartTriggerPartialStartMessageTask;
-import com.hazelcast.client.impl.protocol.task.management.MatchMCConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.management.MatchClientFilteringConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.PollMCEventsMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.PromoteLiteMemberMessageTask;
 import com.hazelcast.client.impl.protocol.task.management.PromoteToCPMemberMessageTask;
@@ -1777,9 +1777,9 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories.put(MCGetTimedMemberStateCodec.REQUEST_MESSAGE_TYPE,
                 (cm, con) -> new GetTimedMemberStateMessageTask(cm, node, con));
         factories.put(MCMatchMCConfigCodec.REQUEST_MESSAGE_TYPE,
-                (cm, con) -> new MatchMCConfigMessageTask(cm, node, con));
+                (cm, con) -> new MatchClientFilteringConfigMessageTask(cm, node, con));
         factories.put(MCApplyMCConfigCodec.REQUEST_MESSAGE_TYPE,
-                (cm, con) -> new ApplyMCConfigMessageTask(cm, node, con));
+                (cm, con) -> new ApplyClientFilteringConfigMessageTask(cm, node, con));
         factories.put(MCGetClusterMetadataCodec.REQUEST_MESSAGE_TYPE,
                 (cm, con) -> new GetClusterMetadataMessageTask(cm, node, con));
         factories.put(MCShutdownClusterCodec.REQUEST_MESSAGE_TYPE,

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/AddWanBatchPublisherConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/AddWanBatchPublisherConfigMessageTask.java
@@ -37,7 +37,7 @@ import static com.hazelcast.config.WanBatchPublisherConfig.DEFAULT_QUEUE_FULL_BE
 
 public class AddWanBatchPublisherConfigMessageTask extends AbstractCallableMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.addBatchPublisherConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.addBatchPublisherConfig");
 
     public AddWanBatchPublisherConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/AddWanBatchPublisherConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/AddWanBatchPublisherConfigMessageTask.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.WanQueueFullBehavior;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.wan.impl.AddWanConfigResult;
 import com.hazelcast.wan.impl.WanReplicationService;
 
@@ -35,6 +36,9 @@ import static com.hazelcast.config.WanBatchPublisherConfig.DEFAULT_ACKNOWLEDGE_T
 import static com.hazelcast.config.WanBatchPublisherConfig.DEFAULT_QUEUE_FULL_BEHAVIOUR;
 
 public class AddWanBatchPublisherConfigMessageTask extends AbstractCallableMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.addBatchPublisherConfig");
+
     public AddWanBatchPublisherConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -83,7 +87,7 @@ public class AddWanBatchPublisherConfigMessageTask extends AbstractCallableMessa
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ApplyClientFilteringConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ApplyClientFilteringConfigMessageTask.java
@@ -17,37 +17,48 @@
 package com.hazelcast.client.impl.protocol.task.management;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.MCMatchMCConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.MCApplyMCConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.MCApplyMCConfigCodec.RequestParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.internal.management.dto.ClientBwListDTO;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
-public class MatchMCConfigMessageTask extends AbstractCallableMessageTask<String> {
+public class ApplyClientFilteringConfigMessageTask extends AbstractCallableMessageTask<RequestParameters> {
 
-    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("clientfiltering.matchConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("clientfiltering.applyConfig");
 
-    public MatchMCConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    public ApplyClientFilteringConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
     protected Object call() throws Exception {
-        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
-        return mcService != null && parameters.equals(mcService.getLastMCConfigETag());
+        ManagementCenterService mcs = nodeEngine.getManagementCenterService();
+        if (mcs == null) {
+            throw new HazelcastException("ManagementCenterService is not initialized yet");
+        }
+        ClientBwListDTO.Mode mode = ClientBwListDTO.Mode.getById(parameters.clientBwListMode);
+        if (mode == null) {
+            throw new IllegalArgumentException("Unexpected client B/W list mode = [" + parameters.clientBwListMode + "]");
+        }
+        mcs.applyMCConfig(parameters.eTag, new ClientBwListDTO(mode, parameters.clientBwListEntries));
+        return null;
     }
 
     @Override
-    protected String decodeClientMessage(ClientMessage clientMessage) {
-        return MCMatchMCConfigCodec.decodeRequest(clientMessage);
+    protected RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MCApplyMCConfigCodec.decodeRequest(clientMessage);
     }
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MCMatchMCConfigCodec.encodeResponse((Boolean) response);
+        return MCApplyMCConfigCodec.encodeResponse();
     }
 
     @Override
@@ -67,12 +78,16 @@ public class MatchMCConfigMessageTask extends AbstractCallableMessageTask<String
 
     @Override
     public String getMethodName() {
-        return "matchMCConfig";
+        return "applyMCConfig";
     }
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters};
+        return new Object[] {
+                parameters.eTag,
+                parameters.clientBwListMode,
+                parameters.clientBwListEntries
+        };
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ApplyMCConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ApplyMCConfigMessageTask.java
@@ -25,10 +25,13 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.dto.ClientBwListDTO;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class ApplyMCConfigMessageTask extends AbstractCallableMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("applyMCConfig");
 
     public ApplyMCConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -65,7 +68,7 @@ public class ApplyMCConfigMessageTask extends AbstractCallableMessageTask<Reques
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ApplyMCConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ApplyMCConfigMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 
 public class ApplyMCConfigMessageTask extends AbstractCallableMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("applyMCConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("clientfiltering.applyConfig");
 
     public ApplyMCConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterStateMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ChangeClusterStateOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
@@ -32,6 +33,8 @@ import java.security.Permission;
 import static com.hazelcast.client.impl.protocol.codec.MCChangeClusterStateCodec.decodeRequest;
 
 public class ChangeClusterStateMessageTask extends AbstractInvocationMessageTask<Integer> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.changeState");
 
     public ChangeClusterStateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -70,7 +73,7 @@ public class ChangeClusterStateMessageTask extends AbstractInvocationMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterStateMessageTask.java
@@ -34,7 +34,7 @@ import static com.hazelcast.client.impl.protocol.codec.MCChangeClusterStateCodec
 
 public class ChangeClusterStateMessageTask extends AbstractInvocationMessageTask<Integer> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.changeState");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.changeState");
 
     public ChangeClusterStateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterVersionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterVersionMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 
 public class ChangeClusterVersionMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.changeVersion");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.changeVersion");
 
     public ChangeClusterVersionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterVersionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeClusterVersionMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ChangeClusterVersionOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.version.Version;
@@ -31,6 +32,8 @@ import com.hazelcast.version.Version;
 import java.security.Permission;
 
 public class ChangeClusterVersionMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.changeVersion");
 
     public ChangeClusterVersionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -65,7 +68,7 @@ public class ChangeClusterVersionMessageTask extends AbstractInvocationMessageTa
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeWanReplicationStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeWanReplicationStateMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.operation.ChangeWanStateOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.wan.WanPublisherState;
@@ -31,6 +32,9 @@ import com.hazelcast.wan.impl.WanReplicationService;
 import java.security.Permission;
 
 public class ChangeWanReplicationStateMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.changeReplicationState");
+
     public ChangeWanReplicationStateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -70,7 +74,7 @@ public class ChangeWanReplicationStateMessageTask extends AbstractInvocationMess
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeWanReplicationStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ChangeWanReplicationStateMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 
 public class ChangeWanReplicationStateMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.changeReplicationState");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.changeReplicationState");
 
     public ChangeWanReplicationStateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/CheckWanConsistencyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/CheckWanConsistencyMessageTask.java
@@ -22,12 +22,16 @@ import com.hazelcast.client.impl.protocol.codec.MCCheckWanConsistencyCodec.Reque
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.wan.impl.WanReplicationService;
 
 import java.security.Permission;
 import java.util.UUID;
 
 public class CheckWanConsistencyMessageTask extends AbstractCallableMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.checkConsistency");
+
     public CheckWanConsistencyMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -55,7 +59,7 @@ public class CheckWanConsistencyMessageTask extends AbstractCallableMessageTask<
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/CheckWanConsistencyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/CheckWanConsistencyMessageTask.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 public class CheckWanConsistencyMessageTask extends AbstractCallableMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.checkConsistency");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.checkConsistency");
 
     public CheckWanConsistencyMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ClearWanQueuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ClearWanQueuesMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 
 public class ClearWanQueuesMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.clearQueues");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.clearQueues");
 
     public ClearWanQueuesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ClearWanQueuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ClearWanQueuesMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.operation.ClearWanQueuesOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.wan.impl.WanReplicationService;
@@ -30,6 +31,9 @@ import com.hazelcast.wan.impl.WanReplicationService;
 import java.security.Permission;
 
 public class ClearWanQueuesMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.clearQueues");
+
     public ClearWanQueuesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -62,7 +66,7 @@ public class ClearWanQueuesMessageTask extends AbstractInvocationMessageTask<Req
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetCPMembersMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetCPMembersMessageTask.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class GetCPMembersMessageTask extends AbstractAsyncMessageTask<Void, List<SimpleEntry<UUID, UUID>>> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.getCPMembers");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cp.getCPMembers");
 
     public GetCPMembersMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetCPMembersMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetCPMembersMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 import java.util.AbstractMap.SimpleEntry;
@@ -35,6 +36,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class GetCPMembersMessageTask extends AbstractAsyncMessageTask<Void, List<SimpleEntry<UUID, UUID>>> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.getCPMembers");
 
     public GetCPMembersMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -73,7 +76,7 @@ public class GetCPMembersMessageTask extends AbstractAsyncMessageTask<Void, List
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetClusterMetadataMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetClusterMetadataMessageTask.java
@@ -25,10 +25,14 @@ import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class GetClusterMetadataMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.getMetadata");
+
     public GetClusterMetadataMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -66,7 +70,7 @@ public class GetClusterMetadataMessageTask extends AbstractCallableMessageTask<V
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetClusterMetadataMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetClusterMetadataMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 
 public class GetClusterMetadataMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.getMetadata");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.getMetadata");
 
     public GetClusterMetadataMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMapConfigMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 
 public class GetMapConfigMessageTask extends AbstractInvocationMessageTask<String> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("map.getConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("map.getConfig");
 
     public GetMapConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMapConfigMessageTask.java
@@ -25,12 +25,16 @@ import com.hazelcast.internal.config.MapConfigReadOnly;
 import com.hazelcast.internal.management.operation.GetMapConfigOperation;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
 
 public class GetMapConfigMessageTask extends AbstractInvocationMessageTask<String> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("map.getConfig");
+
     public GetMapConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -81,7 +85,7 @@ public class GetMapConfigMessageTask extends AbstractInvocationMessageTask<Strin
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMemberConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMemberConfigMessageTask.java
@@ -30,7 +30,7 @@ import java.security.Permission;
 
 public class GetMemberConfigMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getConfig");
 
     public GetMemberConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMemberConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetMemberConfigMessageTask.java
@@ -24,10 +24,13 @@ import com.hazelcast.config.ConfigXmlGenerator;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class GetMemberConfigMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getConfig");
 
     public GetMemberConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -57,7 +60,7 @@ public class GetMemberConfigMessageTask extends AbstractCallableMessageTask<Void
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetSystemPropertiesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetSystemPropertiesMessageTask.java
@@ -34,7 +34,7 @@ import static java.util.stream.Collectors.toList;
 
 public class GetSystemPropertiesMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getSystemProperties");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getSystemProperties");
 
     public GetSystemPropertiesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetSystemPropertiesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetSystemPropertiesMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 import java.util.AbstractMap.SimpleEntry;
@@ -32,6 +33,9 @@ import java.util.Objects;
 import static java.util.stream.Collectors.toList;
 
 public class GetSystemPropertiesMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getSystemProperties");
+
     public GetSystemPropertiesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -61,7 +65,7 @@ public class GetSystemPropertiesMessageTask extends AbstractCallableMessageTask<
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetThreadDumpMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetThreadDumpMessageTask.java
@@ -23,12 +23,16 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ThreadDumpOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
 
 public class GetThreadDumpMessageTask extends AbstractInvocationMessageTask<Boolean> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getThreadDump");
+
     public GetThreadDumpMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -61,7 +65,7 @@ public class GetThreadDumpMessageTask extends AbstractInvocationMessageTask<Bool
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetThreadDumpMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetThreadDumpMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 
 public class GetThreadDumpMessageTask extends AbstractInvocationMessageTask<Boolean> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getThreadDump");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getThreadDump");
 
     public GetThreadDumpMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetTimedMemberStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetTimedMemberStateMessageTask.java
@@ -28,7 +28,7 @@ import java.security.Permission;
 
 public class GetTimedMemberStateMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("getTimedMemberState");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.getTimedMemberState");
 
     public GetTimedMemberStateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetTimedMemberStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetTimedMemberStateMessageTask.java
@@ -22,10 +22,13 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class GetTimedMemberStateMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("getTimedMemberState");
 
     public GetTimedMemberStateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -59,7 +62,7 @@ public class GetTimedMemberStateMessageTask extends AbstractCallableMessageTask<
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartInterruptBackupMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartInterruptBackupMessageTask.java
@@ -29,7 +29,7 @@ import java.security.Permission;
 public class HotRestartInterruptBackupMessageTask
         extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.interruptBackup");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.interruptBackup");
 
     private final Node node;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartInterruptBackupMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartInterruptBackupMessageTask.java
@@ -22,11 +22,14 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class HotRestartInterruptBackupMessageTask
         extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.interruptBackup");
 
     private final Node node;
 
@@ -58,7 +61,7 @@ public class HotRestartInterruptBackupMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerBackupMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerBackupMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 
 import java.security.Permission;
@@ -34,6 +35,8 @@ import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 
 public class HotRestartTriggerBackupMessageTask
         extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerBackup");
 
     private final Node node;
 
@@ -78,7 +81,7 @@ public class HotRestartTriggerBackupMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerBackupMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerBackupMessageTask.java
@@ -36,7 +36,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 public class HotRestartTriggerBackupMessageTask
         extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerBackup");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerBackup");
 
     private final Node node;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerForceStartMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerForceStartMessageTask.java
@@ -29,7 +29,7 @@ import java.security.Permission;
 public class HotRestartTriggerForceStartMessageTask
         extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerForceStart");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerForceStart");
 
     private Node node;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerForceStartMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerForceStartMessageTask.java
@@ -22,11 +22,14 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class HotRestartTriggerForceStartMessageTask
         extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerForceStart");
 
     private Node node;
 
@@ -62,7 +65,7 @@ public class HotRestartTriggerForceStartMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerPartialStartMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerPartialStartMessageTask.java
@@ -22,11 +22,14 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class HotRestartTriggerPartialStartMessageTask
         extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerPartialStart");
 
     private final Node node;
 
@@ -62,7 +65,7 @@ public class HotRestartTriggerPartialStartMessageTask
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerPartialStartMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerPartialStartMessageTask.java
@@ -29,7 +29,7 @@ import java.security.Permission;
 public class HotRestartTriggerPartialStartMessageTask
         extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerPartialStart");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerPartialStart");
 
     private final Node node;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/MatchMCConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/MatchMCConfigMessageTask.java
@@ -28,7 +28,7 @@ import java.security.Permission;
 
 public class MatchMCConfigMessageTask extends AbstractCallableMessageTask<String> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("matchMCConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("clientfiltering.matchConfig");
 
     public MatchMCConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/MatchMCConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/MatchMCConfigMessageTask.java
@@ -22,10 +22,13 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class MatchMCConfigMessageTask extends AbstractCallableMessageTask<String> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("matchMCConfig");
 
     public MatchMCConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -54,7 +57,7 @@ public class MatchMCConfigMessageTask extends AbstractCallableMessageTask<String
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PollMCEventsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PollMCEventsMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.dto.MCEventDTO;
 import com.hazelcast.internal.management.events.Event;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 import java.util.ArrayList;
@@ -31,6 +32,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class PollMCEventsMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("pollMCEvents");
 
     public PollMCEventsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -67,7 +70,7 @@ public class PollMCEventsMessageTask extends AbstractCallableMessageTask<Void> {
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PollMCEventsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PollMCEventsMessageTask.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 public class PollMCEventsMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("pollMCEvents");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("pollMCEvents");
 
     public PollMCEventsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteLiteMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteLiteMemberMessageTask.java
@@ -23,12 +23,15 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.PromoteLiteMemberOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
 
 public class PromoteLiteMemberMessageTask extends AbstractInvocationMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.promoteLiteMember");
 
     public PromoteLiteMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -62,7 +65,7 @@ public class PromoteLiteMemberMessageTask extends AbstractInvocationMessageTask<
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteLiteMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteLiteMemberMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 
 public class PromoteLiteMemberMessageTask extends AbstractInvocationMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.promoteLiteMember");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.promoteLiteMember");
 
     public PromoteLiteMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteToCPMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteToCPMemberMessageTask.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class PromoteToCPMemberMessageTask extends AbstractAsyncMessageTask<Void, Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.promoteToCPMember");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cp.promoteToCPMember");
 
     public PromoteToCPMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteToCPMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/PromoteToCPMemberMessageTask.java
@@ -23,11 +23,14 @@ import com.hazelcast.cp.CPSubsystemManagementService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 import java.util.concurrent.CompletableFuture;
 
 public class PromoteToCPMemberMessageTask extends AbstractAsyncMessageTask<Void, Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.promoteToCPMember");
 
     public PromoteToCPMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -57,7 +60,7 @@ public class PromoteToCPMemberMessageTask extends AbstractAsyncMessageTask<Void,
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RemoveCPMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RemoveCPMemberMessageTask.java
@@ -23,12 +23,15 @@ import com.hazelcast.cp.CPSubsystemManagementService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class RemoveCPMemberMessageTask extends AbstractAsyncMessageTask<UUID, Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.removeCPMember");
 
     public RemoveCPMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -58,7 +61,7 @@ public class RemoveCPMemberMessageTask extends AbstractAsyncMessageTask<UUID, Vo
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RemoveCPMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RemoveCPMemberMessageTask.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class RemoveCPMemberMessageTask extends AbstractAsyncMessageTask<UUID, Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.removeCPMember");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cp.removeCPMember");
 
     public RemoveCPMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ResetCPSubsystemMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ResetCPSubsystemMessageTask.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class ResetCPSubsystemMessageTask extends AbstractAsyncMessageTask<Void, Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.resetCPSubsystem");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cp.resetCPSubsystem");
 
     public ResetCPSubsystemMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ResetCPSubsystemMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ResetCPSubsystemMessageTask.java
@@ -23,11 +23,14 @@ import com.hazelcast.cp.CPSubsystemManagementService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 import java.util.concurrent.CompletableFuture;
 
 public class ResetCPSubsystemMessageTask extends AbstractAsyncMessageTask<Void, Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.resetCPSubsystem");
 
     public ResetCPSubsystemMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -57,7 +60,7 @@ public class ResetCPSubsystemMessageTask extends AbstractAsyncMessageTask<Void, 
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunConsoleCommandMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunConsoleCommandMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 
 public class RunConsoleCommandMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("runConsoleCommand");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("runConsoleCommand");
 
     public RunConsoleCommandMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunConsoleCommandMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunConsoleCommandMessageTask.java
@@ -24,12 +24,15 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.RunConsoleCommandOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
 
 public class RunConsoleCommandMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("runConsoleCommand");
 
     public RunConsoleCommandMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -62,7 +65,7 @@ public class RunConsoleCommandMessageTask extends AbstractInvocationMessageTask<
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunGcMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunGcMessageTask.java
@@ -30,7 +30,7 @@ import java.security.Permission;
 
 public class RunGcMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.runGc");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.runGc");
 
     public RunGcMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunGcMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunGcMessageTask.java
@@ -22,11 +22,16 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.security.Permission;
 
 public class RunGcMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.runGc");
+
     public RunGcMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -55,7 +60,7 @@ public class RunGcMessageTask extends AbstractCallableMessageTask<Void> {
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunScriptMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunScriptMessageTask.java
@@ -24,12 +24,15 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.RunScriptOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
 
 public class RunScriptMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.runScript");
 
     public RunScriptMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -62,7 +65,7 @@ public class RunScriptMessageTask extends AbstractInvocationMessageTask<RequestP
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunScriptMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/RunScriptMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 
 public class RunScriptMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.runScript");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.runScript");
 
     public RunScriptMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownClusterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownClusterMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 
 import java.security.Permission;
@@ -33,6 +34,8 @@ import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 
 public class ShutdownClusterMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.shutdown");
 
     public ShutdownClusterMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -74,7 +77,7 @@ public class ShutdownClusterMessageTask extends AbstractCallableMessageTask<Void
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownClusterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownClusterMessageTask.java
@@ -35,7 +35,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 
 public class ShutdownClusterMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.shutdown");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.shutdown");
 
     public ShutdownClusterMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownMemberMessageTask.java
@@ -28,7 +28,7 @@ import java.security.Permission;
 
 public class ShutdownMemberMessageTask extends AbstractCallableMessageTask<Void> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.shutdown");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.shutdown");
 
     public ShutdownMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownMemberMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownMemberMessageTask.java
@@ -22,10 +22,14 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 
 import java.security.Permission;
 
 public class ShutdownMemberMessageTask extends AbstractCallableMessageTask<Void> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("member.shutdown");
+
     public ShutdownMemberMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -53,7 +57,7 @@ public class ShutdownMemberMessageTask extends AbstractCallableMessageTask<Void>
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/UpdateMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/UpdateMapConfigMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 
 public class UpdateMapConfigMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("map.updateConfig");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("map.updateConfig");
 
     public UpdateMapConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/UpdateMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/UpdateMapConfigMessageTask.java
@@ -24,12 +24,16 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.security.Permission;
 
 public class UpdateMapConfigMessageTask extends AbstractInvocationMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("map.updateConfig");
+
     public UpdateMapConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -69,7 +73,7 @@ public class UpdateMapConfigMessageTask extends AbstractInvocationMessageTask<Re
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/WanSyncMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/WanSyncMapMessageTask.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 public class WanSyncMapMessageTask extends AbstractCallableMessageTask<RequestParameters> {
 
-    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.syncMap");
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.syncMap");
 
     public WanSyncMapMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/WanSyncMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/WanSyncMapMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.codec.MCWanSyncMapCodec.RequestParamet
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.wan.impl.WanReplicationService;
 import com.hazelcast.wan.impl.WanSyncType;
 
@@ -29,6 +30,8 @@ import java.security.Permission;
 import java.util.UUID;
 
 public class WanSyncMapMessageTask extends AbstractCallableMessageTask<RequestParameters> {
+
+    public static final Permission REQUIRED_PERMISSION = new ManagementPermission("wan.syncMap");
 
     public WanSyncMapMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -79,7 +82,7 @@ public class WanSyncMapMessageTask extends AbstractCallableMessageTask<RequestPa
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/metrics/ReadMetricsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/metrics/ReadMetricsMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.metrics.impl.MetricsService;
 import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer;
 import com.hazelcast.internal.metrics.managementcenter.ReadMetricsOperation;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
@@ -32,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 public class ReadMetricsMessageTask extends AbstractInvocationMessageTask<MCReadMetricsCodec.RequestParameters> {
+
+    private static final Permission REQUIRED_PERMISSION = new ManagementPermission("metrics.read");
 
     public ReadMetricsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -80,7 +83,7 @@ public class ReadMetricsMessageTask extends AbstractInvocationMessageTask<MCRead
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return REQUIRED_PERMISSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -164,7 +164,11 @@ public class PermissionConfig implements IdentifiedDataSerializable {
         /**
          * ReplicatedMap
          */
-        REPLICATEDMAP("replicatedmap-permission")
+        REPLICATEDMAP("replicatedmap-permission"),
+        /**
+         * Cluster Management
+         */
+        MANAGEMENT("management-permission"),
         ;
         private final String nodeName;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2647,9 +2647,9 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     void handleSecurityPermission(Node node, PermissionConfig.PermissionType type) {
         SecurityConfig cfg = config.getSecurityConfig();
         Node nameNode = getNamedItemNode(node, "name");
-        String name = nameNode != null ? getTextContent(nameNode) : "*";
+        String name = nameNode != null ? getTextContent(nameNode) : null;
         Node principalNode = getNamedItemNode(node, "principal");
-        String principal = principalNode != null ? getTextContent(principalNode) : "*";
+        String principal = principalNode != null ? getTextContent(principalNode) : null;
         PermissionConfig permConfig = new PermissionConfig(type, name, principal);
         cfg.addClientPermissionConfig(permConfig);
         for (Node child : childElements(node)) {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ManagementPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ManagementPermission.java
@@ -22,6 +22,9 @@ import java.security.Permission;
  * Hazelcast Permission type used in client protocol actions intended for Management Center operations. It has a similar
  * behavior as the {@link RuntimePermission} - i.e. actions are not used and the permission name can end with a wildcard
  * <code>".*"</code> (e.g. <code>"cluster.*"</code>).
+ * <p>
+ * The {@code "*"} (star character) or {@code null} used as the name means that such permission {@code implies} all other
+ * {@link ManagementPermission} instances.
  */
 public class ManagementPermission extends ClusterPermission {
 

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ManagementPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ManagementPermission.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security.permission;
+
+import java.security.Permission;
+
+/**
+ * Hazelcast Permission type used in client protocol actions intended for Management Center operations. It has a similar
+ * behavior as the {@link RuntimePermission} - i.e. actions are not used and the permission name can end with a wildcard
+ * <code>".*"</code> (e.g. <code>"cluster.*"</code>).
+ */
+public class ManagementPermission extends ClusterPermission {
+
+    final String prefix;
+
+    public ManagementPermission(String name) {
+        super(name);
+        prefix = (name != null && name.endsWith(".*")) ? name.substring(0, name.length() - 1) : null;
+    }
+
+    @Override
+    public boolean implies(Permission permission) {
+        if (permission == null || getClass() != permission.getClass()) {
+            return false;
+        }
+        ManagementPermission that = (ManagementPermission) permission;
+        String name = getName();
+        String thatName = that.getName();
+        if (name == null || name.equals("*") || name.equals(thatName) || (prefix != null && thatName.startsWith(prefix))) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String getActions() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "ManagementPermission [getName()=" + getName() + "]";
+    }
+}

--- a/hazelcast/src/main/resources/hazelcast-config-4.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.2.xsd
@@ -2692,7 +2692,7 @@
             <xs:element name="ring-buffer-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="reliable-topic-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="replicatedmap-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="management-permission" type="base-permission" minOccurs="0"/>
+            <xs:element name="management-permission" type="management-permission" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
         <xs:attribute name="on-join-operation" type="permission-on-join-operation" default="RECEIVE"/>
     </xs:complexType>
@@ -2733,6 +2733,19 @@
                     <xs:annotation>
                         <xs:documentation>
                             Name of the permission. Wildcards(*) can be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="management-permission">
+        <xs:complexContent>
+            <xs:extension base="base-permission">
+                <xs:attribute name="name" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Optional name of the permission. Simple wildcard (*) or prefixes (prefix.*) can be used.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-config-4.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.2.xsd
@@ -2692,6 +2692,7 @@
             <xs:element name="ring-buffer-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="reliable-topic-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="replicatedmap-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="management-permission" type="base-permission" minOccurs="0"/>
         </xs:choice>
         <xs:attribute name="on-join-operation" type="permission-on-join-operation" default="RECEIVE"/>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2487,7 +2487,7 @@
                     <action>all</action>
                 </actions>
             </cache-permission>
-            <user-code-deployment-permission name="*">
+            <user-code-deployment-permission name="*" principal="*">
                 <actions>
                     <action>all</action>
                 </actions>
@@ -2502,6 +2502,11 @@
                     <action>all</action>
                 </actions>
             </replicatedmap-permission>
+            <management-permission principal="management">
+                <endpoints>
+                    <endpoint>127.0.0.1</endpoint>
+                </endpoints>
+            </management-permission>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
         <security-interceptors>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2416,6 +2416,7 @@ hazelcast:
             - all
       user-code-deployment:
         - name: "*"
+          principal: "*"
           actions:
             - all
       pn-counter:
@@ -2426,6 +2427,10 @@ hazelcast:
         - name: "*"
           actions:
             - all
+      management:
+        - principal: management
+          endpoints:
+            - 127.0.0.1
     client-block-unmapped-actions: true
     security-interceptors:
       - com.your-package.YourSecurityInterceptorImplementation

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -546,6 +546,11 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                                 .setName("mycounter")
                                 .setPrincipal("devos"),
                         new PermissionConfig()
+                                .setType(PermissionConfig.PermissionType.MANAGEMENT)
+                                .setPrincipal("mcadmin"),
+                        new PermissionConfig()
+                                .setType(PermissionConfig.PermissionType.CONFIG),
+                        new PermissionConfig()
                                 .setActions(newHashSet("read", "create"))
                                 .setType(PermissionConfig.PermissionType.REPLICATEDMAP)
                                 .setName("rmap")

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3096,7 +3096,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + SECURITY_END_TAG + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        PermissionConfig expected = new PermissionConfig(CONFIG, "*", "dev");
+        PermissionConfig expected = new PermissionConfig(CONFIG, null, "dev");
         expected.getEndpoints().add("127.0.0.1");
         assertPermissionConfig(expected, config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3105,7 +3105,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          - 127.0.0.1";
 
         Config config = buildConfig(yaml);
-        PermissionConfig expected = new PermissionConfig(CONFIG, "*", "dev");
+        PermissionConfig expected = new PermissionConfig(CONFIG, null, "dev");
         expected.getEndpoints().add("127.0.0.1");
         assertPermissionConfig(expected, config);
     }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -854,7 +854,7 @@
                     <action>all</action>
                 </actions>
             </countdown-latch-permission>
-            <semaphore-permission name="*">
+            <semaphore-permission name="*" principal="*">
                 <actions>
                     <action>all</action>
                 </actions>
@@ -874,7 +874,7 @@
                     <action>all</action>
                 </actions>
             </cardinality-estimator-permission>
-            <scheduled-executor-permission name="*">
+            <scheduled-executor-permission name="*" principal="*">
                 <actions>
                     <action>all</action>
                 </actions>
@@ -884,7 +884,7 @@
                     <action>all</action>
                 </actions>
             </cache-permission>
-            <user-code-deployment-permission name="*">
+            <user-code-deployment-permission name="*" principal="*">
                 <actions>
                     <action>all</action>
                 </actions>
@@ -894,7 +894,7 @@
                     <action>all</action>
                 </actions>
             </pn-counter-permission>
-            <ring-buffer-permission name="*">
+            <ring-buffer-permission name="*" principal="*">
                 <actions>
                     <action>all</action>
                 </actions>
@@ -909,6 +909,7 @@
                     <action>all</action>
                 </actions>
             </replicatedmap-permission>
+            <management-permission principal="mcadmin"/>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
     </security>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -750,12 +750,10 @@ hazelcast:
             - all
       set:
         - name: "*"
-          principal: "*"
           actions:
             - all
       cardinality-estimator:
         - name: "*"
-          principal: "*"
           actions:
             - all
       scheduled-executor:
@@ -765,19 +763,16 @@ hazelcast:
             - all
       atomic-long:
         - name: "*"
-          principal: "*"
           actions:
             - all
       atomic-reference:
         - name: "*"
-          principal: "*"
           actions:
             - all
       transaction:
         principal: deployer
       pn-counter:
         - name: "*"
-          principal: "*"
           actions:
             - all
       semaphore:
@@ -792,7 +787,6 @@ hazelcast:
             - all
       durable-executor-service:
         - name: "*"
-          principal: "*"
           actions:
             - all
       map:
@@ -807,27 +801,22 @@ hazelcast:
             - read
       flake-id-generator:
         - name: "*"
-          principal: "*"
           actions:
             - all
       topic:
         - name: "*"
-          principal: "*"
           actions:
             - all
       multimap:
         - name: "*"
-          principal: "*"
           actions:
             - all
       cache:
         - name: "*"
-          principal: "*"
           actions:
             - all
       lock:
         - name: "*"
-          principal: "*"
           actions:
             - all
       queue:
@@ -836,12 +825,10 @@ hazelcast:
             - all
       list:
         - name: "*"
-          principal: "*"
           actions:
             - all
       executor-service:
         - name: "*"
-          principal: "*"
           actions:
             - all
       ring-buffer:
@@ -851,14 +838,14 @@ hazelcast:
             - all
       replicatedmap:
         - name: "*"
-          principal: "*"
           actions:
             - all
       reliable-topic:
         - name: "*"
-          principal: "*"
           actions:
             - all
+      management:
+        - principal: "mcadmin"
     client-block-unmapped-actions: true
 
   member-attributes:


### PR DESCRIPTION
This PR adds a new permission type for management MessageTasks.

Newly the client used in Management Center will need to have either the `all-permission` granted or the new permission type `management-permission`. E.g.

```xml
<hazelcast xmlns="http://www.hazelcast.com/schema/config"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.hazelcast.com/schema/config
           http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
    <security enabled="true">
        <!--
           define security realm and client-authentication here
        -->
        <client-permissions>
            <management-permission principal="management">
                <endpoints>
                    <endpoint>127.0.0.1</endpoint>
                </endpoints>
            </management-permission>
        </client-permissions>
    </security>
</hazelcast>
```

```yaml
hazelcast:
  security:
    enabled: true
    client-permissions:
      management:
        - principal: management
          endpoints:
            - 127.0.0.1
```

This change can affect Hazelcast Enterprise users with security enabled but without the management client having the `all-permission` granted. In such a case ManagementCenter operations on the cluster will fail with the `AccessControlException` thrown.