### PR TITLE
Fixes CPMemberAddRemoveTest concurrent shutdown test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/exception/CannotRemoveCPMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/exception/CannotRemoveCPMemberException.java
@@ -28,7 +28,7 @@ public class CannotRemoveCPMemberException extends HazelcastException {
     private static final long serialVersionUID = -3631327013406551312L;
 
     public CannotRemoveCPMemberException(String message) {
-        super(message, null);
+        super(message);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -27,6 +27,7 @@ import java.io.StringWriter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
@@ -223,6 +224,7 @@ public final class ExceptionUtil {
      * @param cause          cause to be set to the exception
      * @return {@code null} if can not find a constructor as described above, otherwise returns newly constructed exception
      */
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public static <T extends Throwable> T tryCreateExceptionWithMessageAndCause(Class<? extends Throwable> exceptionClass,
                                                                                 String message, @Nullable Throwable cause) {
         MethodHandle constructor;
@@ -230,27 +232,39 @@ public final class ExceptionUtil {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING_THROWABLE);
             T clone = (T) constructor.invokeWithArguments(message, cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         try {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_THROWABLE);
             T clone = (T) constructor.invokeWithArguments(cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         try {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING);
             T clone = (T) constructor.invokeWithArguments(message);
             clone.initCause(cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         try {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT);
             T clone = (T) constructor.invokeWithArguments();
             clone.initCause(cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         return null;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -37,10 +37,8 @@ import com.hazelcast.instance.StaticMemberNodeContext;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,11 +61,9 @@ import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getSnapshotEntry;
 import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
 import static com.hazelcast.instance.impl.HazelcastInstanceFactory.newHazelcastInstance;
 import static com.hazelcast.internal.util.FutureUtil.returnWithDeadline;
-import static com.hazelcast.spi.properties.ClusterProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
 import static com.hazelcast.test.Accessors.getAddress;
 import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
-import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.TestHazelcastInstanceFactory.initOrCreateConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.greaterThan;
@@ -85,9 +81,6 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({SlowTest.class, ParallelJVMTest.class})
 public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
-
-    @Rule
-    public OverridePropertyRule gracefulShutdownTimeoutRule = clear(GRACEFUL_SHUTDOWN_MAX_WAIT.getName());
 
     @Test
     public void testAwaitDiscoveryCompleted() throws InterruptedException {
@@ -1023,7 +1016,6 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
 
     @Test
     public void when_cpMembersShutdownConcurrently_then_theyCompleteTheirShutdown() throws ExecutionException, InterruptedException {
-        gracefulShutdownTimeoutRule.setOrClearProperty("10");
         // When there are N CP members, we can perform partially-concurrent shutdown in 2 steps:
         // In the first step, we shut down N - 2 members concurrently.
         // Once those members are done, we shutdown the last 2 CP members serially.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ExceptionTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.cp.internal.exception.CannotRemoveCPMemberException;
 import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -63,6 +64,8 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 // RuntimeException with no constructor accepting a Throwable cause
                 new Object[] {JOIN_INTERNAL, new IllegalThreadStateException("message"), IllegalThreadStateException.class,
                         IsNull.nullValue(Throwable.class)},
+                new Object[] {JOIN_INTERNAL, new CannotRemoveCPMemberException("message"), CannotRemoveCPMemberException.class,
+                        IsNull.nullValue(Throwable.class)},
                 // OperationTimeoutException: OperationTimeoutException is only expected to be
                 // thrown with a local stack trace; this test is about verifying the exception remains unwrapped
                 new Object[] {JOIN_INTERNAL, new OperationTimeoutException("message"), OperationTimeoutException.class,
@@ -85,6 +88,8 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 // RuntimeException with no constructor accepting a Throwable cause
                 new Object[] {JOIN, new IllegalThreadStateException("message"), CompletionException.class,
                               new RootCauseMatcher(IllegalThreadStateException.class, "message")},
+                new Object[]{ JOIN, new CannotRemoveCPMemberException("message"), CompletionException.class,
+                        new RootCauseMatcher(CannotRemoveCPMemberException.class, "message")},
                 // OperationTimeoutException is wrapped in CompletionException
                 new Object[] {JOIN, new OperationTimeoutException("message"), CompletionException.class,
                               new RootCauseMatcher(OperationTimeoutException.class, "message")},
@@ -105,6 +110,8 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 // RuntimeException with no constructor accepting a Throwable cause
                 new Object[] {GET, new IllegalThreadStateException("message"), ExecutionException.class,
                               new RootCauseMatcher(IllegalThreadStateException.class, "message")},
+                new Object[] {GET, new CannotRemoveCPMemberException("message"), ExecutionException.class,
+                        new RootCauseMatcher(CannotRemoveCPMemberException.class, "message")},
                 // OperationTimeoutException is wrapped in ExecutionException
                 new Object[] {GET, new OperationTimeoutException("message"), ExecutionException.class,
                               new RootCauseMatcher(OperationTimeoutException.class, "message")},


### PR DESCRIPTION
The bug is caused by not being able to transfer CannotRemoveCPMemberException
correctly from one member to another as a response. It comes out null on the
caller side. And this breaks the retry logic of CP gracefull shutdown.

The reason that it comes out as null because we are setting `null` to cause
in the constructor of `CannotRemoveCPMemberException`. 
When we create the exception in `tryCreateExceptionWithMessageAndCause`
we are trying to set the cause with `initCause` method. If the cause 
is already set, it throws `IllegalStateException` where we ignore and
return null eventually.

Fixed CannotRemoveCPMemberException by not setting cause as null in the constructor.
Refactored ExceptionUtil.tryCreateExceptionWithMessageAndCause
so that similar exceptions will not be ignored and can be detected
much earlier.

Refactored ClientInvocation_ExceptionTest to use static methods
to make it run faster.

Removed setting property to when_cpMembersShutdownConcurrently_then_theyCompleteTheirShutdown
because it was the wrong call for the solution.

fixes https://github.com/hazelcast/hazelcast/issues/17650