### PR TITLE
Made the current Java version retrievable from JavaVersion enum

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaMajorVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaMajorVersion.java
@@ -22,7 +22,7 @@ package com.hazelcast.internal.util;
  * to do version comparison safely on runtime environments with versions
  * not listed in {@link JavaVersion}.
  */
-interface JavaMajorVersion {
+public interface JavaMajorVersion {
     /**
      * Returns the major version.
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -44,7 +44,8 @@ public enum JavaVersion implements JavaMajorVersion {
     JAVA_13(13),
     JAVA_14(14),
     JAVA_15(15),
-    JAVA_16(16)
+    JAVA_16(16),
+    JAVA_17(17)
     ;
 
     public static final JavaMajorVersion CURRENT_VERSION = detectCurrentVersion();

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -47,7 +47,7 @@ public enum JavaVersion implements JavaMajorVersion {
     JAVA_16(16)
     ;
 
-    private static final JavaMajorVersion CURRENT_VERSION = detectCurrentVersion();
+    public static final JavaMajorVersion CURRENT_VERSION = detectCurrentVersion();
 
     private int majorVersion;
 


### PR DESCRIPTION
OS side change to fix the hazelcast/hazelcast-enterprise#3920

This PR changes the visibility of `JavaVersion.CURRENT_VERSION` constant. The `JavaVersion` is not part of public API (its an internal enum).