### PR TITLE
Github workflow - Build Hazelcast snapshot docker images

### DIFF
--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -1,0 +1,78 @@
+name: Build internal snapshot image
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+.z'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'hazelcast'
+    steps:
+      - name: Checkout hazelcast-snapshot repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast-dockerfiles/hazelcast-snapshot
+          ref: master
+          path: hazelcast-snapshot
+      - name: Checkout hazelcast-enterprise-snapshot repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast-dockerfiles/hazelcast-enterprise-snapshot
+          ref: master
+          path: hazelcast-enterprise-snapshot
+      - name: Checkout hazelcast repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast/hazelcast
+          path: hazelcast
+      - name: Checkout hazelcast-enterprise repo
+        uses: actions/checkout@v2
+        with:
+          repository: hazelcast/hazelcast-enterprise
+          ref: ${{ github.ref }}
+          path: hazelcast-enterprise
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build hazelcast with Maven
+        run: |
+          mvn -f hazelcast/pom.xml -B clean install -DskipTests
+          rm hazelcast/hazelcast-all/target/*-sources.jar
+          cp hazelcast/hazelcast-all/target/hazelcast-all-*.jar hazelcast-all.jar
+
+      - name: Docker Build and Push hazelcast-snapshot image
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          TAGS="--tag devopshazelcast/hazelcast-snapshot:${BRANCH}"
+          if [[ "${BRANCH}" == "master" ]]; then
+            TAGS="${TAGS} --tag devopshazelcast/hazelcast-snapshot:latest"
+          fi
+          docker buildx build --push -f hazelcast-snapshot/Dockerfile $TAGS .
+
+      - name: Build hazelcast-enterprise with Maven
+        run: |
+          mvn -f hazelcast-enterprise/pom.xml -B clean install -DskipTests
+          rm hazelcast-enterprise/hazelcast-enterprise-all/target/*-tests.jar
+          cp hazelcast-enterprise/hazelcast-enterprise-all/target/hazelcast-enterprise-all-*.jar hazelcast-enterprise-all.jar
+
+      - name: Docker Build and Push hazelcast-enterprise-snapshot image
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          TAGS="--tag devopshazelcast/hazelcast-enterprise-snapshot:${BRANCH}"
+          if [[ "${BRANCH}" == "master" ]]; then
+            TAGS="${TAGS} --tag devopshazelcast/hazelcast-enterprise-snapshot:latest"
+          fi
+          docker buildx build --push -f hazelcast-enterprise-snapshot/Dockerfile $TAGS .

--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -40,6 +40,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -49,8 +55,11 @@ jobs:
 
       - name: Build hazelcast with Maven
         run: |
-          mvn -f hazelcast/pom.xml -B clean install -DskipTests
-          rm hazelcast/hazelcast-all/target/*-sources.jar
+          mvn -f hazelcast/pom.xml -B -Dmaven.test.skip=true \
+            -Dmaven.site.skip=true -Dmaven.javadoc.skip=true \
+            -Dcheckstyle.skip -Dspotbugs.skip clean install -DskipTests
+          rm hazelcast/hazelcast-all/target/*-sources.jar \
+            hazelcast/hazelcast-all/target/*-tests.jar || true
           cp hazelcast/hazelcast-all/target/hazelcast-all-*.jar hazelcast-all.jar
 
       - name: Docker Build and Push hazelcast-snapshot image
@@ -64,8 +73,11 @@ jobs:
 
       - name: Build hazelcast-enterprise with Maven
         run: |
-          mvn -f hazelcast-enterprise/pom.xml -B clean install -DskipTests
-          rm hazelcast-enterprise/hazelcast-enterprise-all/target/*-tests.jar
+          mvn -f hazelcast-enterprise/pom.xml -B -Dmaven.test.skip=true \
+            -Dmaven.site.skip=true -Dmaven.javadoc.skip=true \
+            -Dcheckstyle.skip -Dspotbugs.skip clean install -DskipTests
+          rm hazelcast-enterprise/hazelcast-enterprise-all/target/*-sources.jar \
+            hazelcast-enterprise/hazelcast-enterprise-all/target/*-tests.jar || true
           cp hazelcast-enterprise/hazelcast-enterprise-all/target/hazelcast-enterprise-all-*.jar hazelcast-enterprise-all.jar
 
       - name: Docker Build and Push hazelcast-enterprise-snapshot image


### PR DESCRIPTION
Forward port of #18418

The first commit is a 1:1 cherry-pick and the second adds `.m2` caching and skips some build steps to speed up the build.