### PR TITLE
Update and unify Guava dependencies

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-5/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1-jre</version>
+            <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1-jre</version>
+            <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1-jre</version>
+            <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -20,9 +20,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hazelcast-jet-grpc</artifactId>
-    <properties>
-        <guava.version>28.1-android</guava.version>
-    </properties>
 
     <parent>
         <groupId>com.hazelcast.jet</groupId>

--- a/hazelcast-sql-core/pom.xml
+++ b/hazelcast-sql-core/pom.xml
@@ -37,7 +37,6 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
 
         <calcite.version>1.23.0</calcite.version>
-        <guava.version>30.1-jre</guava.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <felix.utils.version>1.11.6</felix.utils.version>
         <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
         <http.components.version>4.3.6</http.components.version>
+        <guava.version>30.1.1-jre</guava.version>
 
         <sonar.jacoco.jar>${basedir}/lib/jacocoagent.jar</sonar.jacoco.jar>
         <!--<sonar.phase>post-integration-test</sonar.phase>-->
@@ -1262,7 +1263,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>29.0-jre</version>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
This PR unifies the Guava version in Hazelcast.

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
