### PR TITLE
Make PortableGenericRecords queryable when the InMemoryFormat is OBJECT

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.serialization.impl.portable;
 
 import com.hazelcast.internal.serialization.impl.AbstractGenericRecord;
+import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
@@ -35,7 +36,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Set;
 
-public class PortableGenericRecord extends AbstractGenericRecord {
+public class PortableGenericRecord extends AbstractGenericRecord implements InternalGenericRecord {
 
     private final ClassDefinition classDefinition;
     private final Object[] objects;
@@ -249,6 +250,156 @@ public class PortableGenericRecord extends AbstractGenericRecord {
         return get(fieldName, FieldType.TIMESTAMP_WITH_TIMEZONE_ARRAY);
     }
 
+    @Override
+    protected Object getClassIdentifier() {
+        return classDefinition;
+    }
+
+    @Override
+    public String toString() {
+        return "PortableGenericRecord:" + super.toString();
+    }
+
+    @Nullable
+    @Override
+    public Boolean getBooleanFromArray(@Nonnull String fieldName, int index) {
+        boolean[] array = getBooleanArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Byte getByteFromArray(@Nonnull String fieldName, int index) {
+        byte[] array = getByteArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Character getCharFromArray(@Nonnull String fieldName, int index) {
+        char[] array = getCharArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Double getDoubleFromArray(@Nonnull String fieldName, int index) {
+        double[] array = getDoubleArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Float getFloatFromArray(@Nonnull String fieldName, int index) {
+        float[] array = getFloatArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Integer getIntFromArray(@Nonnull String fieldName, int index) {
+        int[] array = getIntArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Long getLongFromArray(@Nonnull String fieldName, int index) {
+        long[] array = getLongArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public Short getShortFromArray(@Nonnull String fieldName, int index) {
+        short[] array = getShortArray(fieldName);
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
+    }
+
+    @Nullable
+    @Override
+    public String getStringFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getStringArray(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public GenericRecord getGenericRecordFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getGenericRecordArray(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public Object getObjectFromArray(@Nonnull String fieldName, int index) {
+        return getGenericRecordFromArray(fieldName, index);
+    }
+
+    @Nullable
+    @Override
+    public Object[] getObjectArray(@Nonnull String fieldName) {
+        return getGenericRecordArray(fieldName);
+    }
+
+    @Nullable
+    @Override
+    public Object getObject(@Nonnull String fieldName) {
+        return getGenericRecord(fieldName);
+    }
+
+    @Nullable
+    @Override
+    public BigDecimal getDecimalFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getDecimalArray(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public LocalTime getTimeFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getTimeArray(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public LocalDate getDateFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getDateArray(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public LocalDateTime getTimestampFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getTimestampArray(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public OffsetDateTime getTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getTimestampWithTimezoneArray(fieldName), index);
+    }
+
     private <T> T get(@Nonnull String fieldName, FieldType fieldType) {
         FieldDefinition fd = check(fieldName, fieldType);
         return (T) objects[fd.getIndex()];
@@ -270,13 +421,10 @@ public class PortableGenericRecord extends AbstractGenericRecord {
         return fd;
     }
 
-    @Override
-    protected Object getClassIdentifier() {
-        return classDefinition;
-    }
-
-    @Override
-    public String toString() {
-        return "PortableGenericRecord:" + super.toString();
+    private <T> T getFromArray(T[] array, int index) {
+        if (array == null || array.length <= index) {
+            return null;
+        }
+        return array[index];
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.impl.portable.PortableGenericRecord;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.QueryException;
@@ -152,6 +153,12 @@ public final class Extractors {
                 }
             } else if (targetObject instanceof HazelcastJsonValue) {
                 return JsonGetter.INSTANCE;
+            } else if (targetObject instanceof PortableGenericRecord) {
+                if (genericPortableGetter == null) {
+                    // will be initialised a couple of times in the worst case
+                    genericPortableGetter = new PortableGetter(ss);
+                }
+                return genericPortableGetter;
             } else {
                 return ReflectionHelper.createGetter(targetObject, attributeName, failOnMissingReflectiveAttribute);
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/PortableGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/PortableGetter.java
@@ -19,6 +19,8 @@ package com.hazelcast.query.impl.getters;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.GenericRecordQueryReader;
+import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
+import com.hazelcast.internal.serialization.impl.portable.PortableGenericRecord;
 
 final class PortableGetter extends Getter {
     private final InternalSerializationService serializationService;
@@ -30,8 +32,13 @@ final class PortableGetter extends Getter {
 
     @Override
     Object getValue(Object target, String fieldPath) throws Exception {
-        Data data = (Data) target;
-        GenericRecordQueryReader reader = new GenericRecordQueryReader(serializationService.readAsInternalGenericRecord(data));
+        InternalGenericRecord record;
+        if (target instanceof PortableGenericRecord) {
+            record = (InternalGenericRecord) target;
+        } else {
+            record = serializationService.readAsInternalGenericRecord((Data) target);
+        }
+        GenericRecordQueryReader reader = new GenericRecordQueryReader(record);
         return reader.read(fieldPath);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/PortableGenericRecordQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/PortableGenericRecordQueryTest.java
@@ -129,10 +129,10 @@ public class PortableGenericRecordQueryTest extends HazelcastTestSupport {
         private int i;
         private int[] ia;
 
-        public ChildPortable() {
+        ChildPortable() {
         }
 
-        public ChildPortable(int i) {
+        ChildPortable(int i) {
             this.i = i;
             this.ia = new int[] {i};
         }
@@ -164,10 +164,10 @@ public class PortableGenericRecordQueryTest extends HazelcastTestSupport {
         private ChildPortable c;
         private String[] sa;
 
-        public ParentPortable() {
+        ParentPortable() {
         }
 
-        public ParentPortable(int i) {
+        ParentPortable(int i) {
             this.c = new ChildPortable(i);
             this.sa = new String[] {String.valueOf(i)};
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/PortableGenericRecordQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/PortableGenericRecordQueryTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.query;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that the member can handle queries on
+ * PortableGenericRecords when it does not have the necessary
+ * PortableFactory in its config.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class PortableGenericRecordQueryTest extends HazelcastTestSupport {
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    public TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Parameterized.Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{{InMemoryFormat.OBJECT}, {InMemoryFormat.BINARY}});
+    }
+
+    @Before
+    public void setup() {
+        MapConfig mapConfig = new MapConfig("default");
+        mapConfig.setInMemoryFormat(inMemoryFormat);
+        Config config = smallInstanceConfig();
+        config.addMapConfig(mapConfig);
+        factory.newHazelcastInstance(config);
+    }
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testQueryOnField() {
+        IMap<Integer, ChildPortable> map = createClientAndGetMap();
+        fillMap(map, 50, ChildPortable::new);
+        Collection<ChildPortable> values = map.values(Predicates.sql("i >= 45"));
+        assertEquals(5, values.size());
+    }
+
+    @Test
+    public void testQueryOnNestedField() {
+        IMap<Integer, ParentPortable> map = createClientAndGetMap();
+        fillMap(map, 100, ParentPortable::new);
+        Collection<ParentPortable> values = map.values(Predicates.sql("c.i >= 90"));
+        assertEquals(10, values.size());
+    }
+
+    @Test
+    public void testQueryOnArrayField() {
+        IMap<Integer, ParentPortable> map = createClientAndGetMap();
+        fillMap(map, 42, ParentPortable::new);
+        Collection<ParentPortable> values = map.values(Predicates.sql("sa[0] == 40"));
+        assertEquals(1, values.size());
+    }
+
+    @Test
+    public void testQueryOnNestedArrayField() {
+        IMap<Integer, ParentPortable> map = createClientAndGetMap();
+        fillMap(map, 14, ParentPortable::new);
+        Collection<ParentPortable> values = map.values(Predicates.sql("c.ia[0] == 12"));
+        assertEquals(1, values.size());
+    }
+
+    private <T> IMap<Integer, T> createClientAndGetMap() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getSerializationConfig()
+                .addPortableFactory(1, new TestPortableFactory());
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        return client.getMap(randomName());
+    }
+
+    private <T> void fillMap(IMap<Integer, T> map, int count, Function<Integer, T> constructor) {
+        for (int i = 0; i < count; i++) {
+            map.put(i, constructor.apply(i));
+        }
+    }
+
+    static class ChildPortable implements Portable {
+        private int i;
+        private int[] ia;
+
+        public ChildPortable() {
+        }
+
+        public ChildPortable(int i) {
+            this.i = i;
+            this.ia = new int[] {i};
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+
+        @Override
+        public int getClassId() {
+            return 1;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeInt("i", i);
+            writer.writeIntArray("ia", ia);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            i = reader.readInt("i");
+            ia = reader.readIntArray("ia");
+        }
+    }
+
+    static class ParentPortable implements Portable {
+        private ChildPortable c;
+        private String[] sa;
+
+        public ParentPortable() {
+        }
+
+        public ParentPortable(int i) {
+            this.c = new ChildPortable(i);
+            this.sa = new String[] {String.valueOf(i)};
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+
+        @Override
+        public int getClassId() {
+            return 2;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writePortable("c", c);
+            writer.writeStringArray("sa", sa);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            c = reader.readPortable("c");
+            sa = reader.readStringArray("sa");
+        }
+    }
+
+    static class TestPortableFactory implements PortableFactory {
+        @Override
+        public Portable create(int classId) {
+            if (classId == 1) {
+                return new ChildPortable();
+            } else if (classId == 2) {
+                return new ParentPortable();
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
We were not handling the case in which the target object we want to
extract attributes from is PortableGenericRecord in our query system.
Due to that, when the InMemoryFormat is OBJECT, queries on the
objects were throwing exceptions since it was trying to use generic
reflection-based attribute getter.

Now, we are handling this case.

Closes #18336 