### PR TITLE
Implement default timeout for CustomSpringJUnit4ClassRunner

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
@@ -80,6 +80,7 @@ public class CustomSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
             return TimeUnit.SECONDS.toMillis(DEFAULT_TEST_TIMEOUT_IN_SECONDS);
         }
         return annotation.timeout();
+    }
 
     protected Statement withBeforeClasses(Statement statement) {
         setProperties();


### PR DESCRIPTION
There are some failures in the spring tests, causing the tests to run indefinitely and timing out the whole job.
This adds default timeout to the CustomSpringJUnit4ClassRunner, which will timeout the individual tests.

This is a copy of the same functionality from AbstractHazelcastClassRunner.

The actual cause of the failures should be addressed by #18467.
