### PR TITLE
Fix transaction timeout does not throw TransactionTimeOutException issue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionProxy.java
@@ -23,11 +23,11 @@ import com.hazelcast.client.impl.protocol.codec.TransactionCommitCodec;
 import com.hazelcast.client.impl.protocol.codec.TransactionCreateCodec;
 import com.hazelcast.client.impl.protocol.codec.TransactionRollbackCodec;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ThreadUtil;
+import com.hazelcast.transaction.TransactionTimedOutException;
 
 import java.util.UUID;
 
@@ -141,7 +141,7 @@ final class TransactionProxy {
 
     private void checkTimeout() {
         if (startTime + options.getTimeoutMillis() < Clock.currentTimeMillis()) {
-            throw new TransactionException("Transaction is timed-out!");
+            throw new TransactionTimedOutException("Transaction is timed-out!");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -308,9 +308,9 @@ public class TransactionImpl implements Transaction {
         }
     }
 
-    private void checkTimeout() throws TransactionException {
+    private void checkTimeout() throws TransactionTimedOutException {
         if (startTime + timeoutMillis < currentTimeMillis()) {
-            throw new TransactionException("Transaction is timed-out!");
+            throw new TransactionTimedOutException("Transaction is timed-out!");
         }
     }
 


### PR DESCRIPTION
This small PR changes the type of thrown exception in `checkTimeout()` methods from `TransactionException` to `TransactionTimeOutException` .

Fixes #17808