### PR TITLE
[FORWARDPORT] Fix queue size display in Dot representation when default is changed

### DIFF
--- a/distribution/src/root/release_notes.txt
+++ b/distribution/src/root/release_notes.txt
@@ -46,10 +46,12 @@ Thank you for your valuable contributions!
 3. Fixes
 
 [core] Jet now doesn't close System.out during JVM shutdown (#2649)
+[core] Fixed queue size display in `DAG.toDotString()` when default is changed (#2887).
 
 4. Breaking Changes
 
 [jdbc] Added `batchLimit` parameter to `SinkProcessors.writeJdbcP()` method.
+[core] Added `defaultQueueSize` parameter to `DAG.toDotString(int)` method.
 
 <<< END TEMPLATE FOR THE NEXT VERSION
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -125,6 +125,7 @@ public class MasterJobContext {
     private final MasterContext mc;
     private final ILogger logger;
     private final int defaultParallelism;
+    private final int defaultQueueSize;
 
     private volatile long executionStartTime = System.currentTimeMillis();
     private volatile ExecutionFailureCallback executionFailureCallback;
@@ -161,6 +162,8 @@ public class MasterJobContext {
         this.logger = logger;
         this.defaultParallelism = mc.getJetService().getConfig()
               .getInstanceConfig().getCooperativeThreadCount();
+        this.defaultQueueSize = mc.getJetService().getJetInstance().getConfig()
+                .getDefaultEdgeConfig().getQueueSize();
     }
 
     public CompletableFuture<Void> jobCompletionFuture() {
@@ -199,7 +202,7 @@ public class MasterJobContext {
                 DAG dag = dagAndClassloader.f0();
                 ClassLoader classLoader = dagAndClassloader.f1();
                 // must call this before rewriteDagWithSnapshotRestore()
-                String dotRepresentation = dag.toDotString(defaultParallelism);
+                String dotRepresentation = dag.toDotString(defaultParallelism, defaultQueueSize);
                 long snapshotId = jobExecRec.snapshotId();
                 String snapshotName = mc.jobConfig().getInitialSnapshotName();
                 String mapName =


### PR DESCRIPTION
(cherry picked from commit f9c56cff89e0896f0294c3d138a69ce491aa8484)

Forward port of https://github.com/hazelcast/hazelcast-jet/pull/2887.

Checklist:
- [x] Labels and Milestone set

