### PR TITLE
 Allow compatibility tests for 5.0 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -322,7 +322,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * Adds an entry listener for this multimap.
      * <p>
      * The listener will be notified for all multimap
-     * add/remove/update/evict events.
+     * add/remove/update events.
      *
      * @param listener     entry listener for this multimap
      * @param includeValue {@code true} if {@code EntryEvent} should contain the value,
@@ -345,7 +345,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
     /**
      * Adds the specified entry listener for the specified key.
      * <p>
-     * The listener will be notified for all add/remove/update/evict events for
+     * The listener will be notified for all add/remove/update events for
      * the specified key only.
      * <p>
      * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of

--- a/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.test;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.test.compatibility.SamplingSerializationService;
 
 @SuppressWarnings("WeakerAccess")
@@ -47,7 +46,10 @@ public final class TestEnvironment {
      * @return {@code true} when compatibility tests are to be executed on a mixed version cluster
      */
     public static boolean isRunningCompatibilityTest() {
-        return Boolean.getBoolean(EXECUTE_COMPATIBILITY_TESTS) && Versions.CURRENT_CLUSTER_VERSION.getMinor() > 0;
+        // RU_COMPAT_4_2 normally no compatibility tests are to be executed
+        // on a X.0 version, because we do not guarantee RU compatibility
+        // across major versions. However 5.0 is different in this respect.
+        return Boolean.getBoolean(EXECUTE_COMPATIBILITY_TESTS);
     }
 
     public static boolean isRecordingSerializedClassNames() {


### PR DESCRIPTION
Normally X.0 versions don't require
EE compatibility tests, however 5.0
is an exception and will support
rolling upgrade.

Also, tiny javadoc fix for `MultiMap` (eviction is not supported)
