### PR TITLE
Fix ClientInvocation Retry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/IExecutorDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/IExecutorDelegatingFuture.java
@@ -26,7 +26,6 @@ import com.hazelcast.client.impl.spi.ClientContext;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.cluster.Member;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -111,9 +110,7 @@ public final class IExecutorDelegatingFuture<V> extends ClientDelegatingFuture<V
     }
 
     private void waitForRequestToBeSend() throws InterruptedException {
-        InternalCompletableFuture future = getFuture();
-        ClientInvocationFuture clientCallFuture = (ClientInvocationFuture) future;
-        clientCallFuture.getInvocation().getSendConnectionOrWait();
+        ClientInvocationFuture future = getFuture();
+        future.getInvocation().waitInvoked();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientInvocationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientInvocationService.java
@@ -21,13 +21,15 @@ import com.hazelcast.client.impl.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.nio.ConnectionListener;
 
 import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
  * Invocation service for Hazelcast clients.
- *
+ * <p>
  * Allows remote invocations on different targets like {@link ClientConnection},
  * partition owners or {@link Member} based targets.
  */
@@ -67,4 +69,13 @@ public interface ClientInvocationService {
     boolean isRedoOperation();
 
     Consumer<ClientMessage> getResponseHandler();
+
+    /**
+     * This will be called on each connection close.
+     * Note that is different than {@link ConnectionListener#connectionRemoved(Connection)} where `connectionRemoved`
+     * means an authenticated connection is disconnected
+     *
+     * @param connection closed connection
+     */
+    void onConnectionClose(ClientConnection connection);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
@@ -159,10 +159,12 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
 
     public void start() {
         responseHandlerSupplier.start();
-        TaskScheduler executionService = client.getTaskScheduler();
-        long cleanResourcesMillis = client.getProperties().getPositiveMillisOrDefault(CLEAN_RESOURCES_MILLIS);
-        executionService.scheduleWithRepetition(new CleanResourcesTask(), cleanResourcesMillis,
-                cleanResourcesMillis, MILLISECONDS);
+        if (isBackupAckToClientEnabled) {
+            TaskScheduler executionService = client.getTaskScheduler();
+            long cleanResourcesMillis = client.getProperties().getPositiveMillisOrDefault(CLEAN_RESOURCES_MILLIS);
+            executionService.scheduleWithRepetition(new BackupTimeoutTask(), cleanResourcesMillis,
+                    cleanResourcesMillis, MILLISECONDS);
+        }
     }
 
     @Override
@@ -213,6 +215,16 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
     }
 
     @Override
+    public void onConnectionClose(ClientConnection connection) {
+        for (ClientInvocation invocation : invocations.values()) {
+            if (invocation.getPermissionToNotifyForDeadConnection(connection)) {
+                Exception ex = new TargetDisconnectedException(connection.getCloseReason(), connection.getCloseCause());
+                invocation.notifyExceptionWithOwnedPermission(ex);
+            }
+        }
+    }
+
+    @Override
     public boolean isRedoOperation() {
         return client.getClientConfig().getNetworkConfig().isRedoOperation();
     }
@@ -222,26 +234,28 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
             throw new HazelcastClientNotActiveException();
         }
 
+        ClientMessage clientMessage = invocation.getClientMessage();
         if (isBackupAckToClientEnabled) {
-            invocation.getClientMessage().getStartFrame().flags |= ClientMessage.BACKUP_AWARE_FLAG;
+            clientMessage.getStartFrame().flags |= ClientMessage.BACKUP_AWARE_FLAG;
         }
 
         registerInvocation(invocation, connection);
 
-        ClientMessage clientMessage = invocation.getClientMessage();
-        if (!writeToConnection(connection, clientMessage)) {
-            if (invocationLogger.isFinestEnabled()) {
-                invocationLogger.finest("Packet not sent to " + connection.getEndPoint() + " " + clientMessage);
+        //After this is set, a second thread can notify this invocation
+        //Connection could be closed. From this point on, we need to reacquire the permission to notify if needed.
+        invocation.setSentConnection(connection);
+
+        if (!connection.write(clientMessage)) {
+            if (invocation.getPermissionToNotifyForDeadConnection(connection)) {
+                IOException exception = new IOException("Packet not sent to " + connection.getEndPoint() + " "
+                        + clientMessage);
+                invocation.notifyExceptionWithOwnedPermission(exception);
             }
-            return false;
+        } else {
+            invocation.invoked();
         }
 
-        invocation.setSendConnection(connection);
         return true;
-    }
-
-    private boolean writeToConnection(ClientConnection connection, ClientMessage clientMessage) {
-        return connection.write(clientMessage);
     }
 
     // package-visible for tests
@@ -272,7 +286,8 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         responseHandlerSupplier.shutdown();
 
         for (ClientInvocation invocation : invocations.values()) {
-            invocation.notifyException(new HazelcastClientNotActiveException());
+            //connection manager and response handler threads are closed at this point.
+            invocation.notifyExceptionWithOwnedPermission(new HazelcastClientNotActiveException());
         }
     }
 
@@ -288,28 +303,12 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         return isSmartRoutingEnabled;
     }
 
-    private class CleanResourcesTask implements Runnable {
+    private class BackupTimeoutTask implements Runnable {
         @Override
         public void run() {
             for (ClientInvocation invocation : invocations.values()) {
-
-                ClientConnection connection = invocation.getSendConnection();
-                if (connection == null) {
-                    continue;
-                }
-
-                if (!connection.isAlive()) {
-                    notifyException(invocation, connection);
-                    continue;
-                }
-
                 invocation.detectAndHandleBackupTimeout(operationBackupTimeoutMillis);
             }
-        }
-
-        private void notifyException(ClientInvocation invocation, ClientConnection connection) {
-            Exception ex = new TargetDisconnectedException(connection.getCloseReason(), connection.getCloseCause());
-            invocation.notifyException(ex);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BaseInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BaseInvocation.java
@@ -107,8 +107,6 @@ public abstract class BaseInvocation {
     }
 
     /**
-     * gets called from the Clean resources task
-     *
      * @param timeoutMillis timeout value to wait for backups after  the response received
      * @return true if invocation is completed
      */

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImplTest.java
@@ -18,11 +18,10 @@ package com.hazelcast.client.impl.spi.impl;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.nio.ClientConnection;
-import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.config.Config;
-import com.hazelcast.internal.nio.Bits;
-import com.hazelcast.spi.impl.executionservice.TaskScheduler;
-import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.client.impl.protocol.codec.ClientPingCodec;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,17 +31,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import static com.hazelcast.client.impl.protocol.ClientMessage.CORRELATION_ID_FIELD_OFFSET;
-import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueAllTheTime;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -51,103 +39,99 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClientInvocationServiceImplTest {
+public class ClientInvocationServiceImplTest extends ClientTestSupport {
 
-    private static final int MOCK_FRAME_LENGTH = CORRELATION_ID_FIELD_OFFSET + Bits.LONG_SIZE_IN_BYTES;
-
-    private ClientInvocationServiceImpl invocationService;
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     private HazelcastClientInstanceImpl client;
-    private SingleThreadedTaskScheduler taskScheduler;
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
 
     @Before
     public void setUp() {
-        client = mock(HazelcastClientInstanceImpl.class, RETURNS_DEEP_STUBS);
-        when(client.getProperties()).thenReturn(new HazelcastProperties(new Config()));
-        taskScheduler = new SingleThreadedTaskScheduler();
-        when(client.getTaskScheduler()).thenReturn(taskScheduler);
-        invocationService = new ClientInvocationServiceImpl(client);
-        when(client.getInvocationService()).thenReturn(invocationService);
-    }
-
-    @After
-    public void tearDown() {
-        invocationService.shutdown();
-        taskScheduler.shutdown();
+        hazelcastFactory.newHazelcastInstance();
+        client = getHazelcastClientInstanceImpl(hazelcastFactory.newHazelcastClient());
     }
 
     @Test
     public void testCleanResourcesTask_rejectsPendingInvocationsWithClosedConnections() {
-        invocationService.start();
+        ClientConnection closedConn = closedConnection();
+        ClientInvocation invocation = new ClientInvocation(client, ClientPingCodec.encodeRequest(), null, closedConn);
 
-        ClientConnection conn = prepareConnection(false);
-        ClientInvocation invocation = prepareInvocation(1);
-        invocation.setSendConnection(conn);
-        invocationService.registerInvocation(invocation, conn);
-
-        ClientInvocationFuture future = invocation.getClientInvocationFuture();
+        ClientInvocationFuture future = invocation.invoke();
         assertTrueEventually(() -> assertTrue(future.isDone() && future.isCompletedExceptionally()));
     }
 
-    @Test
-    public void testCleanResourcesTask_ignoresPendingInvocationsWithAliveConnections() {
-        invocationService.start();
-
-        ClientConnection closedConn = prepareConnection(false);
-        ClientInvocation invocation1 = prepareInvocation(1);
-        invocation1.setSendConnection(closedConn);
-        invocationService.registerInvocation(invocation1, closedConn);
-
-        ClientConnection aliveConn = prepareConnection(true);
-        ClientInvocation invocation2 = prepareInvocation(2);
-        invocationService.registerInvocation(invocation2, aliveConn);
-
-        ClientInvocationFuture future1 = invocation1.getClientInvocationFuture();
-        ClientInvocationFuture future2 = invocation2.getClientInvocationFuture();
-        assertTrueEventually(() -> assertTrue(future1.isDone() && future1.isCompletedExceptionally()));
-        assertTrueAllTheTime(() -> assertFalse(future2.isDone()), 1);
-    }
-
-    private ClientInvocation prepareInvocation(long correlationId) {
-        ClientMessage message = ClientMessage.createForEncode();
-        ClientMessage.Frame initialFrame =
-                new ClientMessage.Frame(new byte[MOCK_FRAME_LENGTH], UNFRAGMENTED_MESSAGE);
-        message.add(initialFrame);
-        message.setCorrelationId(correlationId);
-        return new ClientInvocation(client, message, null);
-    }
-
-    private ClientConnection prepareConnection(boolean alive) {
+    private ClientConnection closedConnection() {
         ClientConnection conn = mock(ClientConnection.class, RETURNS_DEEP_STUBS);
-        when(conn.isAlive()).thenReturn(alive);
+        when(conn.isAlive()).thenReturn(false);
         return conn;
     }
 
-    private static class SingleThreadedTaskScheduler implements TaskScheduler {
+    @Test
+    public void testInvocation_willNotBeNotifiedForDeadConnection_afterResponse() {
+        ClientConnection connection = (ClientConnection) client.getConnectionManager().getRandomConnection();
+        ClientInvocation invocation = new ClientInvocation(client, ClientPingCodec.encodeRequest(), null, connection);
 
-        private final ScheduledExecutorService internalExecutor = Executors.newScheduledThreadPool(1);
+        //Do all the steps necessary to invoke a connection but do not put it in the write queue
+        ClientInvocationServiceImpl invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
+        long correlationId = invocationService.getCallIdSequence().next();
+        invocation.getClientMessage().setCorrelationId(correlationId);
+        invocationService.registerInvocation(invocation, connection);
+        invocation.setSentConnection(connection);
 
-        @Override
-        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-            return internalExecutor.schedule(command, delay, unit);
-        }
+        //Simulate a response coming back
+        invocation.notify(ClientPingCodec.encodeResponse().setCorrelationId(correlationId));
 
-        @Override
-        public <V> ScheduledFuture<Future<V>> schedule(Callable<V> command, long delay, TimeUnit unit) {
-            return (ScheduledFuture<Future<V>>) internalExecutor.schedule(command, delay, unit);
-        }
+        //Sent connection dies
+        assertFalse(invocation.getPermissionToNotifyForDeadConnection(connection));
+    }
 
-        @Override
-        public ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long period, TimeUnit unit) {
-            return internalExecutor.scheduleAtFixedRate(command, initialDelay, period, unit);
-        }
+    @Test
+    public void testInvocation_willNotBeNotified_afterAConnectionIsNotifiedForDead() {
+        ClientConnection connection = (ClientConnection) client.getConnectionManager().getRandomConnection();
+        ClientInvocation invocation = new ClientInvocation(client, ClientPingCodec.encodeRequest(), null, connection);
 
-        @Override
-        public void execute(Runnable command) {
-            internalExecutor.execute(command);
-        }
+        //Do all the steps necessary to invoke a connection but do not put it in the write queue
+        ClientInvocationServiceImpl invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
+        long correlationId = invocationService.getCallIdSequence().next();
+        invocation.getClientMessage().setCorrelationId(correlationId);
+        invocationService.registerInvocation(invocation, connection);
+        invocation.setSentConnection(connection);
 
-        public void shutdown() {
-            internalExecutor.shutdownNow();
-        }
+        //Sent connection dies
+        assertTrue(invocation.getPermissionToNotifyForDeadConnection(connection));
+        invocation.notifyExceptionWithOwnedPermission(new TargetDisconnectedException(""));
+
+        //Simulate a response coming back
+        assertFalse(invocation.getPermissionToNotify(correlationId));
+    }
+
+    @Test
+    public void testInvocation_willNotBeNotifiedForOldStalledResponse_afterARetry() {
+        ClientConnection connection = (ClientConnection) client.getConnectionManager().getRandomConnection();
+        ClientInvocation invocation = new ClientInvocation(client, ClientPingCodec.encodeRequest(), null, connection);
+
+        //Do all the steps necessary to invoke a connection but do not put it in the write queue
+        ClientInvocationServiceImpl invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
+        long correlationId = invocationService.getCallIdSequence().next();
+        invocation.getClientMessage().setCorrelationId(correlationId);
+        invocationService.registerInvocation(invocation, connection);
+        invocation.setSentConnection(connection);
+
+        //Sent connection dies
+        assertTrue(invocation.getPermissionToNotifyForDeadConnection(connection));
+
+        //simulate a retry
+        invocationService.deRegisterInvocation(correlationId);
+        long retryCorrelationId = invocationService.getCallIdSequence().next();
+        invocation.getClientMessage().setCorrelationId(retryCorrelationId);
+        invocationService.registerInvocation(invocation, connection);
+        invocation.setSentConnection(connection);
+
+        //Simulate the stalled old response trying to notify the invocation
+        assertFalse(invocation.getPermissionToNotify(correlationId));
     }
 }


### PR DESCRIPTION
Bug Description:
There seems to be multiple problems which is caused by single problem
we allow multiple threads to retry/change state of single invocation.
Example:
A connection is closed. CleanResourcesTask checks periodically and
handles invocation with connection closed.
https://github.com/hazelcast/hazelcast/blob/04e9df4c2f406238267a8d45fbc9ae476b40c7d5/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java#L290-L301

This continues and schedules a retry here
https://github.com/hazelcast/hazelcast/blob/04e9df4c2f406238267a8d45fbc9ae476b40c7d5/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java#L305-L315

Before this task gets a chance to run, CleanResoursTask can wakeup
check the same connection and schedule a new retry.

As a solution I first, try to sync them on `deRegisterInvocation(callid)`
,but this does not work. The idea was to only one that can
deRegisterInvocation will retry. Also a response/exception from
remote will notify if they can deregister the invocation.
One problem is correlation id is changed by the retried task, and
other threads are trying to deregister by reading that correlationId.
In response path, we have correlation id coming from remote but in
connection closed case, we don't have one to use(instead of reading
from invocation itself)

Another problem is how we handle connection close. Lets say a member
is about the close and we send an invocation to it. It can send,
ClusterPassive, InstanceNotActive like exceptions. And it closes the
connection after that. We have two cases to handle on the client side.
Lets say we have detected that connection is closed again in
CleanResoursesTask, and we are about to notify the invocation.
In the mean time we got InstanceNotActiveException as well, and we
retried it on another connection/with new call id.
Notify for connection close deregisters the new retry which should
not happen.

I have noticed we had similar problems on the core side.
https://github.com/hazelcast/hazelcast/issues/7270

I have investigate the solutions and core codebase
https://github.com/hazelcast/hazelcast/pull/9296
https://github.com/hazelcast/hazelcast/pull/9303

They are not suitable for the client. Especially connection close
case is different. On the member, we have MemberLeftException
which is guarded by `MemberListVersion` which are not applicable
to the client. So for the client, solution grew around `connection`
naturally.

Solution:
We coordinate all threads that wants to notify the invocation.
We achieve synchronization of different threads via `sentConnection`
field sentConnection starts as null.
It is set to a non-null when `connection` to be sent is determined.
It is set to null when a response/exception is going to be notified.
It is trying to be compared and set to null on connection close case
with dead connection, to prevent invocation to be notified which is
already retried on another connection.
Only one thread that can set this to null can be actively notify
a response/exception.

This way we make sure that only one thread changes the states
(changing correlation id/deregistration of invication).

fixes #18062
backport of #18309 and #18365
(cherry picked from commit b78ce05074c5c482873165749c4a32053352282f)
(cherry picked from commit 84d8af51941ba61786a9d26b2bb0ff7643b1d38b)