### PR TITLE
Propagate interrupts to test statements

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
@@ -82,10 +82,10 @@ public class FailOnTimeoutStatement extends Statement {
                 return task.get();
             }
         } catch (InterruptedException e) {
-            // caller will re-throw; no need to call Thread.interrupt()
+            // propagate interrupt
+            thread.interrupt();
             return e;
         } catch (ExecutionException e) {
-            // test failed; have caller re-throw the exception thrown by the test
             return e.getCause();
         } catch (TimeoutException e) {
             return createTimeoutException(thread);

--- a/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
@@ -86,6 +86,7 @@ public class FailOnTimeoutStatement extends Statement {
             thread.interrupt();
             return e;
         } catch (ExecutionException e) {
+            // test failed; have caller re-throw the exception thrown by the test
             return e.getCause();
         } catch (TimeoutException e) {
             return createTimeoutException(thread);


### PR DESCRIPTION
In Jet we quite often use `@ClassRule public static Timeout...` in combination with `@RunWith(HazelcastSerialClassRunner.class)`.

Such setup results in one thread spawned for the entire class (single timeout for `@BeforeClass`, `@Before`, `@After`, `@AfterClass` and all the tests) and a separate thread spawned for each `@Test` (a timeout for each test separately).

The problem is: whenever a timeout occurs for the entire class, the interrupt isn't propagated to the test thread which if blocked (i.e. `sleep()`) won't get unstuck . The result is non-completed cleanups, hanging clients and instances.