### PR TITLE
Tidy up the DefaultNodeEntension and JetExtension

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -135,7 +135,14 @@ import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceC
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity", "checkstyle:classdataabstractioncoupling"})
 public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
+    private static final String PLATFORM_LOGO
+            = "\to  o   O  o---o o--o o      o-o   O   o-o  o-O-o     o--o  o      O  o-O-o o--o  o-o  o--o  o   o \n"
+            + "\t|  |  / \\    /  |    |     /     / \\ |       |       |   | |     / \\   |   |    o   o |   | |\\ /| \n"
+            + "\tO--O o---o -O-  O-o  |    O     o---o o-o    |       O--o  |    o---o  |   O-o  |   | O-Oo  | O | \n"
+            + "\t|  | |   | /    |    |     \\    |   |    |   |       |     |    |   |  |   |    o   o |  \\  |   | \n"
+            + "\to  o o   oo---o o--o O---o  o-o o   oo--o    o       o     O---oo   o  o   o     o-o  o   o o   o";
 
+    private static final String COPYRIGHT_LINE = "Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.";
     private static final String JET_DISABLED_PROPERTY = "hazelcast.jet.disabled";
 
     protected final Node node;
@@ -155,7 +162,10 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
         checkPersistenceAllowed();
         createAndSetPhoneHome();
         if (!jetDisabled(node)) {
+            systemLogger.info("Jet extension is enabled.");
             jetExtension = new JetExtension(node, createService(JetService.class));
+        } else {
+            systemLogger.info("Jet extension is disabled.");
         }
     }
 
@@ -206,16 +216,10 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
 
     @Override
     public void printNodeInfo() {
-        if (jetExtension != null) {
-            jetExtension.printNodeInfo(systemLogger, "Hazelcast Platform");
-        } else {
-            BuildInfo buildInfo = node.getBuildInfo();
-
-            printBannersBeforeNodeInfo();
-
-            String build = constructBuildString(buildInfo);
-            printNodeInfoInternal(buildInfo, build);
-        }
+        BuildInfo buildInfo = node.getBuildInfo();
+        printBannersBeforeNodeInfo();
+        String build = constructBuildString(buildInfo);
+        printNodeInfoInternal(buildInfo, build);
     }
 
     @Override
@@ -247,6 +251,8 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     }
 
     protected void printBannersBeforeNodeInfo() {
+        systemLogger.info('\n' + PLATFORM_LOGO);
+        systemLogger.info(COPYRIGHT_LINE);
     }
 
     protected String constructBuildString(BuildInfo buildInfo) {
@@ -261,11 +267,12 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     private void printNodeInfoInternal(BuildInfo buildInfo, String build) {
         systemLogger.info(getEditionString() + " " + buildInfo.getVersion()
                 + " (" + build + ") starting at " + node.getThisAddress());
+        systemLogger.info("Cluster name: " + node.getConfig().getClusterName());
         systemLogger.fine("Configured Hazelcast Serialization version: " + buildInfo.getSerializationVersion());
     }
 
     protected String getEditionString() {
-        return "Hazelcast";
+        return "Hazelcast Platform";
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -136,11 +136,11 @@ import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceC
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity", "checkstyle:classdataabstractioncoupling"})
 public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     private static final String PLATFORM_LOGO
-            = "\to  o   O  o---o o--o o      o-o   O   o-o  o-O-o     o--o  o      O  o-O-o o--o  o-o  o--o  o   o \n"
-            + "\t|  |  / \\    /  |    |     /     / \\ |       |       |   | |     / \\   |   |    o   o |   | |\\ /| \n"
-            + "\tO--O o---o -O-  O-o  |    O     o---o o-o    |       O--o  |    o---o  |   O-o  |   | O-Oo  | O | \n"
-            + "\t|  | |   | /    |    |     \\    |   |    |   |       |     |    |   |  |   |    o   o |  \\  |   | \n"
-            + "\to  o o   oo---o o--o O---o  o-o o   oo--o    o       o     O---oo   o  o   o     o-o  o   o o   o";
+            = "\to  o   O   o---o o--o o      o-o   O    o-o  o-O-o     o--o  o       O  o-O-o o--o  o-o  o--o  o   o \n"
+            + "\t|  |  / \\     /  |    |     /     / \\  |       |       |   | |      / \\   |   |    o   o |   | |\\ /| \n"
+            + "\tO--O o---o  -O-  O-o  |    O     o---o  o-o    |       O--o  |     o---o  |   O-o  |   | O-Oo  | O | \n"
+            + "\t|  | |   |  /    |    |     \\    |   |     |   |       |     |     |   |  |   |    o   o |  \\  |   | \n"
+            + "\to  o o   o o---o o--o O---o  o-o o   o o--o    o       o     O---o o   o  o   o     o-o  o   o o   o";
 
     private static final String COPYRIGHT_LINE = "Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.";
     private static final String JET_DISABLED_PROPERTY = "hazelcast.jet.disabled";

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -162,10 +162,7 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
         checkPersistenceAllowed();
         createAndSetPhoneHome();
         if (!jetDisabled(node)) {
-            systemLogger.info("Jet extension is enabled.");
             jetExtension = new JetExtension(node, createService(JetService.class));
-        } else {
-            systemLogger.info("Jet extension is disabled.");
         }
     }
 
@@ -210,7 +207,10 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     @Override
     public void beforeStart() {
         if (jetExtension != null) {
+            systemLogger.info("Jet extension is enabled.");
             jetExtension.beforeStart();
+        } else {
+            systemLogger.info("Jet extension is disabled.");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
@@ -51,7 +51,6 @@ public class JetExtension {
         this.node = node;
         this.logger = node.getLogger(getClass().getName());
         this.jetService = jetService;
-        checkLosslessRestartAllowed();
     }
 
     private void checkLosslessRestartAllowed() {
@@ -86,6 +85,8 @@ public class JetExtension {
         config.addMapConfig(internalMapConfig)
                 .addMapConfig(resultsMapConfig)
                 .addMapConfig(metricsMapConfig);
+
+        checkLosslessRestartAllowed();
     }
 
     public void afterStart() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
@@ -19,7 +19,7 @@ package com.hazelcast.instance.impl;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.instance.JetBuildInfo;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.JetConfig;
@@ -30,7 +30,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
 import com.hazelcast.sql.impl.JetSqlCoreBackend;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -43,14 +42,6 @@ import static com.hazelcast.jet.impl.JobRepository.JOB_RESULTS_MAP_NAME;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 
 public class JetExtension {
-    private static final String JET_LOGO
-            = "\to  o   O  o---o o--o o      o-o   O   o-o  o-O-o     o--o  o      O  o-O-o o--o  o-o  o--o  o   o \n"
-            + "\t|  |  / \\    /  |    |     /     / \\ |       |       |   | |     / \\   |   |    o   o |   | |\\ /| \n"
-            + "\tO--O o---o -O-  O-o  |    O     o---o o-o    |       O--o  |    o---o  |   O-o  |   | O-Oo  | O | \n"
-            + "\t|  | |   | /    |    |     \\    |   |    |   |       |     |    |   |  |   |    o   o |  \\  |   | \n"
-            + "\to  o o   oo---o o--o O---o  o-o o   oo--o    o       o     O---oo   o  o   o     o-o  o   o o   o";
-
-    private static final String COPYRIGHT_LINE = "Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.";
 
     private final Node node;
     private final ILogger logger;
@@ -60,16 +51,22 @@ public class JetExtension {
         this.node = node;
         this.logger = node.getLogger(getClass().getName());
         this.jetService = jetService;
+        checkLosslessRestartAllowed();
+    }
+
+    private void checkLosslessRestartAllowed() {
+        Config config = node.config.getStaticConfig();
+        JetConfig jetConfig = config.getJetConfig();
+        if (jetConfig.getInstanceConfig().isLosslessRestartEnabled()) {
+            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
+                throw new IllegalStateException("Lossless Restart requires Hazelcast Enterprise Edition");
+            }
+        }
     }
 
     public void beforeStart() {
         Config config = node.config.getStaticConfig();
         JetConfig jetConfig = config.getJetConfig();
-
-        if (jetConfig.getInstanceConfig().isLosslessRestartEnabled()) {
-            throw new UnsupportedOperationException("Lossless Restart is not available in the open-source version of "
-                    + "Hazelcast Jet");
-        }
 
         MapConfig internalMapConfig = new MapConfig(INTERNAL_JET_OBJECTS_PREFIX + '*')
                 .setBackupCount(jetConfig.getInstanceConfig().getBackupCount())
@@ -89,13 +86,6 @@ public class JetExtension {
         config.addMapConfig(internalMapConfig)
                 .addMapConfig(resultsMapConfig)
                 .addMapConfig(metricsMapConfig);
-        // TODO we should move this to enterprise node extension
-        if (jetConfig.getInstanceConfig().isLosslessRestartEnabled()
-                && !config.getHotRestartPersistenceConfig().isEnabled()) {
-            logger.warning("Lossless Restart is enabled but Hot Restart is disabled. Auto-enabling Hot Restart. "
-                    + "The following path will be used: " + config.getHotRestartPersistenceConfig().getBaseDir());
-            config.getHotRestartPersistenceConfig().setEnabled(true);
-        }
     }
 
     public void afterStart() {
@@ -133,15 +123,6 @@ public class JetExtension {
         jetService.handlePacket(packet);
     }
 
-    public void printNodeInfo(ILogger log, String addToProductName) {
-        log.info(versionAndAddressMessage(addToProductName));
-        log.info(imdgVersionMessage());
-        log.info(clusterNameMessage());
-        log.fine(serializationVersionMessage());
-        log.info('\n' + JET_LOGO);
-        log.info(COPYRIGHT_LINE);
-    }
-
     public Map<String, Object> createExtensionServices() {
         Map<String, Object> extensionServices = new HashMap<>();
 
@@ -156,34 +137,6 @@ public class JetExtension {
 
     public JetInstance getJetInstance() {
         return jetService.getJetInstance();
-    }
-
-    private String versionAndAddressMessage(@Nonnull String addToName) {
-        JetBuildInfo jetBuildInfo = node.getBuildInfo().getJetBuildInfo();
-        String build = jetBuildInfo.getBuild();
-        String revision = jetBuildInfo.getRevision();
-        if (!revision.isEmpty()) {
-            build += " - " + revision;
-        }
-        return "Hazelcast Jet" + addToName + ' ' + jetBuildInfo.getVersion()
-                + " (" + build + ") starting at " + node.getThisAddress();
-    }
-
-    private String imdgVersionMessage() {
-        String build = node.getBuildInfo().getBuild();
-        String revision = node.getBuildInfo().getRevision();
-        if (!revision.isEmpty()) {
-            build += " - " + revision;
-        }
-        return "Based on Hazelcast IMDG version: " + node.getVersion() + " (" + build + ")";
-    }
-
-    private String serializationVersionMessage() {
-        return "Configured Hazelcast Serialization version: " + node.getBuildInfo().getSerializationVersion();
-    }
-
-    private String clusterNameMessage() {
-        return "Cluster name: " + node.getConfig().getClusterName();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
@@ -103,8 +103,8 @@ public class JobConfigTest extends JetTestSupport {
         config.getJetConfig().getInstanceConfig().setLosslessRestartEnabled(true);
 
         // Then
-        exception.expect(UnsupportedOperationException.class);
-        exception.expectMessage("Lossless Restart is not available in the open-source version of Hazelcast Jet");
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("Lossless Restart requires Hazelcast Enterprise Edition");
         createJetMember(config);
     }
 


### PR DESCRIPTION
In this PR, moved `NodeInfo` printings from `JetExtension` to `DefaultNodeExtension`
and also changed the style of lossless restart allowed check.

I was thinking of calling `JetExtension.beforeStart()` on the enterprise side, and not checking `BuildInfoProvider.getBuildInfo().IsEnterprise()` was creating a problem.

Checklist:
- [x] Labels and Milestone set

