### PR TITLE
Adjust Jet extension related test

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import javax.annotation.Nonnull;
 import java.sql.Connection;
@@ -47,6 +48,12 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 @Category(NightlyTest.class)
 public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
+
+    private static final DockerImageName MYSQL_IMAGE =
+            DockerImageName.parse("debezium/example-mysql:1.3").asCompatibleSubstituteFor("mysql");
+
+    private static final DockerImageName POSTGRES_IMAGE =
+            DockerImageName.parse("debezium/example-postgres:1.3").asCompatibleSubstituteFor("postgres");
 
     @Test
     public void mysql() throws Exception {
@@ -216,7 +223,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     private MySQLContainer<?> mySqlContainer() {
         return namedTestContainer(
-                new MySQLContainer<>("debezium/example-mysql:1.3")
+                new MySQLContainer<>(MYSQL_IMAGE)
                         .withUsername("mysqluser")
                         .withPassword("mysqlpw")
         );
@@ -372,7 +379,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     private PostgreSQLContainer<?> postgresContainer() {
         return namedTestContainer(
-                new PostgreSQLContainer<>("debezium/example-postgres:1.3")
+                new PostgreSQLContainer<>(POSTGRES_IMAGE)
                         .withDatabaseName("postgres")
                         .withUsername("postgres")
                         .withPassword("postgres")

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 @Category({IgnoreInJenkinsOnWindows.class})
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.3")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.3")
             .asCompatibleSubstituteFor("mysql");
 
     @Rule

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcIntegrationTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -49,7 +48,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.jet.Util.entry;
 
-@Ignore("https://github.com/hazelcast/hazelcast/issues/18451")
 public class MySqlCdcIntegrationTest extends AbstractMySqlCdcIntegrationTest {
 
     @Test

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -333,7 +333,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private MySQLContainer<?> initMySql(Network network, Integer fixedExposedPort) {
         MySQLContainer<?> mysql = namedTestContainer(
-                new MySQLContainer<>("debezium/example-mysql:1.3")
+                new MySQLContainer<>(AbstractMySqlCdcIntegrationTest.DOCKER_IMAGE)
                         .withUsername("mysqluser")
                         .withPassword("mysqlpw")
         );

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -38,11 +38,12 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @Category({IgnoreInJenkinsOnWindows.class})
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.3")
+            .asCompatibleSubstituteFor("postgres");
+
     protected static final String DATABASE_NAME = "postgres";
     protected static final String REPLICATION_SLOT_NAME = "debezium";
 
-    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.3")
-            .asCompatibleSubstituteFor("postgres");
     private static final String SCHEMA = "inventory";
 
     @Rule

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -28,7 +28,9 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -46,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 
+@Category(NightlyTest.class)
 public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
     private static final int MAX_CONCURRENT_OPERATIONS = 1;

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
@@ -36,7 +36,6 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
@@ -60,7 +60,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
-@Ignore("https://github.com/hazelcast/hazelcast/issues/18453")
 public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
     @Test

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -338,7 +338,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
 
     private PostgreSQLContainer<?> initPostgres(Network network, Integer fixedExposedPort) {
         PostgreSQLContainer<?> postgres = namedTestContainer(
-                new PostgreSQLContainer<>("debezium/example-postgres:1.3")
+                new PostgreSQLContainer<>(AbstractPostgresCdcIntegrationTest.DOCKER_IMAGE)
                         .withDatabaseName("postgres")
                         .withUsername("postgres")
                         .withPassword("postgres")

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -97,38 +97,4 @@
             <classifier>tests</classifier>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                    <runOrder>random</runOrder>
-                    <trimStackTrace>false</trimStackTrace>
-                    <argLine>
-                        ${argLine}
-                    </argLine>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>serial-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${maven.test.skip}</skip>
-                            <forkCount>1</forkCount>
-                            <groups>com.hazelcast.jet.test.SerialTest</groups>
-                            <excludedGroups>
-                                com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -127,24 +127,6 @@
                             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>regular-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration combine.self="override">
-                            <skip>${maven.test.skip}</skip>
-                            <forkCount>4</forkCount>
-                            <includes>
-                                <include>/com/hazelcast/jet/**/**.java</include>
-                            </includes>
-                            <groups/>
-                            <excludedGroups>
-                                com.hazelcast.jet.test.SerialTest,com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -144,24 +144,6 @@
                             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>regular-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration combine.self="override">
-                            <skip>${maven.test.skip}</skip>
-                            <forkCount>4</forkCount>
-                            <includes>
-                                <include>/com/hazelcast/jet/**/**.java</include>
-                            </includes>
-                            <groups/>
-                            <excludedGroups>
-                                com.hazelcast.jet.test.SerialTest,com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
 

--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -128,23 +128,6 @@
                         ${argLine}
                     </argLine>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>serial-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${maven.test.skip}</skip>
-                            <forkCount>1</forkCount>
-                            <groups>com.hazelcast.jet.test.SerialTest</groups>
-                            <excludedGroups>
-                                com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/hazelcast-jet-sql/pom.xml
+++ b/hazelcast-jet-sql/pom.xml
@@ -497,24 +497,6 @@
                             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>regular-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration combine.self="override">
-                            <skip>${maven.test.skip}</skip>
-                            <forkCount>4</forkCount>
-                            <includes>
-                                <include>/com/hazelcast/jet/**/**.java</include>
-                            </includes>
-                            <groups/>
-                            <excludedGroups>
-                                com.hazelcast.jet.test.SerialTest,com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/hazelcast-jet-sql/pom.xml
+++ b/hazelcast-jet-sql/pom.xml
@@ -470,35 +470,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                    <runOrder>random</runOrder>
-                    <trimStackTrace>false</trimStackTrace>
-                    <argLine>
-                        ${argLine}
-                    </argLine>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>serial-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${maven.test.skip}</skip>
-                            <forkCount>1</forkCount>
-                            <groups>com.hazelcast.jet.test.SerialTest</groups>
-                            <excludedGroups>
-                                com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Removes the `regular-tests` execution, produces duplicates.
Re-enables CDC tests, because they pass fine locally, if they fail, then it's a Jenkins issue.