### PR TITLE
Enable usage of ExpressionEvalContext while evaluating table function arguments

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -78,8 +78,8 @@ class SeriesSqlConnector implements SqlConnector {
 
     @Nonnull
     @SuppressWarnings("SameParameterValue")
-    static SeriesTable createTable(String schemaName, String name, Integer start, Integer stop, Integer step) {
-        return new SeriesTable(INSTANCE, FIELDS, schemaName, name, start, stop, step);
+    static SeriesTable createTable(String schemaName, String name, List<Expression<?>> argumentExpressions) {
+        return new SeriesTable(INSTANCE, FIELDS, schemaName, name, argumentExpressions);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesTable.java
@@ -64,7 +64,7 @@ class SeriesTable extends JetTable {
                     Integer stop = evaluate(argumentExpressions.get(1), null, context);
                     Integer step = evaluate(argumentExpressions.get(2), 1, context);
                     if (start == null || stop == null || step == null) {
-                        throw QueryException.error("null arguments to GENERATE_SERIES functions");
+                        throw QueryException.error("null argument to GENERATE_SERIES function");
                     }
                     if (step == 0) {
                         throw QueryException.error("step cannot equal zero");

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesTable.java
@@ -64,10 +64,12 @@ class SeriesTable extends JetTable {
                     Integer stop = evaluate(argumentExpressions.get(1), null, context);
                     Integer step = evaluate(argumentExpressions.get(2), 1, context);
                     if (start == null || stop == null || step == null) {
-                        throw QueryException.error("null argument to GENERATE_SERIES function");
+                        throw QueryException.error("Invalid argument of a call to function GENERATE_SERIES" +
+                                " - null argument(s)");
                     }
                     if (step == 0) {
-                        throw QueryException.error("step cannot be equal to zero");
+                        throw QueryException.error("Invalid argument of a call to function GENERATE_SERIES" +
+                                " - step cannot be equal to zero");
                     }
 
                     return new DataGenerator(start, stop, step, predicate, projections, context);
@@ -103,11 +105,11 @@ class SeriesTable extends JetTable {
                 SimpleExpressionEvalContext context
         ) {
             this.iterator = IntStream.iterate(start, i -> i + step)
-                                     .limit(numberOfItems(start, stop, step))
-                                     .mapToObj(i -> ExpressionUtil.evaluate(predicate, projections, new Object[]{i},
-                                             context))
-                                     .filter(Objects::nonNull)
-                                     .iterator();
+                    .limit(numberOfItems(start, stop, step))
+                    .mapToObj(i -> ExpressionUtil.evaluate(predicate, projections, new Object[]{i},
+                            context))
+                    .filter(Objects::nonNull)
+                    .iterator();
         }
 
         private void fillBuffer(SourceBuffer<Object[]> buffer) {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesTable.java
@@ -67,7 +67,7 @@ class SeriesTable extends JetTable {
                         throw QueryException.error("null argument to GENERATE_SERIES function");
                     }
                     if (step == 0) {
-                        throw QueryException.error("step cannot equal zero");
+                        throw QueryException.error("step cannot be equal to zero");
                     }
 
                     return new DataGenerator(start, stop, step, predicate, projections, context);

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamGeneratorTableFunction.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamGeneratorTableFunction.java
@@ -26,11 +26,13 @@ import com.hazelcast.sql.impl.calcite.validate.HazelcastCallBinding;
 import com.hazelcast.sql.impl.calcite.validate.operand.OperandCheckerProgram;
 import com.hazelcast.sql.impl.calcite.validate.operand.TypedOperandChecker;
 import com.hazelcast.sql.impl.calcite.validate.operators.ReplaceUnknownOperandTypeInference;
+import com.hazelcast.sql.impl.expression.Expression;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
 
@@ -43,7 +45,7 @@ public final class StreamGeneratorTableFunction extends JetSpecificTableFunction
     public StreamGeneratorTableFunction() {
         super(
                 FUNCTION_NAME,
-                binding -> toTable(0).getRowType(binding.getTypeFactory()),
+                binding -> toTable0(emptyList()).getRowType(binding.getTypeFactory()),
                 new ReplaceUnknownOperandTypeInference(INTEGER),
                 StreamSqlConnector.INSTANCE
         );
@@ -73,14 +75,12 @@ public final class StreamGeneratorTableFunction extends JetSpecificTableFunction
     }
 
     @Override
-    public HazelcastTable toTable(List<Object> arguments) {
-        Integer rate = (Integer) arguments.get(0);
-
-        return toTable(rate);
+    public HazelcastTable toTable(List<Expression<?>> argumentExpressions) {
+        return toTable0(argumentExpressions);
     }
 
-    private static HazelcastTable toTable(Integer rate) {
-        StreamTable table = StreamSqlConnector.createTable(SCHEMA_NAME_STREAM, randomName(), rate);
+    private static HazelcastTable toTable0(List<Expression<?>> argumentExpressions) {
+        StreamTable table = StreamSqlConnector.createTable(SCHEMA_NAME_STREAM, randomName(), argumentExpressions);
         return new HazelcastTable(table, new HazelcastTableStatistic(Integer.MAX_VALUE));
     }
 

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -78,8 +78,8 @@ class StreamSqlConnector implements SqlConnector {
 
     @Nonnull
     @SuppressWarnings("SameParameterValue")
-    static StreamTable createTable(String schemaName, String name, Integer rate) {
-        return new StreamTable(INSTANCE, FIELDS, schemaName, name, rate);
+    static StreamTable createTable(String schemaName, String name, List<Expression<?>> argumentExpressions) {
+        return new StreamTable(INSTANCE, FIELDS, schemaName, name, argumentExpressions);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamTable.java
@@ -62,10 +62,12 @@ class StreamTable extends JetTable {
 
                     Integer rate = evaluate(argumentExpressions.get(0), context);
                     if (rate == null) {
-                        throw QueryException.error("rate cannot be null");
+                        throw QueryException.error("Invalid argument of a call to function GENERATE_STREAM" +
+                                " - rate cannot be null");
                     }
                     if (rate < 0) {
-                        throw QueryException.error("rate cannot be less than zero");
+                        throw QueryException.error("Invalid argument of a call to function GENERATE_STREAM" +
+                                " - rate cannot be less than zero");
                     }
 
                     return new DataGenerator(rate, predicate, projections, context);

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/JetSpecificTableFunction.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/JetSpecificTableFunction.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import com.hazelcast.sql.impl.calcite.validate.operators.common.HazelcastFunction;
+import com.hazelcast.sql.impl.expression.Expression;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
@@ -55,5 +56,5 @@ public abstract class JetSpecificTableFunction extends HazelcastFunction impleme
         return connector.isStream();
     }
 
-    public abstract HazelcastTable toTable(List<Object> arguments);
+    public abstract HazelcastTable toTable(List<Expression<?>> argumentExpressions);
 }

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlSeriesGeneratorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlSeriesGeneratorTest.java
@@ -138,7 +138,7 @@ public class SqlSeriesGeneratorTest extends SqlTestSupport {
 
     @Test
     public void when_stepIsZero_then_throws() {
-        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(0, 5, 0))"))
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(0, 5, 0))").iterator().next())
                 .hasMessageContaining("step cannot equal zero");
     }
 
@@ -150,8 +150,8 @@ public class SqlSeriesGeneratorTest extends SqlTestSupport {
 
     @Test
     public void test_nullArgument() {
-        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(null, null))"))
-                .hasMessage("null arguments to GENERATE_SERIES functions");
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(null, null))").iterator().next())
+                .hasMessageContaining("null arguments to GENERATE_SERIES functions");
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlSeriesGeneratorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlSeriesGeneratorTest.java
@@ -139,7 +139,7 @@ public class SqlSeriesGeneratorTest extends SqlTestSupport {
     @Test
     public void when_stepIsZero_then_throws() {
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(0, 5, 0))").iterator().next())
-                .hasMessageContaining("step cannot equal zero");
+                .hasMessageContaining("GENERATE_SERIES - step cannot be equal to zero");
     }
 
     @Test
@@ -151,7 +151,7 @@ public class SqlSeriesGeneratorTest extends SqlTestSupport {
     @Test
     public void test_nullArgument() {
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(null, null))").iterator().next())
-                .hasMessageContaining("null arguments to GENERATE_SERIES functions");
+                .hasMessageContaining("GENERATE_SERIES - null argument(s)");
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlStreamGeneratorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlStreamGeneratorTest.java
@@ -100,7 +100,7 @@ public class SqlStreamGeneratorTest extends SqlTestSupport {
 
     @Test
     public void when_rateIsNegative_then_throws() {
-        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(-1))"))
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(-1))").iterator().next())
                 .hasMessageContaining("rate cannot be less than zero");
     }
 
@@ -112,8 +112,8 @@ public class SqlStreamGeneratorTest extends SqlTestSupport {
 
     @Test
     public void test_nullArgument() {
-        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(null))"))
-                .hasMessage("rate cannot be null");
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(null))").iterator().next())
+                .hasMessageContaining("rate cannot be null");
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlStreamGeneratorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlStreamGeneratorTest.java
@@ -101,7 +101,7 @@ public class SqlStreamGeneratorTest extends SqlTestSupport {
     @Test
     public void when_rateIsNegative_then_throws() {
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(-1))").iterator().next())
-                .hasMessageContaining("rate cannot be less than zero");
+                .hasMessageContaining("GENERATE_STREAM - rate cannot be less than zero");
     }
 
     @Test
@@ -113,7 +113,7 @@ public class SqlStreamGeneratorTest extends SqlTestSupport {
     @Test
     public void test_nullArgument() {
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(null))").iterator().next())
-                .hasMessageContaining("rate cannot be null");
+                .hasMessageContaining("GENERATE_STREAM - rate cannot be null");
     }
 
     @Test


### PR DESCRIPTION
Refactored table functions, so the evaluation of arguments is performed during `DAG` creation - it's an enabler for future work on dynamic parameters.