### PR TITLE
Deprecate symmetric encryption

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
@@ -88,8 +88,11 @@ public class EndpointConfig implements NamedConfig {
      * Gets the {@link SymmetricEncryptionConfig}. The value can be {@code null} which means that no symmetric encryption should
      * be used.
      *
+     * @deprecated since 4.2
+     *
      * @return the SymmetricEncryptionConfig
      */
+    @Deprecated
     public SymmetricEncryptionConfig getSymmetricEncryptionConfig() {
         return symmetricEncryptionConfig;
     }
@@ -97,10 +100,13 @@ public class EndpointConfig implements NamedConfig {
     /**
      * Sets the {@link SymmetricEncryptionConfig}. The value can be {@code null} if no symmetric encryption should be used.
      *
+     * @deprecated since 4.2
+     *
      * @param symmetricEncryptionConfig the SymmetricEncryptionConfig to set
      * @return the updated NetworkConfig
      * @see #getSymmetricEncryptionConfig()
      */
+    @Deprecated
     public EndpointConfig setSymmetricEncryptionConfig(SymmetricEncryptionConfig symmetricEncryptionConfig) {
         this.symmetricEncryptionConfig = symmetricEncryptionConfig;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/JavaKeyStoreSecureStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JavaKeyStoreSecureStoreConfig.java
@@ -66,6 +66,12 @@ public class JavaKeyStoreSecureStoreConfig
 
     /**
      * Creates a new Java KeyStore Secure Store configuration.
+     */
+    public JavaKeyStoreSecureStoreConfig() {
+    }
+
+    /**
+     * Creates a new Java KeyStore Secure Store configuration.
      * @param path the KeyStore file path
      */
     public JavaKeyStoreSecureStoreConfig(File path) {

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -296,7 +296,9 @@ public class NetworkConfig {
      * be used.
      *
      * @return the SymmetricEncryptionConfig
+     * @deprecated since 4.2
      */
+    @Deprecated
     public SymmetricEncryptionConfig getSymmetricEncryptionConfig() {
         return symmetricEncryptionConfig;
     }
@@ -307,7 +309,9 @@ public class NetworkConfig {
      * @param symmetricEncryptionConfig the SymmetricEncryptionConfig to set
      * @return the updated NetworkConfig
      * @see #getSymmetricEncryptionConfig()
+     * @deprecated since 4.2
      */
+    @Deprecated
     public NetworkConfig setSymmetricEncryptionConfig(final SymmetricEncryptionConfig symmetricEncryptionConfig) {
         this.symmetricEncryptionConfig = symmetricEncryptionConfig;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
@@ -20,7 +20,9 @@ import static java.util.Arrays.copyOf;
 
 /**
  * Contains configuration for symmetric encryption
+ * @deprecated since 4.2
  */
+@Deprecated
 public class SymmetricEncryptionConfig
         extends AbstractSymmetricEncryptionConfig<SymmetricEncryptionConfig> {
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -119,6 +119,7 @@ import static com.hazelcast.instance.impl.NodeShutdownHelper.shutdownNodeByFirin
 import static com.hazelcast.internal.cluster.impl.MulticastService.createMulticastService;
 import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.allUsePublicAddress;
 import static com.hazelcast.internal.config.ConfigValidator.checkAdvancedNetworkConfig;
+import static com.hazelcast.internal.config.ConfigValidator.warnForUsageOfDeprecatedSymmetricEncryption;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.FutureUtil.waitWithDeadline;
@@ -250,6 +251,7 @@ public class Node {
 
             serializationService = nodeExtension.createSerializationService();
             securityContext = config.getSecurityConfig().isEnabled() ? nodeExtension.getSecurityContext() : null;
+            warnForUsageOfDeprecatedSymmetricEncryption(config, logger);
             nodeEngine = new NodeEngineImpl(this);
             config.setConfigurationService(nodeEngine.getConfigurationService());
             config.onSecurityServiceUpdated(getSecurityService());

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -242,14 +242,18 @@ public final class ConfigValidator {
 
     public static void warnForUsageOfDeprecatedSymmetricEncryption(Config config, ILogger logger) {
         String warn = "Symmetric encryption is deprecated and will be removed in a future version. Consider using TLS instead.";
+        boolean usesAdvancedNetworkConfig = config.getAdvancedNetworkConfig().isEnabled();
 
         if (config.getNetworkConfig() != null
                 && config.getNetworkConfig().getSymmetricEncryptionConfig() != null
-                && config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
+                && config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()
+                && !usesAdvancedNetworkConfig) {
                 logger.warning(warn);
         }
 
-        if (config.getAdvancedNetworkConfig() != null && config.getAdvancedNetworkConfig().getEndpointConfigs() != null) {
+        if (config.getAdvancedNetworkConfig() != null
+                && config.getAdvancedNetworkConfig().getEndpointConfigs() != null
+                && usesAdvancedNetworkConfig) {
             for (EndpointConfig endpointConfig : config.getAdvancedNetworkConfig().getEndpointConfigs().values()) {
                 if (endpointConfig.getSymmetricEncryptionConfig() != null
                         && endpointConfig.getSymmetricEncryptionConfig().isEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -241,12 +241,24 @@ public final class ConfigValidator {
     }
 
     public static void warnForUsageOfDeprecatedSymmetricEncryption(Config config, ILogger logger) {
-        if (config.getNetworkConfig() == null || config.getNetworkConfig().getSymmetricEncryptionConfig() == null) {
-            return;
+        String warn = "Symmetric encryption is deprecated and will be removed in a future version. Consider using TLS instead.";
+
+        if (config.getNetworkConfig() != null
+                && config.getNetworkConfig().getSymmetricEncryptionConfig() != null
+                && config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
+                logger.warning(warn);
         }
-        if (config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
-            logger.warning("Symmetric encryption is deprecated and will be removed in a future version. "
-                    + "Consider using TLS instead.");
+
+        if (config.getAdvancedNetworkConfig() != null && config.getAdvancedNetworkConfig().getEndpointConfigs() != null) {
+            for (EndpointConfig endpointConfig : config.getAdvancedNetworkConfig().getEndpointConfigs().values()) {
+                if (endpointConfig.getSymmetricEncryptionConfig() != null
+                        && endpointConfig.getSymmetricEncryptionConfig().isEnabled()) {
+                    logger.warning(warn);
+
+                    // Write error message once if more than one endpoint use symmetric encryption
+                    break;
+                }
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -240,6 +240,15 @@ public final class ConfigValidator {
         }
     }
 
+    public static void warnForUsageOfDeprecatedSymmetricEncryption(Config config, ILogger logger) {
+        if (config.getNetworkConfig() == null || config.getNetworkConfig().getSymmetricEncryptionConfig() == null) {
+            return;
+        }
+        if (config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
+            logger.warning("Symmetric encryption is deprecated and may be vulnerable to security problems. Consider TLS instead");
+        }
+    }
+
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity",
             "checkstyle:booleanexpressioncomplexity"})
     public static void checkAdvancedNetworkConfig(Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -245,7 +245,7 @@ public final class ConfigValidator {
             return;
         }
         if (config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
-            logger.warning("Symmetric encryption is deprecated. Consider using TLS instead.");
+            logger.warning("Symmetric encryption is deprecated and will be removed in a future version. Consider using TLS instead.");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -245,7 +245,7 @@ public final class ConfigValidator {
             return;
         }
         if (config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
-            logger.warning("Symmetric encryption is deprecated and may be vulnerable to security problems. Consider TLS instead");
+            logger.warning("Symmetric encryption is deprecated. Consider using TLS instead.");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -245,7 +245,8 @@ public final class ConfigValidator {
             return;
         }
         if (config.getNetworkConfig().getSymmetricEncryptionConfig().isEnabled()) {
-            logger.warning("Symmetric encryption is deprecated and will be removed in a future version. Consider using TLS instead.");
+            logger.warning("Symmetric encryption is deprecated and will be removed in a future version. "
+                    + "Consider using TLS instead.");
         }
     }
 
@@ -642,7 +643,7 @@ public final class ConfigValidator {
      * is {@link InMemoryFormat#NATIVE} and index configurations include {@link IndexType#BITMAP}.
      *
      * @param inMemoryFormat supplied inMemoryFormat
-     * @param indexConfigs {@link List} of {@link IndexConfig}
+     * @param indexConfigs   {@link List} of {@link IndexConfig}
      */
     private static void checkNotBitmapIndexWhenNativeMemory(InMemoryFormat inMemoryFormat, List<IndexConfig> indexConfigs) {
         if (inMemoryFormat == NATIVE) {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
@@ -18,6 +18,7 @@ package com.hazelcast.test.starter.constructor;
 
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 
+import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -52,7 +53,7 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
             return null;
         }
 
-        Class thisConfigClass = thisConfigObject.getClass();
+        Class<?> thisConfigClass = thisConfigObject.getClass();
         if (shouldProxy(thisConfigClass, new Class[0]) == RETURN_SAME) {
             return thisConfigObject;
         }
@@ -62,7 +63,13 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
             return cloneSplitBrainProtectionFunctionImplementation(thisConfigObject, otherConfigClass);
         }
 
-        Object otherConfigObject = ClassLoaderUtil.newInstance(otherConfigClass.getClassLoader(), otherConfigClass.getName());
+        Object otherConfigObject;
+        if (thisConfigClass.getName().equals("com.hazelcast.config.JavaKeyStoreSecureStoreConfig")) {
+            otherConfigObject = cloneJavaKeyStoreConfig(thisConfigObject, otherConfigClass);
+        } else {
+            otherConfigObject = ClassLoaderUtil.newInstance(otherConfigClass.getClassLoader(), otherConfigClass.getName());
+        }
+
         for (Method method : thisConfigClass.getMethods()) {
             if (!isGetter(method)) {
                 continue;
@@ -73,7 +80,8 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
                 otherReturnType = getOtherReturnType(classloader, returnType);
             } catch (ClassNotFoundException e) {
                 // new configuration option, return type was not found in target classloader
-                debug("Configuration option %s is not available in target classloader: %s", method.getName(), e.getMessage());
+                debug("Configuration option %s is not available in target classloader: %s",
+                        method.getName(), e.getMessage());
                 continue;
             }
 
@@ -214,24 +222,30 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
     /**
      * Clones the built-in SplitBrainProtectionFunction implementations.
      */
-    private static Object cloneSplitBrainProtectionFunctionImplementation(Object splitBrainProtectionFunction, Class<?> targetClass) throws Exception {
+    private static Object cloneSplitBrainProtectionFunctionImplementation(Object splitBrainProtectionFunction,
+                                                                          Class<?> targetClass) throws Exception {
         if (targetClass.getName().equals("com.hazelcast.splitbrainprotection.impl.ProbabilisticSplitBrainProtectionFunction")) {
             int size = (Integer) getFieldValueReflectively(splitBrainProtectionFunction, "minimumClusterSize");
-            double suspicionThreshold = (Double) getFieldValueReflectively(splitBrainProtectionFunction, "suspicionThreshold");
+            double suspicionThreshold = (Double) getFieldValueReflectively(splitBrainProtectionFunction,
+                    "suspicionThreshold");
             int maxSampleSize = (Integer) getFieldValueReflectively(splitBrainProtectionFunction, "maxSampleSize");
-            long minStdDeviationMillis = (Long) getFieldValueReflectively(splitBrainProtectionFunction, "minStdDeviationMillis");
+            long minStdDeviationMillis = (Long) getFieldValueReflectively(splitBrainProtectionFunction,
+                    "minStdDeviationMillis");
             long acceptableHeartbeatPauseMillis = (Long) getFieldValueReflectively(splitBrainProtectionFunction,
                     "acceptableHeartbeatPauseMillis");
-            long heartbeatIntervalMillis = (Long) getFieldValueReflectively(splitBrainProtectionFunction, "heartbeatIntervalMillis");
+            long heartbeatIntervalMillis =
+                    (Long) getFieldValueReflectively(splitBrainProtectionFunction, "heartbeatIntervalMillis");
 
             Constructor<?> constructor = targetClass.getConstructor(Integer.TYPE, Long.TYPE, Long.TYPE, Integer.TYPE, Long.TYPE,
                     Double.TYPE);
 
             return constructor.newInstance(size, heartbeatIntervalMillis, acceptableHeartbeatPauseMillis,
                     maxSampleSize, minStdDeviationMillis, suspicionThreshold);
-        } else if (targetClass.getName().equals("com.hazelcast.splitbrainprotection.impl.RecentlyActiveSplitBrainProtectionFunction")) {
+        } else if (targetClass.getName()
+                .equals("com.hazelcast.splitbrainprotection.impl.RecentlyActiveSplitBrainProtectionFunction")) {
             int size = (Integer) getFieldValueReflectively(splitBrainProtectionFunction, "minimumClusterSize");
-            int heartbeatToleranceMillis = (Integer) getFieldValueReflectively(splitBrainProtectionFunction, "heartbeatToleranceMillis");
+            int heartbeatToleranceMillis =
+                    (Integer) getFieldValueReflectively(splitBrainProtectionFunction, "heartbeatToleranceMillis");
 
             Constructor<?> constructor = targetClass.getConstructor(Integer.TYPE, Integer.TYPE);
             return constructor.newInstance(size, heartbeatToleranceMillis);
@@ -243,7 +257,14 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
 
     private static boolean isSplitBrainProtectionFunctionImplementation(Class<?> klass) throws Exception {
         ClassLoader classLoader = klass.getClassLoader();
-        Class<?> splitBrainProtectionFunctionInterface = classLoader.loadClass("com.hazelcast.splitbrainprotection.SplitBrainProtectionFunction");
+        Class<?> splitBrainProtectionFunctionInterface =
+                classLoader.loadClass("com.hazelcast.splitbrainprotection.SplitBrainProtectionFunction");
         return splitBrainProtectionFunctionInterface.isAssignableFrom(klass);
+    }
+
+    private static Object cloneJavaKeyStoreConfig(Object javaKeyStoreConfig, Class<?> targetClass) throws Exception {
+        File path = getFieldValueReflectively(javaKeyStoreConfig, "path");
+        Constructor<?> constructor = targetClass.getConstructor(File.class);
+        return constructor.newInstance(path);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
@@ -63,6 +63,8 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
             return cloneSplitBrainProtectionFunctionImplementation(thisConfigObject, otherConfigClass);
         }
 
+        // RU_COMPAT_4_1
+        // since empty constructor is added this could be reverted in later versions
         Object otherConfigObject;
         if (thisConfigClass.getName().equals("com.hazelcast.config.JavaKeyStoreSecureStoreConfig")) {
             otherConfigObject = cloneJavaKeyStoreConfig(thisConfigObject, otherConfigClass);
@@ -262,6 +264,8 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
         return splitBrainProtectionFunctionInterface.isAssignableFrom(klass);
     }
 
+    // RU_COMPAT_4_1
+    // since empty constructor is added this could be reverted in later versions
     private static Object cloneJavaKeyStoreConfig(Object javaKeyStoreConfig, Class<?> targetClass) throws Exception {
         File path = getFieldValueReflectively(javaKeyStoreConfig, "path");
         Constructor<?> constructor = targetClass.getConstructor(File.class);


### PR DESCRIPTION
Deprecates symmetric encryption and logs a warning message if it's used.

Related https://github.com/hazelcast/hazelcast-enterprise/pull/3978