### PR TITLE
Don't shift expiry time when scanning over index

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreAdapter.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.map.impl.recordstore;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.impl.StoreAdapter;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 
 /**
@@ -38,15 +38,12 @@ public class RecordStoreAdapter implements StoreAdapter<Record> {
         ensureCallingFromPartitionOperationThread();
 
         record = recordStore.getOrNullIfExpired(key, record, now, backup);
-        if (record == null) {
-            // free memory of expired record
-            recordStore.disposeDeferredBlocks();
-            return true;
+        if (record != null) {
+            return false;
         }
-
-        // not expired record, update access info
-        recordStore.accessRecord(record, now);
-        return false;
+        // free memory of expired record
+        recordStore.disposeDeferredBlocks();
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -17,13 +17,13 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.MapUtil;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static com.hazelcast.internal.util.MapUtil.isNullOrEmpty;
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 
 /**
@@ -138,10 +138,6 @@ public abstract class BaseIndexStore implements IndexStore {
         }
     }
 
-    boolean isExpirable() {
-        return isIndexStoreExpirable;
-    }
-
     interface CopyFunctor<A, B> {
 
         Map<A, B> invoke(Map<A, B> map);
@@ -154,30 +150,19 @@ public abstract class BaseIndexStore implements IndexStore {
 
     }
 
-    private class PassThroughFunctor implements CopyFunctor<Data, QueryableEntry> {
+    private static class PassThroughFunctor implements CopyFunctor<Data, QueryableEntry> {
 
         @Override
         public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
-            if (MapUtil.isNullOrEmpty(map)) {
-                return map;
-            }
-
             return map;
         }
     }
 
-    private class CopyInputFunctor implements CopyFunctor<Data, QueryableEntry> {
+    private static class CopyInputFunctor implements CopyFunctor<Data, QueryableEntry> {
 
         @Override
         public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
-            if (MapUtil.isNullOrEmpty(map)) {
-                return map;
-            }
-
-            return new HashMap<>(map);
+            return isNullOrEmpty(map) ? map : new HashMap<>(map);
         }
-
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -18,9 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.MapUtil;
-import com.hazelcast.map.impl.record.Record;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -164,7 +162,7 @@ public abstract class BaseIndexStore implements IndexStore {
                 return map;
             }
 
-            return isExpirable() ? new ExpirationAwareHashMapDelegate(map) : map;
+            return map;
         }
     }
 
@@ -176,83 +174,10 @@ public abstract class BaseIndexStore implements IndexStore {
                 return map;
             }
 
-            Map<Data, QueryableEntry> newMap = new HashMap<>(map);
-            return isExpirable() ? new ExpirationAwareHashMapDelegate(newMap) : newMap;
+            return new HashMap<>(map);
         }
 
     }
 
-    /**
-     * This delegating Map updates the {@link Record}'s access time on every
-     * {@link QueryableEntry} retrieved through the {@link Map#entrySet()},
-     * {@link Map#get} or {@link Map#values()}.
-     */
-    protected static final class ExpirationAwareHashMapDelegate implements Map<Data, QueryableEntry> {
 
-        private final Map<Data, QueryableEntry> delegateMap;
-
-        ExpirationAwareHashMapDelegate(Map<Data, QueryableEntry> map) {
-            this.delegateMap = map;
-        }
-
-        @Override
-        public int size() {
-            return delegateMap.size();
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return delegateMap.isEmpty();
-        }
-
-        @Override
-        public boolean containsKey(Object o) {
-            return delegateMap.containsKey(o);
-        }
-
-        @Override
-        public boolean containsValue(Object o) {
-            return delegateMap.containsValue(o);
-        }
-
-        @Override
-        public QueryableEntry put(Data data, QueryableEntry queryableEntry) {
-            return delegateMap.put(data, queryableEntry);
-        }
-
-        @Override
-        public QueryableEntry remove(Object o) {
-            return delegateMap.remove(o);
-        }
-
-        @Override
-        public void putAll(Map<? extends Data, ? extends QueryableEntry> map) {
-            delegateMap.putAll(map);
-        }
-
-        @Override
-        public void clear() {
-            delegateMap.clear();
-        }
-
-        @Override
-        public Set<Data> keySet() {
-            return delegateMap.keySet();
-        }
-
-        @Override
-        public QueryableEntry get(Object o) {
-            return delegateMap.get(o);
-        }
-
-        @Override
-        public Collection<QueryableEntry> values() {
-            return delegateMap.values();
-        }
-
-        @Override
-        public Set<Entry<Data, QueryableEntry>> entrySet() {
-            return delegateMap.entrySet();
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BitmapIndexStore.java
@@ -373,7 +373,7 @@ public final class BitmapIndexStore extends BaseIndexStore {
             QueryableEntry entry = iterator.next();
             map.put(entry.getKeyData(), entry);
         }
-        return isExpirable() && !map.isEmpty() ? new ExpirationAwareHashMapDelegate(map) : map;
+        return map;
     }
 
     private long extractLongKey(Data entryKey, Object entryValue) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -222,14 +222,14 @@ public class EvictionTest extends HazelcastTestSupport {
         Collection<Employee> valuesNullCity = map.values(predicateCityNull);
         Collection<Employee> valuesNotNullCity = map.values(Predicates.equal("city", "cityname"));
         assertEquals(entryCount, valuesNullCity.size() + valuesNotNullCity.size());
-        // check that evaluating the predicate updated the last access time of the returned records
+        // check that evaluating the predicate didn't update the last access time of the returned records
         for (int i = 0; i < entryCount; ++i) {
             EntryView view = map.getEntryView(i);
             assertNotNull(view);
             long lastAccessTime = view.getLastAccessTime();
             long prevLastAccessTime = lastAccessTimes.get(i);
-            assertTrue("lastAccessTime=" + lastAccessTime + ", prevLastAccessTime=" + prevLastAccessTime,
-                    lastAccessTime > prevLastAccessTime);
+            assertEquals("lastAccessTime=" + lastAccessTime + ", prevLastAccessTime=" + prevLastAccessTime,
+                    lastAccessTime, prevLastAccessTime);
         }
     }
 


### PR DESCRIPTION
backport of #18334

**Modifications:**
- Removed `accessRecord` usage and related delegates