### PR TITLE
Fix racy CopyOnWrite data structure serialization write

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArrayListStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArrayListStreamSerializer.java
@@ -50,7 +50,9 @@ public class CopyOnWriteArrayListStreamSerializer<E> extends AbstractCollectionS
     @SuppressWarnings("DuplicatedCode")
     public void write(ObjectDataOutput out, CopyOnWriteArrayList<E> collection) throws IOException {
         Spliterator<E> cowSplitIterator = collection.spliterator();
-        out.writeInt((int) cowSplitIterator.getExactSizeIfKnown());
+        int size = (int) cowSplitIterator.getExactSizeIfKnown();
+        assert size != -1;
+        out.writeInt(size);
         cowSplitIterator.forEachRemaining(object -> {
             try {
                 out.writeObject(object);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArraySetStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArraySetStreamSerializer.java
@@ -18,9 +18,12 @@ package com.hazelcast.internal.serialization.impl.defaultserializers;
 
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -41,5 +44,19 @@ public class CopyOnWriteArraySetStreamSerializer<E> extends AbstractCollectionSt
         deserializeEntriesInto(in, size, collection);
 
         return new CopyOnWriteArraySet<>(collection);
+    }
+
+    @Override
+    @SuppressWarnings("DuplicatedCode")
+    public void write(ObjectDataOutput out, CopyOnWriteArraySet<E> collection) throws IOException {
+        Spliterator<E> cowSplitIterator = collection.spliterator();
+        out.writeInt((int) cowSplitIterator.getExactSizeIfKnown());
+        cowSplitIterator.forEachRemaining(object -> {
+            try {
+                out.writeObject(object);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArraySetStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/CopyOnWriteArraySetStreamSerializer.java
@@ -50,7 +50,9 @@ public class CopyOnWriteArraySetStreamSerializer<E> extends AbstractCollectionSt
     @SuppressWarnings("DuplicatedCode")
     public void write(ObjectDataOutput out, CopyOnWriteArraySet<E> collection) throws IOException {
         Spliterator<E> cowSplitIterator = collection.spliterator();
-        out.writeInt((int) cowSplitIterator.getExactSizeIfKnown());
+        int size = (int) cowSplitIterator.getExactSizeIfKnown();
+        assert size != -1;
+        out.writeInt(size);
         cowSplitIterator.forEachRemaining(object -> {
             try {
                 out.writeObject(object);


### PR DESCRIPTION
As discussed in #18129 all concurrent data structures are prone to race conditions when serialized if they are not cloned. However due to nature of the COW data structures there are ways to make them serialize without cloning. For example pseudocode in #18129. In order to not break backward compatibility, this PR uses splititerators to get size directly from the iterator.

Fixes #18129 