### PR TITLE
Fire membership events when persistence enabled

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -699,12 +699,12 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
         private void handleSuccessResult(ClientAuthenticationCodec.ResponseParameters result) {
             connection.setRemoteEndpoint(result.address);
+            if (result.serverHazelcastVersionExist) {
+                connection.setConnectedServerVersion(result.serverHazelcastVersion);
+            }
             if (asOwner) {
                 if (result.partitionCountExist) {
                     clusterPartitionCount = result.partitionCount;
-                }
-                if (result.serverHazelcastVersionExist) {
-                    connection.setConnectedServerVersion(result.serverHazelcastVersion);
                 }
                 if (result.clusterIdExist) {
                     if (clusterId != null && !result.clusterId.equals(clusterId)) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -201,6 +201,10 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         this.clientMembershipListener.cleanupOnDisconnect();
     }
 
+    public void clearMemberList() {
+        this.clientMembershipListener.clearMemberListOnClusterRestart();
+    }
+
     public void start() {
         this.clientMembershipListener = new ClientMembershipListener(client);
     }
@@ -263,7 +267,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
     }
 
     public void reset() {
-        clientMembershipListener.clearMembers();
+        clientMembershipListener.clearMembersOnClusterChange();
         synchronized (initialMembershipListenerMutex) {
             members.set(Collections.<Address, Member>emptyMap());
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -49,7 +49,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
         implements EventHandler<ClientMessage> {
 
     private static final int INITIAL_MEMBERS_TIMEOUT_SECONDS = 120;
-    private static final Set<Member> CLUSTER_SWITCH_EMPTY_MEMBERS = new HashSet<>();
+    private static final Set<Member> CLUSTER_SWITCH_EMPTY_MEMBERS = new HashSet<Member>();
     private final ILogger logger;
     private final HazelcastClientInstanceImpl client;
     private final ClientClusterServiceImpl clusterService;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -105,6 +105,7 @@ public class ClientClusterRestartEventTest {
         });
 
         instance.shutdown();
+        hazelcastFactory.cleanup();
         instance = hazelcastFactory.newHazelcastInstance(newConfig());
         Member newMember = instance.getCluster().getLocalMember();
 
@@ -162,6 +163,8 @@ public class ClientClusterRestartEventTest {
                 }
             }
         });
+
+        hazelcastFactory.cleanup();
 
         Future<HazelcastInstance> f1 = spawn(new Callable<HazelcastInstance>() {
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -127,7 +127,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
 
     public EvictionConfig(EvictionConfig config) {
         this.defaultSize = config.defaultSize;
-        this.size = checkPositive(config.size, "Size must be positive number!");
+        this.size = config.size;
         this.maxSizePolicy = checkNotNull(config.maxSizePolicy, "Max-Size policy cannot be null!");
         if (config.evictionPolicy != null) {
             this.evictionPolicy = config.evictionPolicy;


### PR DESCRIPTION
When persistence enabled, client does not fire membership
events because members starts with same uuid's.

With this pr, we make sure that when cluster restarted,
we always update the local memberlist with empty member list
first.
This way, we will be able to fire member removed/added events
even if member uuid's does not change.

Note that if cluster uuid does not change, we will not fire
any event. This happens client disconnected and connected
back to the same cluster.
Note that cluster uuid is not preserved on hotrestart with
persistence.

There was already a test to verify this behaviour but it
was working wrong.
ClientHotRestartTest extends ClientClusterRestartEventTest
In this pr, we make sure that the test uses same address
for the restarted member to test this correctly.

backport of https://github.com/hazelcast/hazelcast/pull/18245

=== WARNING === 
Note that for 3.12.x we could not cherry-pick the code because
these parts are refactored a lot. Same solution is applied in
different parts of the code. 
=== WARNING === 

fixes https://github.com/hazelcast/hazelcast/issues/18234