### PR TITLE
Register class definitions and check compatibility of nested portable…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableContext.java
@@ -39,6 +39,8 @@ public interface PortableContext {
 
     ClassDefinition registerClassDefinition(ClassDefinition cd);
 
+    ClassDefinition registerClassDefinition(ClassDefinition cd, boolean throwOnIncompatibleClassDefinitions);
+
     ClassDefinition lookupOrRegisterClassDefinition(Portable portable) throws IOException;
 
     FieldDefinition getFieldDefinition(ClassDefinition cd, String name);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableSerializer.java
@@ -193,14 +193,6 @@ public final class PortableSerializer implements StreamSerializer<Object> {
 
     private void writePortableGenericRecord(ObjectDataOutput out, PortableGenericRecord record) throws IOException {
         ClassDefinition cd = record.getClassDefinition();
-        if (context.shouldCheckClassDefinitionErrors()) {
-            ClassDefinition existingCd = context.lookupClassDefinition(cd.getFactoryId(), cd.getClassId(), cd.getVersion());
-            if (existingCd != null && !existingCd.equals(cd)) {
-                throw new HazelcastSerializationException("Inconsistent class definition found. New class definition : " + cd
-                        + ", Existing class definition " + existingCd);
-            }
-        }
-        context.registerClassDefinition(cd);
         out.writeInt(cd.getFactoryId());
         out.writeInt(cd.getClassId());
         writePortableGenericRecordInternal(out, record);
@@ -209,6 +201,9 @@ public final class PortableSerializer implements StreamSerializer<Object> {
     @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:CyclomaticComplexity"})
     void writePortableGenericRecordInternal(ObjectDataOutput out, PortableGenericRecord record) throws IOException {
         ClassDefinition cd = record.getClassDefinition();
+        // Class definition compatibility will be checked implicitly on the
+        // register call below.
+        context.registerClassDefinition(cd, context.shouldCheckClassDefinitionErrors());
         out.writeInt(cd.getVersion());
 
         BufferObjectDataOutput output = (BufferObjectDataOutput) out;


### PR DESCRIPTION
… fields of generic records

We were registering the class definition of the parent generic record
and checking the class definition compatibility if the `checkClassDefErrors`
set to true on the serialization config.

But we were not doing it for the nested portable fields
(for child portables and elements of portable arrays). Now, we are checking them too.

Also, on the class definition registration, we were checking the class definition
compatibility again, without looking at the `checkClassDefErrors` property. Responsibility
of the class definition compatibility check is moved to the registration and it is
refactored such that it will not throw if a boolean flag is set to false.

Also, an unnecessary factory id check (since the portable context is created for the
factory id of the class definition, hence, it cannot be different) and unnecessary
second put to the registration map is removed.

Backport of  #18180