### PR TITLE
Make locked keys reachable over index even if they have expired

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -163,7 +163,8 @@ public class MapContainer {
                 .indexProvider(mapServiceContext.getIndexProvider(mapConfig))
                 .usesCachedQueryableEntries(mapConfig.getCacheDeserializedValues() != CacheDeserializedValues.NEVER)
                 .partitionCount(partitionCount)
-                .resultFilterFactory(new IndexResultFilterFactory()).build();
+                .resultFilterFactory(new IndexResultFilterFactory())
+                .build();
     }
 
     private class IndexResultFilterFactory implements Supplier<Predicate<QueryableEntry>> {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -139,9 +139,8 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     }
 
     @Override
-    public boolean isExpired(Data dataKey, long now, boolean backup) {
-        return expirySystem.hasExpired(dataKey, now, backup)
-                != NOT_EXPIRED;
+    public boolean isExpired(Data key, long now, boolean backup) {
+         return hasExpired(key, now, backup) != NOT_EXPIRED;
     }
 
     @Override


### PR DESCRIPTION
This is a regression from version 4.1.
Locked expired keys should be reachable till unlock.