### PR TITLE
Respect `migrating` flag while computing member state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -234,10 +234,7 @@ public class MigrationManager {
                 } else {
                     operationService.execute(op);
                 }
-
-                // We remove active migration in the end of the FinalizeMigrationOperation to make sure
-                // the cluster comes to a SAFE state only when indexes on partitions being populated
-                // completely.
+                removeActiveMigration(partitionId);
             } else {
                 PartitionReplica partitionOwner = partitionStateManager.getPartitionImpl(partitionId).getOwnerReplicaOrNull();
                 if (localReplica.equals(partitionOwner)) {
@@ -327,7 +324,7 @@ public class MigrationManager {
      * removed.
      * Acquires the partition service lock.
      */
-    public boolean removeActiveMigration(int partitionId) {
+    private boolean removeActiveMigration(int partitionId) {
         partitionServiceLock.lock();
         try {
             if (activeMigrationInfo != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -77,6 +77,7 @@ public class PartitionReplicaStateChecker {
         this.migrationManager = partitionService.getMigrationManager();
     }
 
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public PartitionServiceState getPartitionServiceState() {
         if (partitionService.isFetchMostRecentPartitionTableTaskRequired()) {
             return FETCHING_PARTITION_TABLE;
@@ -87,6 +88,10 @@ public class PartitionReplicaStateChecker {
         }
 
         if (migrationManager.hasOnGoingMigration()) {
+            return MIGRATION_LOCAL;
+        }
+
+        if (partitionStateManager.hasMigratingPartitions()) {
             return MIGRATION_LOCAL;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -95,6 +95,19 @@ public class PartitionStateManager {
         partitionStateGenerator = new PartitionStateGeneratorImpl();
     }
 
+    /**
+     * @return {@code true} if there are partitions having {@link
+     * InternalPartitionImpl#isMigrating()} flag set, {@code false} otherwise.
+     */
+    boolean hasMigratingPartitions() {
+        for (int i = 0; i < partitionCount; ++i) {
+            if (partitions[i].isMigrating()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Probe(name = PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_LOCAL_PARTITION_COUNT)
     private int localPartitionCount() {
         int count = 0;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -54,6 +54,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
      * This constructor should not be used to obtain an instance of this class; it exists to fulfill IdentifiedDataSerializable
      * coding conventions.
      */
+    @SuppressWarnings("unused")
     public FinalizeMigrationOperation() {
         migrationInfo = null;
         endpoint = null;
@@ -97,7 +98,6 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
         }
 
         partitionStateManager.clearMigratingFlag(partitionId);
-        partitionService.getMigrationManager().removeActiveMigration(partitionId);
         if (success) {
             nodeEngine.onPartitionMigrate(migrationInfo);
         }


### PR DESCRIPTION
Before this change, member state was considered safe once all migrations
are committed. Technically, after that point a member can safely execute
queries. But some queries might be executed using full scans (instead of
index scans) since global indexes are populated during the migration
finalization phase which goes after the migration commit phase.

Tests verifying indexing behavior expect indexes to be fully populated
once member state reported as safe. There was an attempt to fix that:
https://github.com/hazelcast/hazelcast/pull/17738, but apparently it
introduced some race condition in migration management leading to
assertion and test failures.

This fix also considers a member to be safe only after the finalization
phase is finished on it, but does it in a different way without changing
the migration logic.

Fixes: https://github.com/hazelcast/hazelcast/issues/17805
Backport of: https://github.com/hazelcast/hazelcast/pull/18231