### PR TITLE
Move connectioClose back to member event handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -308,7 +308,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             }
         }
 
-        executor.scheduleWithFixedDelay(new ConnectionManagementTask(), 1, 1, TimeUnit.SECONDS);
+        executor.scheduleWithFixedDelay(new ConnectToAllClusterMembersTask(), 1, 1, TimeUnit.SECONDS);
     }
 
     protected void startNetworking() {
@@ -1010,10 +1010,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     /**
-     * 1) schedules a task to open a connection if there is no connection for the member in the member list
-     * 2) closes a connection if it is no longer in the member list
+     * Schedules a task to open a connection if there is no connection for the member in the member list
      */
-    private class ConnectionManagementTask implements Runnable {
+    private class ConnectToAllClusterMembersTask implements Runnable {
 
         private final Set<UUID> connectingAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -1024,12 +1023,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 return;
             }
 
-            HashSet<UUID> activeConnectionUuids = new HashSet<>(activeConnections.keySet());
-
             for (Member member : client.getClientClusterService().getMemberList()) {
                 UUID uuid = member.getUuid();
-                activeConnectionUuids.remove(uuid);
-
                 if (activeConnections.get(uuid) != null) {
                     continue;
                 }
@@ -1052,15 +1047,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         connectingAddresses.remove(uuid);
                     }
                 });
-            }
-            //whatever remains in the set should be closed since there is no corresponding member in the member list
-            for (UUID uuidOutsideCurrentMemberlist : activeConnectionUuids) {
-                ClientConnection connection = activeConnections.get(uuidOutsideCurrentMemberlist);
-                if (connection != null) {
-                    connection.close(null,
-                            new TargetDisconnectedException("The client has closed the connection to this member,"
-                                    + " after receiving a member left event from the cluster. " + connection));
-                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -35,10 +35,12 @@ import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.MemberSelectingCollection;
+import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
@@ -79,6 +81,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
     private final ConcurrentMap<UUID, MembershipListener> listeners = new ConcurrentHashMap<>();
     private final Set<String> labels;
     private final ILogger logger;
+    private final ClientConnectionManager connectionManager;
     private final Object clusterViewLock = new Object();
     //read and written under clusterViewLock
     private CountDownLatch initialListFetchedLatch = new CountDownLatch(1);
@@ -97,6 +100,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         this.client = client;
         labels = unmodifiableSet(client.getClientConfig().getLabels());
         logger = client.getLoggingService().getLogger(ClientClusterService.class);
+        connectionManager = client.getConnectionManager();
     }
 
     @Override
@@ -180,7 +184,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
 
     public void start(Collection<EventListener> configuredListeners) {
         configuredListeners.stream().filter(listener -> listener instanceof MembershipListener)
-                           .forEach(listener -> addMembershipListener((MembershipListener) listener));
+                .forEach(listener -> addMembershipListener((MembershipListener) listener));
     }
 
     public void waitInitialMemberListFetched() {
@@ -294,6 +298,12 @@ public class ClientClusterServiceImpl implements ClientClusterService {
 
         for (Member member : deadMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, currentMembers));
+            Connection connection = connectionManager.getConnection(member.getUuid());
+            if (connection != null) {
+                connection.close(null,
+                        new TargetDisconnectedException("The client has closed the connection to this member,"
+                                + " after receiving a member left event from the cluster. " + connection));
+            }
         }
         for (Member member : newMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, currentMembers));


### PR DESCRIPTION
Partially reverts https://github.com/hazelcast/hazelcast/pull/18033

When we give the closing connection to periodic task, it can close
a connection unncessarily because it can always read a stale
member list. This was causing `ConfiguredBehaviourTest` to fail.

fixes https://github.com/hazelcast/hazelcast/issues/18323
backport of https://github.com/hazelcast/hazelcast/pull/18332
(cherry picked from commit 9d620a3300a5cf4216b1a288597abe7917739449)