### PR TITLE
Documentation: Fix comments regarding a client's disconnection from cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -130,7 +130,7 @@ public class ClientStateListener
      *
      * @param timeout the maximum time to wait
      * @param unit    the time unit of the {@code timeout} argument
-     * @return true if the client is disconnected to the cluster. On returning false,
+     * @return true if the client is disconnected from the cluster. On returning false,
      * you can check if timeout occured or the client is shutdown using {@code isShutdown} {@code getCurrentState}
      * @throws InterruptedException
      */

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -77,7 +77,7 @@ public final class LifecycleEvent {
         MERGE_FAILED,
 
         /**
-         * Fired when a client is connected to the member.
+         * Fired when a client is connected to the cluster.
          */
         CLIENT_CONNECTED,
 

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -82,7 +82,7 @@ public final class LifecycleEvent {
         CLIENT_CONNECTED,
 
         /**
-         * Fired when a client is disconnected from the member.
+         * Fired when a client is disconnected from the cluster.
          */
         CLIENT_DISCONNECTED,
 


### PR DESCRIPTION
This only changes comments in code

## Changes
* The 'DISCONNECTED' lifecycle event is fired when the client is disconnected from a "cluster", not from a "member".
* fixes another `disconnect` usage grammatically. 