### PR TITLE
Adds quick build profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,18 +120,6 @@ You can use the following channels for getting help with Hazelcast:
   development team and other Hazelcast users.
 * [Stack Overflow](https://stackoverflow.com/tags/hazelcast)
 
-## Contributing
-
-We encourage Pull Requests and process them promptly.
-
-To contribute:
-
-* see [Developing with Git](https://hazelcast.atlassian.net/wiki/display/COM/Developing+with+Git) for our Git process
-* complete the [Hazelcast Contributor Agreement](https://hazelcast.atlassian.net/wiki/display/COM/Hazelcast+Contributor+Agreement)
-
-For an enhancement or larger feature, create a GitHub issue first to
-discuss.
-
 ### Using Snapshot Releases
 
 Maven snippet:
@@ -157,8 +145,16 @@ Maven snippet:
 
 ### Building From Source
 
-Pull latest from repo `git pull origin master` and use Maven install (or
-package) to build `mvn clean install`.
+Building Hazelcast requires JDK 1.8. Pull the latest source from the repository and use
+Maven install (or package) to build:
+```bash
+$ git pull origin master
+$ mvn clean install
+```
+
+Take into account that the default build executes thousands of tests which may take a
+considerable amount of time. Additionally, there is a `quick` profile that skips
+checkstyle validation and does not build `extensions` and `distribution` modules. 
 
 ### Testing
 
@@ -174,7 +170,7 @@ Hazelcast has 3 testing profiles:
 ### Checkstyle
 
 Hazelcast uses static code analysis tools to check if a Pull Request is
-ready for merge. Run the following commandslocally to check if your
+ready for merge. Run the following commands locally to check if your
 contribution is Checkstyle compatible.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ $ mvn clean install
 ```
 
 Take into account that the default build executes thousands of tests which may take a
-considerable amount of time. Additionally, there is a `quick` profile that skips
-checkstyle validation and does not build `extensions` and `distribution` modules. 
+considerable amount of time. Additionally, there is a `quick` build activated by
+setting the `-Dquick` system property that skips tests, checkstyle validation,
+javadoc and source plugins and does not build `extensions` and `distribution` modules.
 
 ### Testing
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,19 +28,6 @@
     <description>Hazelcast In-Memory DataGrid</description>
     <url>http://www.hazelcast.com/</url>
 
-    <modules>
-        <module>extensions</module>
-        <module>hazelcast</module>
-        <module>hazelcast-jet-sql</module>
-        <module>hazelcast-spring</module>
-        <module>hazelcast-spring-tests</module>
-        <module>hazelcast-build-utils</module>
-        <module>hazelcast-sql-core</module>
-        <module>hazelcast-sql</module>
-        <module>hazelcast-all</module>
-        <module>distribution</module>
-    </modules>
-
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -443,6 +430,24 @@
 
     <profiles>
         <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
+        </profile>
+        <profile>
             <!-- used by the PR builder -->
             <id>parallelTest</id>
             <build>
@@ -593,6 +598,18 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
 
         <profile>
@@ -664,6 +681,18 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
 
         <profile>
@@ -726,6 +755,18 @@
                     </plugin>
                 </plugins>
             </reporting>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
 
         <profile>
@@ -833,6 +874,18 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
 
         <profile>
@@ -890,7 +943,16 @@
                 </plugins>
             </build>
             <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
                 <module>hazelcast-all</module>
+                <module>distribution</module>
             </modules>
         </profile>
 
@@ -901,7 +963,16 @@
                 <javadoc>true</javadoc>
             </properties>
             <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
                 <module>hazelcast-all</module>
+                <module>distribution</module>
             </modules>
             <build>
                 <plugins>
@@ -929,6 +1000,32 @@
         <profile>
             <id>zip</id>
             <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>quick</id>
+            <properties>
+                <checkstyle.skip>true</checkstyle.skip>
+            </properties>
+            <modules>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
                 <module>hazelcast-all</module>
             </modules>
         </profile>
@@ -1000,6 +1097,18 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
 
         <profile>
@@ -1061,6 +1170,18 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
 
         <profile>
@@ -1095,6 +1216,16 @@
                 </javaModuleArgs>
             </properties>
             <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
                 <module>modulepath-tests</module>
             </modules>
         </profile>
@@ -1152,6 +1283,18 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>extensions</module>
+                <module>hazelcast</module>
+                <module>hazelcast-jet-sql</module>
+                <module>hazelcast-spring</module>
+                <module>hazelcast-spring-tests</module>
+                <module>hazelcast-build-utils</module>
+                <module>hazelcast-sql-core</module>
+                <module>hazelcast-sql</module>
+                <module>hazelcast-all</module>
+                <module>distribution</module>
+            </modules>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,19 @@
     <description>Hazelcast In-Memory DataGrid</description>
     <url>http://www.hazelcast.com/</url>
 
+    <modules>
+        <module>extensions</module>
+        <module>hazelcast</module>
+        <module>hazelcast-jet-sql</module>
+        <module>hazelcast-spring</module>
+        <module>hazelcast-spring-tests</module>
+        <module>hazelcast-build-utils</module>
+        <module>hazelcast-sql-core</module>
+        <module>hazelcast-sql</module>
+        <module>hazelcast-all</module>
+        <module>distribution</module>
+    </modules>
+
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -430,24 +443,6 @@
 
     <profiles>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
-        </profile>
-        <profile>
             <!-- used by the PR builder -->
             <id>parallelTest</id>
             <build>
@@ -598,18 +593,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
 
         <profile>
@@ -681,18 +664,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
 
         <profile>
@@ -755,18 +726,6 @@
                     </plugin>
                 </plugins>
             </reporting>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
 
         <profile>
@@ -874,18 +833,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
 
         <profile>
@@ -943,16 +890,7 @@
                 </plugins>
             </build>
             <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
                 <module>hazelcast-all</module>
-                <module>distribution</module>
             </modules>
         </profile>
 
@@ -963,16 +901,7 @@
                 <javadoc>true</javadoc>
             </properties>
             <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
                 <module>hazelcast-all</module>
-                <module>distribution</module>
             </modules>
             <build>
                 <plugins>
@@ -1000,32 +929,6 @@
         <profile>
             <id>zip</id>
             <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>quick</id>
-            <properties>
-                <checkstyle.skip>true</checkstyle.skip>
-            </properties>
-            <modules>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
                 <module>hazelcast-all</module>
             </modules>
         </profile>
@@ -1097,18 +1000,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
 
         <profile>
@@ -1170,18 +1061,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
 
         <profile>
@@ -1216,16 +1095,6 @@
                 </javaModuleArgs>
             </properties>
             <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
                 <module>modulepath-tests</module>
             </modules>
         </profile>
@@ -1283,18 +1152,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-                <module>extensions</module>
-                <module>hazelcast</module>
-                <module>hazelcast-jet-sql</module>
-                <module>hazelcast-spring</module>
-                <module>hazelcast-spring-tests</module>
-                <module>hazelcast-build-utils</module>
-                <module>hazelcast-sql-core</module>
-                <module>hazelcast-sql</module>
-                <module>hazelcast-all</module>
-                <module>distribution</module>
-            </modules>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <url>http://www.hazelcast.com/</url>
 
     <modules>
-        <module>extensions</module>
         <module>hazelcast</module>
         <module>hazelcast-jet-sql</module>
         <module>hazelcast-spring</module>
@@ -38,7 +37,6 @@
         <module>hazelcast-sql-core</module>
         <module>hazelcast-sql</module>
         <module>hazelcast-all</module>
-        <module>distribution</module>
     </modules>
 
     <properties>
@@ -1152,6 +1150,34 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>not-quick</id>
+            <activation>
+                <property>
+                    <name>!quick</name>
+                </property>
+            </activation>
+            <modules>
+                <module>extensions</module>
+                <module>distribution</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>quick</id>
+            <activation>
+                <property>
+                    <name>quick</name>
+                </property>
+            </activation>
+            <properties>
+                <checkstyle.skip>true</checkstyle.skip>
+                <spotbugs.skip>true</spotbugs.skip>
+                <skipTests>true</skipTests>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <maven.source.skip>true</maven.source.skip>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Quick profile does not build `extensions` and
`distribution` modules. Also disables `checkstyle` validation.