### PR TITLE
[FORWARDPORT] Prevent cancellation exception printing when user cancels the job

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/RootResultConsumerSink.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/RootResultConsumerSink.java
@@ -27,10 +27,14 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.sql.impl.JetQueryResultProducer;
 import com.hazelcast.jet.sql.impl.JetSqlCoreBackendImpl;
 import com.hazelcast.sql.impl.JetSqlCoreBackend;
+import com.hazelcast.sql.impl.QueryException;
 
 import javax.annotation.Nonnull;
 
+import java.util.concurrent.CancellationException;
+
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.forceTotalParallelismOne;
+import static com.hazelcast.sql.impl.SqlErrorCode.CANCELLED_BY_USER;
 
 public final class RootResultConsumerSink implements Processor {
 
@@ -49,13 +53,27 @@ public final class RootResultConsumerSink implements Processor {
 
     @Override
     public boolean tryProcess() {
-        rootResultConsumer.ensureNotDone();
+        try {
+            rootResultConsumer.ensureNotDone();
+        } catch (QueryException e) {
+            if (e.getCode() == CANCELLED_BY_USER) {
+                throw new CancellationException();
+            }
+            throw e;
+        }
         return true;
     }
 
     @Override
     public void process(int ordinal, @Nonnull Inbox inbox) {
-        rootResultConsumer.consume(inbox);
+        try {
+            rootResultConsumer.consume(inbox);
+        } catch (QueryException e) {
+            if (e.getCode() == CANCELLED_BY_USER) {
+                throw new CancellationException();
+            }
+            throw e;
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -370,8 +371,14 @@ public class TaskletExecutionService {
                 }
                 progressTracker.mergeWith(result);
             } catch (Throwable e) {
-                logger.warning("Exception in " + t.tasklet, e);
-                t.executionTracker.exception(new JetException("Exception in " + t.tasklet + ": " + e, e));
+                if (e instanceof CancellationException) {
+                    logger.info("Job was cancelled by the user.");
+                    CancellationException ex = (CancellationException) e;
+                    t.executionTracker.exception(ex);
+                } else {
+                    logger.warning("Exception in " + t.tasklet, e);
+                    t.executionTracker.exception(new JetException("Exception in " + t.tasklet + ": " + e, e));
+                }
             } finally {
                 userMetricsContextContainer.setContext(null);
             }


### PR DESCRIPTION
Fixes: https://github.com/hazelcast/hazelcast-jet/issues/2940
Port of: https://github.com/hazelcast/hazelcast-jet/pull/2974