### PR TITLE
Increase AsyncSnapshotWriterImplTest timeout

### DIFF
--- a/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeUtils.java
+++ b/hazelcast-sql-core/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeUtils.java
@@ -103,7 +103,8 @@ public final class HazelcastTypeUtils {
     }
 
     public static QueryDataType toHazelcastType(SqlTypeName sqlTypeName) {
-        switch (sqlTypeName.getFamily()) {
+        // some types have null family (e.g. SqlTypeName.ROW), we fall back to default branch for those
+        switch (sqlTypeName.getFamily() != null ? sqlTypeName.getFamily() : SqlTypeFamily.ANY) {
             case INTERVAL_YEAR_MONTH:
                 return QueryDataType.INTERVAL_YEAR_MONTH;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
@@ -268,7 +268,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
 
         // Then
         assertTrueEventually(() ->
-                assertThat(String.valueOf(writer.getError()), StringContains.containsString("Always failing store")), 10);
+                assertThat(String.valueOf(writer.getError()), StringContains.containsString("Always failing store")));
     }
 
     @Test


### PR DESCRIPTION
Maybe fixes https://github.com/hazelcast/hazelcast-jet/issues/2972. The logs are garbled (it's a parallel test), the full
log is garbled too, artifacts have 45 bytes:
https://s3.console.aws.amazon.com/s3/object/j-artifacts?region=us-east-1&prefix=jet-oss-maintenance-oracle-jdk8/261/jet-oss-maintenance-oracle-jdk8-261.tar.
So this is just an attempt.