### PR TITLE
[Backport 4.0.4] Fix racy CopyOnWrite data structure serialization write (#18285)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/CopyOnWriteArrayListStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/CopyOnWriteArrayListStreamSerializer.java
@@ -17,9 +17,12 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -40,5 +43,21 @@ public class CopyOnWriteArrayListStreamSerializer<E> extends AbstractCollectionS
         deserializeEntriesInto(in, size, collection);
 
         return new CopyOnWriteArrayList<>(collection);
+    }
+
+    @Override
+    @SuppressWarnings("DuplicatedCode")
+    public void write(ObjectDataOutput out, CopyOnWriteArrayList<E> collection) throws IOException {
+        Spliterator<E> cowSplitIterator = collection.spliterator();
+        int size = (int) cowSplitIterator.getExactSizeIfKnown();
+        assert size != -1;
+        out.writeInt(size);
+        cowSplitIterator.forEachRemaining(object -> {
+            try {
+                out.writeObject(object);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/CopyOnWriteArraySetStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/CopyOnWriteArraySetStreamSerializer.java
@@ -17,9 +17,12 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -40,5 +43,21 @@ public class CopyOnWriteArraySetStreamSerializer<E> extends AbstractCollectionSt
         deserializeEntriesInto(in, size, collection);
 
         return new CopyOnWriteArraySet<>(collection);
+    }
+
+    @Override
+    @SuppressWarnings("DuplicatedCode")
+    public void write(ObjectDataOutput out, CopyOnWriteArraySet<E> collection) throws IOException {
+        Spliterator<E> cowSplitIterator = collection.spliterator();
+        int size = (int) cowSplitIterator.getExactSizeIfKnown();
+        assert size != -1;
+        out.writeInt(size);
+        cowSplitIterator.forEachRemaining(object -> {
+            try {
+                out.writeObject(object);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
     }
 }


### PR DESCRIPTION
* Implement CopyOnWriteArrayListStreamSerializer#write with reflection

* Implement CopyOnWrite write methods with splitIterator

* Add assertions

(cherry picked from commit 6ba5cdaef0ff242c98a98139c58c73f5ead4601d)