### PR TITLE
Remove sleep statements - Reduce delays when joining a cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -1073,8 +1073,13 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return "ClusterService" + "{address=" + getThisAddress() + '}';
     }
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
-    public void blockOnJoin(long millis) throws InterruptedException {
-        joined.get().latch.await(millis, TimeUnit.MILLISECONDS);
+    /**
+     *
+     * @param millis
+     * @return true is cluster has been joined, false if timed out
+     * @throws InterruptedException
+     */
+    public boolean blockOnJoin(long millis) throws InterruptedException {
+        return joined.get().latch.await(millis, TimeUnit.MILLISECONDS);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -96,7 +96,7 @@ public class MulticastJoiner extends AbstractJoiner {
             }
 
             try {
-                Thread.sleep(JOIN_RETRY_INTERVAL);
+                clusterService.blockOnJoin(JOIN_RETRY_INTERVAL);
             } catch (InterruptedException e) {
                 currentThread().interrupt();
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SERVICE_NAME;
 import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import com.hazelcast.internal.server.ServerConnectionManager;
 import static com.hazelcast.internal.util.AddressUtil.AddressHolder;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.FutureUtil.RETHROW_EVERYTHING;
@@ -112,11 +113,11 @@ public class TcpIpJoiner extends AbstractJoiner {
             long joinStartTime = Clock.currentTimeMillis();
             Connection connection;
             while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
-
-                connection = node.getServer().getConnectionManager(MEMBER).getOrConnect(targetAddress);
+                ServerConnectionManager connectionManager = node.getServer().getConnectionManager(MEMBER);
+                connection = connectionManager.getOrConnect(targetAddress);
                 if (connection == null) {
                     //noinspection BusyWait
-                    Thread.sleep(JOIN_RETRY_WAIT_TIME);
+                    connectionManager.blockOnConnect(targetAddress, JOIN_RETRY_WAIT_TIME, 0);
                     continue;
                 }
                 if (logger.isFineEnabled()) {
@@ -124,7 +125,9 @@ public class TcpIpJoiner extends AbstractJoiner {
                 }
                 clusterJoinManager.sendJoinRequest(targetAddress);
                 //noinspection BusyWait
-                Thread.sleep(JOIN_RETRY_WAIT_TIME);
+                if (!clusterService.isJoined()) {
+                    clusterService.blockOnJoin(JOIN_RETRY_WAIT_TIME);
+                }
             }
         } catch (final Exception e) {
             logger.warning(e);
@@ -260,7 +263,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             }
 
             if (!clusterService.isJoined()) {
-                Thread.sleep(JOIN_RETRY_WAIT_TIME);
+                clusterService.blockOnJoin(JOIN_RETRY_WAIT_TIME);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
@@ -222,7 +222,7 @@ public interface ServerConnectionManager
      * @param address
      * @param millis
      * @param streamId
-     * @return true is connected successfully, false if timed out
+     * @return true if connected successfully, false if timed out
      * @throws java.lang.InterruptedException
      */
     default boolean blockOnConnect(Address address, long millis, int streamId) throws InterruptedException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
@@ -218,7 +218,7 @@ public interface ServerConnectionManager
 
     /**
      * blocks the caller thread until a connection is established (or failed)
-     * or the time runs out
+     * or the time runs out. Callers must ensure a connection is established after this method returns {@code true}.
      * @param address
      * @param millis
      * @param streamId

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
@@ -24,6 +24,8 @@ import com.hazelcast.internal.nio.Packet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -213,4 +215,16 @@ public interface ServerConnectionManager
      * @return the Server.
      */
     Server getServer();
+
+    /**
+     * blocks the caller thread until a connection is established (or failed)
+     * or the time runs out
+     * @param address
+     * @param millis
+     * @param streamId
+     * @throws java.lang.InterruptedException
+     */
+    default void blockOnConnect(Address address, long millis, int streamId) throws InterruptedException {
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(millis));
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
@@ -222,9 +222,11 @@ public interface ServerConnectionManager
      * @param address
      * @param millis
      * @param streamId
+     * @return true is connected successfully, false if timed out
      * @throws java.lang.InterruptedException
      */
-    default void blockOnConnect(Address address, long millis, int streamId) throws InterruptedException {
+    default boolean blockOnConnect(Address address, long millis, int streamId) throws InterruptedException {
         LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(millis));
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
@@ -37,6 +37,7 @@ import java.net.Socket;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Future;
 
 /**
  * Contains many of the dependencies passed to the {@link Server}.
@@ -101,7 +102,7 @@ public interface ServerContext {
 
     void onDisconnect(Address endpoint, Throwable cause);
 
-    void executeAsync(Runnable runnable);
+    Future<Void> executeAsync(Runnable runnable);
 
     EventService getEventService();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerContext.java
@@ -102,7 +102,7 @@ public interface ServerContext {
 
     void onDisconnect(Address endpoint, Throwable cause);
 
-    Future<Void> executeAsync(Runnable runnable);
+    Future<Void> submitAsync(Runnable runnable);
 
     EventService getEventService();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -296,7 +296,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
                 .addParameter("remoteAddress", socketChannel.getRemoteAddress())
                 .log();
             if (serverContext.isSocketInterceptorEnabled(qualifier)) {
-                serverContext.executeAsync(() -> newConnection0(connectionManager, channel));
+                serverContext.submitAsync(() -> newConnection0(connectionManager, channel));
             } else {
                 newConnection0(connectionManager, channel);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -44,9 +44,11 @@ import static com.hazelcast.spi.properties.ClusterProperty.CHANNEL_COUNT;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import static java.util.Collections.newSetFromMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -114,7 +116,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
 
     static class Plane {
         final ConcurrentHashMap<Address, TcpServerConnection> connectionMap = new ConcurrentHashMap<>(100);
-        final Set<Address> connectionsInProgress = newSetFromMap(new ConcurrentHashMap<>());
+        final Map<Address, CountDownLatch> connectionsInProgress = new ConcurrentHashMap<>();
         final ConcurrentHashMap<Address, TcpServerConnectionErrorHandler> errorHandlers = new ConcurrentHashMap<>(100);
         final int index;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -116,7 +116,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
 
     static class Plane {
         final ConcurrentHashMap<Address, TcpServerConnection> connectionMap = new ConcurrentHashMap<>(100);
-        final Map<Address, CountDownLatch> connectionsInProgress = new ConcurrentHashMap<>();
+        final Map<Address, Future<Void>> connectionsInProgress = new ConcurrentHashMap<>();
         final ConcurrentHashMap<Address, TcpServerConnectionErrorHandler> errorHandlers = new ConcurrentHashMap<>(100);
         final int index;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnector.java
@@ -75,7 +75,7 @@ class TcpServerConnector {
 
     Future<Void> asyncConnect(Address address, boolean silent, int planeIndex) {
         serverContext.shouldConnectTo(address);
-        return serverContext.executeAsync(new ConnectTask(address, silent, planeIndex));
+        return serverContext.submitAsync(new ConnectTask(address, silent, planeIndex));
     }
 
     private boolean useAnyOutboundPort() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnector.java
@@ -34,6 +34,7 @@ import java.net.UnknownHostException;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_BIND;
@@ -72,9 +73,9 @@ class TcpServerConnector {
         this.planeCount = connectionManager.planeCount;
     }
 
-    void asyncConnect(Address address, boolean silent, int planeIndex) {
+    Future<Void> asyncConnect(Address address, boolean silent, int planeIndex) {
         serverContext.shouldConnectTo(address);
-        serverContext.executeAsync(new ConnectTask(address, silent, planeIndex));
+        return serverContext.executeAsync(new ConnectTask(address, silent, planeIndex));
     }
 
     private boolean useAnyOutboundPort() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
@@ -54,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
@@ -265,8 +266,9 @@ public class TcpServerContext implements ServerContext {
     }
 
     @Override
-    public void executeAsync(final Runnable runnable) {
-        nodeEngine.getExecutionService().execute(ExecutionService.IO_EXECUTOR, runnable);
+    @SuppressWarnings("unchecked")
+    public Future<Void> executeAsync(final Runnable runnable) {
+        return (Future<Void>) nodeEngine.getExecutionService().submit(ExecutionService.IO_EXECUTOR, runnable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
@@ -267,7 +267,7 @@ public class TcpServerContext implements ServerContext {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Future<Void> executeAsync(final Runnable runnable) {
+    public Future<Void> submitAsync(final Runnable runnable) {
         return (Future<Void>) nodeEngine.getExecutionService().submit(ExecutionService.IO_EXECUTOR, runnable);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
@@ -146,7 +146,7 @@ public final class TcpServerControl {
                                        Collection<Address> remoteAddressAliases,
                                        MemberHandshake handshake) {
         final Address remoteAddress = new Address(connection.getRemoteSocketAddress());
-        if (connectionManager.planes[handshake.getPlaneIndex()].connectionsInProgress.contains(remoteAddress)) {
+        if (connectionManager.planes[handshake.getPlaneIndex()].connectionsInProgress.containsKey(remoteAddress)) {
             // this is the connection initiator side --> register the connection under the address that was requested
             remoteEndpoint = remoteAddress;
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -247,7 +247,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
 
         warmUpPartitions(instance1, instance2);
         String keyOwnedBy2 = generateKeyOwnedBy(instance2);
-
+        makeSureConnectedToServers(client, 2);
 
         IMap<Object, Object> clientMap = client.getMap("test");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
@@ -258,6 +258,7 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
         newHazelcastInstance(initOrCreateConfig(new Config()),
                 randomName(), new StaticMemberNodeContext(factory, member4.getUuid(), member3.getAddress()));
         assertClusterSizeEventually(3, hz1, hz2);
+        waitAllForSafeState(hz1, hz2);
 
         OperationServiceImpl operationService = getOperationService(hz1);
         operationService.invokeOnPartition(null, new NonRetryablePartitionOperation(), member3PartitionId).join();

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -55,6 +55,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -196,14 +198,16 @@ public class MockServerContext implements ServerContext {
     }
 
     @Override
-    public void executeAsync(final Runnable runnable) {
-        new Thread(() -> {
+    public Future<Void> executeAsync(final Runnable runnable) {
+        FutureTask<Void> future = new FutureTask<>(() -> {
             try {
                 runnable.run();
             } catch (Throwable t) {
                 logger.severe(t);
             }
-        }).start();
+        }, null);
+        new Thread(() -> future.run()).start();
+        return future;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -198,7 +198,7 @@ public class MockServerContext implements ServerContext {
     }
 
     @Override
-    public Future<Void> executeAsync(final Runnable runnable) {
+    public Future<Void> submitAsync(final Runnable runnable) {
         FutureTask<Void> future = new FutureTask<>(() -> {
             try {
                 runnable.run();

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -83,7 +83,7 @@ class MockJoiner extends AbstractJoiner {
                 break;
             }
             try {
-                Thread.sleep(500);
+                clusterService.blockOnJoin(500);
             } catch (InterruptedException e) {
                 e.printStackTrace();
                 break;


### PR DESCRIPTION
Eliminated sleep delays when joining a cluster. Shaves 2-3 seconds from join procedure. 
Removed sleep statements and replaced them with events
Relates to #17427 and payara/Payara#4858
Clean version of the "client side" fix for #17428