### PR TITLE
Report Java classpath in phone homes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -41,6 +41,7 @@ class BuildInfoCollector implements MetricsCollector {
         metricsConsumer.accept(PhoneHomeMetrics.BUILD_VERSION, imdgInfo.getVersion());
         metricsConsumer.accept(PhoneHomeMetrics.JET_BUILD_VERSION,
                 jetInfo == null ? "" : jetInfo.getVersion());
+        metricsConsumer.accept(PhoneHomeMetrics.JAVA_CLASSPATH, System.getProperty("java.class.path"));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -26,11 +26,14 @@ import java.util.Properties;
 import java.util.function.BiConsumer;
 
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static java.lang.Math.min;
 
 /**
  * Collects metadata about this instance
  */
 class BuildInfoCollector implements MetricsCollector {
+
+    private static final int CLASSPATH_MAX_LENGTH = 10_000;
 
     @Override
     public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
@@ -41,7 +44,11 @@ class BuildInfoCollector implements MetricsCollector {
         metricsConsumer.accept(PhoneHomeMetrics.BUILD_VERSION, imdgInfo.getVersion());
         metricsConsumer.accept(PhoneHomeMetrics.JET_BUILD_VERSION,
                 jetInfo == null ? "" : jetInfo.getVersion());
-        metricsConsumer.accept(PhoneHomeMetrics.JAVA_CLASSPATH, System.getProperty("java.class.path"));
+        String classpath = System.getProperty("java.class.path");
+        if (classpath != null) {
+            metricsConsumer.accept(PhoneHomeMetrics.JAVA_CLASSPATH,
+                    classpath.substring(0, min(CLASSPATH_MAX_LENGTH, classpath.length())));
+        }
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -26,6 +26,7 @@ public enum PhoneHomeMetrics {
     JAVA_VERSION_OF_SYSTEM("jvmv"),
     BUILD_VERSION("version"),
     JET_BUILD_VERSION("jetv"),
+    JAVA_CLASSPATH("classpath"),
 
     //CLIENT INFO METRICS
     CLIENTS_WITH_CPP_CONNECTION("ccpp"),

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
@@ -43,6 +43,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 
 import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
@@ -66,7 +68,7 @@ import static org.mockito.Mockito.when;
 public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+    public WireMockRule wireMockRule = new WireMockRule(options().jettyHeaderBufferSize(16384));
 
     private Node node;
     private PhoneHome phoneHome;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -86,6 +86,7 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
         assertEquals(parameters.get(PhoneHomeMetrics.BUILD_VERSION.getRequestParameterName()), BuildInfoProvider.getBuildInfo().getVersion());
+        assertEquals(parameters.get(PhoneHomeMetrics.JAVA_CLASSPATH.getRequestParameterName()), System.getProperty("java.class.path"));
         assertEquals(UUID.fromString(parameters.get(PhoneHomeMetrics.UUID_OF_CLUSTER.getRequestParameterName())), node.getLocalMember().getUuid());
         assertNull(parameters.get("e"));
         assertNull(parameters.get("oem"));


### PR DESCRIPTION
With this change, we add reporting of the Java classpath that the members run on. Since we pass the info as
part of the request URI, the header section might become very large depending on the classpath of the project.
For this reason, we will need to increase maximum size of the HTTP message header in phone home server application.

One important caveat of this PR (as raised by @erosb) is that we won't be able to determine what libraries are used
 by a user if they are deploying their application as a fat JAR which is common for projects that use Spring Boot. In the 
future, we should change to scanning the classpath for libraries that we're interested of.

The classpath is not cleaned up on the member side (i.e. the paths that lead to actual JARs are not trimmed). Reason for 
it is that sometimes only the paths leading to the actual JAR contain the artifact named and not the artifact itself.

Closes #18262