### PR TITLE
Replace concrete class with ClientEngine interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl;
 
+import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.metrics.impl.MetricsService;
@@ -120,7 +121,7 @@ public class JetService implements ManagedService, MembershipAwareService, LiveO
         nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(jobExecutionService);
         networking = new Networking(engine, jobExecutionService, config.getInstanceConfig().getFlowControlPeriodMs());
 
-        ClientEngineImpl clientEngine = engine.getService(ClientEngineImpl.SERVICE_NAME);
+        ClientEngine clientEngine = engine.getService(ClientEngineImpl.SERVICE_NAME);
         ExceptionUtil.registerJetExceptions(clientEngine.getExceptionFactory());
 
         logger.info("Setting number of cooperative threads and default parallelism to "


### PR DESCRIPTION
There are 2 implementations of `ClientEngine` (`NoOpClientEngine` when
no endpoint for `CLIENT` protocol is defined and `ClientEngineImpl` when
`CLIENT` protocol is served). Any can be used in a `HazelcastInstance`
so there should be no expectation of a specific implementation.

Fixes #18442