### PR TITLE
Copy Nearcacheconfig when it needs to be changed 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
@@ -65,7 +65,6 @@ import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProper
 import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties.PRODUCT;
 import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties.START_TIMESTAMP;
 import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties.VERSION;
-import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.InstanceTrackingUtil.writeInstanceTrackingFile;
@@ -208,7 +207,6 @@ public class DefaultClientExtension implements ClientExtension {
             NearCacheConfig nearCacheConfig = clientConfig.getNearCacheConfig(id);
             if (nearCacheConfig != null) {
                 checkNearCacheConfig(id, nearCacheConfig, clientConfig.getNativeMemoryConfig(), true);
-                initDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
                 return new NearCachedClientMapProxy(MapService.SERVICE_NAME, id, context);
             } else {
                 return new ClientMapProxy(MapService.SERVICE_NAME, id, context);

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -65,7 +65,6 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
@@ -461,7 +460,6 @@ public class Config {
         name = getBaseName(name);
         MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, name);
         if (config != null) {
-            initDefaultMaxSizeForOnHeapMaps(config.getNearCacheConfig());
             return new MapConfigReadOnly(config);
         }
         return new MapConfigReadOnly(getMapConfig("default"));

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -18,11 +18,11 @@ package com.hazelcast.config;
 
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.internal.eviction.EvictionConfiguration;
-import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.internal.eviction.EvictionStrategyType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -30,12 +30,12 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import static com.hazelcast.internal.util.Preconditions.checkHasText;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * Configuration for eviction.
- *
+ * <p>
  * You can set a limit for number of
  * entries or total memory cost of entries.
  * <p>
@@ -288,10 +288,10 @@ public class EvictionConfig implements EvictionConfiguration, IdentifiedDataSeri
         EvictionConfig that = (EvictionConfig) o;
 
         return size == that.size
-            && maxSizePolicy == that.maxSizePolicy
-            && evictionPolicy == that.evictionPolicy
-            && Objects.equals(comparatorClassName, that.comparatorClassName)
-            && Objects.equals(comparator, that.comparator);
+                && maxSizePolicy == that.maxSizePolicy
+                && evictionPolicy == that.evictionPolicy
+                && Objects.equals(comparatorClassName, that.comparatorClassName)
+                && Objects.equals(comparator, that.comparator);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -28,14 +28,23 @@ public final class NearCacheConfigAccessor {
     private NearCacheConfigAccessor() {
     }
 
-    public static void initDefaultMaxSizeForOnHeapMaps(NearCacheConfig nearCacheConfig) {
+    public static NearCacheConfig copyWithInitializedDefaultMaxSizeForOnHeapMaps(NearCacheConfig nearCacheConfig) {
         if (nearCacheConfig == null) {
-            return;
+            return null;
         }
 
         EvictionConfig evictionConfig = nearCacheConfig.getEvictionConfig();
-        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE && !evictionConfig.sizeConfigured) {
-            evictionConfig.setSize(MapConfig.DEFAULT_MAX_SIZE);
+        if (nearCacheConfig.getInMemoryFormat() == InMemoryFormat.NATIVE
+                || evictionConfig.sizeConfigured) {
+            return nearCacheConfig;
         }
+
+        // create copy of eviction config
+        EvictionConfig copyEvictionConfig = new EvictionConfig(evictionConfig)
+                .setSize(MapConfig.DEFAULT_MAX_SIZE);
+
+        // create copy of nearCache config and set eviction config
+        return new NearCacheConfig(nearCacheConfig)
+                .setEvictionConfig(copyEvictionConfig);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -34,8 +34,8 @@ public final class NearCacheConfigAccessor {
         }
 
         EvictionConfig evictionConfig = nearCacheConfig.getEvictionConfig();
-        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE) {
-            evictionConfig.defaultSize = MapConfig.DEFAULT_MAX_SIZE;
+        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE && !evictionConfig.sizeConfigured) {
+            evictionConfig.setSize(MapConfig.DEFAULT_MAX_SIZE);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/DynamicFirstSearcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/DynamicFirstSearcher.java
@@ -18,14 +18,12 @@ package com.hazelcast.internal.dynamicconfig.search;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigPatternMatcher;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.dynamicconfig.ConfigurationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
 
-import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
@@ -48,10 +46,6 @@ class DynamicFirstSearcher<T extends IdentifiedDataSerializable> implements Sear
         T config = configSupplier.getDynamicConfig(configurationService, baseName);
         if (config == null) {
             config = lookupByPattern(configPatternMatcher, staticCacheConfigs, baseName);
-            if (config != null && MapConfig.class.isAssignableFrom(config.getClass())) {
-                // this is required only for map config
-                initDefaultMaxSizeForOnHeapMaps(((MapConfig) config).getNearCacheConfig());
-            }
         }
         if (config == null) {
             config = configSupplier.getStaticConfig(staticConfig, fallbackName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/StaticFirstSearcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/StaticFirstSearcher.java
@@ -18,14 +18,12 @@ package com.hazelcast.internal.dynamicconfig.search;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigPatternMatcher;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.dynamicconfig.ConfigurationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
 
-import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
@@ -48,9 +46,6 @@ class StaticFirstSearcher<T extends IdentifiedDataSerializable> implements Searc
         T config = lookupByPattern(configPatternMatcher, staticCacheConfigs, baseName);
         if (config == null) {
             config = configSupplier.getDynamicConfig(configurationService, baseName);
-        } else if (MapConfig.class.isAssignableFrom(config.getClass())) {
-            // this is required only for map config
-            initDefaultMaxSizeForOnHeapMaps(((MapConfig) config).getNearCacheConfig());
         }
         if (config == null && fallbackName != null) {
             config = configSupplier.getStaticConfig(staticConfig, fallbackName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.nearcache.impl;
 
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.NearCacheConfigAccessor;
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.nearcache.NearCache;
@@ -89,7 +90,8 @@ public class DefaultNearCacheManager implements NearCacheManager {
     }
 
     protected <K, V> NearCache<K, V> createNearCache(String name, NearCacheConfig nearCacheConfig) {
-        return new DefaultNearCache<>(name, nearCacheConfig, serializationService,
+        NearCacheConfig copy = NearCacheConfigAccessor.copyWithInitializedDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
+        return new DefaultNearCache<>(name, copy, serializationService,
                 scheduler, classLoader, properties);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -27,7 +27,6 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 
 import java.util.UUID;
 
-import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigValidator.checkMapConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 
@@ -56,7 +55,6 @@ class MapRemoteService implements RemoteService {
                 mapServiceContext.getNodeEngine().getProperties());
 
         if (mapConfig.isNearCacheEnabled()) {
-            initDefaultMaxSizeForOnHeapMaps(mapConfig.getNearCacheConfig());
             checkNearCacheConfig(name, mapConfig.getNearCacheConfig(), config.getNativeMemoryConfig(), false);
             return new NearCachedMapProxyImpl(name, mapServiceContext.getService(), nodeEngine, mapConfig);
         } else {

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -42,7 +42,7 @@ public class EvictionConfigTest {
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
         EqualsVerifier.forClass(EvictionConfig.class)
-                .allFieldsShouldBeUsedExcept("defaultSize")
+                .allFieldsShouldBeUsedExcept("sizeConfigured")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .withPrefabValues(EvictionConfig.class,
                         new EvictionConfig().setSize(1000).setMaxSizePolicy(ENTRY_COUNT).setEvictionPolicy(LFU),

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
@@ -38,25 +36,5 @@ public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
     @Test
     public void testInitDefaultMaxSizeForOnHeapMaps_whenNull_thenDoNothing() {
         NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(null);
-    }
-
-    @Test
-    public void testNearCacheConfigEqual_BeforeAndAfterDefaultSizeIsInitialized() {
-        NearCacheConfig config1 = new NearCacheConfig();
-        NearCacheConfig config2 = new NearCacheConfig();
-        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(config1);
-
-        assertEquals(config1, config2);
-    }
-
-    @Test
-    public void testEvictionConfigCopy_whenDefaultSizeIsInitialized() {
-        NearCacheConfig config1 = new NearCacheConfig();
-        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(config1);
-
-        EvictionConfig evictionConfig = config1.getEvictionConfig();
-        EvictionConfig evictionConfig2 = new EvictionConfig(evictionConfig);
-
-        assertEquals(evictionConfig.getSize(), evictionConfig2.getSize());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
@@ -34,7 +37,25 @@ public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testInitDefaultMaxSizeForOnHeapMaps_whenNull_thenDoNothing() {
-        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(null);
+    public void testCopyInitDefaultMaxSizeForOnHeapMaps_whenNull_thenDoNothing() {
+        NearCacheConfigAccessor.copyWithInitializedDefaultMaxSizeForOnHeapMaps(null);
+    }
+
+    @Test
+    public void testCopyInitDefaultMaxSizeForOnHeapMaps_doesNotChangeOriginal_createsChangedCopy() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        NearCacheConfig copy = NearCacheConfigAccessor.copyWithInitializedDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
+
+        assertEquals(copy.getEvictionConfig().getSize(), MapConfig.DEFAULT_MAX_SIZE);
+        assertEquals(nearCacheConfig.getEvictionConfig().getSize(), EvictionConfig.DEFAULT_MAX_ENTRY_COUNT);
+    }
+
+    @Test
+    public void testCopyInitDefaultMaxSizeForOnHeapMaps_doesNotCopy_whenSizeIsConfigured() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setEvictionConfig(new EvictionConfig().setSize(10));
+        NearCacheConfig copy = NearCacheConfigAccessor.copyWithInitializedDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
+
+        assertTrue(nearCacheConfig == copy);
     }
 }


### PR DESCRIPTION
This reverts commit dbfafeee60b6202c78dfcd7f2f375ef2b398be01.

Copies NearcacheConfig and EvictionConfig when they needs
to be changed by NearcacheConfigAccessor so that the object
on ClientConfig/Config does not change when used.
backport of #18348
fixes  #17952
fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3966