### PR TITLE
Add total number of created proxies per service to phone home data

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/DistributedObjectCounterCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/DistributedObjectCounterCollector.java
@@ -25,53 +25,97 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.crdt.pncounter.PNCounterService;
+import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.impl.proxyservice.InternalProxyService;
 import com.hazelcast.topic.impl.TopicService;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_CACHES;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_CACHES_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_CARDINALITY_ESTIMATORS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_CARDINALITY_ESTIMATORS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_FLAKE_ID_GENERATORS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_FLAKE_ID_GENERATORS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_LISTS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_LISTS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_MAPS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_MAPS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_MULTIMAPS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_MULTIMAPS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_PN_COUNTERS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_PN_COUNTERS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_QUEUES;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_QUEUES_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_REPLICATED_MAPS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_REPLICATED_MAPS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_RING_BUFFERS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_RING_BUFFERS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_SETS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_SETS_ALL_TIME;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_TOPICS;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeMetrics.COUNT_OF_TOPICS_ALL_TIME;
 import static java.util.stream.Collectors.groupingBy;
 
+@SuppressWarnings("checkstyle:magicnumber")
 class DistributedObjectCounterCollector implements MetricsCollector {
 
-    private static final Map<String, PhoneHomeMetrics> SERVICE_NAME_TO_METRIC_NAME;
+    private static final Map<String, PhoneHomeMetrics[]> SERVICE_NAME_TO_METRIC_NAME;
 
     static {
-        SERVICE_NAME_TO_METRIC_NAME = new HashMap<>();
-        SERVICE_NAME_TO_METRIC_NAME.put(MapService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_MAPS);
-        SERVICE_NAME_TO_METRIC_NAME.put(SetService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_SETS);
-        SERVICE_NAME_TO_METRIC_NAME.put(QueueService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_QUEUES);
-        SERVICE_NAME_TO_METRIC_NAME.put(MultiMapService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_MULTIMAPS);
-        SERVICE_NAME_TO_METRIC_NAME.put(ListService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_LISTS);
-        SERVICE_NAME_TO_METRIC_NAME.put(RingbufferService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_RING_BUFFERS);
-        SERVICE_NAME_TO_METRIC_NAME.put(CacheService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_CACHES);
-        SERVICE_NAME_TO_METRIC_NAME.put(TopicService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_TOPICS);
-        SERVICE_NAME_TO_METRIC_NAME.put(ReplicatedMapService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_REPLICATED_MAPS);
+        SERVICE_NAME_TO_METRIC_NAME = MapUtil.createHashMap(12);
+        SERVICE_NAME_TO_METRIC_NAME.put(MapService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_MAPS, COUNT_OF_MAPS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(SetService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_SETS, COUNT_OF_SETS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(QueueService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_QUEUES, COUNT_OF_QUEUES_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(MultiMapService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_MULTIMAPS, COUNT_OF_MULTIMAPS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(ListService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_LISTS, COUNT_OF_LISTS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(RingbufferService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_RING_BUFFERS, COUNT_OF_RING_BUFFERS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(CacheService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_CACHES, COUNT_OF_CACHES_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(TopicService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_TOPICS, COUNT_OF_TOPICS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(ReplicatedMapService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_REPLICATED_MAPS, COUNT_OF_REPLICATED_MAPS_ALL_TIME});
         SERVICE_NAME_TO_METRIC_NAME.put(CardinalityEstimatorService.SERVICE_NAME,
-                PhoneHomeMetrics.COUNT_OF_CARDINALITY_ESTIMATORS);
-        SERVICE_NAME_TO_METRIC_NAME.put(PNCounterService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_PN_COUNTERS);
-        SERVICE_NAME_TO_METRIC_NAME.put(FlakeIdGeneratorService.SERVICE_NAME, PhoneHomeMetrics.COUNT_OF_FLAKE_ID_GENERATORS);
+                new PhoneHomeMetrics[]{COUNT_OF_CARDINALITY_ESTIMATORS, COUNT_OF_CARDINALITY_ESTIMATORS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(PNCounterService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_PN_COUNTERS, COUNT_OF_PN_COUNTERS_ALL_TIME});
+        SERVICE_NAME_TO_METRIC_NAME.put(FlakeIdGeneratorService.SERVICE_NAME,
+                new PhoneHomeMetrics[]{COUNT_OF_FLAKE_ID_GENERATORS, COUNT_OF_FLAKE_ID_GENERATORS_ALL_TIME});
     }
 
     @Override
     public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
-        Collection<DistributedObject> objects = node.hazelcastInstance.getDistributedObjects();
+        InternalProxyService proxyService = node.nodeEngine.getProxyService();
+        Collection<DistributedObject> objects = proxyService.getAllDistributedObjects();
         Map<String, Long> objectsPerService =
                 objects.stream()
-                       .filter(obj -> SERVICE_NAME_TO_METRIC_NAME.containsKey(obj.getServiceName()))
-                       .collect(groupingBy(DistributedObject::getServiceName, Collectors.counting()));
+                        .filter(obj -> SERVICE_NAME_TO_METRIC_NAME.containsKey(obj.getServiceName()))
+                        .collect(groupingBy(DistributedObject::getServiceName, Collectors.counting()));
 
-        SERVICE_NAME_TO_METRIC_NAME.forEach((serviceName, metricName) ->
-                metricsConsumer.accept(
-                        metricName,
-                        String.valueOf(objectsPerService.getOrDefault(serviceName, 0L))));
+        SERVICE_NAME_TO_METRIC_NAME.forEach((serviceName, metricNames) -> {
+            metricsConsumer.accept(
+                    metricNames[0],
+                    String.valueOf(objectsPerService.getOrDefault(serviceName, 0L)));
+
+            metricsConsumer.accept(
+                    metricNames[1],
+                    String.valueOf(proxyService.getCreatedCount(serviceName)));
+        });
+
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -50,6 +50,7 @@ public enum PhoneHomeMetrics {
 
     // MAP METRICS
     COUNT_OF_MAPS("mpct"),
+    COUNT_OF_MAPS_ALL_TIME("mpcta"),
     MAP_COUNT_WITH_READ_ENABLED("mpbrct"),
     MAP_COUNT_WITH_MAP_STORE_ENABLED("mpmsct"),
     MAP_COUNT_WITH_ATLEAST_ONE_QUERY_CACHE("mpaoqcct"),
@@ -66,19 +67,30 @@ public enum PhoneHomeMetrics {
 
     //CACHE METRICS
     COUNT_OF_CACHES("cact"),
+    COUNT_OF_CACHES_ALL_TIME("cacta"),
     CACHE_COUNT_WITH_WAN_REPLICATION("cawact"),
 
     //OTHER DISTRIBUTED OBJECTS
     COUNT_OF_SETS("sect"),
+    COUNT_OF_SETS_ALL_TIME("secta"),
     COUNT_OF_QUEUES("quct"),
+    COUNT_OF_QUEUES_ALL_TIME("qucta"),
     COUNT_OF_MULTIMAPS("mmct"),
+    COUNT_OF_MULTIMAPS_ALL_TIME("mmcta"),
     COUNT_OF_LISTS("lict"),
+    COUNT_OF_LISTS_ALL_TIME("licta"),
     COUNT_OF_RING_BUFFERS("rbct"),
+    COUNT_OF_RING_BUFFERS_ALL_TIME("rbcta"),
     COUNT_OF_TOPICS("tpct"),
+    COUNT_OF_TOPICS_ALL_TIME("tpcta"),
     COUNT_OF_REPLICATED_MAPS("rpct"),
+    COUNT_OF_REPLICATED_MAPS_ALL_TIME("rpcta"),
     COUNT_OF_CARDINALITY_ESTIMATORS("cect"),
+    COUNT_OF_CARDINALITY_ESTIMATORS_ALL_TIME("cecta"),
     COUNT_OF_PN_COUNTERS("pncct"),
+    COUNT_OF_PN_COUNTERS_ALL_TIME("pnccta"),
     COUNT_OF_FLAKE_ID_GENERATORS("figct"),
+    COUNT_OF_FLAKE_ID_GENERATORS_ALL_TIME("figcta"),
 
     //CLOUD METRICS
     /*

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/ProxyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/ProxyService.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.internal.services.CoreService;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -43,6 +44,15 @@ public interface ProxyService extends CoreService {
     Collection<String> getDistributedObjectNames(String serviceName);
 
     Collection<DistributedObject> getAllDistributedObjects();
+
+    /**
+     * Returns the total number of created proxies for the given {@code serviceName},
+     * even if some have already been destroyed.
+     *
+     * @param serviceName the distributed service name
+     * @return the total count of created proxies
+     */
+    long getCreatedCount(@Nonnull String serviceName);
 
     UUID addProxyListener(DistributedObjectListener distributedObjectListener);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -41,7 +41,6 @@ import com.hazelcast.spi.impl.proxyservice.impl.operations.DistributedObjectDest
 import com.hazelcast.spi.impl.proxyservice.impl.operations.PostJoinProxyOperation;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -282,11 +281,13 @@ public class ProxyServiceImpl
         listeners.clear();
     }
 
-    private static @Nonnull String checkServiceNameNotNull(@Nullable String serviceName) {
+    private static @Nonnull
+    String checkServiceNameNotNull(@Nonnull String serviceName) {
         return checkNotNull(serviceName, "Service name is required!");
     }
 
-    private static @Nonnull String checkObjectNameNotNull(@Nullable String name) {
+    private static @Nonnull
+    String checkObjectNameNotNull(@Nonnull String name) {
         return checkNotNull(name, "Object name is required!");
     }
 }


### PR DESCRIPTION
As per discussion on slack, this adds information about proxies that
were created but were subsequently destroyed.