### PR TITLE
Add missing config check for merge policy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -140,7 +140,8 @@ public final class ConfigValidator {
 
         checkMapEvictionConfig(mapConfig.getEvictionConfig());
         checkMapMaxSizePolicyPerInMemoryFormat(mapConfig);
-        checkMapMergePolicy(mapConfig, mergePolicyProvider);
+        checkMapMergePolicy(mapConfig,
+                mapConfig.getMergePolicyConfig().getPolicy(), mergePolicyProvider);
     }
 
     static void checkMapMaxSizePolicyPerInMemoryFormat(MapConfig mapConfig) {
@@ -633,7 +634,7 @@ public final class ConfigValidator {
      * is {@link InMemoryFormat#NATIVE} and index configurations include {@link IndexType#BITMAP}.
      *
      * @param inMemoryFormat supplied inMemoryFormat
-     * @param indexConfigs {@link List} of {@link IndexConfig}
+     * @param indexConfigs   {@link List} of {@link IndexConfig}
      */
     private static void checkNotBitmapIndexWhenNativeMemory(InMemoryFormat inMemoryFormat, List<IndexConfig> indexConfigs) {
         if (inMemoryFormat == NATIVE) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -57,6 +57,7 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.wan.impl.DelegatingWanScheme;
 import com.hazelcast.wan.impl.WanReplicationService;
 
@@ -70,6 +71,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.config.ConsistencyCheckStrategy.MERKLE_TREES;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.internal.config.MergePolicyValidator.checkMapMergePolicy;
 import static com.hazelcast.internal.eviction.EvictionPolicyEvaluatorProvider.getEvictionPolicyComparator;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
 import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
@@ -271,8 +273,9 @@ public class MapContainer {
 
         WanReplicationService wanReplicationService = nodeEngine.getWanReplicationService();
         wanReplicationDelegate = wanReplicationService.getWanReplicationPublishers(wanReplicationRefName);
-        wanMergePolicy = nodeEngine.getSplitBrainMergePolicyProvider()
-                .getMergePolicy(wanReplicationRef.getMergePolicyClassName());
+        SplitBrainMergePolicyProvider mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
+        wanMergePolicy = mergePolicyProvider.getMergePolicy(wanReplicationRef.getMergePolicyClassName());
+        checkMapMergePolicy(mapConfig, wanReplicationRef.getMergePolicyClassName(), mergePolicyProvider);
 
         WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(wanReplicationRefName);
         if (wanReplicationConfig != null) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/AbstractMergePolicyValidatorIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/AbstractMergePolicyValidatorIntegrationTest.java
@@ -112,6 +112,6 @@ public abstract class AbstractMergePolicyValidatorIntegrationTest extends Hazelc
     void expectedMapStatisticsDisabledException(MergePolicyConfig mergePolicyConfig) {
         expectedException.expect(InvalidConfigurationException.class);
         expectedException.expectMessage(containsString(mergePolicyConfig.getPolicy()));
-        expectedException.expectMessage(containsString("map statistics"));
+        expectedException.expectMessage(containsString("perEntryStatsEnabled field of map-config"));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -81,6 +82,12 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
         checkMapConfig(getMapConfig(BINARY), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void checkMapConfig_fails_with_merge_policy_which_requires_per_entry_stats_enabled() {
+        checkMapConfig(getMapConfig(BINARY).setPerEntryStatsEnabled(false),
+                nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
+    }
+
     @Test
     public void checkMapConfig_OBJECT() {
         checkMapConfig(getMapConfig(OBJECT), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
@@ -95,8 +102,12 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
     }
 
     private MapConfig getMapConfig(InMemoryFormat inMemoryFormat) {
-        return new MapConfig()
-                .setInMemoryFormat(inMemoryFormat);
+        MapConfig mapConfig = new MapConfig()
+                .setInMemoryFormat(inMemoryFormat)
+                .setPerEntryStatsEnabled(true);
+        mapConfig.getMergePolicyConfig()
+                .setPolicy(HigherHitsMergePolicy.class.getName());
+        return mapConfig;
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorMapIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorMapIntegrationTest.java
@@ -40,12 +40,12 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyValidatorIntegrationTest {
 
-    private boolean isStatisticsEnabled = false;
+    private boolean perEntryStatsEnabled = false;
 
     @Override
     void addConfig(Config config, String name, MergePolicyConfig mergePolicyConfig) {
         MapConfig mapConfig = new MapConfig(name)
-                .setStatisticsEnabled(isStatisticsEnabled)
+                .setPerEntryStatsEnabled(perEntryStatsEnabled)
                 .setMergePolicyConfig(mergePolicyConfig);
 
         config.addMapConfig(mapConfig);
@@ -68,6 +68,7 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withHigherHitsMergePolicy() {
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("higherHits", higherHitsMergePolicy);
 
         hz.getMap("higherHits");
@@ -88,13 +89,12 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
     public void testMap_withExpirationTimeMergePolicy() {
         HazelcastInstance hz = getHazelcastInstance("expirationTime", expirationTimeMergePolicy);
 
-        expectedMapStatisticsDisabledException(expirationTimeMergePolicy);
         hz.getMap("expirationTime");
     }
 
     @Test
     public void testMap_withExpirationTimeMergePolicy_withStatsEnabled() {
-        isStatisticsEnabled = true;
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("expirationTime", expirationTimeMergePolicy);
 
         hz.getMap("expirationTime");
@@ -113,7 +113,7 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withLastStoredMergePolicy_withStatsEnabled() {
-        isStatisticsEnabled = true;
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("lastStoredTime", lastStoredTimeMergePolicy);
 
         hz.getMap("lastStoredTime");
@@ -132,7 +132,7 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withLastStoredMergePolicyNoTypeVariable_withStatsEnabled() {
-        isStatisticsEnabled = true;
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("lastStoredTimeNoTypeVariable", lastStoredTimeMergePolicyNoTypeVariable);
 
         hz.getMap("lastStoredTimeNoTypeVariable");
@@ -146,13 +146,12 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
     public void testMap_withComplexCustomMergePolicy() {
         HazelcastInstance hz = getHazelcastInstance("complexCustom", complexCustomMergePolicy);
 
-        expectedMapStatisticsDisabledException(complexCustomMergePolicy);
         hz.getMap("complexCustom");
     }
 
     @Test
     public void testMap_withComplexCustomMergePolicy_withStatsEnabled() {
-        isStatisticsEnabled = true;
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("complexCustom", complexCustomMergePolicy);
 
         hz.getMap("complexCustom");
@@ -172,7 +171,7 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withCustomMapMergePolicy_withStatsEnabled() {
-        isStatisticsEnabled = true;
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("customMap", customMapMergePolicy);
 
         hz.getMap("customMap");
@@ -192,7 +191,7 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withCustomMapMergePolicyNoTypeVariable_withStatsEnabled() {
-        isStatisticsEnabled = true;
+        perEntryStatsEnabled = true;
         HazelcastInstance hz = getHazelcastInstance("customMapNoTypeVariable", customMapMergePolicyNoTypeVariable);
 
         hz.getMap("customMapNoTypeVariable");


### PR DESCRIPTION
ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/3982

These are missing checks which should have been added in https://github.com/hazelcast/hazelcast/pull/18093. With these checks, fail-fast behavior is introduced for some merge-policy types if `perEntryStatsEnabled` field of map-config is `false`.