### PR TITLE
Move connectioClose back to member event handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -35,10 +35,12 @@ import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.MemberSelectingCollection;
+import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
@@ -80,6 +82,7 @@ public class ClientClusterServiceImpl
     private final ConcurrentMap<UUID, MembershipListener> listeners = new ConcurrentHashMap<>();
     private final Set<String> labels;
     private final ILogger logger;
+    private final ClientConnectionManager connectionManager;
     private final Object clusterViewLock = new Object();
     //read and written under clusterViewLock
     private CountDownLatch initialListFetchedLatch = new CountDownLatch(1);
@@ -98,6 +101,7 @@ public class ClientClusterServiceImpl
         this.client = client;
         labels = unmodifiableSet(client.getClientConfig().getLabels());
         logger = client.getLoggingService().getLogger(ClientClusterService.class);
+        connectionManager = client.getConnectionManager();
     }
 
     @Override
@@ -295,6 +299,12 @@ public class ClientClusterServiceImpl
 
         for (Member member : deadMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, currentMembers));
+            Connection connection = connectionManager.getConnection(member.getUuid());
+            if (connection != null) {
+                connection.close(null,
+                        new TargetDisconnectedException("The client has closed the connection to this member,"
+                                + " after receiving a member left event from the cluster. " + connection));
+            }
         }
         for (Member member : newMembers) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, currentMembers));


### PR DESCRIPTION
Partially reverts https://github.com/hazelcast/hazelcast/pull/18033

When we give the closing connection to periodic task, it can close
a connection unncessarily because it can always read a stale
member list. This was causing `ConfiguredBehaviourTest` to fail.

fixes https://github.com/hazelcast/hazelcast/issues/18323
backport of https://github.com/hazelcast/hazelcast/pull/18332
(cherry picked from commit 9d620a3300a5cf4216b1a288597abe7917739449)