### PR TITLE
Check memberlist snapshot before clearing it

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -201,8 +201,8 @@ public class ClientClusterServiceImpl implements ClientClusterService {
                 logger.fine("Resetting the member list version ");
             }
             MemberListSnapshot clusterViewSnapshot = memberListSnapshot.get();
-            //This check is necessary so that `clearMemberListVersion` when handling auth response will not
-            //intervene with client failover logic
+            // This check is necessary so that when handling auth response, it will not
+            // intervene with client failover logic
             if (clusterViewSnapshot != EMPTY_SNAPSHOT) {
                 memberListSnapshot.set(new MemberListSnapshot(0, clusterViewSnapshot.members));
             }
@@ -213,16 +213,24 @@ public class ClientClusterServiceImpl implements ClientClusterService {
      * Clears the member list and fires member removed event for members in the list.
      */
     public void clearMemberList() {
-        List<MembershipEvent> events;
+        List<MembershipEvent> events = null;
         synchronized (clusterViewLock) {
             if (logger.isFineEnabled()) {
                 logger.fine("Resetting the member list ");
             }
-            Collection<Member> prevMembers = memberListSnapshot.get().members.values();
-            memberListSnapshot.set(new MemberListSnapshot(0, new LinkedHashMap<>()));
-            events = detectMembershipEvents(prevMembers, EMPTY_SET);
+            MemberListSnapshot clusterViewSnapshot = this.memberListSnapshot.get();
+            // This check is necessary so that when handling auth response, it will not
+            // intervene with client failover logic
+            if (clusterViewSnapshot != EMPTY_SNAPSHOT) {
+                Collection<Member> prevMembers = clusterViewSnapshot.members.values();
+                this.memberListSnapshot.set(new MemberListSnapshot(0, new LinkedHashMap<>()));
+                events = detectMembershipEvents(prevMembers, EMPTY_SET);
+            }
+
         }
-        fireEvents(events);
+        if (events != null) {
+            fireEvents(events);
+        }
     }
 
     public void reset() {


### PR DESCRIPTION
With blue-green, when the connection to the current cluster is lost, we reset
the memberlist snapshot to EMPTY_SNAPSHOT, before trying to connect to the
next cluster. On authentication with the next cluster, after https://github.com/hazelcast/hazelcast/pull/18245
we call `clearMemberList`, which sets the snapshot to something else,
before checking whether or not the current value is equal to the
EMPTY_SNAPSHOT. That causes the client to not apply the initial state
for the current cluster, and the client hangs while waiting for the
first memberlist event.

As a fix, if the current snapshot is equal to EMPTY_SNAPSHOT,
we will skip clearing the snapshot on `clearMemberList`.