### PR TITLE
Fix GC metrics not getting updates issue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -70,7 +70,7 @@ public final class GarbageCollectionMetricSet {
         checkNotNull(metricsRegistry, "metricsRegistry");
 
         GcStats stats = new GcStats();
-        metricsRegistry.scheduleAtFixedRate(stats, PUBLISH_FREQUENCY_SECONDS, SECONDS, INFO);
+        metricsRegistry.scheduleAtFixedRate(stats, PUBLISH_FREQUENCY_SECONDS, SECONDS, MANDATORY);
         metricsRegistry.scanAndRegister(stats, "gc");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -26,7 +26,6 @@ import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.Set;
 
-import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SetUtil.createHashSet;


### PR DESCRIPTION
Fixes: #17144 

Although GC metrics are `MANDATORY` metrics, the periodic publisher
of these metrics was registered at the `INFO` level. Since the default
`hazelcast.diagnostics.metric.level` is `MANDATORY` in this IMDG
version, GC metrics did not get updates by default. In this PR, I changed
 that metric publisher registration to `MANDATORY` level.

The reason why this issue is not seen in future versions is that the default
 value of `hazelcast.diagnostics.metric.level` property is changed to `INFO`.