### PR TITLE
Move connection close back to member event handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -331,7 +331,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
             }
         }
 
-        executor.scheduleWithFixedDelay(new ConnectionManagementTask(), 1, 1, TimeUnit.SECONDS);
+        executor.scheduleWithFixedDelay(new ConnectToAllClusterMembersTask(), 1, 1, TimeUnit.SECONDS);
     }
 
     protected void startNetworking() {
@@ -1079,10 +1079,9 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
     }
 
     /**
-     * 1) schedules a task to open a connection if there is no connection for the member in the member list
-     * 2) closes a connection if it is no longer in the member list
+     * Schedules a task to open a connection if there is no connection for the member in the member list
      */
-    private class ConnectionManagementTask implements Runnable {
+    private class ConnectToAllClusterMembersTask implements Runnable {
 
         private final Set<UUID> connectingAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -1093,12 +1092,8 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                 return;
             }
 
-            HashSet<UUID> activeConnectionUuids = new HashSet<>(activeConnections.keySet());
-
             for (Member member : client.getClientClusterService().getMemberList()) {
                 UUID uuid = member.getUuid();
-                activeConnectionUuids.remove(uuid);
-
                 if (activeConnections.get(uuid) != null) {
                     continue;
                 }
@@ -1121,15 +1116,6 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                         connectingAddresses.remove(uuid);
                     }
                 });
-            }
-            //whatever remains in the set should be closed since there is no corresponding member in the member list
-            for (UUID uuidOutsideCurrentMemberlist : activeConnectionUuids) {
-                TcpClientConnection connection = activeConnections.get(uuidOutsideCurrentMemberlist);
-                if (connection != null) {
-                    connection.close(null,
-                            new TargetDisconnectedException("The client has closed the connection to this member,"
-                                    + " after receiving a member left event from the cluster. " + connection));
-                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -35,10 +35,12 @@ import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.MemberSelectingCollection;
+import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
@@ -79,6 +81,7 @@ public class ClientClusterServiceImpl
     private final ConcurrentMap<UUID, MembershipListener> listeners = new ConcurrentHashMap<>();
     private final Set<String> labels;
     private final ILogger logger;
+    private final ClientConnectionManager connectionManager;
     private final Object clusterViewLock = new Object();
     private final TranslateToPublicAddressProvider translateToPublicAddress;
     //read and written under clusterViewLock
@@ -99,6 +102,7 @@ public class ClientClusterServiceImpl
         this.client = client;
         labels = unmodifiableSet(client.getClientConfig().getLabels());
         logger = client.getLoggingService().getLogger(ClientClusterService.class);
+        connectionManager = client.getConnectionManager();
         translateToPublicAddress = new TranslateToPublicAddressProvider(client.getClientConfig().getNetworkConfig(),
                 client.getProperties(), logger);
     }
@@ -304,6 +308,12 @@ public class ClientClusterServiceImpl
 
         for (Member member : deadMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, currentMembers));
+            Connection connection = connectionManager.getConnection(member.getUuid());
+            if (connection != null) {
+                connection.close(null,
+                        new TargetDisconnectedException("The client has closed the connection to this member,"
+                                + " after receiving a member left event from the cluster. " + connection));
+            }
         }
         for (Member member : newMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, currentMembers));


### PR DESCRIPTION
Partially reverts https://github.com/hazelcast/hazelcast/pull/18033

When we give the closing connection to periodic task, it can close
a connection unncessarily because it can always read a stale
member list. This was causing `ConfiguredBehaviourTest` to fail.

fixes https://github.com/hazelcast/hazelcast/issues/18323