### PR TITLE
Increase thread-count for multipleJVM tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -67,7 +67,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
             // when running tests in multiple JVMs in parallel then we want to put a cap
             // on parallelism inside each JVM. otherwise it's easy to use too much resource
             // and the test duration is actually longer and not shorter.
-            cpuWorkers = min(1, cpuWorkers);
+            cpuWorkers = min(2, cpuWorkers);
         }
         return cpuWorkers;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -67,7 +67,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
             // when running tests in multiple JVMs in parallel then we want to put a cap
             // on parallelism inside each JVM. otherwise it's easy to use too much resource
             // and the test duration is actually longer and not shorter.
-            cpuWorkers = min(2, cpuWorkers);
+            cpuWorkers = min(4, cpuWorkers);
         }
         return cpuWorkers;
     }


### PR DESCRIPTION
we've decreased the max thread count  to 1 for parallel tests if running `multipleJVM`
this is an attempt to increase it (to 2)
let's see if it causes issues on builder, or improves the times



Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
