### PR TITLE
Incorporate smallInstanceConfig to spring tests

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
@@ -61,7 +61,7 @@ public class TestClientNetworkConfig {
 
     @Test
     public void smokeMember() {
-        int memberCountInConfigurationXml = 2;
+        int memberCountInConfigurationXml = 10;
         ClientConfig config = client.getClientConfig();
         assertEquals(memberCountInConfigurationXml, config.getNetworkConfig().getAddresses().size());
     }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestEmptyApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestEmptyApplicationContext.java
@@ -16,12 +16,10 @@
 
 package com.hazelcast.spring;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,8 +35,6 @@ import static org.junit.Assert.assertNotNull;
 @Category(QuickTest.class)
 public class TestEmptyApplicationContext {
 
-    private Config config;
-
     @Resource(name = "instance")
     private HazelcastInstance instance;
 
@@ -48,13 +44,8 @@ public class TestEmptyApplicationContext {
         Hazelcast.shutdownAll();
     }
 
-    @Before
-    public void before() {
-        config = instance.getConfig();
-    }
-
     @Test
     public void testXmlWithoutConfig() {
-        assertNotNull(config);
+        assertNotNull(instance.getConfig());
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -773,7 +773,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         NetworkConfig networkConfig = config.getNetworkConfig();
         assertNotNull(networkConfig);
         assertEquals(5700, networkConfig.getPort());
-        assertFalse(networkConfig.isPortAutoIncrement());
+        assertTrue(networkConfig.isPortAutoIncrement());
 
         Collection<String> allowedPorts = networkConfig.getOutboundPortDefinitions();
         assertEquals(2, allowedPorts.size());
@@ -793,7 +793,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("10.10.1.*", networkConfig.getInterfaces().getInterfaces().iterator().next());
         TcpIpConfig tcp = networkConfig.getJoin().getTcpIpConfig();
         assertNotNull(tcp);
-        assertTrue(tcp.isEnabled());
+        assertFalse(tcp.isEnabled());
         SymmetricEncryptionConfig symmetricEncryptionConfig = networkConfig.getSymmetricEncryptionConfig();
         assertFalse(symmetricEncryptionConfig.isEnabled());
         assertEquals("PBEWithMD5AndDES", symmetricEncryptionConfig.getAlgorithm());
@@ -1062,7 +1062,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     @Test
     public void testPartitionGroupConfig() {
         PartitionGroupConfig pgc = config.getPartitionGroupConfig();
-        assertTrue(pgc.isEnabled());
+        assertFalse(pgc.isEnabled());
         assertEquals(PartitionGroupConfig.MemberGroupType.CUSTOM, pgc.getGroupType());
         assertEquals(2, pgc.getMemberGroupConfigs().size());
         for (MemberGroupConfig mgc : pgc.getMemberGroupConfigs()) {

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTest.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -34,7 +33,6 @@ import org.springframework.test.context.ContextConfiguration;
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"readtimeout-config.xml"})
 @Category(QuickTest.class)
-@Ignore("https://github.com/hazelcast/hazelcast/issues/18447")
 public class HazelcastCacheReadTimeoutTest extends AbstractHazelcastCacheReadTimeoutTest {
 
     @BeforeClass

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithJavaConfig.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithJavaConfig.java
@@ -17,13 +17,13 @@
 package com.hazelcast.spring.cache;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.cache.annotation.EnableCaching;
@@ -43,7 +43,6 @@ import java.util.Arrays;
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = HazelcastCacheReadTimeoutTestWithJavaConfig.TestConfig.class)
 @Category(QuickTest.class)
-@Ignore("https://github.com/hazelcast/hazelcast/issues/18455")
 public class HazelcastCacheReadTimeoutTestWithJavaConfig extends AbstractHazelcastCacheReadTimeoutTest {
 
     @Configuration
@@ -63,16 +62,14 @@ public class HazelcastCacheReadTimeoutTestWithJavaConfig extends AbstractHazelca
 
         @Bean
         Config config() {
-            Config config = new Config();
-            config.setProperty("hazelcast.wait.seconds.before.join", "0");
+            Config config = smallInstanceConfig();
             config.setProperty("hazelcast.graceful.shutdown.max.wait", "120");
             config.setProperty("hazelcast.partition.backup.sync.interval", "1");
 
-            config.getNetworkConfig().setPort(5701).setPortAutoIncrement(false);
-            config.getNetworkConfig().getJoin()
-                    .getTcpIpConfig()
-                    .setEnabled(true)
-                    .getMembers().add("127.0.0.1:5701");
+            JoinConfig join = config.getNetworkConfig().getJoin();
+            join.getMulticastConfig().setEnabled(false);
+            join.getAutoDetectionConfig().setEnabled(false);
+
             config.getNetworkConfig().getInterfaces()
                     .setEnabled(true)
                     .setInterfaces(Arrays.asList("127.0.0.1"));
@@ -93,7 +90,6 @@ public class HazelcastCacheReadTimeoutTestWithJavaConfig extends AbstractHazelca
         }
 
     }
-
 
     @BeforeClass
     @AfterClass

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithPropFile.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithPropFile.java
@@ -21,7 +21,6 @@ import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -34,7 +33,6 @@ import org.springframework.test.context.ContextConfiguration;
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"readtimeout-config-prop-file.xml"})
 @Category(QuickTest.class)
-@Ignore("https://github.com/hazelcast/hazelcast/issues/18454")
 public class HazelcastCacheReadTimeoutTestWithPropFile extends AbstractHazelcastCacheReadTimeoutTest {
 
     @BeforeClass

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spring.cache;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
@@ -37,7 +36,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -118,14 +116,7 @@ public class TestCacheManager extends HazelcastTestSupport {
             }
         });
 
-        Config config = new Config();
-        config.getNetworkConfig().setPublicAddress("127.0.0.1")
-                .setPort(5101).setPortAutoIncrement(true);
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        join.getTcpIpConfig().setEnabled(true).setMembers(
-                Arrays.asList(
-                        "127.0.0.1"));
-        HazelcastInstance testInstance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance testInstance = Hazelcast.newHazelcastInstance(extractConfig());
         testInstance.getMap(testMap);
         // be sure that test-map is distributed
         HazelcastTestSupport.assertOpenEventually(distributionSignal);
@@ -168,5 +159,17 @@ public class TestCacheManager extends HazelcastTestSupport {
             }
             return null;
         }
+    }
+
+    private Config extractConfig() {
+        Config config = instance.getConfig();
+        Config extractedConfig = new Config();
+        extractedConfig
+                .setClusterName(config.getClusterName())
+                .setNetworkConfig(config.getNetworkConfig())
+                .setJetConfig(config.getJetConfig())
+                .setSqlConfig(config.getSqlConfig());
+
+        return extractedConfig;
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/hotrestart/TestHotRestartEncryptionKeyStoreApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/hotrestart/TestHotRestartEncryptionKeyStoreApplicationContext.java
@@ -16,16 +16,12 @@
 
 package com.hazelcast.spring.hotrestart;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.config.EncryptionAtRestConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.JavaKeyStoreSecureStoreConfig;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.nio.ssl.SSLContextFactory;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,23 +41,14 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class TestHotRestartEncryptionKeyStoreApplicationContext {
 
-    @Resource(name = "instance")
-    private HazelcastInstance instance;
-
-    @Resource
-    private SSLContextFactory sslContextFactory;
-
-    @BeforeClass
-    @AfterClass
-    public static void start() {
-        Hazelcast.shutdownAll();
-    }
+    @Resource(name = "theConfig")
+    private Config config;
 
     @Test
     public void testHotRestart() {
         File dir = new File("/mnt/hot-restart/");
         File hotBackupDir = new File("/mnt/hot-backup/");
-        HotRestartPersistenceConfig hotRestartPersistenceConfig = instance.getConfig().getHotRestartPersistenceConfig();
+        HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
 
         assertFalse(hotRestartPersistenceConfig.isEnabled());
         assertEquals(dir.getAbsolutePath(), hotRestartPersistenceConfig.getBaseDir().getAbsolutePath());

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/hotrestart/TestHotRestartEncryptionVaultApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/hotrestart/TestHotRestartEncryptionVaultApplicationContext.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.spring.hotrestart;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.config.EncryptionAtRestConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.VaultSecureStoreConfig;
 import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.ssl.SSLContextFactory;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -46,8 +46,8 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class TestHotRestartEncryptionVaultApplicationContext {
 
-    @Resource(name = "instance")
-    private HazelcastInstance instance;
+    @Resource(name = "theConfig")
+    private Config config;
 
     @Resource
     private SSLContextFactory sslContextFactory;
@@ -62,7 +62,7 @@ public class TestHotRestartEncryptionVaultApplicationContext {
     public void testHotRestart() {
         File dir = new File("/mnt/hot-restart/");
         File hotBackupDir = new File("/mnt/hot-backup/");
-        HotRestartPersistenceConfig hotRestartPersistenceConfig = instance.getConfig().getHotRestartPersistenceConfig();
+        HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
 
         assertFalse(hotRestartPersistenceConfig.isEnabled());
         assertEquals(dir.getAbsolutePath(), hotRestartPersistenceConfig.getBaseDir().getAbsolutePath());

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/security/SecureApplicationContextTest.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/security/SecureApplicationContextTest.java
@@ -25,15 +25,12 @@ import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SecurityInterceptorConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.security.ICredentialsFactory;
 import com.hazelcast.security.IPermissionPolicy;
 import com.hazelcast.security.SecurityInterceptor;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -64,12 +61,6 @@ public class SecureApplicationContextTest {
 
     @Resource
     private IPermissionPolicy dummyPermissionPolicy;
-
-    @BeforeClass
-    @AfterClass
-    public static void start() {
-        Hazelcast.shutdownAll();
-    }
 
     @Before
     public void init() {

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -26,7 +26,6 @@ import com.hazelcast.transaction.TransactionalTaskContext;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,7 +43,6 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"transaction-applicationContext-hazelcast.xml"})
 @Category(QuickTest.class)
-@Ignore("https://github.com/hazelcast/hazelcast/issues/18448")
 public class TestSpringManagedHazelcastTransaction {
 
     @BeforeClass

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -265,6 +265,14 @@
                 <hz:attribute name="cluster.name">spring-cluster</hz:attribute>
             </hz:member-attributes>
 
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -35,7 +35,7 @@
     <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
         <hz:config>
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
-            <hz:network port="5701">
+            <hz:network port="5950">
                 <hz:join>
                     <hz:multicast enabled="${boolean.false}"/>
                     <hz:aws enabled="false"/>
@@ -53,7 +53,14 @@
             </hz:native-memory>
             <hz:queue name="testQueue" priority-comparator-class-name="com.hazelcast.collection.impl.queue.model.PriorityElementComparator">
             </hz:queue>
-
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -63,9 +70,16 @@
                     redo-operation="true"
                     smart-routing="true">
 
-            <hz:member>127.0.0.1:5701</hz:member>
-            <hz:member>127.0.0.1:5702</hz:member>
-            <hz:member>127.0.0.1:5703</hz:member>
+            <hz:member>127.0.0.1:5950</hz:member>
+            <hz:member>127.0.0.1:5951</hz:member>
+            <hz:member>127.0.0.1:5952</hz:member>
+            <hz:member>127.0.0.1:5953</hz:member>
+            <hz:member>127.0.0.1:5954</hz:member>
+            <hz:member>127.0.0.1:5955</hz:member>
+            <hz:member>127.0.0.1:5956</hz:member>
+            <hz:member>127.0.0.1:5957</hz:member>
+            <hz:member>127.0.0.1:5958</hz:member>
+            <hz:member>127.0.0.1:5959</hz:member>
 
             <hz:socket-options buffer-size="32"
                                keep-alive="false"

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
@@ -30,12 +30,12 @@
 
     <hz:hazelcast id="instance">
         <hz:config>
-            <hz:cluster-name>dev</hz:cluster-name>
-            <hz:network port="5101" port-auto-increment="true">
+            <hz:cluster-name>test-cache-manager</hz:cluster-name>
+            <hz:network port="5101">
                 <hz:join>
                     <hz:multicast enabled="false"/>
                     <hz:tcp-ip enabled="true">
-                        <hz:members>127.0.0.1</hz:members>
+                        <hz:member>127.0.0.1</hz:member>
                     </hz:tcp-ip>
                 </hz:join>
             </hz:network>
@@ -46,6 +46,14 @@
             <hz:map name="null-map"/>
             <hz:map name="map-with-ttl" time-to-live-seconds="1">
             </hz:map>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
@@ -59,6 +59,14 @@
                     <hz:partition-lost-listener class-name="com.hazelcast.spring.cache.JCachePartitionLostListener"/>
                 </hz:partition-lost-listeners>
             </hz:cache>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
@@ -43,6 +43,14 @@
             </hz:network>
             <hz:cache name="name"/>
             <hz:cache name="city"/>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
@@ -46,21 +46,22 @@
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
                 <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
             </hz:properties>
-            <hz:network port="${cluster.port}" port-auto-increment="false">
+            <hz:network port="${cluster.port}">
                 <hz:join>
-                    <hz:multicast enabled="false"
-                                  multicast-group="224.2.2.3"
-                                  multicast-port="54327"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
+                    <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
-                <hz:interfaces enabled="false">
-                    <hz:interface>10.10.1.*</hz:interface>
-                </hz:interfaces>
             </hz:network>
             <hz:cache name="city"/>
             <hz:cache name="name"/>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -72,9 +73,15 @@
         <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
-            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member> 127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
-
+            <hz:member>127.0.0.1:5702</hz:member>
+            <hz:member>127.0.0.1:5703</hz:member>
+            <hz:member>127.0.0.1:5704</hz:member>
+            <hz:member>127.0.0.1:5705</hz:member>
+            <hz:member>127.0.0.1:5707</hz:member>
+            <hz:member>127.0.0.1:5708</hz:member>
+            <hz:member>127.0.0.1:5709</hz:member>
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
                                linger-seconds="3"

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
@@ -31,7 +31,6 @@
         <hz:config>
             <hz:cluster-name>dev</hz:cluster-name>
             <hz:properties>
-                <hz:property name="hazelcast.wait.seconds.before.join">0</hz:property>
                 <hz:property name="hazelcast.graceful.shutdown.max.wait">120</hz:property>
                 <hz:property name="hazelcast.partition.backup.sync.interval">1</hz:property>
             </hz:properties>
@@ -45,6 +44,14 @@
                 </hz:interfaces>
             </hz:network>
             <hz:map name="delayNo"/>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
@@ -36,16 +36,13 @@
         <hz:config>
             <hz:cluster-name>dev</hz:cluster-name>
             <hz:properties>
-                <hz:property name="hazelcast.wait.seconds.before.join">0</hz:property>
                 <hz:property name="hazelcast.graceful.shutdown.max.wait">120</hz:property>
                 <hz:property name="hazelcast.partition.backup.sync.interval">1</hz:property>
             </hz:properties>
-            <hz:network port="5701" port-auto-increment="false">
+            <hz:network port="5701">
                 <hz:join>
                     <hz:multicast enabled="false"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:interface>127.0.0.1:5701</hz:interface>
-                    </hz:tcp-ip>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>
@@ -55,6 +52,14 @@
             <hz:map name="delay50"/>
             <hz:map name="delayNo"/>
             <hz:map name="delay100"/>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
@@ -31,16 +31,13 @@
         <hz:config>
             <hz:cluster-name>dev</hz:cluster-name>
             <hz:properties>
-                <hz:property name="hazelcast.wait.seconds.before.join">0</hz:property>
                 <hz:property name="hazelcast.graceful.shutdown.max.wait">120</hz:property>
                 <hz:property name="hazelcast.partition.backup.sync.interval">1</hz:property>
             </hz:properties>
-            <hz:network port="5701" port-auto-increment="false">
+            <hz:network port="5701">
                 <hz:join>
                     <hz:multicast enabled="false"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:interface>127.0.0.1:5701</hz:interface>
-                    </hz:tcp-ip>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>
@@ -50,6 +47,14 @@
             <hz:map name="delay50"/>
             <hz:map name="delayNo"/>
             <hz:map name="delay100"/>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
@@ -25,6 +25,14 @@
     <hz:hazelcast id="instance">
         <hz:config>
             <hz:map name="test"/>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
@@ -22,9 +22,22 @@
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring-5.0.xsd">
 
-    <hz:hazelcast id="instance"/>
+    <hz:hazelcast id="instance">
+        <hz:config>
+            <hz:cluster-name>client-network-default</hz:cluster-name>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
+        </hz:config>
+    </hz:hazelcast>
 
     <hz:client id="client">
+        <hz:cluster-name>client-network-default</hz:cluster-name>
         <hz:network/>
     </hz:client>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -40,14 +40,10 @@
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
                 <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
             </hz:properties>
-            <hz:network port="${cluster.port}" port-auto-increment="false">
+            <hz:network port="${cluster.port}">
                 <hz:join>
-                    <hz:multicast enabled="false"
-                                  multicast-group="224.2.2.3"
-                                  multicast-port="54327"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
+                    <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="false">
                     <hz:interface>10.10.1.*</hz:interface>
@@ -62,6 +58,14 @@
                     </hz:properties>
                 </hz:ssl>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -72,6 +76,14 @@
                     smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:5702</hz:member>
+            <hz:member>127.0.0.1:5703</hz:member>
+            <hz:member>127.0.0.1:5704</hz:member>
+            <hz:member>127.0.0.1:5705</hz:member>
+            <hz:member>127.0.0.1:5706</hz:member>
+            <hz:member>127.0.0.1:5707</hz:member>
+            <hz:member>127.0.0.1:5708</hz:member>
+            <hz:member>127.0.0.1:5709</hz:member>
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
                                linger-seconds="3"

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
@@ -43,6 +43,14 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -55,6 +63,14 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
@@ -46,6 +46,14 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
@@ -42,9 +42,17 @@
             <hz:network port="${cluster.port}">
                 <hz:join>
                     <hz:multicast enabled="false"/>
-                    <hz:tcp-ip enabled="true"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
@@ -124,6 +124,15 @@
                       cache-loader="com.hazelcast.config.CacheConfigTest$MyCacheLoader"
                       cache-writer="com.hazelcast.config.CacheConfigTest$EmptyCacheWriter"
             />
+
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
@@ -37,6 +37,15 @@
                 </hz:interfaces>
             </hz:network>
             <hz:lite-member enabled="true"/>
+
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-applicationContext.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-applicationContext.xml
@@ -35,28 +35,54 @@
 
     <hz:hazelcast id="instance">
         <hz:config>
+            <hz:cluster-name>${cluster.name}</hz:cluster-name>
             <hz:network port="${cluster.port}" port-auto-increment="false">
                 <hz:join>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
+                    <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
     <hz:client id="client1">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000" smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:5702</hz:member>
+            <hz:member>127.0.0.1:5703</hz:member>
+            <hz:member>127.0.0.1:5704</hz:member>
+            <hz:member>127.0.0.1:5705</hz:member>
+            <hz:member>127.0.0.1:5706</hz:member>
+            <hz:member>127.0.0.1:5707</hz:member>
+            <hz:member>127.0.0.1:5708</hz:member>
+            <hz:member>127.0.0.1:5709</hz:member>
         </hz:network>
         <hz:load-balancer type="custom" class-name="com.hazelcast.client.test.CustomLoadBalancer"/>
     </hz:client>
 
     <hz:client id="client2">
+        <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network connection-timeout="1000" smart-routing="false">
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:5702</hz:member>
+            <hz:member>127.0.0.1:5703</hz:member>
+            <hz:member>127.0.0.1:5704</hz:member>
+            <hz:member>127.0.0.1:5705</hz:member>
+            <hz:member>127.0.0.1:5706</hz:member>
+            <hz:member>127.0.0.1:5707</hz:member>
+            <hz:member>127.0.0.1:5708</hz:member>
+            <hz:member>127.0.0.1:5709</hz:member>
         </hz:network>
         <hz:load-balancer type="custom" implementation="customLoadBalancer"/>
     </hz:client>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/discoveryConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/discoveryConfig-applicationContext-hazelcast.xml
@@ -72,6 +72,14 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -125,7 +125,7 @@
             <hz:wan-replication name="testWan3">
                 <hz:consumer persist-wan-replicated-data="false"/>
             </hz:wan-replication>
-            <hz:network port="${cluster.port}" port-auto-increment="false" port-count="42">
+            <hz:network port="${cluster.port}" port-auto-increment="true" port-count="42">
                 <hz:outbound-ports>
                     <hz:ports>35000-35100</hz:ports>
                     <hz:ports>36000,36100</hz:ports>
@@ -137,7 +137,7 @@
                             <hz:interface>10.10.10.*</hz:interface>
                         </hz:trusted-interfaces>
                     </hz:multicast>
-                    <hz:tcp-ip enabled="${boolean.true}">
+                    <hz:tcp-ip enabled="${boolean.false}">
                         <hz:required-member>127.0.0.1:5700</hz:required-member>
                         <!--                         <hz:members>${cluster.members}</hz:members> -->
                         <hz:interface>127.0.0.1:5700</hz:interface>
@@ -215,7 +215,7 @@
                 </hz:rest-api>
                 <hz:memcache-protocol enabled="true"/>
             </hz:network>
-            <hz:partition-group enabled="true" group-type="CUSTOM">
+            <hz:partition-group enabled="false" group-type="CUSTOM">
                 <hz:member-group>
                     <hz:interface>127.0.0.1</hz:interface>
                     <hz:interface>127.0.0.2</hz:interface>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
@@ -38,22 +38,22 @@
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
             <hz:network port="${cluster.port}" port-auto-increment="false">
                 <hz:join>
-                    <hz:multicast enabled="false"
-                                  multicast-group="224.2.2.3"
-                                  multicast-port="54327"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
+                    <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
-                <hz:interfaces enabled="false">
-                    <hz:interface>10.10.1.*</hz:interface>
-                </hz:interfaces>
-
             </hz:network>
             <hz:executor-service name="testExec"
                                  pool-size="2"
                                  queue-capacity="100"
             />
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hotrestart/hot-restart-encryption-keystore-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hotrestart/hot-restart-encryption-keystore-applicationContext-hazelcast.xml
@@ -22,33 +22,30 @@
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring-5.0.xsd">
 
-    <hz:hazelcast id="instance">
-        <hz:config>
-            <hz:hot-restart-persistence enabled="false"
-                                        validation-timeout-seconds="1111"
-                                        data-load-timeout-seconds="2222"
-                                        auto-remove-stale-data="false"
-                                        cluster-data-recovery-policy="PARTIAL_RECOVERY_MOST_COMPLETE">
-                <hz:base-dir>/mnt/hot-restart/</hz:base-dir>
-                <hz:backup-dir>/mnt/hot-backup/</hz:backup-dir>
-                <hz:encryption-at-rest enabled="true">
-                    <hz:algorithm>AES/CBC/PKCS5Padding</hz:algorithm>
-                    <hz:salt>sugar</hz:salt>
-                    <hz:key-size>16</hz:key-size>
-                    <hz:secure-store>
-                        <hz:keystore>
-                            <hz:path>/mnt/hot-restart/keystore.p12</hz:path>
-                            <hz:type>PKCS12</hz:type>
-                            <hz:password>password</hz:password>
-                            <hz:current-key-alias>current</hz:current-key-alias>
-                            <hz:polling-interval>60</hz:polling-interval>
-                        </hz:keystore>
-                    </hz:secure-store>
-                </hz:encryption-at-rest>
-            </hz:hot-restart-persistence>
-        </hz:config>
-    </hz:hazelcast>
 
-    <bean id="dummySSLContextFactory" class="com.hazelcast.spring.DummySSLContextFactory"/>
+    <hz:config id="theConfig">
+        <hz:hot-restart-persistence enabled="false"
+                                    validation-timeout-seconds="1111"
+                                    data-load-timeout-seconds="2222"
+                                    auto-remove-stale-data="false"
+                                    cluster-data-recovery-policy="PARTIAL_RECOVERY_MOST_COMPLETE">
+            <hz:base-dir>/mnt/hot-restart/</hz:base-dir>
+            <hz:backup-dir>/mnt/hot-backup/</hz:backup-dir>
+            <hz:encryption-at-rest enabled="true">
+                <hz:algorithm>AES/CBC/PKCS5Padding</hz:algorithm>
+                <hz:salt>sugar</hz:salt>
+                <hz:key-size>16</hz:key-size>
+                <hz:secure-store>
+                    <hz:keystore>
+                        <hz:path>/mnt/hot-restart/keystore.p12</hz:path>
+                        <hz:type>PKCS12</hz:type>
+                        <hz:password>password</hz:password>
+                        <hz:current-key-alias>current</hz:current-key-alias>
+                        <hz:polling-interval>60</hz:polling-interval>
+                    </hz:keystore>
+                </hz:secure-store>
+            </hz:encryption-at-rest>
+        </hz:hot-restart-persistence>
+    </hz:config>
 
 </beans>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hotrestart/hot-restart-encryption-vault-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hotrestart/hot-restart-encryption-vault-applicationContext-hazelcast.xml
@@ -22,33 +22,31 @@
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring-5.0.xsd">
 
-    <hz:hazelcast id="instance">
-        <hz:config>
-            <hz:hot-restart-persistence enabled="false"
-                                        validation-timeout-seconds="1111"
-                                        data-load-timeout-seconds="2222"
-                                        auto-remove-stale-data="false"
-                                        cluster-data-recovery-policy="PARTIAL_RECOVERY_MOST_COMPLETE">
-                <hz:base-dir>/mnt/hot-restart/</hz:base-dir>
-                <hz:backup-dir>/mnt/hot-backup/</hz:backup-dir>
-                <hz:encryption-at-rest enabled="true">
-                    <hz:algorithm>AES/CBC/PKCS5Padding</hz:algorithm>
-                    <hz:salt>sugar</hz:salt>
-                    <hz:key-size>16</hz:key-size>
-                    <hz:secure-store>
-                        <hz:vault>
-                            <hz:address>http://localhost:1234</hz:address>
-                            <hz:secret-path>secret/path</hz:secret-path>
-                            <hz:token>token</hz:token>
-                            <hz:polling-interval>60</hz:polling-interval>
-                            <hz:ssl enabled="true" factory-class-name="com.hazelcast.spring.DummySSLContextFactory"
-                                    factory-implementation="dummySSLContextFactory"/>
-                        </hz:vault>
-                    </hz:secure-store>
-                </hz:encryption-at-rest>
-            </hz:hot-restart-persistence>
-        </hz:config>
-    </hz:hazelcast>
+    <hz:config id="theConfig">
+        <hz:hot-restart-persistence enabled="false"
+                                    validation-timeout-seconds="1111"
+                                    data-load-timeout-seconds="2222"
+                                    auto-remove-stale-data="false"
+                                    cluster-data-recovery-policy="PARTIAL_RECOVERY_MOST_COMPLETE">
+            <hz:base-dir>/mnt/hot-restart/</hz:base-dir>
+            <hz:backup-dir>/mnt/hot-backup/</hz:backup-dir>
+            <hz:encryption-at-rest enabled="true">
+                <hz:algorithm>AES/CBC/PKCS5Padding</hz:algorithm>
+                <hz:salt>sugar</hz:salt>
+                <hz:key-size>16</hz:key-size>
+                <hz:secure-store>
+                    <hz:vault>
+                        <hz:address>http://localhost:1234</hz:address>
+                        <hz:secret-path>secret/path</hz:secret-path>
+                        <hz:token>token</hz:token>
+                        <hz:polling-interval>60</hz:polling-interval>
+                        <hz:ssl enabled="true" factory-class-name="com.hazelcast.spring.DummySSLContextFactory"
+                                factory-implementation="dummySSLContextFactory"/>
+                    </hz:vault>
+                </hz:secure-store>
+            </hz:encryption-at-rest>
+        </hz:hot-restart-persistence>
+    </hz:config>
 
     <bean id="dummySSLContextFactory" class="com.hazelcast.spring.DummySSLContextFactory"/>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/jet/application-context-jet-service.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/jet/application-context-jet-service.xml
@@ -42,6 +42,14 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -42,17 +42,18 @@
             </hz:properties>
             <hz:network port="${cluster.port}" port-auto-increment="true">
                 <hz:join>
-                    <hz:multicast enabled="false"
-                                  multicast-group="224.2.2.3"
-                                  multicast-port="54327"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
+                    <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
-                <hz:interfaces enabled="false">
-                    <hz:interface>10.10.1.*</hz:interface>
-                </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -60,7 +61,16 @@
         <hz:client>
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
             <hz:network>
+                <hz:member>127.0.0.1:5700</hz:member>
                 <hz:member>127.0.0.1:5701</hz:member>
+                <hz:member>127.0.0.1:5702</hz:member>
+                <hz:member>127.0.0.1:5703</hz:member>
+                <hz:member>127.0.0.1:5704</hz:member>
+                <hz:member>127.0.0.1:5705</hz:member>
+                <hz:member>127.0.0.1:5706</hz:member>
+                <hz:member>127.0.0.1:5707</hz:member>
+                <hz:member>127.0.0.1:5708</hz:member>
+                <hz:member>127.0.0.1:5709</hz:member>
             </hz:network>
 
             <hz:connection-strategy async-start="true"></hz:connection-strategy>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -40,19 +40,20 @@
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
                 <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
             </hz:properties>
-            <hz:network port="${cluster.port}" port-auto-increment="true">
+            <hz:network port="6150" port-auto-increment="true">
                 <hz:join>
-                    <hz:multicast enabled="false"
-                                  multicast-group="224.2.2.3"
-                                  multicast-port="54327"/>
-                    <hz:tcp-ip enabled="true">
-                        <hz:members>${cluster.members}</hz:members>
-                    </hz:tcp-ip>
+                    <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
-                <hz:interfaces enabled="false">
-                    <hz:interface>10.10.1.*</hz:interface>
-                </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -64,8 +65,16 @@
         <hz:network connection-timeout="1000"
                     redo-operation="true"
                     smart-routing="true">
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
 
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
@@ -82,8 +91,17 @@
                     redo-operation="false"
                     smart-routing="false">
 
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
+
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
                                linger-seconds="3"
@@ -98,8 +116,18 @@
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
+
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
                                linger-seconds="3"
@@ -174,8 +202,18 @@
         <hz:network connection-timeout="1000"
                     redo-operation="false"
                     smart-routing="false">
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
+
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
                                linger-seconds="3"
@@ -197,8 +235,16 @@
             </hz:connection-retry>
         </hz:connection-strategy>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:security>
             <hz:realms>
@@ -226,8 +272,16 @@
     <hz:client id="client6">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <hz:query-caches>
@@ -268,8 +322,17 @@
                     redo-operation="false"
                     smart-routing="false">
 
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
+
             <hz:socket-options buffer-size="32"
                                keep-alive="false"
                                linger-seconds="3"
@@ -283,8 +346,16 @@
     <hz:client id="client8">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <hz:connection-strategy async-start="true" reconnect-mode="ASYNC"/>
@@ -293,8 +364,16 @@
     <hz:client id="client9-user-code-deployment-test">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <hz:user-code-deployment enabled="false">
@@ -311,8 +390,16 @@
     <hz:client id="client10-flakeIdGenerator">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <hz:flake-id-generator name="gen1" prefetchCount="3" prefetchValidityMillis="3000"/>
@@ -321,8 +408,17 @@
     <hz:client id="client11-icmp-ping">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
+
             <hz:icmp-ping enabled="false">
                 <hz:timeout-milliseconds>2000</hz:timeout-milliseconds>
                 <hz:interval-milliseconds>3000</hz:interval-milliseconds>
@@ -337,8 +433,17 @@
     <hz:client id="client12-hazelcast-cloud">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
+
             <hz:hazelcast-cloud enabled="false">
                 <hz:discovery-token>EXAMPLE_TOKEN</hz:discovery-token>
             </hz:hazelcast-cloud>
@@ -349,8 +454,16 @@
     <hz:client id="client13-exponential-connection-retry">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <hz:connection-strategy async-start="true" reconnect-mode="ASYNC">
@@ -367,8 +480,16 @@
     <hz:client id="client14-reliable-topic">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <!--<hz:reliable-topic name="rel-topic" topic-overload-policy="DISCARD_NEWEST" read-batch-size="100"/>-->
@@ -381,8 +502,16 @@
     <hz:client id="client16-name-and-labels">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:instance-name>clusterName</hz:instance-name>
         <hz:labels>
@@ -393,8 +522,16 @@
     <hz:client id="client17-backupAckToClient">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:backup-ack-to-client-enabled>false</hz:backup-ack-to-client-enabled>
     </hz:client>
@@ -402,8 +539,16 @@
     <hz:client id="client18-metrics">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:metrics enabled="false">
             <hz:jmx enabled="false"/>
@@ -414,8 +559,16 @@
     <hz:client id="client19-instance-tracking">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:instance-tracking enabled="true">
             <hz:file-name>/dummy/file</hz:file-name>
@@ -426,8 +579,16 @@
     <hz:client id="client20-native-memory">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
                           min-block-size="10"
@@ -445,8 +606,16 @@
     <hz:client id="client21-persistent-memory-system-memory">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
         <hz:native-memory enabled="false" allocator-type="STANDARD" metadata-space-percentage="10.2"
                           min-block-size="10"
@@ -459,8 +628,16 @@
     <hz:client id="client22-with-overridden-default-serializers">
         <hz:cluster-name>${cluster.name}</hz:cluster-name>
         <hz:network>
-            <hz:member>127.0.0.1:5700</hz:member>
-            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:member>127.0.0.1:6150</hz:member>
+            <hz:member>127.0.0.1:6151</hz:member>
+            <hz:member>127.0.0.1:6152</hz:member>
+            <hz:member>127.0.0.1:6153</hz:member>
+            <hz:member>127.0.0.1:6154</hz:member>
+            <hz:member>127.0.0.1:6155</hz:member>
+            <hz:member>127.0.0.1:6156</hz:member>
+            <hz:member>127.0.0.1:6157</hz:member>
+            <hz:member>127.0.0.1:6158</hz:member>
+            <hz:member>127.0.0.1:6159</hz:member>
         </hz:network>
 
         <hz:serialization allow-override-default-serializers="true"/>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
@@ -29,6 +29,7 @@
             <hz:network port="5701">
                 <hz:join>
                     <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>
@@ -40,6 +41,14 @@
                     <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener"/>
                 </hz:entry-listeners>
             </hz:replicatedmap>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 </beans>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -26,14 +26,23 @@
     <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
         <hz:config>
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
-            <hz:network port="5701">
+            <hz:network port="5801">
                 <hz:join>
                     <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -43,7 +52,16 @@
                     redo-operation="true"
                     smart-routing="true">
 
-            <hz:member>127.0.0.1</hz:member>
+            <hz:member>127.0.0.1:5801</hz:member>
+            <hz:member>127.0.0.1:5802</hz:member>
+            <hz:member>127.0.0.1:5803</hz:member>
+            <hz:member>127.0.0.1:5804</hz:member>
+            <hz:member>127.0.0.1:5805</hz:member>
+            <hz:member>127.0.0.1:5806</hz:member>
+            <hz:member>127.0.0.1:5807</hz:member>
+            <hz:member>127.0.0.1:5808</hz:member>
+            <hz:member>127.0.0.1:5809</hz:member>
+            <hz:member>127.0.0.1:5810</hz:member>
 
             <hz:socket-options buffer-size="32"
                                keep-alive="false"

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -27,14 +27,23 @@
         <hz:config>
             <hz:spring-aware/>
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
-            <hz:network port="5701">
+            <hz:network port="5750">
                 <hz:join>
                     <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -45,7 +54,16 @@
                     redo-operation="true"
                     smart-routing="true">
 
-            <hz:member>127.0.0.1</hz:member>
+            <hz:member>127.0.0.1:5750</hz:member>
+            <hz:member>127.0.0.1:5751</hz:member>
+            <hz:member>127.0.0.1:5752</hz:member>
+            <hz:member>127.0.0.1:5753</hz:member>
+            <hz:member>127.0.0.1:5754</hz:member>
+            <hz:member>127.0.0.1:5755</hz:member>
+            <hz:member>127.0.0.1:5756</hz:member>
+            <hz:member>127.0.0.1:5757</hz:member>
+            <hz:member>127.0.0.1:5758</hz:member>
+            <hz:member>127.0.0.1:5759</hz:member>
 
             <hz:socket-options buffer-size="32"
                                keep-alive="false"

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -48,14 +48,23 @@
     <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
         <hz:config>
             <hz:cluster-name>${cluster.name}</hz:cluster-name>
-            <hz:network port="5701" port-auto-increment="false">
+            <hz:network port="5850" port-auto-increment="false">
                 <hz:join>
                     <hz:multicast enabled="false"/>
+                    <hz:auto-detection enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
+            <hz:jet>
+                <hz:instance>
+                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
+                </hz:instance>
+            </hz:jet>
+            <hz:sql>
+                <hz:executor-pool-size>2</hz:executor-pool-size>
+            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -65,7 +74,16 @@
                     redo-operation="true"
                     smart-routing="true">
 
-            <hz:member>127.0.0.1</hz:member>
+            <hz:member>127.0.0.1:5850</hz:member>
+            <hz:member>127.0.0.1:5851</hz:member>
+            <hz:member>127.0.0.1:5852</hz:member>
+            <hz:member>127.0.0.1:5853</hz:member>
+            <hz:member>127.0.0.1:5854</hz:member>
+            <hz:member>127.0.0.1:5855</hz:member>
+            <hz:member>127.0.0.1:5856</hz:member>
+            <hz:member>127.0.0.1:5857</hz:member>
+            <hz:member>127.0.0.1:5858</hz:member>
+            <hz:member>127.0.0.1:5859</hz:member>
 
             <hz:socket-options buffer-size="32"
                                keep-alive="false"

--- a/hazelcast-spring-tests/src/test/resources/hazelcast-default.properties
+++ b/hazelcast-spring-tests/src/test/resources/hazelcast-default.properties
@@ -31,3 +31,5 @@ testMap.merkleTree.enabled=true
 testMap.merkleTree.depth=20
 map.conf.cache.deserialized.values=ALWAYS
 wan.queue.capacity=5000
+jet.cooperative.thread.count=2
+sql.executor.pool.size=2


### PR DESCRIPTION
Most of the tests require a fixed port in the configuration
which fails to create the instance if that port is not available,
likely when running tests in parallel.

I've enabled port-increment and also disabled join for the tests
excluding the ones needs a cluster.

The spring runner was setting some system properties in a static
block which persists through the rest of the test suite. Moved setting
them to before-class and restored them in after-class.

Fixes https://github.com/hazelcast/hazelcast/issues/18447 , https://github.com/hazelcast/hazelcast/issues/18455 , https://github.com/hazelcast/hazelcast/issues/18454 , https://github.com/hazelcast/hazelcast/issues/18448 , https://github.com/hazelcast/hazelcast/issues/18476

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
