### PR TITLE
Add table name & upsert descriptors to map PlanObjectKey

### DIFF
--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/plan/cache/MapPlanObjectKeyTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/impl/plan/cache/MapPlanObjectKeyTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -53,8 +52,11 @@ public class MapPlanObjectKeyTest extends SqlTestSupport {
         String schema1 = "schema1";
         String schema2 = "schema2";
 
-        String name1 = "map1";
-        String name2 = "map2";
+        String tableName1 = "table1";
+        String tableName2 = "table2";
+
+        String mapName1 = "map1";
+        String mapName2 = "map2";
 
         List<TableField> fields1 = singletonList(new MapTableField("field1", QueryDataType.INT, true, QueryPath.KEY_PATH));
         List<TableField> fields2 = singletonList(new MapTableField("field2", QueryDataType.INT, true, QueryPath.KEY_PATH));
@@ -68,24 +70,33 @@ public class MapPlanObjectKeyTest extends SqlTestSupport {
         QueryTargetDescriptor valueDescriptor1 = GenericQueryTargetDescriptor.DEFAULT;
         QueryTargetDescriptor valueDescriptor2 = new TestTargetDescriptor();
 
+        Object keyJetMetadata1 = new Object();
+        Object valueJetMetadata1 = new Object();
+
+        Object keyJetMetadata2 = new Object();
+        Object valueJetMetadata2 = new Object();
+
         List<MapTableIndex> indexes1 = singletonList(new MapTableIndex("idx", IndexType.SORTED, 0, emptyList(), emptyList()));
         List<MapTableIndex> indexes2 = singletonList(new MapTableIndex("idx", IndexType.HASH, 0, emptyList(), emptyList()));
 
         boolean hd1 = false;
         boolean hd2 = true;
 
-        PartitionedMapPlanObjectKey objectId = new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes1, hd1);
+        PartitionedMapPlanObjectKey objectId = new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1);
 
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes1, hd1), true);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), true);
 
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, name1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes1, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name2, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes1, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields2, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes1, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas2, keyDescriptor1, valueDescriptor1, indexes1, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas1, keyDescriptor2, valueDescriptor1, indexes1, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, indexes1, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes2, hd1), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, name1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, indexes1, hd2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, tableName2, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName2, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields2, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas2, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor2, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata1, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata2, valueJetMetadata1, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata1, valueJetMetadata2, indexes1, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes2, hd1), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd2), false);
     }
 
     private static class TestTargetDescriptor implements QueryTargetDescriptor {
@@ -95,12 +106,12 @@ public class MapPlanObjectKeyTest extends SqlTestSupport {
         }
 
         @Override
-        public void writeData(ObjectDataOutput out) throws IOException {
+        public void writeData(ObjectDataOutput out) {
             // No-op.
         }
 
         @Override
-        public void readData(ObjectDataInput in) throws IOException {
+        public void readData(ObjectDataInput in) {
             // No-op.
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PartitionedMapPlanObjectKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PartitionedMapPlanObjectKey.java
@@ -21,34 +21,44 @@ import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.MapTableIndex;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class PartitionedMapPlanObjectKey implements PlanObjectKey {
 
     private final String schemaName;
-    private final String name;
+    private final String tableName;
+    private final String mapName;
     private final List<TableField> fields;
     private final QueryTargetDescriptor keyDescriptor;
     private final QueryTargetDescriptor valueDescriptor;
+    private final Object keyJetMetadata;
+    private final Object valueJetMetadata;
     private final List<MapTableIndex> indexes;
     private final boolean hd;
     private final Set<String> conflictingSchemas;
 
     public PartitionedMapPlanObjectKey(
         String schemaName,
-        String name,
+        String tableName,
+        String mapName,
         List<TableField> fields,
         Set<String> conflictingSchemas,
         QueryTargetDescriptor keyDescriptor,
         QueryTargetDescriptor valueDescriptor,
+        Object keyJetMetadata,
+        Object valueJetMetadata,
         List<MapTableIndex> indexes,
         boolean hd
     ) {
         this.schemaName = schemaName;
-        this.name = name;
+        this.tableName = tableName;
+        this.mapName = mapName;
         this.fields = fields;
         this.keyDescriptor = keyDescriptor;
         this.valueDescriptor = valueDescriptor;
+        this.keyJetMetadata = keyJetMetadata;
+        this.valueJetMetadata = valueJetMetadata;
         this.indexes = indexes;
         this.hd = hd;
         this.conflictingSchemas = conflictingSchemas;
@@ -68,10 +78,13 @@ public class PartitionedMapPlanObjectKey implements PlanObjectKey {
 
         return hd == that.hd
             && schemaName.equals(that.schemaName)
-            && name.equals(that.name)
+            && tableName.equals(that.tableName)
+            && mapName.equals(that.mapName)
             && fields.equals(that.fields)
             && keyDescriptor.equals(that.keyDescriptor)
             && valueDescriptor.equals(that.valueDescriptor)
+            && Objects.equals(keyJetMetadata, that.keyJetMetadata)
+            && Objects.equals(valueJetMetadata, that.valueJetMetadata)
             && indexes.equals(that.indexes)
             && conflictingSchemas.equals(that.conflictingSchemas);
     }
@@ -79,10 +92,13 @@ public class PartitionedMapPlanObjectKey implements PlanObjectKey {
     @Override
     public int hashCode() {
         int result = schemaName.hashCode();
-        result = 31 * result + name.hashCode();
+        result = 31 * result + tableName.hashCode();
+        result = 31 * result + mapName.hashCode();
         result = 31 * result + fields.hashCode();
         result = 31 * result + keyDescriptor.hashCode();
         result = 31 * result + valueDescriptor.hashCode();
+        result = 31 * result + Objects.hashCode(keyJetMetadata);
+        result = 31 * result + Objects.hashCode(valueJetMetadata.hashCode());
         result = 31 * result + indexes.hashCode();
         result = 31 * result + (hd ? 1 : 0);
         result = 31 * result + conflictingSchemas.hashCode();

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PartitionedMapPlanObjectKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PartitionedMapPlanObjectKey.java
@@ -38,6 +38,7 @@ public class PartitionedMapPlanObjectKey implements PlanObjectKey {
     private final boolean hd;
     private final Set<String> conflictingSchemas;
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     public PartitionedMapPlanObjectKey(
         String schemaName,
         String tableName,
@@ -65,6 +66,7 @@ public class PartitionedMapPlanObjectKey implements PlanObjectKey {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:cyclomaticcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PartitionedMapPlanObjectKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PartitionedMapPlanObjectKey.java
@@ -100,7 +100,7 @@ public class PartitionedMapPlanObjectKey implements PlanObjectKey {
         result = 31 * result + keyDescriptor.hashCode();
         result = 31 * result + valueDescriptor.hashCode();
         result = 31 * result + Objects.hashCode(keyJetMetadata);
-        result = 31 * result + Objects.hashCode(valueJetMetadata.hashCode());
+        result = 31 * result + Objects.hashCode(valueJetMetadata);
         result = 31 * result + indexes.hashCode();
         result = 31 * result + (hd ? 1 : 0);
         result = 31 * result + conflictingSchemas.hashCode();

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PlanObjectKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PlanObjectKey.java
@@ -19,6 +19,7 @@ package com.hazelcast.sql.impl.plan.cache;
 /**
  * ID of an object used in the plan.
  */
+@SuppressWarnings("checkstyle:interfaceistype")
 public interface PlanObjectKey {
 
     PlanObjectKey NON_CACHEABLE_OBJECT_ID = new PlanObjectKey() {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PlanObjectKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/plan/cache/PlanObjectKey.java
@@ -20,5 +20,7 @@ package com.hazelcast.sql.impl.plan.cache;
  * ID of an object used in the plan.
  */
 public interface PlanObjectKey {
-    // No-op.
+
+    PlanObjectKey NON_CACHEABLE_OBJECT_ID = new PlanObjectKey() {
+    };
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTable.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTable.java
@@ -78,11 +78,14 @@ public class PartitionedMapTable extends AbstractMapTable {
 
         return new PartitionedMapPlanObjectKey(
             getSchemaName(),
+            getSqlName(),
             getMapName(),
             getFields(),
             getConflictingSchemas(),
             getKeyDescriptor(),
             getValueDescriptor(),
+            getKeyJetMetadata(),
+            getValueJetMetadata(),
             getIndexes(),
             isHd()
         );


### PR DESCRIPTION
Added sql table name & upsert descriptors to map `PlanObjectKey` as they are required by Jet to support plan caching.