### PR TITLE
Follow up to ClientInvocationRetry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -735,9 +735,9 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
     }
 
     void onConnectionClose(TcpClientConnection connection) {
+        client.getInvocationService().onConnectionClose(connection);
         Address endpoint = connection.getRemoteAddress();
         UUID memberUuid = connection.getRemoteUuid();
-
         if (endpoint == null) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Destroying " + connection + ", but it has end-point set to null "
@@ -951,9 +951,9 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
 
     private void checkClientStateOnClusterIdChange(TcpClientConnection connection) {
         if (activeConnections.isEmpty()) {
-            //We only have single connection established
+            // We only have single connection established
             if (failoverConfigProvided) {
-                //If failover is provided, and this single connection is established after failover logic kicks in
+                // If failover is provided, and this single connection is established after failover logic kicks in
                 // (checked via `switchingToNextCluster`), then it is OK to continue. Otherwise, we force the failover logic
                 // to be used by throwing `ClientNotAllowedInClusterException`
                 if (switchingToNextCluster) {
@@ -965,8 +965,17 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                 }
             }
         } else {
-            //If there are other connections that means we have a connection to wrong cluster.
-            //We should not stay connected.
+            // If there are other connections that means we have a connection to wrong cluster.
+            // We should not stay connected to this new connection.
+            // Note that in some racy scenarios we might close a connection that we can continue operating on.
+            // In those cases, we rely on the fact that we will reopen the connections and continue. Here is one scenario:
+            // 1. There were 2 members.
+            // 2. The client is connected to the first one.
+            // 3. While the client is trying to open the second connection, both members are restarted.
+            // 4. In this case we will close the connection to the second member, thinking that it is not part of the
+            // cluster we think we are in. We will reconnect to this member, and the connection is closed unnecessarily.
+            // 5. The connection to the first cluster will be gone after that and we will initiate a reconnect to the cluster.
+
             String reason = "Connection does not belong to this cluster";
             connection.close(reason, null);
             throw new IllegalStateException(reason);
@@ -1087,7 +1096,6 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
 
         @Override
         public void run() {
-
             if (!client.getLifecycleService().isRunning()) {
                 return;
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientInvocationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientInvocationService.java
@@ -21,13 +21,15 @@ import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.nio.ConnectionListener;
 
 import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
  * Invocation service for Hazelcast clients.
- *
+ * <p>
  * Allows remote invocations on different targets like {@link ClientConnection},
  * partition owners or {@link Member} based targets.
  */
@@ -67,4 +69,13 @@ public interface ClientInvocationService {
     boolean isRedoOperation();
 
     Consumer<ClientMessage> getResponseHandler();
+
+    /**
+     * This will be called on each connection close.
+     * Note that is different than {@link ConnectionListener#connectionRemoved(Connection)} where `connectionRemoved`
+     * means an authenticated connection is disconnected
+     *
+     * @param connection closed connection
+     */
+    void onConnectionClose(ClientConnection connection);
 }


### PR DESCRIPTION
Handling connection removal via ConnectionListener did not work
because it is fired only if conneciton is authenticated.
We can not remove the invocations of authentication in case
the connection is closed before authentication.

Introduced a new method on ClientInvocationService that will be
called in all close cases(including unauthenticated ones)

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3976
fixes https://github.com/hazelcast/hazelcast-enterprise/issues/3977