### PR TITLE
Set ClientInvocationFuture only once

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
@@ -254,8 +254,8 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         }
     }
 
-    void deRegisterInvocation(long callId) {
-        invocations.remove(callId);
+    boolean deRegisterInvocation(long callId) {
+        return invocations.remove(callId) != null;
     }
 
     ClientInvocation getInvocation(long callId) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BaseInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BaseInvocation.java
@@ -107,8 +107,6 @@ public abstract class BaseInvocation {
     }
 
     /**
-     * gets called from the Clean resources task
-     *
      * @param timeoutMillis timeout value to wait for backups after  the response received
      * @return true if invocation is completed
      */


### PR DESCRIPTION
There seems to be a couple of problems.  
1. An invocation can be retried more than once before we gave the first retry to chance to finish.
2. We are trying to clientInvocationFuture a second time when we have a racy situation which leads to logs of double completion. 
3. Because of premature retries, we can have same invocation in the invocations map with different keys(correlationIds). This leads to complicated situations on complete. An invocation is completed with requests correlation id(not response). And the correlation id could already be updated by multiple retries. 

Solutions applied:
A complete or retry take action only if it can deregister from invocation map.
Setting exception to invocations are no longer the duty of the
periodic scheduled task. This can lead to removing a invocation from the map which is just
retried.
Instead we will handle connection removal on connectionRemoved event.
We are addressing the 3rd problem by effectively allowing only single invocation in flight. 

fixes https://github.com/hazelcast/hazelcast/issues/18062