### PR TITLE
Convert given key to appropriate nearCacheKey

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -375,7 +375,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
 
         @Override
         public void beforeRemoteCall(Object key, Data keyData, Object value, Data valueData) {
-            nearCacheKey = serializeKeys ? keyData : key;
+            nearCacheKey = serializeKeys ? keyData : mapServiceContext.toObject(key);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnMapNearCacheTest.java
@@ -120,7 +120,6 @@ public class ClientTxnMapNearCacheTest extends HazelcastTestSupport {
 
     @Test
     public void remove_invalidates_server_side_near_cache() {
-        // update map in a client txn
         TransactionContext context = client.newTransactionContext();
         context.beginTransaction();
         TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
@@ -140,7 +139,6 @@ public class ClientTxnMapNearCacheTest extends HazelcastTestSupport {
 
     @Test
     public void removeIfSame_invalidates_server_side_near_cache() {
-        // update map in a client txn
         TransactionContext context = client.newTransactionContext();
         context.beginTransaction();
         TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
@@ -160,7 +158,6 @@ public class ClientTxnMapNearCacheTest extends HazelcastTestSupport {
 
     @Test
     public void replace_invalidates_server_side_near_cache() {
-        // update map in a client txn
         TransactionContext context = client.newTransactionContext();
         context.beginTransaction();
         TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
@@ -180,7 +177,6 @@ public class ClientTxnMapNearCacheTest extends HazelcastTestSupport {
 
     @Test
     public void replaceIfSame_invalidates_server_side_near_cache() {
-        // update map in a client txn
         TransactionContext context = client.newTransactionContext();
         context.beginTransaction();
         TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientTxnMapNearCacheTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.txn;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.nearcache.NearCacheStats;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionalMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientTxnMapNearCacheTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean serializeKeys;
+
+    @Parameterized.Parameters(name = "serializeKeys:{0},")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true},
+                {false},
+        });
+    }
+
+    private static final String MAP_NAME = "default";
+    private static final int KEY_COUNT = 1_000;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private HazelcastInstance server;
+    private HazelcastInstance client;
+    private IMap serverMap;
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Before
+    public void setup() {
+        Config config = smallInstanceConfig();
+
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setSerializeKeys(serializeKeys);
+        nearCacheConfig.setCacheLocalEntries(true);
+
+        config.getMapConfig("default").setNearCacheConfig(nearCacheConfig);
+        server = hazelcastFactory.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        serverMap = server.getMap(MAP_NAME);
+
+        // populate server-side-map
+        for (int i = 0; i < KEY_COUNT; i++) {
+            serverMap.set(i, i);
+        }
+
+        // populate server-side-map's near-cache
+        for (int i = 0; i < KEY_COUNT; i++) {
+            serverMap.get(i);
+        }
+    }
+
+    @Test
+    public void put_invalidates_server_side_near_cache() {
+        // update map in a client txn
+        TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            txnMap.put(i, i);
+        }
+        context.commitTransaction();
+
+        NearCacheStats nearCacheStats = serverMap.getLocalMapStats().getNearCacheStats();
+        long ownedEntryCount = nearCacheStats.getOwnedEntryCount();
+        long invalidations = nearCacheStats.getInvalidations();
+
+        assertEquals(0, ownedEntryCount);
+        assertEquals(KEY_COUNT, invalidations);
+    }
+
+    @Test
+    public void remove_invalidates_server_side_near_cache() {
+        // update map in a client txn
+        TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            txnMap.remove(i);
+        }
+        context.commitTransaction();
+
+        NearCacheStats nearCacheStats = serverMap.getLocalMapStats().getNearCacheStats();
+        long ownedEntryCount = nearCacheStats.getOwnedEntryCount();
+        long invalidations = nearCacheStats.getInvalidations();
+
+        assertEquals(0, ownedEntryCount);
+        assertEquals(KEY_COUNT, invalidations);
+    }
+
+    @Test
+    public void removeIfSame_invalidates_server_side_near_cache() {
+        // update map in a client txn
+        TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            txnMap.remove(i, i);
+        }
+        context.commitTransaction();
+
+        NearCacheStats nearCacheStats = serverMap.getLocalMapStats().getNearCacheStats();
+        long ownedEntryCount = nearCacheStats.getOwnedEntryCount();
+        long invalidations = nearCacheStats.getInvalidations();
+
+        assertEquals(0, ownedEntryCount);
+        assertEquals(KEY_COUNT, invalidations);
+    }
+
+    @Test
+    public void replace_invalidates_server_side_near_cache() {
+        // update map in a client txn
+        TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            txnMap.replace(i, i);
+        }
+        context.commitTransaction();
+
+        NearCacheStats nearCacheStats = serverMap.getLocalMapStats().getNearCacheStats();
+        long ownedEntryCount = nearCacheStats.getOwnedEntryCount();
+        long invalidations = nearCacheStats.getInvalidations();
+
+        assertEquals(0, ownedEntryCount);
+        assertEquals(KEY_COUNT, invalidations);
+    }
+
+    @Test
+    public void replaceIfSame_invalidates_server_side_near_cache() {
+        // update map in a client txn
+        TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Object, Object> txnMap = context.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            txnMap.replace(i, i, i);
+        }
+        context.commitTransaction();
+
+        NearCacheStats nearCacheStats = serverMap.getLocalMapStats().getNearCacheStats();
+        long ownedEntryCount = nearCacheStats.getOwnedEntryCount();
+        long invalidations = nearCacheStats.getInvalidations();
+
+        assertEquals(0, ownedEntryCount);
+        assertEquals(KEY_COUNT, invalidations);
+    }
+}


### PR DESCRIPTION
…ractions

Fixes `IllegalArgumentException` when there is near-cache configured for both server and client sides for the same map and `serialize-keys` is `false`(default value). In this situation, txn done with client-side proxy doesn't proceed.

```
java.lang.IllegalArgumentException: key cannot be of type Data!

	at com.hazelcast.internal.util.Preconditions.checkNotInstanceOf(Preconditions.java:300)
	at com.hazelcast.internal.nearcache.impl.DefaultNearCache.checkKeyFormat(DefaultNearCache.java:221)
	at com.hazelcast.internal.nearcache.impl.DefaultNearCache.invalidate(DefaultNearCache.java:140)
	at com.hazelcast.map.impl.tx.TransactionalMapProxySupport.invalidateNearCache(TransactionalMapProxySupport.java:174)
	at com.hazelcast.map.impl.tx.TransactionalMapProxySupport$InvalidationHook.onRemoteCallFailure(TransactionalMapProxySupport.java:388)
	at com.hazelcast.map.impl.tx.MapTransactionLogRecord.onCommitFailure(MapTransactionLogRecord.java:92)
	at com.hazelcast.transaction.impl.TransactionLog.onCommitFailure(TransactionLog.java:105)
	at com.hazelcast.transaction.impl.TransactionImpl.commit(TransactionImpl.java:301)
	at com.hazelcast.transaction.impl.TransactionContextImpl.commitTransaction(TransactionContextImpl.java:76)
	at com.hazelcast.client.impl.protocol.task.transaction.TransactionCommitMessageTask.innerCall(TransactionCommitMessageTask.java:40)
	at com.hazelcast.client.impl.protocol.task.AbstractTransactionalMessageTask.call(AbstractTransactionalMessageTask.java:35)
	at com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask.processMessage(AbstractCallableMessageTask.java:35)
	at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.initializeAndProcessMessage(AbstractMessageTask.java:153)
	at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.run(AbstractMessageTask.java:116)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.lang.Thread.run(Thread.java:832)
	at com.hazelcast.internal.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
	at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
```