### PR TITLE
Re-enable MemberJmxMetricsTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,7 +32,6 @@ import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-@Ignore("see https://hazelcast.atlassian.net/browse/PLAT-177")
 public class MemberJmxMetricsTest {
     private static final String DOMAIN_PREFIX = "com.hazelcast";
 


### PR DESCRIPTION
This test was disabled during the merge. Seems to be a flaky test. Need
more info.

Fixes #18484
