### PR TITLE
Don't shift expiry time when scanning over index

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreAdapter.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.map.impl.recordstore;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 
 /**
@@ -38,15 +38,12 @@ public class RecordStoreAdapter implements StoreAdapter<Record> {
         ensureCallingFromPartitionOperationThread();
 
         record = recordStore.getOrNullIfExpired(key, record, now, backup);
-        if (record == null) {
-            // free memory of expired record
-            recordStore.disposeDeferredBlocks();
-            return true;
+        if (record != null) {
+            return false;
         }
-
-        // not expired record, update access info
-        recordStore.accessRecord(record, now);
-        return false;
+        // free memory of expired record
+        recordStore.disposeDeferredBlocks();
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -17,13 +17,13 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.MapUtil;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static com.hazelcast.internal.util.MapUtil.isNullOrEmpty;
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 
 /**
@@ -146,10 +146,6 @@ public abstract class BaseIndexStore implements IndexStore {
         }
     }
 
-    boolean isExpirable() {
-        return isIndexStoreExpirable;
-    }
-
     interface CopyFunctor<A, B> {
 
         Map<A, B> invoke(Map<A, B> map);
@@ -162,30 +158,19 @@ public abstract class BaseIndexStore implements IndexStore {
 
     }
 
-    private class PassThroughFunctor implements CopyFunctor<Data, QueryableEntry> {
+    private static class PassThroughFunctor implements CopyFunctor<Data, QueryableEntry> {
 
         @Override
         public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
-            if (MapUtil.isNullOrEmpty(map)) {
-                return map;
-            }
-
             return map;
         }
     }
 
-    private class CopyInputFunctor implements CopyFunctor<Data, QueryableEntry> {
+    private static class CopyInputFunctor implements CopyFunctor<Data, QueryableEntry> {
 
         @Override
         public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
-            if (MapUtil.isNullOrEmpty(map)) {
-                return map;
-            }
-
-            return new HashMap<>(map);
+            return isNullOrEmpty(map) ? map : new HashMap<>(map);
         }
-
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -18,9 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.MapUtil;
-import com.hazelcast.map.impl.record.Record;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -172,7 +170,7 @@ public abstract class BaseIndexStore implements IndexStore {
                 return map;
             }
 
-            return isExpirable() ? new ExpirationAwareHashMapDelegate(map) : map;
+            return map;
         }
     }
 
@@ -184,83 +182,10 @@ public abstract class BaseIndexStore implements IndexStore {
                 return map;
             }
 
-            Map<Data, QueryableEntry> newMap = new HashMap<>(map);
-            return isExpirable() ? new ExpirationAwareHashMapDelegate(newMap) : newMap;
+            return new HashMap<>(map);
         }
 
     }
 
-    /**
-     * This delegating Map updates the {@link Record}'s access time on every
-     * {@link QueryableEntry} retrieved through the {@link Map#entrySet()},
-     * {@link Map#get} or {@link Map#values()}.
-     */
-    protected static final class ExpirationAwareHashMapDelegate implements Map<Data, QueryableEntry> {
 
-        private final Map<Data, QueryableEntry> delegateMap;
-
-        ExpirationAwareHashMapDelegate(Map<Data, QueryableEntry> map) {
-            this.delegateMap = map;
-        }
-
-        @Override
-        public int size() {
-            return delegateMap.size();
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return delegateMap.isEmpty();
-        }
-
-        @Override
-        public boolean containsKey(Object o) {
-            return delegateMap.containsKey(o);
-        }
-
-        @Override
-        public boolean containsValue(Object o) {
-            return delegateMap.containsValue(o);
-        }
-
-        @Override
-        public QueryableEntry put(Data data, QueryableEntry queryableEntry) {
-            return delegateMap.put(data, queryableEntry);
-        }
-
-        @Override
-        public QueryableEntry remove(Object o) {
-            return delegateMap.remove(o);
-        }
-
-        @Override
-        public void putAll(Map<? extends Data, ? extends QueryableEntry> map) {
-            delegateMap.putAll(map);
-        }
-
-        @Override
-        public void clear() {
-            delegateMap.clear();
-        }
-
-        @Override
-        public Set<Data> keySet() {
-            return delegateMap.keySet();
-        }
-
-        @Override
-        public QueryableEntry get(Object o) {
-            return delegateMap.get(o);
-        }
-
-        @Override
-        public Collection<QueryableEntry> values() {
-            return delegateMap.values();
-        }
-
-        @Override
-        public Set<Entry<Data, QueryableEntry>> entrySet() {
-            return delegateMap.entrySet();
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -39,14 +39,6 @@ public abstract class BaseIndexStore implements IndexStore {
 
     private final CopyFunctor<Data, QueryableEntry> resultCopyFunctor;
 
-    /**
-     * {@code true} if this index store has at least one candidate entry
-     * for expiration (idle or tll), otherwise {@code false}.
-     * <p>
-     * The field is updated on every update of the index.
-     */
-    private volatile boolean isIndexStoreExpirable;
-
     BaseIndexStore(IndexCopyBehavior copyOn, boolean enableGlobalLock) {
         if (copyOn == IndexCopyBehavior.COPY_ON_WRITE || copyOn == IndexCopyBehavior.NEVER) {
             resultCopyFunctor = new PassThroughFunctor();
@@ -140,10 +132,6 @@ public abstract class BaseIndexStore implements IndexStore {
     }
 
     void markIndexStoreExpirableIfNecessary(QueryableEntry record) {
-        // StoreAdapter is not set in plenty of internal unit tests
-        if (record.getStoreAdapter() != null) {
-            isIndexStoreExpirable = record.getStoreAdapter().isExpirable();
-        }
     }
 
     interface CopyFunctor<A, B> {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -17,18 +17,14 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.map.impl.record.Record;
 
-import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Consumer;
 
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 
@@ -254,87 +250,17 @@ public abstract class BaseIndexStore implements IndexStore {
 
         @Override
         public QueryableEntry get(Object o) {
-            QueryableEntry queryableEntry = delegateMap.get(o);
-            if (queryableEntry != null) {
-                long now = Clock.currentTimeMillis();
-                queryableEntry.getRecord().onAccessSafe(now);
-            }
-            return queryableEntry;
+            return delegateMap.get(o);
         }
 
         @Override
         public Collection<QueryableEntry> values() {
-            long now = Clock.currentTimeMillis();
-            return new ExpirationAwareSet<>(delegateMap.values(), queryableEntry -> queryableEntry.getRecord().onAccessSafe(now));
+            return delegateMap.values();
         }
 
         @Override
         public Set<Entry<Data, QueryableEntry>> entrySet() {
-            long now = Clock.currentTimeMillis();
-            return new ExpirationAwareSet<>(delegateMap.entrySet(), entry -> entry.getValue().getRecord().onAccessSafe(now));
-        }
-
-        private static class ExpirationAwareSet<V> extends AbstractSet<V> {
-
-            private final Collection<V> delegateCollection;
-            private final Consumer<V> recordUpdater;
-
-            ExpirationAwareSet(Collection<V> delegateCollection, Consumer<V> recordUpdater) {
-                this.delegateCollection = delegateCollection;
-                this.recordUpdater = recordUpdater;
-            }
-
-            @Override
-            public int size() {
-                return delegateCollection.size();
-            }
-
-            @Override
-            public Iterator<V> iterator() {
-                return new ExpirationAwareIterator(delegateCollection.iterator());
-            }
-
-            public boolean add(V v) {
-                return delegateCollection.add(v);
-            }
-
-            @Override
-            public boolean remove(Object o) {
-                return delegateCollection.remove(o);
-            }
-
-            @Override
-            public void clear() {
-                delegateCollection.clear();
-            }
-
-            private class ExpirationAwareIterator implements Iterator<V> {
-
-                private final Iterator<V> delegateIterator;
-
-                ExpirationAwareIterator(Iterator<V> iterator) {
-                    this.delegateIterator = iterator;
-                }
-
-                @Override
-                public boolean hasNext() {
-                    return delegateIterator.hasNext();
-                }
-
-                @Override
-                public V next() {
-                    V next = delegateIterator.next();
-                    if (next != null) {
-                        recordUpdater.accept(next);
-                    }
-                    return next;
-                }
-
-                @Override
-                public void remove() {
-                    delegateIterator.remove();
-                }
-            }
+            return delegateMap.entrySet();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -416,7 +416,7 @@ public final class BitmapIndexStore extends BaseIndexStore {
             QueryableEntry entry = iterator.next();
             map.put(entry.getKeyData(), entry);
         }
-        return isExpirable() && !map.isEmpty() ? new ExpirationAwareHashMapDelegate(map) : map;
+        return map;
     }
 
     private long extractLongKey(Data entryKey, Object entryValue) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -133,8 +133,6 @@ public final class BitmapIndexStore extends BaseIndexStore {
 
             takeWriteLock();
             try {
-                markIndexStoreExpirableIfNecessary(entry);
-
                 if (internalKeys != null) {
                     // long-to-long remapping
 
@@ -158,8 +156,6 @@ public final class BitmapIndexStore extends BaseIndexStore {
 
             takeWriteLock();
             try {
-                markIndexStoreExpirableIfNecessary(entry);
-
                 long internalKey = internalKeyCounter++;
                 long replaced = internalObjectKeys.put(key, internalKey);
                 assert replaced == NO_KEY;
@@ -187,8 +183,6 @@ public final class BitmapIndexStore extends BaseIndexStore {
 
             takeWriteLock();
             try {
-                markIndexStoreExpirableIfNecessary(entry);
-
                 if (internalKeys != null) {
                     // long-to-long remapping
 
@@ -219,8 +213,6 @@ public final class BitmapIndexStore extends BaseIndexStore {
 
             takeWriteLock();
             try {
-                markIndexStoreExpirableIfNecessary(entry);
-
                 long internalKey = internalObjectKeys.getValue(key);
                 if (internalKey == NO_KEY) {
                     // see https://github.com/hazelcast/hazelcast/issues/17342#issuecomment-680840612

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
@@ -65,7 +65,6 @@ public class OrderedIndexStore extends BaseSingleValueIndexStore {
 
     @Override
     Object insertInternal(Comparable value, QueryableEntry record) {
-        markIndexStoreExpirableIfNecessary(record);
         return addFunctor.invoke(value, record);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnorderedIndexStore.java
@@ -59,7 +59,6 @@ public class UnorderedIndexStore extends BaseSingleValueIndexStore {
 
     @Override
     Object insertInternal(Comparable value, QueryableEntry record) {
-        markIndexStoreExpirableIfNecessary(record);
         return addFunctor.invoke(value, record);
     }
 
@@ -170,10 +169,10 @@ public class UnorderedIndexStore extends BaseSingleValueIndexStore {
 
     @Override
     public Iterator<QueryableEntry> getSqlRecordIterator(
-        Comparable from,
-        boolean fromInclusive,
-        Comparable to,
-        boolean toInclusive
+            Comparable from,
+            boolean fromInclusive,
+            Comparable to,
+            boolean toInclusive
     ) {
         throw new UnsupportedOperationException();
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -230,14 +230,14 @@ public class EvictionTest extends HazelcastTestSupport {
         Collection<Employee> valuesNullCity = map.values(predicateCityNull);
         Collection<Employee> valuesNotNullCity = map.values(Predicates.equal("city", "cityname"));
         assertEquals(entryCount, valuesNullCity.size() + valuesNotNullCity.size());
-        // check that evaluating the predicate updated the last access time of the returned records
+        // check that evaluating the predicate didn't update the last access time of the returned records
         for (int i = 0; i < entryCount; ++i) {
             EntryView view = map.getEntryView(i);
             assertNotNull(view);
             long lastAccessTime = view.getLastAccessTime();
             long prevLastAccessTime = lastAccessTimes.get(i);
-            assertTrue("lastAccessTime=" + lastAccessTime + ", prevLastAccessTime=" + prevLastAccessTime,
-                    lastAccessTime > prevLastAccessTime);
+            assertEquals("lastAccessTime=" + lastAccessTime + ", prevLastAccessTime=" + prevLastAccessTime,
+                    lastAccessTime, prevLastAccessTime);
         }
     }
 


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/18334

**Modifications:**
- Removed `accessRecord` usage and related delegates