### PR TITLE
Enable debug logs in Jet tests running in IDE

### DIFF
--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -35,6 +35,7 @@
         <Logger name="com.hazelcast.client.impl.operations" level="debug"/>
         <Logger name="com.hazelcast.client.impl.spi.ClientListenerService" level="trace"/>
         <Logger name="com.hazelcast.cp.internal" level="trace"/>
+        <Logger name="com.hazelcast.jet" level="debug"/>
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientInvocationService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.connection.ClientConnectionManager" level="trace"/>-->
     </Loggers>


### PR DESCRIPTION
The changed config is used when running from IDE, it didn't include debug level for jet tests.