### PR TITLE
Set retry timeout in the test to prevent test timeout

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/AdvancedNetworkingClientCommunicationIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/AdvancedNetworkingClientCommunicationIntegrationTest.java
@@ -58,6 +58,7 @@ public class AdvancedNetworkingClientCommunicationIntegrationTest extends Abstra
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().addAddress("127.0.0.1:" + port);
         clientConfig.getNetworkConfig().setConnectionTimeout(3000);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(3000);
         return HazelcastClient.newHazelcastClient(clientConfig);
     }
 


### PR DESCRIPTION
Set retry timeout in the test to prevent test timeout

Fix #18278 