### PR TITLE
Rewrite ringbuffer tests to use less resource by sharing single cluster

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferBasicClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ringbuffer/RingbufferBasicClientTest.java
@@ -23,26 +23,32 @@ import com.hazelcast.ringbuffer.impl.RingbufferAbstractTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.function.Function;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RingbufferBasicClientTest extends RingbufferAbstractTest {
-    private TestHazelcastFactory factory = new TestHazelcastFactory();
 
-    @After
-    public void teardown() {
-        factory.terminateAll();
+    private static TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Function<Config, HazelcastInstance[]> instanceCreator = config -> {
+            HazelcastInstance member = factory.newHazelcastInstance(config);
+            HazelcastInstance client = factory.newHazelcastClient();
+            return new HazelcastInstance[]{client, member};
+        };
+
+        prepare(instanceCreator);
     }
 
-
-    @Override
-    protected HazelcastInstance[] newInstances(Config config) {
-        HazelcastInstance member = factory.newHazelcastInstance(config);
-        HazelcastInstance client = factory.newHazelcastClient();
-
-        return new HazelcastInstance[]{client, member};
+    @AfterClass
+    public static void afterClass() throws Exception {
+        factory.terminateAll();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicDistributedTest.java
@@ -16,35 +16,29 @@
 
 package com.hazelcast.ringbuffer.impl;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RingbufferBasicDistributedTest extends RingbufferAbstractTest {
 
-    @Override
-    protected HazelcastInstance[] newInstances(Config config) {
-        return createHazelcastInstanceFactory(2).newInstances(config);
+    private static TestHazelcastInstanceFactory factory
+            = new TestHazelcastInstanceFactory(2);
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        prepare(factory::newInstances);
     }
 
-    @Test
-    public void sizeShouldNotExceedCapacity_whenPromotedFromBackup() {
-        for (int i = 0; i < 100; i++) {
-            ringbuffer.add(randomString());
-        }
-
-        waitAllForSafeState(instances);
-        instances[instances.length - 1].getLifecycleService().terminate();
-
-        assertEquals(ringbuffer.capacity(), ringbuffer.size());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        factory.terminateAll();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicLocalTest.java
@@ -16,11 +16,12 @@
 
 package com.hazelcast.ringbuffer.impl;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -28,8 +29,16 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RingbufferBasicLocalTest extends RingbufferAbstractTest {
 
-    @Override
-    protected HazelcastInstance[] newInstances(Config config) {
-        return createHazelcastInstanceFactory(1).newInstances(config);
+    private static TestHazelcastInstanceFactory factory
+            = new TestHazelcastInstanceFactory(1);
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        prepare(factory::newInstances);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        factory.terminateAll();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferFailoverTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.ringbuffer.impl.RingbufferAbstractTest.initAndGetConfig;
+import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RingbufferFailoverTest extends HazelcastTestSupport {
+
+    @Test
+    public void sizeShouldNotExceedCapacity_whenPromotedFromBackup() {
+        Config config = initAndGetConfig();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance primaryInstance = factory.newHazelcastInstance(config);
+        HazelcastInstance backupInstance = factory.newHazelcastInstance(config);
+
+        String name = HazelcastTestSupport.randomNameOwnedBy(primaryInstance, getTestMethodName());
+        Ringbuffer<String> ringbuffer = backupInstance.getRingbuffer(name);
+
+        for (int i = 0; i < 100; i++) {
+            ringbuffer.add(randomString());
+        }
+
+        waitAllForSafeState(factory.getAllHazelcastInstances());
+        primaryInstance.getLifecycleService().terminate();
+
+        assertEquals(ringbuffer.capacity(), ringbuffer.size());
+    }
+}


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/18294

Test was aggressively using machine resources, due to the this, timeout and retries were happening.
Changed test to use one single cluster to run all tests methods. 