### PR TITLE
[4.1.z] Github workflow - Build Hazelcast snapshot docker images

### DIFF
--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -1,0 +1,81 @@
+name: Build internal snapshot image
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+.z'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'hazelcast'
+    steps:
+      - name: Checkout hazelcast-snapshot repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast-dockerfiles/hazelcast-snapshot
+          ref: master
+          path: hazelcast-snapshot
+      - name: Checkout hazelcast-enterprise-snapshot repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast-dockerfiles/hazelcast-enterprise-snapshot
+          ref: master
+          path: hazelcast-enterprise-snapshot
+      - name: Checkout hazelcast repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast/hazelcast
+          path: hazelcast
+      - name: Checkout hazelcast-enterprise repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast/hazelcast-enterprise
+          ref: ${{ github.ref }}
+          path: hazelcast-enterprise
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build hazelcast with Maven
+        run: |
+          mvn -f hazelcast/pom.xml -B clean install -DskipTests
+          rm hazelcast/hazelcast-all/target/*-sources.jar
+          cp hazelcast/hazelcast-all/target/hazelcast-all-*.jar hazelcast-all.jar
+
+      - name: Docker Build and Push hazelcast-snapshot image
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          TAGS="--tag devopshazelcast/hazelcast-snapshot:${BRANCH}"
+          if [[ "${BRANCH}" == "master" ]]; then
+            TAGS="${TAGS} --tag devopshazelcast/hazelcast-snapshot:latest"
+          fi
+          docker buildx build --push -f hazelcast-snapshot/Dockerfile $TAGS .
+
+      - name: Build hazelcast-enterprise with Maven
+        run: |
+          mvn -f hazelcast-enterprise/pom.xml -B clean install -DskipTests
+          rm hazelcast-enterprise/hazelcast-enterprise-all/target/*-tests.jar
+          cp hazelcast-enterprise/hazelcast-enterprise-all/target/hazelcast-enterprise-all-*.jar hazelcast-enterprise-all.jar
+
+      - name: Docker Build and Push hazelcast-enterprise-snapshot image
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          TAGS="--tag devopshazelcast/hazelcast-enterprise-snapshot:${BRANCH}"
+          if [[ "${BRANCH}" == "master" ]]; then
+            TAGS="${TAGS} --tag devopshazelcast/hazelcast-enterprise-snapshot:latest"
+          fi
+          docker buildx build --push -f hazelcast-enterprise-snapshot/Dockerfile $TAGS .


### PR DESCRIPTION
This PR introduces Github workflow for building `devopshazelcast/hazelcast-snapshot` and `devopshazelcast/hazelcast-enterprise-snapshot` Docker images on a push to the given branch.
These internal images are used for regular dynamic security scanning (using GVM+OpenVAS scanner).

It replaces the old way of building those images:
* GitHub hook triggers an action on our highfive server
* the highfive server translates the call to Docker hub trigger
* Docker hub builds the image

The PR is first sent to  `4.1.z` branch where we can verify if it proceeds correctly and then we can cherry-pick the change to other z-stream patch branches and to the `master`.