### PR TITLE
Unit test fix: wait for safe state

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/exec/scan/index/MapIndexScanExecTest.java
@@ -95,8 +95,12 @@ public class MapIndexScanExecTest extends SqlTestSupport {
         instance1 = factory.newHazelcastInstance(getInstanceConfig());
         instance2 = factory.newHazelcastInstance(getInstanceConfig());
 
+        assertClusterSizeEventually(2, instance1, instance2);
+
         IMap<Integer, Integer> map = instance1.getMap(MAP_NAME);
         map.addIndex(new IndexConfig().setName(INDEX_NAME).setType(IndexType.SORTED).addAttribute("this"));
+
+        waitAllForSafeState(instance1, instance2);
     }
 
     @After


### PR DESCRIPTION
in the MapIndexScanExecTest waitt for SAFE state

Closes https://github.com/hazelcast/hazelcast/issues/18310