### PR TITLE
Control temporary allocations for background expiry task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -58,12 +58,11 @@ import static com.hazelcast.map.impl.record.Record.UNSET;
  */
 public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
 
-    // MAX_SAMPLE_AT_A_TIME and SAMPLING_LIST is used for background expiry task.
+    private static final int ONE_HUNDRED_PERCENT = 100;
     private static final int MAX_SAMPLE_AT_A_TIME = 16;
     private static final int MIN_TOTAL_NUMBER_OF_KEYS_TO_SCAN = 100;
-    private static final int ONE_HUNDRED_PERCENT = 100;
     private static final ThreadLocal<List> SAMPLING_LIST
-            = ThreadLocal.withInitial(() -> new ArrayList<>(MAX_SAMPLE_AT_A_TIME));
+            = ThreadLocal.withInitial(() -> new ArrayList<>(MAX_SAMPLE_AT_A_TIME << 1));
 
     protected final long expiryDelayMillis;
     protected final Address thisAddress;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -146,7 +146,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         do {
             checkedEntryCount += findKeys();
             evictedCount += evictKeys(now, backup);
-        } while (expirationIterator.hasNext() && checkedEntryCount >= maxIterationCount);
+        } while (expirationIterator.hasNext() && checkedEntryCount < maxIterationCount);
 
         return evictedCount;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MCEventStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MCEventStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Previously, temporarily created ArrayList can grow, at worst, to the number of keys in a partition while sampling keys, in an aggressive expiry configuration this can cause problems like increasing GC pressure and CPU usage spikes. Now we use a thread local fixed size queue and doing sampling in a loop to prevent uncontrolled grow of this queue.