### PR TITLE
Fixes CPMemberAddRemoveTest concurrent shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/exception/CannotRemoveCPMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/exception/CannotRemoveCPMemberException.java
@@ -28,7 +28,7 @@ public class CannotRemoveCPMemberException extends HazelcastException {
     private static final long serialVersionUID = -3631327013406551312L;
 
     public CannotRemoveCPMemberException(String message) {
-        super(message, null);
+        super(message);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -27,6 +27,7 @@ import java.io.StringWriter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
@@ -223,6 +224,7 @@ public final class ExceptionUtil {
      * @param cause          cause to be set to the exception
      * @return {@code null} if can not find a constructor as described above, otherwise returns newly constructed exception
      */
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public static <T extends Throwable> T tryCreateExceptionWithMessageAndCause(Class<? extends Throwable> exceptionClass,
                                                                                 String message, @Nullable Throwable cause) {
         MethodHandle constructor;
@@ -230,27 +232,39 @@ public final class ExceptionUtil {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING_THROWABLE);
             T clone = (T) constructor.invokeWithArguments(message, cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         try {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_THROWABLE);
             T clone = (T) constructor.invokeWithArguments(cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         try {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT_STRING);
             T clone = (T) constructor.invokeWithArguments(message);
             clone.initCause(cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         try {
             constructor = LOOKUP.findConstructor(exceptionClass, MT_INIT);
             T clone = (T) constructor.invokeWithArguments();
             clone.initCause(cause);
             return clone;
-        } catch (Throwable ignored) {
+        } catch (ClassCastException | WrongMethodTypeException
+                | IllegalAccessException | SecurityException | NoSuchMethodException ignored) {
+        } catch (Throwable t) {
+            throw new RuntimeException("Exception creation failed ", t);
         }
         return null;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ExceptionTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.cp.internal.exception.CannotRemoveCPMemberException;
 import com.hazelcast.internal.util.RootCauseMatcher;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -63,6 +64,8 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 // RuntimeException with no constructor accepting a Throwable cause
                 new Object[] {JOIN_INTERNAL, new IllegalThreadStateException("message"), IllegalThreadStateException.class,
                         IsNull.nullValue(Throwable.class)},
+                new Object[] {JOIN_INTERNAL, new CannotRemoveCPMemberException("message"), CannotRemoveCPMemberException.class,
+                        IsNull.nullValue(Throwable.class)},
                 // OperationTimeoutException: OperationTimeoutException is only expected to be
                 // thrown with a local stack trace; this test is about verifying the exception remains unwrapped
                 new Object[] {JOIN_INTERNAL, new OperationTimeoutException("message"), OperationTimeoutException.class,
@@ -85,6 +88,8 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 // RuntimeException with no constructor accepting a Throwable cause
                 new Object[] {JOIN, new IllegalThreadStateException("message"), CompletionException.class,
                               new RootCauseMatcher(IllegalThreadStateException.class, "message")},
+                new Object[]{ JOIN, new CannotRemoveCPMemberException("message"), CompletionException.class,
+                        new RootCauseMatcher(CannotRemoveCPMemberException.class, "message")},
                 // OperationTimeoutException is wrapped in CompletionException
                 new Object[] {JOIN, new OperationTimeoutException("message"), CompletionException.class,
                               new RootCauseMatcher(OperationTimeoutException.class, "message")},
@@ -105,6 +110,8 @@ public class Invocation_ExceptionTest extends HazelcastTestSupport {
                 // RuntimeException with no constructor accepting a Throwable cause
                 new Object[] {GET, new IllegalThreadStateException("message"), ExecutionException.class,
                               new RootCauseMatcher(IllegalThreadStateException.class, "message")},
+                new Object[] {GET, new CannotRemoveCPMemberException("message"), ExecutionException.class,
+                        new RootCauseMatcher(CannotRemoveCPMemberException.class, "message")},
                 // OperationTimeoutException is wrapped in ExecutionException
                 new Object[] {GET, new OperationTimeoutException("message"), ExecutionException.class,
                               new RootCauseMatcher(OperationTimeoutException.class, "message")},


### PR DESCRIPTION
The bug is caused by not being able to transfer CannotRemoveCPMemberException
correctly from one member to another as a response. It comes out null on the
caller side. And this breaks the retry logic of CP gracefull shutdown.

Fixed CannotRemoveCPMemberException by not setting cause as null.
Refactored ExceptionUtil.tryCreateExceptionWithMessageAndCause
so that similar exceptions will not be ignored and can be detected
much earlier.

Refactored ClientInvocation_ExceptionTest to use static methods
to make it run faster.

Removed setting property to when_cpMembersShutdownConcurrently_then_theyCompleteTheirShutdown
because it was the wrong call for the solution.

fixes https://github.com/hazelcast/hazelcast/issues/17650
backport https://github.com/hazelcast/hazelcast/pull/18378
(cherry picked from commit a68ed0302102abd009aa9345c9c993f35419ec0c)