### PR TITLE
Fix test name report

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientDurableExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientDurableExecutorServiceProxy.java
@@ -223,7 +223,7 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
             ClientMessage response = invokeOnPartition(request, partitionId);
             sequence = DurableExecutorSubmitToPartitionCodec.decodeResponse(response).response;
         } catch (Throwable t) {
-            return completedExceptionally(t, ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR);
+            return completedExceptionally(t, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
         ClientMessage clientMessage = DurableExecutorRetrieveResultCodec.encodeRequest(name, sequence);
         ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage, getName(), partitionId).invoke();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientExecutorServiceProxy.java
@@ -36,6 +36,7 @@ import com.hazelcast.executor.impl.ExecutionCallbackAdapter;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
@@ -56,7 +57,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
@@ -467,7 +467,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
                         if (t instanceof RejectedExecutionException) {
                             callback.onFailure(t);
                         }
-                    }, DEFAULT_ASYNC_EXECUTOR);
+                    }, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
         return delegatingFuture;
     }
@@ -498,7 +498,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
                         if (t instanceof RejectedExecutionException) {
                             callback.onFailure(t);
                         }
-                    }, DEFAULT_ASYNC_EXECUTOR);
+                    }, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
     }
 
@@ -530,7 +530,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
                         if (t instanceof RejectedExecutionException) {
                             callback.onFailure(t);
                         }
-                    }, DEFAULT_ASYNC_EXECUTOR);
+                    }, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableTopicProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.spi.ClientContext;
 import com.hazelcast.client.impl.spi.ClientProxy;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.ringbuffer.OverflowPolicy;
@@ -42,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
@@ -77,15 +77,15 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
         this.ringbuffer = client.getRingbuffer(TOPIC_RB_PREFIX + objectId);
         this.serializationService = client.getSerializationService();
         this.config = client.getClientConfig().getReliableTopicConfig(objectId);
-        this.executor = getExecutor(config, client);
+        this.executor = getExecutor(config);
         this.overloadPolicy = config.getTopicOverloadPolicy();
         logger = client.getLoggingService().getLogger(getClass());
     }
 
-    private Executor getExecutor(ClientReliableTopicConfig config, HazelcastClientInstanceImpl client) {
+    private Executor getExecutor(ClientReliableTopicConfig config) {
         Executor executor = config.getExecutor();
         if (executor == null) {
-            executor = DEFAULT_ASYNC_EXECUTOR;
+            executor = ConcurrencyUtil.getDefaultAsyncExecutor();
         }
         return executor;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
@@ -47,7 +47,7 @@ public final class ConcurrencyUtil {
 
     // Default executor for async callbacks: ForkJoinPool.commonPool() or a thread-per-task executor when
     // the common pool does not support parallelism
-    public static final Executor DEFAULT_ASYNC_EXECUTOR;
+    private static Executor defaultAsyncExecutor;
 
     static {
         Executor asyncExecutor;
@@ -56,15 +56,29 @@ public final class ConcurrencyUtil {
         } else {
             asyncExecutor = command -> new Thread(command).start();
         }
-        DEFAULT_ASYNC_EXECUTOR = asyncExecutor;
+        defaultAsyncExecutor = asyncExecutor;
     }
 
     private ConcurrencyUtil() {
     }
 
     /**
+     * WARNING this method should not be called from static context.
+     */
+    public static Executor getDefaultAsyncExecutor() {
+        return defaultAsyncExecutor;
+    }
+
+    /**
+     * Used by AbstractHazelcastClassRunner to override default executor.
+     */
+    public static void setDefaultAsyncExecutor(Executor executor) {
+        defaultAsyncExecutor = executor;
+    }
+
+    /**
      * Atomically sets the max value.
-     *
+     * <p>
      * If the current value is larger than the provided value, the call is ignored.
      * So it will not happen that a smaller value will overwrite a larger value.
      */

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.executor.UnblockableThread;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationservice.WrappableException;
@@ -44,7 +45,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 import static com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static java.util.Objects.requireNonNull;
@@ -1334,7 +1334,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
 
         WaitNode(Object waiter, @Nullable Executor executor) {
             this.waiter = waiter;
-            this.executor = executor == null ? DEFAULT_ASYNC_EXECUTOR : executor;
+            this.executor = executor == null ? ConcurrencyUtil.getDefaultAsyncExecutor() : executor;
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DeserializingCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DeserializingCompletableFuture.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -30,8 +31,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 
 /**
  * Decorates {@link InternalCompletableFuture} to supply:
@@ -60,7 +59,7 @@ public class DeserializingCompletableFuture<V> extends InternalCompletableFuture
     private final boolean deserialize;
 
     public DeserializingCompletableFuture() {
-        this(null, DEFAULT_ASYNC_EXECUTOR, false);
+        this(null, ConcurrencyUtil.getDefaultAsyncExecutor(), false);
     }
 
     public DeserializingCompletableFuture(Executor defaultAsyncExecutor) {
@@ -68,7 +67,7 @@ public class DeserializingCompletableFuture<V> extends InternalCompletableFuture
     }
 
     public DeserializingCompletableFuture(SerializationService serializationService, boolean deserialize) {
-        this(serializationService, DEFAULT_ASYNC_EXECUTOR, deserialize);
+        this(serializationService, ConcurrencyUtil.getDefaultAsyncExecutor(), deserialize);
     }
 
     public DeserializingCompletableFuture(SerializationService serializationService, Executor defaultAsyncExecutor,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalCompletableFuture.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.serialization.Data;
 
@@ -31,7 +32,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.DEFAULT_ASYNC_EXECUTOR;
 import static com.hazelcast.spi.impl.AbstractInvocationFuture.wrapOrPeel;
 
 /**
@@ -50,10 +50,11 @@ import static com.hazelcast.spi.impl.AbstractInvocationFuture.wrapOrPeel;
  * <p>This class provides static factory methods for more specific implementations
  * supporting custom default async executor or deserialization of completion value.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class InternalCompletableFuture<V> extends CompletableFuture<V> {
 
     public Executor defaultExecutor() {
-        return DEFAULT_ASYNC_EXECUTOR;
+        return ConcurrencyUtil.getDefaultAsyncExecutor();
     }
 
     /**
@@ -78,12 +79,27 @@ public class InternalCompletableFuture<V> extends CompletableFuture<V> {
     }
 
     @Override
+    public <U> CompletableFuture<U> thenApplyAsync(Function<? super V, ? extends U> fn) {
+        return super.thenApplyAsync(fn, defaultExecutor());
+    }
+
+    @Override
     public CompletableFuture<Void> thenAccept(Consumer<? super V> action) {
         return super.thenAcceptAsync(action, defaultExecutor());
     }
 
     @Override
+    public CompletableFuture<Void> thenAcceptAsync(Consumer<? super V> action) {
+        return super.thenAcceptAsync(action, defaultExecutor());
+    }
+
+    @Override
     public CompletableFuture<Void> thenRun(Runnable action) {
+        return super.thenRunAsync(action, defaultExecutor());
+    }
+
+    @Override
+    public CompletableFuture<Void> thenRunAsync(Runnable action) {
         return super.thenRunAsync(action, defaultExecutor());
     }
 
@@ -94,8 +110,20 @@ public class InternalCompletableFuture<V> extends CompletableFuture<V> {
     }
 
     @Override
+    public <U, V1> CompletableFuture<V1> thenCombineAsync(CompletionStage<? extends U> other,
+                                                          BiFunction<? super V, ? super U, ? extends V1> fn) {
+        return super.thenCombineAsync(other, fn,  defaultExecutor());
+    }
+
+    @Override
     public <U> CompletableFuture<Void> thenAcceptBoth(CompletionStage<? extends U> other,
                                                       BiConsumer<? super V, ? super U> action) {
+        return super.thenAcceptBothAsync(other, action, defaultExecutor());
+    }
+
+    @Override
+    public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other,
+                                                           BiConsumer<? super V, ? super U> action) {
         return super.thenAcceptBothAsync(other, action, defaultExecutor());
     }
 
@@ -105,7 +133,17 @@ public class InternalCompletableFuture<V> extends CompletableFuture<V> {
     }
 
     @Override
+    public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
+        return super.runAfterBothAsync(other, action, defaultExecutor());
+    }
+
+    @Override
     public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends V> other, Function<? super V, U> fn) {
+        return super.applyToEitherAsync(other, fn, defaultExecutor());
+    }
+
+    @Override
+    public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends V> other, Function<? super V, U> fn) {
         return super.applyToEitherAsync(other, fn, defaultExecutor());
     }
 
@@ -115,7 +153,17 @@ public class InternalCompletableFuture<V> extends CompletableFuture<V> {
     }
 
     @Override
+    public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends V> other, Consumer<? super V> action) {
+        return super.acceptEitherAsync(other, action, defaultExecutor());
+    }
+
+    @Override
     public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
+        return super.runAfterEitherAsync(other, action, defaultExecutor());
+    }
+
+    @Override
+    public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
         return super.runAfterEitherAsync(other, action, defaultExecutor());
     }
 
@@ -125,12 +173,27 @@ public class InternalCompletableFuture<V> extends CompletableFuture<V> {
     }
 
     @Override
+    public <U> CompletableFuture<U> thenComposeAsync(Function<? super V, ? extends CompletionStage<U>> fn) {
+        return super.thenComposeAsync(fn, defaultExecutor());
+    }
+
+    @Override
     public CompletableFuture<V> whenComplete(BiConsumer<? super V, ? super Throwable> action) {
         return super.whenCompleteAsync(action, defaultExecutor());
     }
 
     @Override
+    public CompletableFuture<V> whenCompleteAsync(BiConsumer<? super V, ? super Throwable> action) {
+        return super.whenCompleteAsync(action, defaultExecutor());
+    }
+
+    @Override
     public <U> CompletableFuture<U> handle(BiFunction<? super V, Throwable, ? extends U> fn) {
+        return super.handleAsync(fn, defaultExecutor());
+    }
+
+    @Override
+    public <U> CompletableFuture<U> handleAsync(BiFunction<? super V, Throwable, ? extends U> fn) {
         return super.handleAsync(fn, defaultExecutor());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -19,6 +19,7 @@ package com.hazelcast.test;
 import com.hazelcast.cache.jsr.JsrTestUtil;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.test.compatibility.CompatibilityTestUtils;
@@ -48,12 +49,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.getCachingProviderRegistrySize;
-import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
 import static java.lang.Integer.getInteger;
 
 /**
@@ -124,8 +126,13 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         System.setProperty("hazelcast.wait.seconds.before.join", "1");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         System.setProperty("java.net.preferIPv4Stack", "true");
+        //override default async executor of hazelcast so that it can report correct test names in test runs
+        //if ForkJoinPool parallelism is less than or equal to 1, `thread-per-task` will be used.
+        //In that case there is no need to override defaultAsyncExecutor
+        if (ForkJoinPool.getCommonPoolParallelism() > 1) {
+            ConcurrencyUtil.setDefaultAsyncExecutor(new TestLoggingUtils.CustomTestNameAwareForkJoinPool());
+        }
     }
-
 
     /**
      * Creates a BlockJUnit4ClassRunner to run {@code clazz}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
@@ -18,6 +18,10 @@ package com.hazelcast.test;
 
 import org.apache.logging.log4j.ThreadContext;
 
+import javax.annotation.Nonnull;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+
 import static com.hazelcast.test.JenkinsDetector.isOnJenkins;
 
 public final class TestLoggingUtils {
@@ -73,4 +77,41 @@ public final class TestLoggingUtils {
         }
         return false;
     }
+
+    public static class CustomTestNameAwareForkJoinPool implements Executor {
+
+        private final Executor defaultExecutor = ForkJoinPool.commonPool();
+
+        @Override
+        public void execute(@Nonnull Runnable task) {
+            defaultExecutor.execute(new TestNameAwareRunnable(task));
+        }
+
+        public static class TestNameAwareRunnable implements Runnable {
+
+            private final String testName;
+            private final Runnable runnable;
+
+            public TestNameAwareRunnable(Runnable runnable) {
+                testName = IS_LOG4J2_AVAILABLE ? ThreadContext.get("test-name") : null;
+                this.runnable = runnable;
+            }
+
+            @Override
+            public void run() {
+                setThreadLocalTestMethodName(testName);
+                try {
+                    runnable.run();
+                } finally {
+                    removeThreadLocalTestMethodName();
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "CustomTestNameAwareForkJoinPool";
+        }
+    }
+
 }


### PR DESCRIPTION
Since ForkJoinPoolWorkers inherits the inheritableThreadLocal names
where they created, when they reused by other tests, they have
the wrong name.

This is a candidate fix to use a ForkJoinPool which wraps
Runnable's with a TestNameAwareRunnable's.
This ForkJoinPool is overriden statically  only in tests
see AbstractHazelcastClassRunner.initialize

backport of https://github.com/hazelcast/hazelcast/pull/18181
(cherry picked from commit fee644fb23d9df6f26ac49c363d27267d1173e3e)