### PR TITLE
[FORWARDPORT] Exclude log4j (1.2.x) from hadoop module dependencies

### DIFF
--- a/distribution/src/root/NOTICE
+++ b/distribution/src/root/NOTICE
@@ -117,7 +117,6 @@ Apache License, Version 2.0
   perfmark:perfmark-api:0.19.0
   jmx_prometheus_javaagent:0.13.0
   Joda-Time:2.10.1
-  Apache Log4j:1.2.17
   ASM based accessors helper used by json-smart:1.2
   JSON Small and Fast Parser:2.3
   Apache Avro:1.10.2

--- a/extensions/hadoop-dist/files-azure/src/root/NOTICE
+++ b/extensions/hadoop-dist/files-azure/src/root/NOTICE
@@ -46,7 +46,6 @@ Apache License, Version 2.0
   Apache Commons Logging:1.2
   Apache Commons Net:3.6
   Commons Pool:1.6
-  Apache Log4j:1.2.17
   ASM based accessors helper used by json-smart:1.2
   JSON Small and Fast Parser:2.3
   Apache Avro:1.10.2

--- a/extensions/hadoop-dist/files-gcs/src/root/NOTICE
+++ b/extensions/hadoop-dist/files-gcs/src/root/NOTICE
@@ -80,7 +80,6 @@ Apache License, Version 2.0
   OpenCensus:0.24.0
   OpenCensus:0.24.0
   perfmark:perfmark-api:0.19.0
-  Apache Log4j:1.2.17
   ASM based accessors helper used by json-smart:1.2
   JSON Small and Fast Parser:2.3
   Apache Avro:1.10.2

--- a/extensions/hadoop-dist/files-s3/src/root/NOTICE
+++ b/extensions/hadoop-dist/files-s3/src/root/NOTICE
@@ -47,7 +47,6 @@ Apache License, Version 2.0
   Apache Commons Logging:1.2
   Apache Commons Net:3.6
   Commons Pool:1.6
-  Apache Log4j:1.2.17
   ASM based accessors helper used by json-smart:1.2
   JSON Small and Fast Parser:2.3
   Apache Avro:1.10.2

--- a/extensions/hadoop-dist/hadoop-all/src/root/NOTICE
+++ b/extensions/hadoop-dist/hadoop-all/src/root/NOTICE
@@ -46,7 +46,6 @@ Apache License, Version 2.0
   Apache Commons Logging:1.2
   Apache Commons Net:3.6
   Commons Pool:1.6
-  Apache Log4j:1.2.17
   ASM based accessors helper used by json-smart:1.2
   JSON Small and Fast Parser:2.3
   Apache Avro:1.10.2

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -172,6 +172,10 @@
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-servlet</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
It seems we actually don't need this dependency.
If it turns out log4j 1.2.x is needed we will add a
compatibility bridge instead.

Fixes: https://github.com/hazelcast/hazelcast-jet/issues/2981
Forward-port of: https://github.com/hazelcast/hazelcast-jet/pull/3014