### PR TITLE
Update the sql error message when the cluster topology changed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryException.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/QueryException.java
@@ -68,15 +68,18 @@ public final class QueryException extends HazelcastException {
     }
 
     public static QueryException memberConnection(UUID memberId) {
-        return error(SqlErrorCode.CONNECTION_PROBLEM, "Member cannot be reached: " + memberId).markInvalidate();
+        return error(SqlErrorCode.CONNECTION_PROBLEM, "Cluster topology changed while a query was executed: "
+                + "Member cannot be reached: " + memberId).markInvalidate();
     }
 
     public static QueryException memberConnection(Address address) {
-        return error(SqlErrorCode.CONNECTION_PROBLEM, "Member cannot be reached: " + address).markInvalidate();
+        return error(SqlErrorCode.CONNECTION_PROBLEM, "Cluster topology changed while a query was executed: "
+                + "Member cannot be reached: " + address).markInvalidate();
     }
 
     public static QueryException memberConnection(Collection<UUID> memberIds) {
-        return error(SqlErrorCode.CONNECTION_PROBLEM, "Members cannot be reached: " + memberIds).markInvalidate();
+        return error(SqlErrorCode.CONNECTION_PROBLEM, "Cluster topology changed while a query was executed: "
+                + "Members cannot be reached: " + memberIds).markInvalidate();
     }
 
     public static QueryException clientMemberConnection(UUID clientId) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -108,7 +108,7 @@ public class MapScanExecIterator implements KeyValueIterator {
                     if (!isOwned) {
                         throw QueryException.error(
                                 SqlErrorCode.PARTITION_DISTRIBUTION,
-                                "Cluster topology changed while a query was executed: "
+                                "Partition was migrated while a query was executed: "
                                         + "Partition is not owned by member: " + nextPart
                         ).markInvalidate();
                     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/exec/scan/MapScanExecIterator.java
@@ -108,7 +108,8 @@ public class MapScanExecIterator implements KeyValueIterator {
                     if (!isOwned) {
                         throw QueryException.error(
                                 SqlErrorCode.PARTITION_DISTRIBUTION,
-                                "Partition is not owned by member: " + nextPart
+                                "Cluster topology changed while a query was executed: "
+                                        + "Partition is not owned by member: " + nextPart
                         ).markInvalidate();
                     }
 


### PR DESCRIPTION
Fixes #17849 

This PR adds more details to the SQL error message shown after the cluster topology change while executing a SQL query.