### PR TITLE
Fixed an issue in ORDER BY clause

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/index/IndexResolver.java
@@ -170,7 +170,7 @@ public final class IndexResolver {
         );
 
         if (candidates.isEmpty()) {
-            return Collections.emptyList();
+            return fullScanRelsMap.values();
         }
 
         List<RelNode> rels = new ArrayList<>(supportedIndexes.size());

--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
@@ -348,6 +348,19 @@ public class SqlOrderByTest extends SqlTestSupport {
     }
 
     @Test
+    public void testSelectWithOrderByAndWhereNotIndexedField() {
+        IMap<Object, AbstractPojo> map = getTarget().getMap(mapName());
+        String intValField = "intVal";
+        String realValField = "realVal";
+        addIndex(Arrays.asList(realValField), SORTED);
+
+        String sql = "SELECT " + intValField + ", " + realValField + " FROM " + mapName()
+            + " WHERE " + intValField + " = 1 ORDER BY " + realValField;
+
+        assertSqlResultOrdered(sql, Arrays.asList(realValField), Arrays.asList(false), 1);
+    }
+
+    @Test
     public void testSelectWithOrderByAndWhere2Conditions() {
         IMap<Object, AbstractPojo> map = getTarget().getMap(mapName());
         String intValField = "intVal";


### PR DESCRIPTION
If there is a filter in WHERE clause without supporting indexes the full
index scans are not emitted by MapScanPhysicalRule. The PR fixes the
issue.

Closes https://github.com/hazelcast/hazelcast/issues/18339