### PR TITLE
Return right record per config

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
@@ -98,12 +98,12 @@ public class DataRecordFactory implements RecordFactory<Data> {
             }
 
             if (mapConfig.getEvictionConfig().getEvictionPolicy() == EvictionPolicy.RANDOM) {
-                return new CachedSimpleRecord(valueData);
+                return new SimpleRecord<>(valueData);
             }
 
             return new DataRecordWithStats(valueData);
         }
 
-        return new CachedSimpleRecord(valueData);
+        return new SimpleRecord<>(valueData);
     }
 }


### PR DESCRIPTION
ee counterpart is https://github.com/hazelcast/hazelcast-enterprise/pull/3957

**Modifications:**
- Returned `SimpleRecord` instead of `CachedSimpleRecord` when `CacheDeserializedValues.NEVER`.
- Added extensive tests for per-config record creation