### PR TITLE
Fix ClientInvocation Retry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/IExecutorDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/IExecutorDelegatingFuture.java
@@ -26,7 +26,6 @@ import com.hazelcast.client.impl.spi.ClientContext;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.cluster.Member;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -111,9 +110,7 @@ public final class IExecutorDelegatingFuture<V> extends ClientDelegatingFuture<V
     }
 
     private void waitForRequestToBeSend() throws InterruptedException {
-        InternalCompletableFuture future = getFuture();
-        ClientInvocationFuture clientCallFuture = (ClientInvocationFuture) future;
-        clientCallFuture.getInvocation().getSendConnectionOrWait();
+        ClientInvocationFuture future = getFuture();
+        future.getInvocation().waitInvoked();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.impl.spi.ClientListenerService;
 import com.hazelcast.client.impl.spi.ClientPartitionService;
 import com.hazelcast.client.impl.spi.EventHandler;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
@@ -158,10 +159,13 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
 
     public void start() {
         responseHandlerSupplier.start();
-        TaskScheduler executionService = client.getTaskScheduler();
-        long cleanResourcesMillis = client.getProperties().getPositiveMillisOrDefault(CLEAN_RESOURCES_MILLIS);
-        executionService.scheduleWithRepetition(new CleanResourcesTask(), cleanResourcesMillis,
-                cleanResourcesMillis, MILLISECONDS);
+        if (isBackupAckToClientEnabled) {
+            TaskScheduler executionService = client.getTaskScheduler();
+            long cleanResourcesMillis = client.getProperties().getPositiveMillisOrDefault(CLEAN_RESOURCES_MILLIS);
+            executionService.scheduleWithRepetition(new BackupTimeoutTask(), cleanResourcesMillis,
+                    cleanResourcesMillis, MILLISECONDS);
+        }
+        connectionManager.addConnectionListener(new ConnectionRemovedListener());
     }
 
     @Override
@@ -221,26 +225,29 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
             throw new HazelcastClientNotActiveException();
         }
 
+        ClientMessage clientMessage = invocation.getClientMessage();
         if (isBackupAckToClientEnabled) {
-            invocation.getClientMessage().getStartFrame().flags |= ClientMessage.BACKUP_AWARE_FLAG;
+            clientMessage.getStartFrame().flags |= ClientMessage.BACKUP_AWARE_FLAG;
         }
 
         registerInvocation(invocation, connection);
 
-        ClientMessage clientMessage = invocation.getClientMessage();
-        if (!writeToConnection(connection, clientMessage)) {
-            if (invocationLogger.isFinestEnabled()) {
-                invocationLogger.finest("Packet not sent to " + connection.getRemoteAddress() + " " + clientMessage);
+        //After this is set, a second thread can notify this invocation
+        //Connection could be closed. From this point on, we need to reacquire the permission to notify if needed.
+        invocation.setSentConnection(connection);
+
+
+        if (!connection.write(clientMessage)) {
+            if (invocation.getPermissionToNotifyForDeadConnection(connection)) {
+                IOException exception = new IOException("Packet not sent to " + connection.getRemoteAddress() + " "
+                        + clientMessage);
+                invocation.notifyExceptionWithOwnedPermission(exception);
             }
-            return false;
+        } else {
+            invocation.invoked();
         }
 
-        invocation.setSendConnection(connection);
         return true;
-    }
-
-    private boolean writeToConnection(ClientConnection connection, ClientMessage clientMessage) {
-        return connection.write(clientMessage);
     }
 
     // package-visible for tests
@@ -271,7 +278,8 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         responseHandlerSupplier.shutdown();
 
         for (ClientInvocation invocation : invocations.values()) {
-            invocation.notifyException(new HazelcastClientNotActiveException());
+            //connection manager and response handler threads are closed at this point.
+            invocation.notifyExceptionWithOwnedPermission(new HazelcastClientNotActiveException());
         }
     }
 
@@ -287,29 +295,29 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         return isSmartRoutingEnabled;
     }
 
-    private class CleanResourcesTask implements Runnable {
+    private class BackupTimeoutTask implements Runnable {
         @Override
         public void run() {
             for (ClientInvocation invocation : invocations.values()) {
-                ClientConnection connection = invocation.getSendConnection();
-                if (connection == null) {
-                    continue;
-                }
-
-                if (!connection.isAlive()) {
-                    notifyException(invocation, connection);
-                    continue;
-                }
-
-                if (isBackupAckToClientEnabled) {
-                    invocation.detectAndHandleBackupTimeout(operationBackupTimeoutMillis);
-                }
+                invocation.detectAndHandleBackupTimeout(operationBackupTimeoutMillis);
             }
         }
+    }
 
-        private void notifyException(ClientInvocation invocation, ClientConnection connection) {
-            Exception ex = new TargetDisconnectedException(connection.getCloseReason(), connection.getCloseCause());
-            invocation.notifyException(ex);
+    private class ConnectionRemovedListener implements ConnectionListener<ClientConnection> {
+        @Override
+        public void connectionAdded(ClientConnection connection) {
+
+        }
+
+        @Override
+        public void connectionRemoved(ClientConnection connection) {
+            for (ClientInvocation invocation : invocations.values()) {
+                if (invocation.getPermissionToNotifyForDeadConnection(connection)) {
+                    Exception ex = new TargetDisconnectedException(connection.getCloseReason(), connection.getCloseCause());
+                    invocation.notifyExceptionWithOwnedPermission(ex);
+                }
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BaseInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BaseInvocation.java
@@ -107,8 +107,6 @@ public abstract class BaseInvocation {
     }
 
     /**
-     * gets called from the Clean resources task
-     *
      * @param timeoutMillis timeout value to wait for backups after  the response received
      * @return true if invocation is completed
      */


### PR DESCRIPTION
Bug Description:
There seems to be multiple problems which is caused by single problem
we allow multiple threads to retry/change state of single invocation.
Example:
A connection is closed. CleanResourcesTask checks periodically and
handles invocation with connection closed.
   https://github.com/hazelcast/hazelcast/blob/04e9df4c2f406238267a8d45fbc9ae476b40c7d5/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java#L290-L301

This continues and schedules a retry here
    https://github.com/hazelcast/hazelcast/blob/04e9df4c2f406238267a8d45fbc9ae476b40c7d5/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java#L305-L315

Before this task gets a chance to run, CleanResoursTask can wakeup
check the same connection and schedule a new retry.

As a solution I first, try to sync them on `deRegisterInvocation(callid)`
,but this does not work. The idea was to only one that can
deRegisterInvocation will retry. Also a response/exception from
remote will notify if they can deregister the invocation.
One problem is correlation id is changed by the retried task, and
other threads are trying to deregister by reading that correlationId.
In response path, we have correlation id coming from remote but in
connection closed case, we don't have one to use(instead of reading
from invocation itself)

Another problem is how we handle connection close. Lets say a member
is about the close and we send an invocation to it. It can send,
ClusterPassive, InstanceNotActive like exceptions. And it closes the
connection after that. We have two cases to handle on the client side.
Lets say we have detected that connection is closed again in
CleanResoursesTask, and we are about to notify the invocation.
In the mean time we got InstanceNotActiveException as well, and we
retried it on another connection/with new call id.
Notify for connection close deregisters the new retry which should
not happen.

I have noticed we had similar problems on the core side.
#7270

I have investigate the solutions and core codebase
#9296
#9303

They are not suitable for the client. Especially connection close
case is different. On the member, we have MemberLeftException
which is guarded by `MemberListVersion` which are not applicable
to the client. So for the client, solution grew around `connection`
naturally.

Solution:
We coordinate all threads that wants to notify the invocation.
We achieve synchronization of different threads via `sentConnection`
field sentConnection starts as null.
It is set to a non-null when `connection` to be sent is determined.
It is set to null when a response/exception is going to be notified.
It is trying to be compared and set to null on connection close case
with dead connection, to prevent invocation to be notified which is
already retried on another connection.
Only one thread that can set this to null can be actively notify
a response/exception.

This way we make sure that only one thread changes the states
(changing correlation id/deregistration of invication).

fixes #18062