### PR TITLE
Use ConfigFactory to create the default config instances.

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1493,7 +1493,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     @Test
     public void testSqlConfig() {
         SqlConfig sqlConfig = config.getSqlConfig();
-        assertEquals(10, sqlConfig.getExecutorPoolSize());
+        assertEquals(5, sqlConfig.getExecutorPoolSize());
         assertEquals(30L, sqlConfig.getStatementTimeoutMillis());
     }
 

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
@@ -165,6 +165,7 @@ public class TestCacheManager extends HazelcastTestSupport {
         Config config = instance.getConfig();
         Config extractedConfig = new Config();
         extractedConfig
+                .setProperties(config.getProperties())
                 .setClusterName(config.getClusterName())
                 .setNetworkConfig(config.getNetworkConfig())
                 .setJetConfig(config.getJetConfig())

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/config/ConfigFactoryAccessor.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/config/ConfigFactoryAccessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.config;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.config.Config;
+
+import java.util.function.Supplier;
+
+/**
+ * Provides accessors for
+ * {@link ConfigFactory#setConfigSupplier(Supplier)},
+ * {@link ConfigFactory#setClientConfigSupplier(Supplier)} and
+ * {@link ConfigFactory#setClientFailoverConfigSupplier(Supplier)}.
+ */
+public final class ConfigFactoryAccessor {
+
+    private ConfigFactoryAccessor() {
+    }
+
+    public static void setConfigSupplier(Supplier<Config> configSupplier) {
+        ConfigFactory.setConfigSupplier(configSupplier);
+    }
+
+    public static void setClientConfigSupplier(Supplier<ClientConfig> clientConfigSupplier) {
+        ConfigFactory.setClientConfigSupplier(clientConfigSupplier);
+    }
+
+    public static void setClientFailoverConfigSupplier(Supplier<ClientFailoverConfig> clientFailoverConfigSupplier) {
+        ConfigFactory.setClientFailoverConfigSupplier(clientFailoverConfigSupplier);
+    }
+
+}

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -264,15 +264,6 @@
             <hz:member-attributes>
                 <hz:attribute name="cluster.name">spring-cluster</hz:attribute>
             </hz:member-attributes>
-
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -53,14 +53,6 @@
             </hz:native-memory>
             <hz:queue name="testQueue" priority-comparator-class-name="com.hazelcast.collection.impl.queue.model.PriorityElementComparator">
             </hz:queue>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
@@ -46,14 +46,6 @@
             <hz:map name="null-map"/>
             <hz:map name="map-with-ttl" time-to-live-seconds="1">
             </hz:map>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
@@ -59,14 +59,6 @@
                     <hz:partition-lost-listener class-name="com.hazelcast.spring.cache.JCachePartitionLostListener"/>
                 </hz:partition-lost-listeners>
             </hz:cache>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
@@ -43,14 +43,6 @@
             </hz:network>
             <hz:cache name="name"/>
             <hz:cache name="city"/>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
@@ -54,14 +54,6 @@
             </hz:network>
             <hz:cache name="city"/>
             <hz:cache name="name"/>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
@@ -44,14 +44,6 @@
                 </hz:interfaces>
             </hz:network>
             <hz:map name="delayNo"/>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
@@ -52,14 +52,6 @@
             <hz:map name="delay50"/>
             <hz:map name="delayNo"/>
             <hz:map name="delay100"/>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
@@ -47,14 +47,6 @@
             <hz:map name="delay50"/>
             <hz:map name="delayNo"/>
             <hz:map name="delay100"/>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
@@ -25,14 +25,6 @@
     <hz:hazelcast id="instance">
         <hz:config>
             <hz:map name="test"/>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
@@ -25,14 +25,6 @@
     <hz:hazelcast id="instance">
         <hz:config>
             <hz:cluster-name>client-network-default</hz:cluster-name>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -58,14 +58,6 @@
                     </hz:properties>
                 </hz:ssl>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
@@ -43,14 +43,6 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -63,14 +55,6 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
@@ -46,14 +46,6 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
@@ -45,14 +45,6 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
@@ -124,15 +124,6 @@
                       cache-loader="com.hazelcast.config.CacheConfigTest$MyCacheLoader"
                       cache-writer="com.hazelcast.config.CacheConfigTest$EmptyCacheWriter"
             />
-
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
@@ -37,15 +37,6 @@
                 </hz:interfaces>
             </hz:network>
             <hz:lite-member enabled="true"/>
-
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-applicationContext.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/customLoadBalancer-applicationContext.xml
@@ -42,14 +42,6 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/discoveryConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/discoveryConfig-applicationContext-hazelcast.xml
@@ -72,14 +72,6 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -1004,7 +1004,7 @@
             </hz:instance-tracking>
 
             <hz:sql>
-                <hz:executor-pool-size>10</hz:executor-pool-size>
+                <hz:executor-pool-size>5</hz:executor-pool-size>
                 <hz:statement-timeout-millis>30</hz:statement-timeout-millis>
             </hz:sql>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
@@ -46,14 +46,6 @@
                                  pool-size="2"
                                  queue-capacity="100"
             />
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/jet/application-context-jet-service.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/jet/application-context-jet-service.xml
@@ -42,14 +42,6 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -78,7 +78,11 @@
                 <hz:member>127.0.0.1:5702</hz:member>
             </hz:network>
 
-            <hz:connection-strategy async-start="true"/>
+            <hz:connection-strategy async-start="true">
+                <hz:connection-retry>
+                    <hz:cluster-connect-timeout-millis>30000</hz:cluster-connect-timeout-millis>
+                </hz:connection-retry>
+            </hz:connection-strategy>
         </hz:client>
     </hz:client-failover>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -46,14 +46,6 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 
@@ -73,7 +65,11 @@
                 <hz:member>127.0.0.1:5709</hz:member>
             </hz:network>
 
-            <hz:connection-strategy async-start="true"></hz:connection-strategy>
+            <hz:connection-strategy async-start="true">
+                <hz:connection-retry>
+                    <hz:cluster-connect-timeout-millis>30_000</hz:cluster-connect-timeout-millis>
+                </hz:connection-retry>
+            </hz:connection-strategy>
         </hz:client>
 
         <hz:client>
@@ -82,7 +78,7 @@
                 <hz:member>127.0.0.1:5702</hz:member>
             </hz:network>
 
-            <hz:connection-strategy async-start="true"></hz:connection-strategy>
+            <hz:connection-strategy async-start="true"/>
         </hz:client>
     </hz:client-failover>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -67,7 +67,7 @@
 
             <hz:connection-strategy async-start="true">
                 <hz:connection-retry>
-                    <hz:cluster-connect-timeout-millis>30_000</hz:cluster-connect-timeout-millis>
+                    <hz:cluster-connect-timeout-millis>30000</hz:cluster-connect-timeout-millis>
                 </hz:connection-retry>
             </hz:connection-strategy>
         </hz:client>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -46,14 +46,6 @@
                     <hz:auto-detection enabled="false"/>
                 </hz:join>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
@@ -41,14 +41,6 @@
                     <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener"/>
                 </hz:entry-listeners>
             </hz:replicatedmap>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 </beans>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -35,14 +35,6 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -36,14 +36,6 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -57,14 +57,6 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:jet>
-                <hz:instance>
-                    <hz:cooperative-thread-count>2</hz:cooperative-thread-count>
-                </hz:instance>
-            </hz:jet>
-            <hz:sql>
-                <hz:executor-pool-size>2</hz:executor-pool-size>
-            </hz:sql>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -18,7 +18,6 @@ package com.hazelcast.spring;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientCloudConfig;
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientConnectionStrategyConfig;
 import com.hazelcast.client.config.ClientFlakeIdGeneratorConfig;
 import com.hazelcast.client.config.ClientIcmpPingConfig;
@@ -52,6 +51,7 @@ import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
 import com.hazelcast.cp.CPSubsystem;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
+import com.hazelcast.spring.config.ConfigFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -136,7 +136,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.parserContext = parserContext;
             this.builder = builder;
 
-            this.configBuilder = rootBeanDefinition(ClientConfig.class);
+            this.configBuilder = rootBeanDefinition(ConfigFactory.class, "newClientConfig");
             configBuilder.addPropertyValue("nearCacheConfigMap", nearCacheConfigMap);
             configBuilder.addPropertyValue("flakeIdGeneratorConfigMap", flakeIdGeneratorConfigMap);
             configBuilder.addPropertyValue("reliableTopicConfigMap", reliableTopicConfigMap);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -42,7 +42,6 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
-import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EncryptionAtRestConfig;
@@ -151,6 +150,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import com.hazelcast.spring.config.ConfigFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -224,7 +225,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         SpringXmlConfigBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
-            this.configBuilder = BeanDefinitionBuilder.rootBeanDefinition(Config.class);
+            this.configBuilder = BeanDefinitionBuilder.rootBeanDefinition(ConfigFactory.class, "newConfig");
             this.mapConfigManagedMap = createManagedMap("mapConfigs");
             this.cacheConfigManagedMap = createManagedMap("cacheConfigs");
             this.queueManagedMap = createManagedMap("queueConfigs");

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastFailoverClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastFailoverClientBeanDefinitionParser.java
@@ -17,7 +17,7 @@
 package com.hazelcast.spring;
 
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.spring.config.ConfigFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -76,7 +76,7 @@ public class HazelcastFailoverClientBeanDefinitionParser extends  AbstractHazelc
         SpringXmlBuilder(ParserContext parserContext, BeanDefinitionBuilder builder) {
             this.parserContext = parserContext;
             this.builder = builder;
-            this.failoverConfigBuilder = rootBeanDefinition(ClientFailoverConfig.class);
+            this.failoverConfigBuilder = rootBeanDefinition(ConfigFactory.class, "newClientFailoverConfig");
         }
 
         AbstractBeanDefinition handleMultipleClusterAwareClient(Element element) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/config/ConfigFactory.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/config/ConfigFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.config;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.spring.HazelcastClientBeanDefinitionParser;
+import com.hazelcast.spring.HazelcastConfigBeanDefinitionParser;
+import com.hazelcast.spring.HazelcastFailoverClientBeanDefinitionParser;
+
+import java.util.function.Supplier;
+
+/**
+ * Provides factory methods for {@link Config} and {@link ClientConfig}.
+ * This class is used in {@link HazelcastConfigBeanDefinitionParser},
+ * {@link HazelcastClientBeanDefinitionParser} and
+ * {@link HazelcastFailoverClientBeanDefinitionParser} to create
+ * `empty` configuration instances. This factory can be used to
+ * pre-configure the configuration instances, see
+ * {@code CustomSpringJUnit4ClassRunner} for the usage.
+ */
+public final class ConfigFactory {
+
+    private static volatile Supplier<Config> configSupplier = Config::new;
+    private static volatile Supplier<ClientConfig> clientConfigSupplier = ClientConfig::new;
+    private static volatile Supplier<ClientFailoverConfig> clientFailoverConfigSupplier = ClientFailoverConfig::new;
+
+    private ConfigFactory() {
+    }
+
+    static void setConfigSupplier(Supplier<Config> configSupplier) {
+        ConfigFactory.configSupplier = configSupplier;
+    }
+
+    static void setClientConfigSupplier(Supplier<ClientConfig> clientConfigSupplier) {
+        ConfigFactory.clientConfigSupplier = clientConfigSupplier;
+    }
+
+    static void setClientFailoverConfigSupplier(Supplier<ClientFailoverConfig> clientFailoverConfigSupplier) {
+        ConfigFactory.clientFailoverConfigSupplier = clientFailoverConfigSupplier;
+    }
+
+    public static Config newConfig() {
+        return configSupplier.get();
+    }
+
+    public static ClientConfig newClientConfig() {
+        return clientConfigSupplier.get();
+    }
+
+    public static ClientFailoverConfig newClientFailoverConfig() {
+        return clientFailoverConfigSupplier.get();
+    }
+
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/config/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/config/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains config factory classes.
+ */
+package com.hazelcast.spring.config;


### PR DESCRIPTION
Currently, we use default constructor to create Config, ClientConfig
and ClientFailoverConfig when parsing the spring application-context.

With these changes, we introduce a factory class to create these config
instances. The factory class uses 'Supplier's to create the config
instances. These suppliers can be changed to provide a pre-configured
instance instead of the default one.

The motivation to use factory methods is that some of the tests stuck
at creating the client, the default connection timeout for the client
is infinite. Instead of changing each and every config xml file, we
want to pre-configure the client (and member for smallInstancesConfig)
and add a finite value for the connection timeout in the tests.


Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
