### PR TITLE
Increase parallelism of Jet test suits

### DIFF
--- a/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSinkTest.java
+++ b/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSinkTest.java
@@ -24,6 +24,8 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericData;
@@ -36,6 +38,7 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -47,6 +50,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroSinkTest extends JetTestSupport {
 
     private static final int TOTAL_RECORD_COUNT = 20;

--- a/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSourceTest.java
+++ b/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSourceTest.java
@@ -23,7 +23,8 @@ import com.hazelcast.jet.avro.generated.SpecificUser;
 import com.hazelcast.jet.avro.model.User;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -37,7 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +46,7 @@ import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroSourceTest extends SimpleTestInClusterSupport {
 
     private static final int TOTAL_RECORD_COUNT = 20;

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcSinksTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcSinksTest.java
@@ -27,7 +27,9 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.SourceBuilder;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -40,6 +42,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+@Category(QuickTest.class)
 public class CdcSinksTest extends PipelineTestSupport {
 
     private static final String MAP = "map";

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcSinksTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcSinksTest.java
@@ -28,7 +28,10 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.SourceBuilder;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -41,6 +44,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class CdcSinksTest extends PipelineTestSupport {
 
     private static final String MAP = "map";

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcSinksTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcSinksTest.java
@@ -27,10 +27,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.SourceBuilder;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -43,7 +40,6 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class CdcSinksTest extends PipelineTestSupport {
 
     private static final String MAP = "map";

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -25,10 +25,13 @@ import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -46,7 +49,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
 public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final DockerImageName MYSQL_IMAGE =

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -49,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 @RunWith(HazelcastSerialClassRunner.class)
 public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/OperationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/OperationTest.java
@@ -16,10 +16,17 @@
 
 package com.hazelcast.jet.cdc;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OperationTest {
 
     @Test

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -19,10 +19,13 @@ package com.hazelcast.jet.cdc.mysql;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -32,7 +35,8 @@ import java.sql.Statement;
 
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
-@Category({IgnoreInJenkinsOnWindows.class})
+@Category({ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
+@RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.3")

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcIntegrationTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -51,7 +52,7 @@ import static com.hazelcast.jet.Util.entry;
 public class MySqlCdcIntegrationTest extends AbstractMySqlCdcIntegrationTest {
 
     @Test
-    //category intentionally left out, we want this one test to run in standard test suits
+    @Category(QuickTest.class)
     public void customers() throws Exception {
         // given
         List<String> expectedRecords = Arrays.asList(

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.retry.RetryStrategy;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -70,7 +69,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -30,9 +30,9 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.retry.RetryStrategy;
-import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -70,7 +70,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({SerialTest.class, NightlyTest.class})
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -20,8 +20,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -35,7 +38,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
-@Category({IgnoreInJenkinsOnWindows.class})
+@Category({ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
+@RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.3")

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -62,7 +63,7 @@ import static org.junit.Assert.fail;
 public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
     @Test
-    //category intentionally left out, we want this one test to run in standard test suits
+    @Category(QuickTest.class)
     public void customers() throws Exception {
         // given
         List<String> expectedRecords = Arrays.asList(
@@ -223,7 +224,7 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
     }
 
     @Test
-    //category intentionally left out, we want this one test to run in standard test suites
+    @Category(QuickTest.class)
     public void restart_noProcessingGuarantee() throws Exception {
         Pipeline pipeline = customersPipeline(250L);
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.retry.RetryStrategy;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Rule;
@@ -68,7 +67,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -30,9 +30,9 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.retry.RetryStrategy;
-import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Rule;
@@ -68,7 +68,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({SerialTest.class, NightlyTest.class})
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -26,6 +28,7 @@ import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -38,6 +41,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSinkBuilderTest extends PipelineTestSupport {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticSourceBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticSourceBuilderTest.java
@@ -18,16 +18,23 @@ package com.hazelcast.jet.elastic;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.pipeline.BatchSource;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourceBuilderTest {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.jet.elastic.impl;
 
 import com.hazelcast.jet.JetException;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -37,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticCatClientTest {
 
     @Mock

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplierTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplierTest.java
@@ -19,7 +19,12 @@ package com.hazelcast.jet.elastic.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.elastic.impl.Shard.Prirep;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -34,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourcePMetaSupplierTest {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
@@ -18,6 +18,9 @@ package com.hazelcast.jet.elastic.impl;
 
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.elastic.impl.Shard.Prirep;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
@@ -31,6 +34,8 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.slice.SliceBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import java.io.Serializable;
@@ -51,6 +56,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourcePTest {
 
     public static final String HIT_SOURCE = "{\"name\": \"Frantisek\"}";

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.elastic.CommonElasticSinksTest.TestItem;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.SlowTest;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -31,6 +32,7 @@ import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 import java.io.IOException;
@@ -39,6 +41,7 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 import static com.hazelcast.jet.elastic.ElasticSupport.PORT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Category(SlowTest.class)
 public class AuthElasticSinksTest extends BaseElasticTest {
 
     private final JetTestInstanceFactory factory = new JetTestInstanceFactory();

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -26,6 +28,7 @@ import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -38,6 +41,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSinkBuilderTest extends PipelineTestSupport {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSourceBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSourceBuilderTest.java
@@ -18,16 +18,23 @@ package com.hazelcast.jet.elastic;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.pipeline.BatchSource;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourceBuilderTest {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -22,6 +22,7 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.function.Supplier;
 
@@ -29,7 +30,8 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 
 public final class ElasticSupport {
 
-    public static final String ELASTICSEARCH_IMAGE = "elasticsearch:6.8.14";
+    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:6.8.14")
+            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.jet.elastic.impl;
 
 import com.hazelcast.jet.JetException;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -36,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticCatClientTest {
 
     @Mock

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplierTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplierTest.java
@@ -19,7 +19,12 @@ package com.hazelcast.jet.elastic.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.elastic.impl.Shard.Prirep;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -34,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourcePMetaSupplierTest {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
@@ -19,6 +19,9 @@ package com.hazelcast.jet.elastic.impl;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.elastic.impl.Shard.Prirep;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -36,6 +39,8 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.slice.SliceBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import java.io.Serializable;
@@ -55,7 +60,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourcePTest {
 
     public static final String HIT_SOURCE = "{\"name\": \"Frantisek\"}";

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -26,6 +28,7 @@ import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -37,6 +40,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSinkBuilderTest extends PipelineTestSupport {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSourceBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSourceBuilderTest.java
@@ -18,16 +18,23 @@ package com.hazelcast.jet.elastic;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.pipeline.BatchSource;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourceBuilderTest {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.jet.elastic.impl;
 
 import com.hazelcast.jet.JetException;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -36,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticCatClientTest {
 
     @Mock

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplierTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplierTest.java
@@ -19,7 +19,12 @@ package com.hazelcast.jet.elastic.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.elastic.impl.Shard.Prirep;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -34,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourcePMetaSupplierTest {
 
     @Test

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
@@ -20,6 +20,9 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.elastic.impl.Shard.Prirep;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -38,6 +41,8 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.slice.SliceBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import java.io.Serializable;
@@ -59,6 +64,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSourcePTest {
 
     public static final String HIT_SOURCE = "{\"name\": \"Frantisek\"}";

--- a/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcServiceTest.java
+++ b/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcServiceTest.java
@@ -30,6 +30,8 @@ import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import io.grpc.BindableService;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
@@ -38,6 +40,7 @@ import io.grpc.stub.StreamObserver;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class GrpcServiceTest extends SimpleTestInClusterSupport {
 
     private static final int ITEM_COUNT = 10_000;

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
@@ -18,10 +18,12 @@ package com.hazelcast.jet.hadoop.impl;
 
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 
-@Category(IgnoreInJenkinsOnWindows.class)
+@Category({QuickTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
 public abstract class HadoopTestSupport extends SimpleTestInClusterSupport {
 
     @Before

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -37,7 +37,8 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.kafka.KafkaSources;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -50,7 +51,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -84,7 +85,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
     private static final int INITIAL_PARTITION_COUNT = 4;

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_StandaloneKafkaTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_StandaloneKafkaTest.java
@@ -22,9 +22,14 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.kafka.KafkaProcessors;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -34,6 +39,8 @@ import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamKafkaP_StandaloneKafkaTest extends JetTestSupport {
 
     @Test

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_TimestampModesTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_TimestampModesTest.java
@@ -20,6 +20,8 @@ import com.hazelcast.jet.kafka.KafkaSources;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.StreamSourceStageTestBase;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -27,6 +29,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -35,6 +38,7 @@ import java.util.Properties;
 import static java.util.Arrays.asList;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamKafkaP_TimestampModesTest extends StreamSourceStageTestBase {
 
     private static KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
@@ -34,7 +34,8 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -46,7 +47,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -61,7 +62,7 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WriteKafkaPTest extends SimpleTestInClusterSupport {
 
     private static final int PARTITION_COUNT = 20;

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
@@ -32,8 +32,13 @@ import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
@@ -51,6 +56,8 @@ import static java.lang.Math.min;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 class AbstractKinesisTest extends JetTestSupport {
 
     protected static final int KEYS = 250;

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -26,14 +26,12 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy;
@@ -55,7 +53,6 @@ import static org.junit.Assert.assertFalse;
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.repeat;
 import static org.testcontainers.utility.DockerImageName.parse;
 
-@RunWith(HazelcastSerialClassRunner.class)
 public class KinesisFailureTest extends AbstractKinesisTest {
 
     @ClassRule

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.pipeline.WindowDefinition;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -41,7 +40,6 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 
@@ -67,7 +65,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.testcontainers.utility.DockerImageName.parse;
 
-@RunWith(HazelcastSerialClassRunner.class)
 public class KinesisIntegrationTest extends AbstractKinesisTest {
 
     @ClassRule

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/RandomizedRateTrackerTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/RandomizedRateTrackerTest.java
@@ -15,10 +15,17 @@
  */
 package com.hazelcast.jet.kinesis.impl;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RandomizedRateTrackerTest {
 
     @Test

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/sink/SlowRecoveryDegraderTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/sink/SlowRecoveryDegraderTest.java
@@ -15,10 +15,17 @@
  */
 package com.hazelcast.jet.kinesis.impl.sink;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SlowRecoveryDegraderTest {
 
     private static final int K = 10;

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/HashRangeTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/HashRangeTest.java
@@ -15,7 +15,12 @@
  */
 package com.hazelcast.jet.kinesis.impl.source;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.math.BigInteger;
 
@@ -24,6 +29,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HashRangeTest {
 
     @Test

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/InitialShardIteratorsTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/InitialShardIteratorsTest.java
@@ -20,12 +20,19 @@ import com.amazonaws.services.kinesis.model.GetShardIteratorRequest;
 import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class InitialShardIteratorsTest {
 
     private static final String STREAM = "stream";

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/ShardQueueTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/ShardQueueTest.java
@@ -16,11 +16,18 @@
 package com.hazelcast.jet.kinesis.impl.source;
 
 import com.amazonaws.services.kinesis.model.Shard;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ShardQueueTest {
 
     @Test

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/ShardTrackerTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/impl/source/ShardTrackerTest.java
@@ -17,7 +17,12 @@ package com.hazelcast.jet.kinesis.impl.source;
 
 import com.amazonaws.services.kinesis.model.HashKeyRange;
 import com.amazonaws.services.kinesis.model.Shard;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -32,6 +37,8 @@ import static com.hazelcast.jet.kinesis.impl.source.ShardTracker.EXPIRATION_MS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ShardTrackerTest {
 
     private static final HashRange[] RANGE_PARTITIONS = {range(0, 1000L), range(1000L, 2000L), range(2000L, 3000L)};

--- a/extensions/protobuf/src/test/java/com/hazelcast/jet/protobuf/JobSerializerTest.java
+++ b/extensions/protobuf/src/test/java/com/hazelcast/jet/protobuf/JobSerializerTest.java
@@ -30,10 +30,11 @@ import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.protobuf.Messages.Animal;
 import com.hazelcast.jet.protobuf.Messages.Person;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -45,7 +46,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobSerializerTest extends SimpleTestInClusterSupport {
 
     private static final int PERSON_TYPE_ID = 1;

--- a/extensions/protobuf/src/test/java/com/hazelcast/jet/protobuf/ProtobufSerializerTest.java
+++ b/extensions/protobuf/src/test/java/com/hazelcast/jet/protobuf/ProtobufSerializerTest.java
@@ -23,7 +23,12 @@ import com.hazelcast.internal.serialization.impl.ObjectDataInputStream;
 import com.hazelcast.internal.serialization.impl.ObjectDataOutputStream;
 import com.hazelcast.jet.protobuf.Messages.Person;
 import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,6 +38,8 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProtobufSerializerTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -43,7 +42,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
     private static final String ECHO_HANDLER_FUNCTION

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -42,7 +43,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Category({NightlyTest.class})
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
     private static final String ECHO_HANDLER_FUNCTION

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
@@ -23,6 +23,8 @@ import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -46,6 +48,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PythonServiceTest extends SimpleTestInClusterSupport {
 
     private static final int ITEM_COUNT = 10_000;

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
@@ -48,7 +48,6 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class PythonServiceTest extends SimpleTestInClusterSupport {
 
     private static final int ITEM_COUNT = 10_000;
@@ -80,7 +79,7 @@ public class PythonServiceTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    //category intentionally left out, we want this one test to run in standard test suits
+    @Category({QuickTest.class, ParallelJVMTest.class})
     public void batchStage_mapUsingPython() {
         // Given
         PythonServiceConfig cfg = new PythonServiceConfig()

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
@@ -24,12 +24,15 @@ import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -38,7 +41,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.experimental.categories.Category;
 
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -47,7 +49,7 @@ import static org.junit.Assert.assertEquals;
 import static software.amazon.awssdk.core.sync.ResponseTransformer.toInputStream;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({IgnoreInJenkinsOnWindows.class})
+@Category({QuickTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
 public class S3MockTest extends S3TestBase {
 
     @ClassRule

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,7 +37,7 @@ import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 @RunWith(HazelcastSerialClassRunner.class)
 public class S3SinkTest extends S3TestBase {
 

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
@@ -19,10 +19,13 @@ package com.hazelcast.jet.s3;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
@@ -35,7 +38,8 @@ import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
 public class S3SinkTest extends S3TestBase {
 
     private static final int WAIT_AFTER_CLEANUP_IN_SECS = 5;

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SourceTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SourceTest.java
@@ -17,16 +17,20 @@
 package com.hazelcast.jet.s3;
 
 import com.hazelcast.function.SupplierEx;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
 public class S3SourceTest extends S3TestBase {
 
     private static final String BUCKET_NAME = "jet-s3-connector-test-bucket-source";

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SourceTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SourceTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.s3;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -29,7 +28,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import java.util.ArrayList;
 import java.util.List;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 @RunWith(HazelcastSerialClassRunner.class)
 public class S3SourceTest extends S3TestBase {
 

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -23,6 +23,9 @@ import com.hazelcast.jet.sql.impl.connector.map.IMapSqlConnector;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlService;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -46,6 +49,7 @@ import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLA
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
 
     /**

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/ExpressionUtilTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/ExpressionUtilTest.java
@@ -23,7 +23,12 @@ import com.hazelcast.sql.impl.expression.FunctionalPredicateExpression;
 import com.hazelcast.sql.impl.expression.math.MultiplyFunction;
 import com.hazelcast.sql.impl.expression.predicate.ComparisonMode;
 import com.hazelcast.sql.impl.expression.predicate.ComparisonPredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
@@ -34,6 +39,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ExpressionUtilTest {
 
     @SuppressWarnings("unchecked")

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/JetQueryResultProducerTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/JetQueryResultProducerTest.java
@@ -22,7 +22,12 @@ import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.ResultIterator;
 import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.Future;
@@ -36,6 +41,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetQueryResultProducerTest extends JetTestSupport {
 
     private final JetQueryResultProducer producer = new JetQueryResultProducer();

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/JetSqlResultImplTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/JetSqlResultImplTest.java
@@ -20,12 +20,19 @@ import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetSqlResultImplTest extends JetTestSupport {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlJobManagementTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlJobManagementTest.java
@@ -22,8 +22,11 @@ import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.sql.impl.connector.test.TestBatchSqlConnector;
 import com.hazelcast.sql.SqlService;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
@@ -35,6 +38,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SqlJobManagementTest extends SimpleTestInClusterSupport {
 
     private static final String COMPLETED_JOB_NAME = "completedJob";

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/CountSqlAggregationTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/CountSqlAggregationTest.java
@@ -18,10 +18,17 @@ package com.hazelcast.jet.sql.impl.aggregate;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class CountSqlAggregationTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/ValueSqlAggregationTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/ValueSqlAggregationTest.java
@@ -18,10 +18,17 @@ package com.hazelcast.jet.sql.impl.aggregate;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ValueSqlAggregationTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/RowProjectorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/RowProjectorTest.java
@@ -25,7 +25,12 @@ import com.hazelcast.sql.impl.expression.math.MultiplyFunction;
 import com.hazelcast.sql.impl.extract.QueryExtractor;
 import com.hazelcast.sql.impl.extract.QueryTarget;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
@@ -34,6 +39,8 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RowProjectorTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/AvroMetadataResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/AvroMetadataResolverTest.java
@@ -19,12 +19,19 @@ package com.hazelcast.jet.sql.impl.connector.file;
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroMetadataResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/AvroResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/AvroResolverTest.java
@@ -18,14 +18,21 @@ package com.hazelcast.jet.sql.impl.connector.file;
 
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/CsvMetadataResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/CsvMetadataResolverTest.java
@@ -19,12 +19,19 @@ package com.hazelcast.jet.sql.impl.connector.file;
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class CsvMetadataResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/CsvResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/CsvResolverTest.java
@@ -19,13 +19,20 @@ package com.hazelcast.jet.sql.impl.connector.file;
 import com.google.common.collect.ImmutableSet;
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class CsvResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/JsonMetadataResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/JsonMetadataResolverTest.java
@@ -19,12 +19,19 @@ package com.hazelcast.jet.sql.impl.connector.file;
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JsonMetadataResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/JsonResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/JsonResolverTest.java
@@ -18,7 +18,12 @@ package com.hazelcast.jet.sql.impl.connector.file;
 
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,6 +33,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JsonResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/ParquetMetadataResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/ParquetMetadataResolverTest.java
@@ -19,12 +19,19 @@ package com.hazelcast.jet.sql.impl.connector.file;
 import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ParquetMetadataResolverTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/infoschema/MappingColumnsTableTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/infoschema/MappingColumnsTableTest.java
@@ -18,7 +18,12 @@ package com.hazelcast.jet.sql.impl.connector.infoschema;
 
 import com.hazelcast.jet.sql.impl.schema.Mapping;
 import com.hazelcast.jet.sql.impl.schema.MappingField;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
@@ -27,6 +32,8 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MappingColumnsTableTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/infoschema/MappingsTableTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/infoschema/MappingsTableTest.java
@@ -17,7 +17,12 @@
 package com.hazelcast.jet.sql.impl.connector.infoschema;
 
 import com.hazelcast.jet.sql.impl.schema.Mapping;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
@@ -26,6 +31,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MappingsTableTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvProjectorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvProjectorTest.java
@@ -23,13 +23,20 @@ import com.hazelcast.jet.sql.impl.inject.UpsertInjector;
 import com.hazelcast.jet.sql.impl.inject.UpsertTarget;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.annotation.Nullable;
 import java.util.Map.Entry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class KvProjectorTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjectorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjectorTest.java
@@ -29,7 +29,12 @@ import com.hazelcast.sql.impl.extract.QueryExtractor;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.extract.QueryTarget;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.sql.impl.ExpressionUtil.NOT_IMPLEMENTED_ARGUMENTS_CONTEXT;
@@ -39,6 +44,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class KvRowProjectorTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
@@ -18,11 +18,18 @@ package com.hazelcast.jet.sql.impl.connector.map;
 
 import com.hazelcast.query.Predicate;
 import com.hazelcast.sql.impl.extract.QueryPath;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.sql.impl.connector.map.QueryUtil.toPredicate;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class QueryUtilTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/AvroQueryTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/AvroQueryTargetTest.java
@@ -18,11 +18,16 @@ package com.hazelcast.jet.sql.impl.extract;
 
 import com.hazelcast.sql.impl.extract.QueryExtractor;
 import com.hazelcast.sql.impl.extract.QueryTarget;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -47,6 +52,8 @@ import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroQueryTargetTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/CsvQueryTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/CsvQueryTargetTest.java
@@ -18,7 +18,12 @@ package com.hazelcast.jet.sql.impl.extract;
 
 import com.hazelcast.sql.impl.extract.QueryExtractor;
 import com.hazelcast.sql.impl.extract.QueryTarget;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -44,6 +49,8 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class CsvQueryTargetTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetDescriptorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetDescriptorTest.java
@@ -18,10 +18,17 @@ package com.hazelcast.jet.sql.impl.inject;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroUpsertTargetDescriptorTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/HazelcastJsonUpsertTargetDescriptorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/HazelcastJsonUpsertTargetDescriptorTest.java
@@ -18,10 +18,17 @@ package com.hazelcast.jet.sql.impl.inject;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HazelcastJsonUpsertTargetDescriptorTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTargetDescriptorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTargetDescriptorTest.java
@@ -18,10 +18,17 @@ package com.hazelcast.jet.sql.impl.inject;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JsonUpsertTargetDescriptorTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PojoUpsertTargetDescriptorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PojoUpsertTargetDescriptorTest.java
@@ -19,11 +19,18 @@ package com.hazelcast.jet.sql.impl.inject;
 import com.google.common.collect.ImmutableMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PojoUpsertTargetDescriptorTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PojoUpsertTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PojoUpsertTargetTest.java
@@ -19,13 +19,20 @@ package com.hazelcast.jet.sql.impl.inject;
 import com.google.common.collect.ImmutableMap;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PojoUpsertTargetTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PortableUpsertTargetDescriptorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PortableUpsertTargetDescriptorTest.java
@@ -19,10 +19,17 @@ package com.hazelcast.jet.sql.impl.inject;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PortableUpsertTargetDescriptorTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PrimitiveUpsertTargetDescriptorTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PrimitiveUpsertTargetDescriptorTest.java
@@ -18,10 +18,17 @@ package com.hazelcast.jet.sql.impl.inject;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PrimitiveUpsertTargetDescriptorTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PrimitiveUpsertTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/PrimitiveUpsertTargetTest.java
@@ -17,10 +17,17 @@
 package com.hazelcast.jet.sql.impl.inject;
 
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PrimitiveUpsertTargetTest {
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingCatalogTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingCatalogTest.java
@@ -21,8 +21,13 @@ import com.hazelcast.jet.sql.impl.connector.SqlConnectorCache;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,6 +41,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MappingCatalogTest {
 
     private MappingCatalog catalog;

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingFieldTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingFieldTest.java
@@ -19,10 +19,17 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MappingFieldTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingStorageTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingStorageTest.java
@@ -17,15 +17,19 @@
 package com.hazelcast.jet.sql.impl.schema;
 
 import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.sql.impl.SqlTestSupport.nodeEngine;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MappingStorageTest extends SimpleTestInClusterSupport {
 
     private MappingStorage storage;

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/MappingTest.java
@@ -20,7 +20,12 @@ import com.google.common.collect.ImmutableMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +33,8 @@ import java.util.HashMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MappingTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/type/converter/ToConvertersTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/type/converter/ToConvertersTest.java
@@ -16,7 +16,12 @@
 
 package com.hazelcast.jet.sql.impl.type.converter;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -35,6 +40,8 @@ import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR_CHARACTER;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ToConvertersTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/JetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/JetTest.java
@@ -19,11 +19,18 @@ package com.hazelcast.jet;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.impl.JobRepository.INTERNAL_JET_OBJECTS_PREFIX;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/TraverserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/TraverserTest.java
@@ -17,7 +17,12 @@
 package com.hazelcast.jet;
 
 import com.hazelcast.jet.core.AppendableTraverser;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +39,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("ResultOfMethodCallIgnored")
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TraverserTest {
 
     private AppendableTraverser<Integer> rootTraverser = new AppendableTraverser<>(3);

--- a/hazelcast/src/test/java/com/hazelcast/jet/TraversersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/TraversersTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -42,6 +45,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TraversersTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/UtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/UtilTest.java
@@ -18,7 +18,10 @@ package com.hazelcast.jet;
 
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Map.Entry;
@@ -29,6 +32,7 @@ import static com.hazelcast.jet.Util.idToString;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class UtilTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/accumulator/AccumulatorSerializerHooksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/accumulator/AccumulatorSerializerHooksTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class AccumulatorSerializerHooksTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/accumulator/EqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/accumulator/EqualityTest.java
@@ -17,12 +17,16 @@
 package com.hazelcast.jet.accumulator;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EqualityTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperation1Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperation1Test.java
@@ -21,7 +21,10 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.function.Functions.wholeItem;
@@ -32,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperation1Test {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperation2Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperation2Test.java
@@ -22,7 +22,10 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.function.Functions.wholeItem;
@@ -35,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperation2Test {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperation3Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperation3Test.java
@@ -22,7 +22,10 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.datamodel.Tuple3;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.function.Functions.wholeItem;
@@ -36,6 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperation3Test {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationTest.java
@@ -22,7 +22,10 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.function.Functions.wholeItem;
@@ -35,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperationTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationToAggregatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationToAggregatorTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.aggregate;
 
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import java.util.Map;
@@ -30,6 +33,7 @@ import static com.hazelcast.jet.aggregate.AggregateOperations.groupingBy;
 import static com.hazelcast.jet.aggregate.AggregateOperations.toAggregator;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperationToAggregatorTest extends PipelineTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
@@ -31,8 +31,11 @@ import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -91,6 +94,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperationsTest {
 
     private static final InternalSerializationService SERIALIZATION_SERVICE =

--- a/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperations_accEqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/aggregate/AggregateOperations_accEqualityTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.aggregate;
 
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -41,6 +44,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AggregateOperations_accEqualityTest {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -55,7 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class BackpressureTest extends JetTestSupport {
 
     private static final int CLUSTER_SIZE = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -56,7 +55,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class BackpressureTest extends JetTestSupport {
 
     private static final int CLUSTER_SIZE = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/EqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/EqualityTest.java
@@ -17,12 +17,16 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EqualityTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/InstanceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/InstanceConfigTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -26,6 +29,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class InstanceConfigTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JetConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JetConfigTest.java
@@ -17,14 +17,18 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetConfigTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
@@ -22,8 +22,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -40,6 +43,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobConfigTest extends JetTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/ResourceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/ResourceConfigTest.java
@@ -19,10 +19,13 @@ package com.hazelcast.jet.config;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -38,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ResourceConfigTest extends JetTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
@@ -26,8 +26,11 @@ import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -45,6 +48,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AbstractProcessorTest {
 
     private static final String MOCK_ITEM = "x";

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/AppendableTraverserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/AppendableTraverserTest.java
@@ -18,13 +18,20 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AppendableTraverserTest {
 
     private AppendableTraverser t = new AppendableTraverser(2);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/CancellationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/CancellationTest.java
@@ -26,10 +26,13 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.jet.impl.operation.SnapshotPhase1Operation;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.PacketFiltersUtil;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -52,6 +55,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class CancellationTest extends JetTestSupport {
 
     private static final int ASSERTION_TIMEOUT_SECONDS = 15;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
@@ -24,9 +24,12 @@ import com.hazelcast.jet.core.TestProcessors.MockPMS;
 import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -37,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ClusterStateChangeTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 3;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/CoreSerializerHooksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/CoreSerializerHooksTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class CoreSerializerHooksTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/DAGTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/DAGTest.java
@@ -19,9 +19,12 @@ package com.hazelcast.jet.core;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -41,6 +44,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class DAGTest {
 
     private static final SupplierEx<Processor> PROCESSOR_SUPPLIER = noopP();

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/DotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/DotTest.java
@@ -23,7 +23,10 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Map.Entry;
@@ -38,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class DotTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/EdgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/EdgeTest.java
@@ -18,8 +18,11 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.core.Edge.RoutingPolicy;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.function.Functions.wholeItem;
@@ -31,6 +34,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EdgeTest {
     private static final String A = "a";
     private static final String B = "b";

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/EventTimeMapperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/EventTimeMapperTest.java
@@ -18,9 +18,14 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Traverser;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.EventTimeMapper.NO_NATIVE_TIME;
 import static com.hazelcast.jet.core.EventTimePolicy.eventTimePolicy;
@@ -31,6 +36,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EventTimeMapperTest {
 
     private static final long LAG = 3;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -44,10 +44,13 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nonnull;
@@ -84,6 +87,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
     private static final int MEMBER_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
@@ -25,9 +25,12 @@ import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -41,6 +44,7 @@ import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ExecutionLifecycle_RestartableExceptionTest extends TestInClusterSupport {
 
     private static final RestartableException RESTARTABLE_EXCEPTION =

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
@@ -29,8 +29,11 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.map.MapStore;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -55,6 +58,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class GracefulShutdownTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdown_LiteMasterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdown_LiteMasterTest.java
@@ -23,8 +23,11 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.DummyStatefulP;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
@@ -34,6 +37,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class GracefulShutdown_LiteMasterTest extends JetTestSupport {
 
     private JetInstance instance;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/HzSerializableProcessorSuppliersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/HzSerializableProcessorSuppliersTest.java
@@ -20,14 +20,18 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.net.URL;
 import java.net.URLClassLoader;
 
 import static java.util.Objects.requireNonNull;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HzSerializableProcessorSuppliersTest extends SimpleTestInClusterSupport {
 
     private final DAG dag = new DAG();

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartStressTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.locks.LockSupport;
@@ -25,6 +28,7 @@ import java.util.concurrent.locks.LockSupport;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class JobRestartStressTest extends JobRestartStressTestBase {
     @Test
     public void stressTest_restart() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -33,10 +33,13 @@ import com.hazelcast.jet.impl.JobExecutionRecord;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -74,7 +77,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class JobRestartWithSnapshotTest extends JetTestSupport {
 
     private static final int LOCAL_PARALLELISM = 4;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
@@ -34,10 +34,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.StreamSerializer;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
@@ -55,7 +56,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobSerializerTest extends SimpleTestInClusterSupport {
 
     private static final String SOURCE_MAP_NAME = "source-map";

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -34,13 +34,14 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.test.ExpectedRuntimeException;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -71,7 +72,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobTest extends SimpleTestInClusterSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/Job_SeparateClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/Job_SeparateClusterTest.java
@@ -27,12 +27,17 @@ import com.hazelcast.jet.JobAlreadyExistsException;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +55,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link Job} with a separate cluster for each test.
  */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class Job_SeparateClusterTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/Job_StaleInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/Job_StaleInstanceTest.java
@@ -22,9 +22,12 @@ import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Iterator;
@@ -38,6 +41,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
  * because it restarted. All tests check that it fails as it should.
  */
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class Job_StaleInstanceTest extends JetTestSupport {
 
     private static JetTestInstanceFactory instanceFactory;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
@@ -31,8 +31,11 @@ import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertAnyOrder;
@@ -40,6 +43,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ManagedContextTest extends JetTestSupport {
 
     static final String INJECTED_VALUE = "injectedValue";

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
@@ -30,9 +30,12 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -57,6 +60,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ManualRestartTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,7 +39,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class MemberReconnectionStressTest extends JetTestSupport {
 
     private final AtomicBoolean terminated = new AtomicBoolean();

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -39,7 +40,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class MemberReconnectionStressTest extends JetTestSupport {
 
     private final AtomicBoolean terminated = new AtomicBoolean();

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,7 +31,7 @@ import org.junit.runner.RunWith;
 import static com.hazelcast.jet.core.Edge.between;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SlowTest.class, ParallelJVMTest.class})
+@Category({SlowTest.class})
 public class MemberReconnectionTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
@@ -23,12 +23,16 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.Edge.between;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class MemberReconnectionTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MultigraphTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MultigraphTest.java
@@ -19,7 +19,12 @@ package com.hazelcast.jet.core;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.processor.SinkProcessors;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +36,8 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MultigraphTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ObservableResultsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ObservableResultsTest.java
@@ -29,10 +29,13 @@ import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.test.SimpleEvent;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.ringbuffer.impl.RingbufferProxy;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -57,6 +60,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ObservableResultsTest extends TestInClusterSupport {
 
     private String observableName;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
@@ -26,8 +26,11 @@ import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.pipeline.test.SimpleEvent;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -39,6 +42,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ObservableShutdownTest extends JetTestSupport {
 
     private static final int MEMBER_COUNT = 3;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.PacketFiltersUtil;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,7 +55,7 @@ import static org.junit.Assert.assertNotNull;
 
 // TODO this test does not test when responses are lost. There is currently no test
 //   harness to simulate that.
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class OperationLossTest extends SimpleTestInClusterSupport {
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.PacketFiltersUtil;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -55,7 +54,7 @@ import static org.junit.Assert.assertNotNull;
 
 // TODO this test does not test when responses are lost. There is currently no test
 //   harness to simulate that.
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class OperationLossTest extends SimpleTestInClusterSupport {
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/OperationTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/OperationTimeoutTest.java
@@ -20,15 +20,19 @@ import com.hazelcast.config.Config;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.TestUtil.executeAndPeel;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OperationTimeoutTest extends JetTestSupport {
 
     private static final int TIMEOUT_MILLIS = 8000;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ParallelStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ParallelStressTest.java
@@ -21,9 +21,12 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.environment.RuntimeAvailableProcessorsRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -34,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ParallelStressTest extends JetTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/PeekingWrapperPreferredParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/PeekingWrapperPreferredParallelismTest.java
@@ -18,7 +18,10 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekInputP;
@@ -27,6 +30,7 @@ import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekSnapshot
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PeekingWrapperPreferredParallelismTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -26,8 +26,11 @@ import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -56,6 +59,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PeekingWrapperTest {
 
     private static final JetEvent<Integer> TEST_JET_EVENT = jetEvent(123, 2);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/PostponedSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/PostponedSnapshotTest.java
@@ -19,7 +19,10 @@ package com.hazelcast.jet.core;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.Future;
@@ -29,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PostponedSnapshotTest extends PostponedSnapshotTestBase {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -24,8 +24,11 @@ import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -58,6 +61,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorsTest extends SimpleTestInClusterSupport {
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,7 +58,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class Processors_slidingWindowingIntegrationTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ResettableSingletonTraverserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ResettableSingletonTraverserTest.java
@@ -17,13 +17,17 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ResettableSingletonTraverserTest {
     private final ResettableSingletonTraverser<Integer> trav = new ResettableSingletonTraverser<>();
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/RoutingPolicyDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/RoutingPolicyDistributedTest.java
@@ -20,10 +20,13 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.core.TestProcessors.CollectPerProcessorSink;
 import com.hazelcast.jet.core.TestProcessors.ListsSourceP;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
@@ -40,6 +43,7 @@ import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RoutingPolicyDistributedTest extends SimpleTestInClusterSupport {
 
     @SuppressWarnings("unchecked")

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/RoutingPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/RoutingPolicyTest.java
@@ -19,9 +19,12 @@ package com.hazelcast.jet.core;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.core.TestProcessors.CollectPerProcessorSink;
 import com.hazelcast.jet.core.TestProcessors.ListsSourceP;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +41,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RoutingPolicyTest extends SimpleTestInClusterSupport {
 
     private static final List<Integer> NUMBERS_LOW = IntStream.range(0, 4096).boxed().collect(toList());

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -35,7 +36,7 @@ import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class ScaleUpTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -36,7 +35,7 @@ import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class ScaleUpTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SlidingWindowPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SlidingWindowPolicyTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.SlidingWindowPolicy.slidingWinPolicy;
@@ -26,6 +29,7 @@ import static com.hazelcast.jet.core.SlidingWindowPolicy.tumblingWinPolicy;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SlidingWindowPolicyTest {
 
     private SlidingWindowPolicy definition;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
@@ -18,8 +18,11 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.Traverser;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.util.stream.IntStream;
@@ -30,6 +33,7 @@ import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SlowSourceYieldTest extends SimpleTestInClusterSupport {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
@@ -29,9 +29,12 @@ import com.hazelcast.jet.core.JobRestartWithSnapshotTest.SequencesInPartitionsGe
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -45,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SnapshotFailureTest extends JetTestSupport {
 
     private static final int LOCAL_PARALLELISM = 4;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.MasterContext;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -53,7 +54,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class SplitBrainTest extends JetSplitBrainTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.MasterContext;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -54,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class SplitBrainTest extends JetSplitBrainTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
@@ -29,8 +29,11 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.map.IMap;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Map;
 
@@ -43,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
 
     private static final Throwable MOCK_ERROR = new AssertionError("mock error");

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendResumeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendResumeTest.java
@@ -26,9 +26,12 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.JobResult;
 import com.hazelcast.jet.impl.exception.JobTerminateRequestedException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -45,6 +48,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class SuspendResumeTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 3;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TerminalSnapshotSynchronizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TerminalSnapshotSynchronizationTest.java
@@ -22,9 +22,12 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.jet.impl.operation.SnapshotPhase1Operation;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
@@ -34,6 +37,7 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TerminalSnapshotSynchronizationTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeDuringJobSubmissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeDuringJobSubmissionTest.java
@@ -24,8 +24,11 @@ import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
@@ -37,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TopologyChangeDuringJobSubmissionTest extends JetTestSupport {
 
     private static final int PARALLELISM = 1;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -38,10 +38,13 @@ import com.hazelcast.jet.impl.operation.InitExecutionOperation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -80,6 +83,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class TopologyChangeTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 3;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/VertexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/VertexTest.java
@@ -18,8 +18,11 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -31,6 +34,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class VertexTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/WatermarkPolicy_withFixedLagTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/WatermarkPolicy_withFixedLagTest.java
@@ -17,13 +17,17 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.WatermarkPolicy.limitingLag;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WatermarkPolicy_withFixedLagTest {
 
     private static final long LAG = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobExecutionMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobExecutionMetricsTest.java
@@ -27,13 +27,17 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.core.JobStatus.FAILED;
 import static com.hazelcast.jet.core.metrics.MetricNames.EXECUTION_COMPLETION_TIME;
 import static com.hazelcast.jet.core.metrics.MetricNames.EXECUTION_START_TIME;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobExecutionMetricsTest extends SimpleTestInClusterSupport {
 
     private static final long JOB_HAS_NOT_FINISHED_YET_TIME = -1;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -26,8 +26,13 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
@@ -41,6 +46,8 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobLifecycleMetricsTest extends JetTestSupport {
 
     private static final int MEMBER_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
@@ -23,8 +23,11 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -38,6 +41,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobMetrics_BatchTest extends TestInClusterSupport {
 
     static final JobConfig JOB_CONFIG_WITH_METRICS = new JobConfig().setStoreMetricsAfterJobCompletion(true);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
@@ -33,9 +33,12 @@ import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.JobRepository;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nonnull;
@@ -56,6 +59,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobMetrics_MiscTest extends TestInClusterSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
@@ -25,8 +25,13 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.TestProcessors;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.metrics.JobMetrics_BatchTest.JOB_CONFIG_WITH_METRICS;
@@ -37,6 +42,8 @@ import static org.junit.Assert.assertTrue;
  * Tests for JobMetrics that don't use shared cluster. The cluster in each test
  * has a specific configuration.
  */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StreamTest.java
@@ -24,9 +24,12 @@ import com.hazelcast.jet.pipeline.JournalInitialPosition;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Collection;
 import java.util.List;
@@ -40,6 +43,7 @@ import static com.hazelcast.jet.core.metrics.MetricNames.EMITTED_COUNT;
 import static com.hazelcast.jet.core.metrics.MetricNames.RECEIVED_COUNT;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobMetrics_StreamTest extends TestInClusterSupport {
 
     private static final String NOT_FILTER_OUT_PREFIX = "ok";

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,7 +45,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class JobMetrics_StressTest extends JetTestSupport {
 
     private static final int RESTART_COUNT = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,7 +44,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class JobMetrics_StressTest extends JetTestSupport {
 
     private static final int RESTART_COUNT = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobSnapshotMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobSnapshotMetricsTest.java
@@ -26,9 +26,13 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobSnapshotMetricsTest extends SimpleTestInClusterSupport {
 
     private static final String SOURCE_VERTEX_NAME = "sourceForSnapshot";

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MeasurementPredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MeasurementPredicatesTest.java
@@ -16,8 +16,13 @@
 
 package com.hazelcast.jet.core.metrics;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +32,8 @@ import static com.hazelcast.jet.Util.entry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MeasurementPredicatesTest {
 
     private Measurement measurement;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
@@ -17,15 +17,22 @@
 package com.hazelcast.jet.core.test;
 
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TestOutboxTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/test/TestSupportTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/test/TestSupportTest.java
@@ -26,7 +26,10 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -48,6 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TestSupportTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/DataModelSerializerHooksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/DataModelSerializerHooksTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,7 +46,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class DataModelSerializerHooksTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/EqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/EqualityTest.java
@@ -17,12 +17,16 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EqualityTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/ItemsByTagTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/ItemsByTagTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Iterator;
@@ -37,6 +40,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ItemsByTagTest {
     private ItemsByTag ibt;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/TagTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/TagTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.datamodel.Tag.tag;
@@ -30,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TagTest {
     private Tag tag;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple2Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple2Test.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
@@ -27,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class Tuple2Test {
     private Tuple2<String, String> t;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple3Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple3Test.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
@@ -27,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class Tuple3Test {
     private Tuple3<String, String, String> t;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple4Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple4Test.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.datamodel.Tuple4.tuple4;
@@ -28,6 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class Tuple4Test {
     private Tuple4<String, String, String, String> t;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple5Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/datamodel/Tuple5Test.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.datamodel;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.datamodel.Tuple5.tuple5;
@@ -28,6 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class Tuple5Test {
     private Tuple5<String, String, String, String, String> t;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/EqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/EqualityTest.java
@@ -17,11 +17,15 @@
 package com.hazelcast.jet.impl;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EqualityTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JetClientInstanceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JetClientInstanceImplTest.java
@@ -21,7 +21,10 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.List;
@@ -30,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetClientInstanceImplTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -33,9 +33,12 @@ import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -51,7 +54,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobRepositoryTest extends JetTestSupport {
 
     private static final long RESOURCES_EXPIRATION_TIME_MILLIS = SECONDS.toMillis(1);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
@@ -29,8 +29,11 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -42,6 +45,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JobSummaryTest extends JetTestSupport {
 
     private static final String SOURCE_NAME = "source";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/LiveOperationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/LiveOperationRegistryTest.java
@@ -21,8 +21,11 @@ import com.hazelcast.jet.impl.operation.AsyncJobOperation;
 import com.hazelcast.spi.impl.operationservice.CallsPerMember;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -36,6 +39,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class LiveOperationRegistryTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ConvenientSourcePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ConvenientSourcePTest.java
@@ -21,9 +21,14 @@ import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.impl.pipeline.transform.StreamSourceTransform;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +37,8 @@ import java.util.HashSet;
 import static com.hazelcast.jet.core.EventTimePolicy.noEventTime;
 import static org.junit.Assert.fail;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ConvenientSourcePTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.EventJournalCacheEvent;
+import com.hazelcast.cache.ICache;
 import com.hazelcast.collection.IList;
 import com.hazelcast.config.Config;
 import com.hazelcast.jet.JetCacheManager;
@@ -26,14 +26,17 @@ import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SourceProcessors;
-import com.hazelcast.map.IMap;
 import com.hazelcast.map.EventJournalMapEvent;
+import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.predicates.TruePredicate;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -61,6 +64,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HazelcastConnectorTest extends SimpleTestInClusterSupport {
 
     private static final int ENTRY_COUNT = 100;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnector_RestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnector_RestartTest.java
@@ -38,8 +38,11 @@ import com.hazelcast.jet.impl.JobExecutionService;
 import com.hazelcast.jet.impl.execution.ExecutionContext;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
@@ -56,6 +59,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HazelcastConnector_RestartTest extends JetTestSupport {
 
     private JetInstance instance1;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastRemoteConnectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastRemoteConnectorTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.EventJournalCacheEvent;
+import com.hazelcast.cache.ICache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.collection.IList;
@@ -35,11 +35,12 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SourceProcessors;
-import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -70,7 +71,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(SerialTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HazelcastRemoteConnectorTest extends JetTestSupport {
 
     private static final int ITEM_COUNT = 20;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastRemoteConnectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/HazelcastRemoteConnectorTest.java
@@ -39,7 +39,6 @@ import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -71,7 +70,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category(QuickTest.class)
 public class HazelcastRemoteConnectorTest extends JetTestSupport {
 
     private static final int ITEM_COUNT = 20;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSinkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSinkIntegrationTest.java
@@ -22,12 +22,15 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQXAConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -43,6 +46,7 @@ import static com.hazelcast.jet.impl.connector.JmsTestUtil.consumeMessages;
 import static java.util.stream.IntStream.range;
 import static javax.jms.Session.DUPS_OK_ACKNOWLEDGE;
 
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class JmsSinkIntegrationTest extends SimpleTestInClusterSupport {
 
     @ClassRule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_ActiveMqArtemis.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_ActiveMqArtemis.java
@@ -17,14 +17,18 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.function.SupplierEx;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
 
 import javax.jms.ConnectionFactory;
 
 @Ignore // ignored due to https://issues.apache.org/jira/browse/ARTEMIS-2735
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JmsSourceIntegrationTest_ActiveMqArtemis extends JmsSourceIntegrationTestBase {
 
     @ClassRule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.connector;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
@@ -26,7 +27,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 
 import javax.jms.ConnectionFactory;
 
-@Category({NightlyTest.class, IgnoreInJenkinsOnWindows.class})
+@Category({NightlyTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
 public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestBase {
 
     @ClassRule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegration_NonSharedClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegration_NonSharedClusterTest.java
@@ -30,10 +30,15 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.TextMessage;
@@ -52,6 +57,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class JmsSourceIntegration_NonSharedClusterTest extends JetTestSupport {
 
     @ClassRule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadFilesPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadFilesPTest.java
@@ -23,9 +23,12 @@ import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +44,7 @@ import static com.hazelcast.jet.Util.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReadFilesPTest extends SimpleTestInClusterSupport {
 
     private File directory;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
@@ -22,8 +22,11 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.List;
@@ -33,6 +36,7 @@ import static com.hazelcast.jet.TestContextSupport.adaptSupplier;
 import static java.util.stream.Collectors.toList;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReadIListPTest extends JetTestSupport {
 
     private JetInstance instance;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
@@ -19,9 +19,12 @@ package com.hazelcast.jet.impl.connector;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -37,6 +40,7 @@ import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertAnyOrder;
 import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertOrdered;
 import static java.util.stream.Collectors.toList;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReadJdbcPTest extends SimpleTestInClusterSupport {
 
     private static final int ITEM_COUNT = 100;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCachePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCachePTest.java
@@ -23,10 +23,11 @@ import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,7 @@ import static com.hazelcast.jet.TestContextSupport.adaptSupplier;
 import static com.hazelcast.jet.Util.entry;
 import static java.util.Collections.emptyList;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReadMapOrCachePTest extends SimpleTestInClusterSupport {
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +57,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category({NightlyTest.class})
 public class ReadMapOrCacheP_ConsistencyTest extends JetTestSupport {
 
     private static final String MAP_NAME = "map";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
@@ -30,10 +30,10 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
-import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SerialTest.class, NightlyTest.class})
+@Category({NightlyTest.class, ParallelJVMTest.class})
 public class ReadMapOrCacheP_ConsistencyTest extends JetTestSupport {
 
     private static final String MAP_NAME = "map";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
@@ -34,8 +34,11 @@ import com.hazelcast.jet.pipeline.JournalInitialPosition;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -58,6 +61,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamEventJournalPTest extends JetTestSupport {
 
     private static final int NUM_PARTITIONS = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalP_WmCoalescingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalP_WmCoalescingTest.java
@@ -28,8 +28,11 @@ import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.HashSet;
@@ -53,6 +56,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamEventJournalP_WmCoalescingTest extends JetTestSupport {
 
     private static final int JOURNAL_CAPACITY = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -28,10 +28,13 @@ import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
@@ -59,6 +62,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamFilesPTest extends JetTestSupport {
 
     private static final long LINE_COUNT = 1_000;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
@@ -23,9 +23,12 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.BufferedWriter;
@@ -54,6 +57,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Ignore
 public class StreamFilesP_integrationTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.StringReader;
@@ -26,6 +29,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamFilesP_readCompleteLineTest {
 
     private StreamFilesP<String> p = new StreamFilesP<>("", UTF_8, "*", false, (file, line) -> line);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
@@ -27,11 +27,14 @@ import com.hazelcast.jet.impl.pipeline.transform.StreamSourceTransform;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.jms.Connection;
@@ -54,6 +57,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamJmsPTest extends JetTestSupport {
 
     @ClassRule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -49,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 public class StreamSocketPTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketP_integrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketP_integrationTest.java
@@ -23,8 +23,11 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.OutputStream;
@@ -44,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamSocketP_integrationTest extends JetTestSupport {
 
     private static final String HOST = "localhost";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/UpdateMapPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/UpdateMapPTest.java
@@ -27,8 +27,11 @@ import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -44,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class UpdateMapPTest extends JetTestSupport {
 
     private static final int COUNT_PER_KEY = 16;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -28,8 +28,11 @@ import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.List;
@@ -42,6 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WriteBufferedPTest extends JetTestSupport {
 
     private static final List<String> events = new CopyOnWriteArrayList<>();

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteFilePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteFilePTest.java
@@ -31,12 +31,13 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.test.TestSources;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedWriter;
@@ -77,7 +78,7 @@ import static java.util.stream.Collectors.joining;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WriteFilePTest extends SimpleTestInClusterSupport {
 
     private static final Semaphore semaphore = new Semaphore(0);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -24,10 +24,13 @@ import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.postgresql.ds.common.BaseDataSource;
 import org.postgresql.xa.PGXADataSource;
@@ -47,14 +50,13 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
-import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.Util.entry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-@Category({IgnoreInJenkinsOnWindows.class})
+@Category({SlowTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
 public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @ClassRule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteLoggerPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteLoggerPTest.java
@@ -23,7 +23,10 @@ import com.hazelcast.jet.core.test.TestInbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.writeLoggerP;
@@ -33,6 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WriteLoggerPTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteSocketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteSocketTest.java
@@ -23,7 +23,10 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.BufferedReader;
@@ -42,6 +45,7 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WriteSocketTest extends JetTestSupport {
 
     private static final int ITEM_COUNT = 1000;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/AbstractDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/AbstractDeploymentTest.java
@@ -29,7 +29,10 @@ import com.hazelcast.jet.pipeline.ServiceFactories;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -54,6 +57,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public abstract class AbstractDeploymentTest extends SimpleTestInClusterSupport {
 
     public static final String CLASS_LOADER_PREFIX = "/cp1/";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeploymentTest.java
@@ -19,16 +19,13 @@ package com.hazelcast.jet.impl.deployment;
 import com.hazelcast.config.Config;
 import com.hazelcast.internal.util.FilteringClassLoader;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
 
 import static java.util.Collections.singletonList;
 
-@RunWith(HazelcastSerialClassRunner.class)
 @Ignore
 public class ClientDeploymentTest extends AbstractDeploymentTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeployment_StandaloneClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeployment_StandaloneClusterTest.java
@@ -21,13 +21,20 @@ import com.hazelcast.config.Config;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.net.URL;
 import java.net.URLClassLoader;
 
 @Ignore
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientDeployment_StandaloneClusterTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/DeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/DeploymentTest.java
@@ -19,14 +19,11 @@ package com.hazelcast.jet.impl.deployment;
 import com.hazelcast.config.Config;
 import com.hazelcast.internal.util.FilteringClassLoader;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.runner.RunWith;
 
 import static java.util.Collections.singletonList;
 
-@RunWith(HazelcastSerialClassRunner.class)
 @Ignore
 public class DeploymentTest extends AbstractDeploymentTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/IMapInputOutputStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/IMapInputOutputStreamTest.java
@@ -19,13 +19,14 @@ package com.hazelcast.jet.impl.deployment;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class IMapInputOutputStreamTest extends SimpleTestInClusterSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -20,10 +20,17 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetClassLoaderTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/NonSmartClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/NonSmartClientTest.java
@@ -31,8 +31,11 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.List;
@@ -43,6 +46,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class NonSmartClientTest extends JetTestSupport {
 
     private JetInstance client;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/EqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/EqualityTest.java
@@ -18,11 +18,15 @@ package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.jet.core.BroadcastKey;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EqualityTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ExecutionSerializerHooksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ExecutionSerializerHooksTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class ExecutionSerializerHooksTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/IsWithinLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/IsWithinLimitTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.impl.execution.ReceiverTasklet.COMPRESSED_SEQ_UNIT_LOG2;
@@ -26,6 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class IsWithinLimitTest {
 
     static final long COMPRESSED_SEQ_UNIT = 1 << COMPRESSED_SEQ_UNIT_LOG2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/OutboxImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/OutboxImplTest.java
@@ -20,9 +20,12 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -39,6 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OutboxImplTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
@@ -24,8 +24,11 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -54,6 +57,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorTaskletTest {
 
     private static final int MOCK_INPUT_SIZE = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
@@ -24,8 +24,11 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -49,6 +52,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorTaskletTest_Blocking {
 
     private static final int MOCK_INPUT_SIZE = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -29,8 +29,11 @@ import com.hazelcast.jet.impl.operation.SnapshotPhase1Operation.SnapshotPhase1Re
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -63,6 +66,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorTaskletTest_Snapshots {
 
     private static final int MOCK_INPUT_SIZE = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
@@ -25,8 +25,11 @@ import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -48,6 +51,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorTaskletTest_Watermarks {
 
     private static final int CALL_COUNT_LIMIT = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
@@ -21,8 +21,11 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.logging.impl.LoggingServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.config.InstanceConfig.DEFAULT_FLOW_CONTROL_PERIOD_MS;
@@ -36,6 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReceiverTaskletSendLimitTest {
 
     private static final long START = SECONDS.toNanos(10);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletStaticTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletStaticTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.impl.execution.ReceiverTasklet.COMPRESSED_SEQ_UNIT_LOG2;
@@ -26,6 +29,7 @@ import static com.hazelcast.jet.impl.execution.ReceiverTasklet.estimatedMemoryFo
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReceiverTaskletStaticTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletTest.java
@@ -22,8 +22,11 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -33,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReceiverTaskletTest {
 
     private ReceiverTasklet t;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
@@ -20,8 +20,11 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.impl.operation.SnapshotPhase1Operation.SnapshotPhase1Result;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -34,6 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SnapshotContextSimpleTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
@@ -20,7 +20,10 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.impl.operation.SnapshotPhase1Operation.SnapshotPhase1Result;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -38,6 +41,7 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SnapshotContextTest {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotLargeChunk_IntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotLargeChunk_IntegrationTest.java
@@ -29,7 +29,10 @@ import com.hazelcast.jet.impl.SnapshotValidationRecord;
 import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -44,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SnapshotLargeChunk_IntegrationTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.impl.operation.SnapshotPhase1Operation.SnapshotPhase1Re
 import com.hazelcast.jet.impl.util.MockAsyncSnapshotWriter;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,7 +50,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StoreSnapshotTaskletTest extends JetTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -27,11 +27,14 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -68,7 +71,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TaskletExecutionServiceTest extends JetTestSupport {
 
     private static final int THREAD_COUNT = 4;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescerTest.java
@@ -16,14 +16,21 @@
 
 package com.hazelcast.jet.impl.execution;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.IDLE_MESSAGE;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.NO_NEW_WM;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WatermarkCoalescerTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_IntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_IntegrationTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -52,7 +53,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class WatermarkCoalescer_IntegrationTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_TerminalSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_TerminalSnapshotTest.java
@@ -33,8 +33,13 @@ import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.pipeline.WindowDefinition;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +55,8 @@ import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WatermarkCoalescer_TerminalSnapshotTest extends JetTestSupport {
 
     private static final int PARTITION_COUNT = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
@@ -25,8 +25,11 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -35,6 +38,7 @@ import java.util.function.Function;
 import static com.hazelcast.jet.impl.JobExecutionRecord.NO_SNAPSHOT;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class DetermineLocalParallelismTest extends SimpleTestInClusterSupport {
 
     private static final int DEFAULT_PARALLELISM = 2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.impl.JobExecutionRecord;
 import com.hazelcast.jet.impl.JobRecord;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -52,7 +53,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class JetInitDataSerializerHookTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/PartitionArrangementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/PartitionArrangementTest.java
@@ -17,12 +17,19 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PartitionArrangementTest {
 
     private Address a0;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
@@ -31,8 +31,11 @@ import com.hazelcast.jet.impl.MasterJobContext;
 import com.hazelcast.jet.impl.execution.SnapshotContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -48,6 +51,7 @@ import static java.util.stream.Collectors.joining;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class VertexDef_HigherPrioritySourceTest extends SimpleTestInClusterSupport {
 
     private static final ProcessorMetaSupplier MOCK_PMS =

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
@@ -37,11 +37,12 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -62,8 +63,8 @@ import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
-import static com.hazelcast.jet.pipeline.GeneralStage.DEFAULT_MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.impl.util.Util.toList;
+import static com.hazelcast.jet.pipeline.GeneralStage.DEFAULT_MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
 import static java.util.stream.Collectors.joining;
@@ -72,7 +73,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AsyncTransformUsingServiceBatchP_IntegrationTest extends SimpleTestInClusterSupport {
 
     private static final int NUM_ITEMS = 100;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
@@ -25,12 +25,13 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.pipeline.ServiceFactories;
 import com.hazelcast.jet.pipeline.ServiceFactory;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -44,7 +45,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AsyncTransformUsingServiceBatchedPTest extends SimpleTestInClusterSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -31,9 +31,12 @@ import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.pipeline.ServiceFactories;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,8 +47,8 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
-import static com.hazelcast.jet.pipeline.GeneralStage.DEFAULT_MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
+import static com.hazelcast.jet.pipeline.GeneralStage.DEFAULT_MAX_CONCURRENT_OPS;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -54,6 +57,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
@@ -38,9 +38,12 @@ import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -74,6 +77,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClusterSupport {
 
     private static final int NUM_ITEMS = 100;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/EqualityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/EqualityTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.jet.impl.processor;
 
 import com.hazelcast.jet.impl.processor.SlidingWindowP.SnapshotKey;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class EqualityTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.impl.processor.HashJoinCollectP.HashJoinArrayList;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -51,8 +52,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-@Category(ParallelJVMTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class HashJoinPTest extends JetTestSupport {
 
     private static final BiFunction mapToOutputBiFn = Tuple2::tuple2;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -51,7 +52,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class InsertWatermarksPTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksP_IntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksP_IntegrationTest.java
@@ -23,8 +23,11 @@ import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
@@ -38,6 +41,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class InsertWatermarksP_IntegrationTest extends JetTestSupport {
 
     private JetInstance instance;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/Processors_globalAggregationIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/Processors_globalAggregationIntegrationTest.java
@@ -25,7 +25,10 @@ import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -45,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class Processors_globalAggregationIntegrationTest extends JetTestSupport {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SessionWindowPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SessionWindowPTest.java
@@ -24,10 +24,13 @@ import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.Repeat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -51,6 +54,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SessionWindowPTest {
 
     private static final int SESSION_TIMEOUT = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,7 +61,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class SlidingWindowPTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_changeWindowSizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_changeWindowSizeTest.java
@@ -21,7 +21,10 @@ import com.hazelcast.jet.core.test.TestInbox;
 import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -41,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SlidingWindowP_changeWindowSizeTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
@@ -33,9 +33,12 @@ import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -61,6 +64,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SlidingWindowP_twoStageSnapshotTest {
 
     private static final Long KEY = 77L;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/TransformBatchedPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/TransformBatchedPTest.java
@@ -19,11 +19,18 @@ package com.hazelcast.jet.impl.processor;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.test.TestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static java.util.Arrays.asList;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TransformBatchedPTest extends JetTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/TransformStatefulPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/TransformStatefulPTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -53,7 +54,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-@Category(ParallelJVMTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @SuppressWarnings("checkstyle:declarationorder")

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/DelegatingSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/DelegatingSerializationServiceTest.java
@@ -26,7 +26,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 
@@ -34,6 +39,8 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class DelegatingSerializationServiceTest {
 
     private static final AbstractSerializationService DELEGATE = new DefaultSerializationServiceBuilder()

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/PlainMemoryReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/PlainMemoryReaderTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.jet.impl.serialization;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PlainMemoryReaderTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/SerializerHooksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/SerializerHooksTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.impl.execution.BroadcastEntry;
 import com.hazelcast.jet.impl.execution.SnapshotBarrier;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -58,8 +59,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 @RunWith(Parameterized.class)
-@Category(ParallelJVMTest.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SerializerHooksTest {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/UnsafeMemoryReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/serialization/UnsafeMemoryReaderTest.java
@@ -16,7 +16,12 @@
 
 package com.hazelcast.jet.impl.serialization;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -24,6 +29,8 @@ import static java.nio.ByteOrder.nativeOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class UnsafeMemoryReaderTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ArrayDequeInboxTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ArrayDequeInboxTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -32,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ArrayDequeInboxTest {
 
     private static final List<Integer> ITEMS = asList(1, 2);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl.SnapshotDataValueTerm
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hamcrest.core.StringContains;
 import org.junit.After;
@@ -64,8 +65,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AsyncSnapshotWriterImplTest extends JetTestSupport {
 
     private static final String ALWAYS_FAILING_MAP = "alwaysFailingMap";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
@@ -21,9 +21,12 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors.MockP;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -35,7 +38,8 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ExceptionUtilTest extends JetTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/FlatMappingTraverserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/FlatMappingTraverserTest.java
@@ -16,7 +16,12 @@
 
 package com.hazelcast.jet.impl.util;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.stream.IntStream;
 
@@ -27,6 +32,8 @@ import static com.hazelcast.jet.Traversers.traverseStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class FlatMappingTraverserTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -18,9 +18,12 @@ package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.test.JetAssert;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
@@ -42,7 +45,8 @@ import static com.hazelcast.jet.impl.util.IOUtil.unzip;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class IOUtilTest extends JetTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
@@ -22,8 +22,11 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.map.IMap;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +35,7 @@ import java.util.stream.IntStream;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ImdgUtilTest extends SimpleTestInClusterSupport {
 
     private static final String NEAR_CACHED_SERIALIZED_MAP = "nearCachedSerialized";

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/JsonUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/JsonUtilTest.java
@@ -19,9 +19,12 @@ package com.hazelcast.jet.impl.util;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.json.JsonUtil;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -41,7 +44,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JsonUtilTest extends JetTestSupport {
 
     static String jsonString;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
@@ -19,7 +19,10 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.jet.impl.util.ReflectionUtils.ClassResource;
 import com.hazelcast.jet.impl.util.ReflectionUtils.Resources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.net.URL;
@@ -43,6 +46,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReflectionUtilsTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/SkewReductionPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/SkewReductionPolicyTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -31,6 +34,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SkewReductionPolicyTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
@@ -19,8 +19,11 @@ package com.hazelcast.jet.impl.util;
 import com.google.common.collect.ImmutableMap;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -54,6 +57,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class UtilTest {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplierTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplierTest.java
@@ -17,11 +17,18 @@
 package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WrappingProcessorMetaSupplierTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplierTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplierTest.java
@@ -17,11 +17,18 @@
 package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WrappingProcessorSupplierTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.test.IgnoredForCoverage;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +46,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SlowTest.class, IgnoredForCoverage.class})
+@Category({SlowTest.class, IgnoredForCoverage.class, ParallelJVMTest.class})
 public final class JobSubmissionSlownessRegressionTest extends JetTestSupport {
 
     private static final int DURATION_SECS = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/BatchAggregateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/BatchAggregateTest.java
@@ -27,8 +27,11 @@ import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +54,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.summingLong;
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class BatchAggregateTest extends PipelineTestSupport {
 
     static final FunctionEx<Entry<Integer, Long>, String> FORMAT_FN =

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -37,7 +37,10 @@ import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.map.IMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,6 +83,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class BatchStageTest extends PipelineTestSupport {
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/LoggerSinkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/LoggerSinkTest.java
@@ -18,14 +18,18 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.JetTestSupport;
-import com.hazelcast.jet.test.SerialTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
-@Category(SerialTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class LoggerSinkTest extends JetTestSupport {
 
     private static final String HAZELCAST_LOGGING_TYPE = "hazelcast.logging.type";

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchParallelismTest.java
@@ -26,7 +26,10 @@ import com.hazelcast.jet.impl.pipeline.PipelineImpl;
 import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -44,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedBatchParallelismTest {
 
     private static final int DEFAULT_PARALLELISM = 8;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
@@ -29,13 +29,10 @@ import com.hazelcast.jet.pipeline.test.Assertions;
 import com.hazelcast.jet.pipeline.test.ParallelBatchP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -54,7 +51,6 @@ import static java.util.stream.Collectors.toList;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedBatchProcessingTest extends JetTestSupport {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
@@ -29,10 +29,13 @@ import com.hazelcast.jet.pipeline.test.Assertions;
 import com.hazelcast.jet.pipeline.test.ParallelBatchP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -51,6 +54,7 @@ import static java.util.stream.Collectors.toList;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedBatchProcessingTest extends JetTestSupport {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
@@ -29,14 +29,15 @@ import com.hazelcast.jet.pipeline.test.GeneratorFunction;
 import com.hazelcast.jet.pipeline.test.ParallelStreamP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
+import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
-
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -53,6 +54,7 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
 import static java.util.stream.Collectors.toList;
 
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedProcessingMergingStagesTest extends JetTestSupport implements Serializable {
 
     private static final int ITEM_COUNT = 250;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
@@ -29,11 +29,13 @@ import com.hazelcast.jet.pipeline.test.GeneratorFunction;
 import com.hazelcast.jet.pipeline.test.ParallelStreamP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.annotation.Nonnull;
@@ -51,6 +53,7 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
 import static java.util.stream.Collectors.toList;
 
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category(QuickTest.class)
 public class OrderedProcessingMergingStagesTest extends JetTestSupport implements Serializable {
 
     private static final int ITEM_COUNT = 250;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
@@ -29,14 +29,11 @@ import com.hazelcast.jet.pipeline.test.GeneratorFunction;
 import com.hazelcast.jet.pipeline.test.ParallelStreamP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.annotation.Nonnull;
@@ -54,7 +51,6 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
 import static java.util.stream.Collectors.toList;
 
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedProcessingMergingStagesTest extends JetTestSupport implements Serializable {
 
     private static final int ITEM_COUNT = 250;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -31,10 +31,12 @@ import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -64,6 +66,7 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
  */
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category(QuickTest.class)
 public class OrderedProcessingMultipleMemberTest extends JetTestSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -31,13 +31,10 @@ import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -67,7 +64,6 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
  */
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedProcessingMultipleMemberTest extends JetTestSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -26,24 +26,25 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.core.JetTestSupport;
-
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.Serializable;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -66,6 +67,7 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
  */
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedProcessingMultipleMemberTest extends JetTestSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamParallelismTest.java
@@ -25,7 +25,10 @@ import com.hazelcast.jet.impl.pipeline.PipelineImpl;
 import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -41,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedStreamParallelismTest {
 
     private static final int DEFAULT_PARALLELISM = 8;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
@@ -32,11 +32,14 @@ import com.hazelcast.jet.pipeline.test.GeneratorFunction;
 import com.hazelcast.jet.pipeline.test.ParallelStreamP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -61,6 +64,7 @@ import static java.util.stream.Collectors.toList;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedStreamProcessingTest extends JetTestSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
@@ -32,14 +32,11 @@ import com.hazelcast.jet.pipeline.test.GeneratorFunction;
 import com.hazelcast.jet.pipeline.test.ParallelStreamP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -64,7 +61,6 @@ import static java.util.stream.Collectors.toList;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class OrderedStreamProcessingTest extends JetTestSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/PipelineStreamTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/PipelineStreamTestSupport.java
@@ -21,6 +21,9 @@ import com.hazelcast.jet.accumulator.LongLongAccumulator;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.jet.datamodel.WindowResult;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
 
 import java.util.List;
 import java.util.Map.Entry;
@@ -32,6 +35,7 @@ import java.util.stream.Stream;
 
 import static java.lang.Long.max;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public abstract class PipelineStreamTestSupport extends PipelineTestSupport {
     static final int ASSERT_TIMEOUT_SECONDS = 30;
     static final long EARLY_RESULTS_PERIOD = 200L;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/PipelineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/PipelineTest.java
@@ -17,10 +17,17 @@
 package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class PipelineTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -22,7 +22,10 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -41,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorTransformParallelismTest {
 
     private static final int DEFAULT_PARALLELISM = 8;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/RebalanceBatchStageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/RebalanceBatchStageTest.java
@@ -30,7 +30,10 @@ import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -66,6 +69,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RebalanceBatchStageTest extends PipelineTestSupport {
 
     private static final AggregateOperation1<Integer, LongAccumulator, Long> SUMMING =

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinkBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinkBuilderTest.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.jet.pipeline;
 
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -40,6 +43,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SinkBuilderTest extends PipelineTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -46,9 +46,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,6 +72,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class SinksTest extends PipelineTestSupport {
 
     private static HazelcastInstance remoteHz;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -46,7 +46,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -72,7 +71,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({SlowTest.class, ParallelJVMTest.class})
+@Category({SlowTest.class})
 public class SinksTest extends PipelineTestSupport {
 
     private static HazelcastInstance remoteHz;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -46,6 +46,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -71,7 +72,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({SlowTest.class})
+@Category({QuickTest.class})
 public class SinksTest extends PipelineTestSupport {
 
     private static HazelcastInstance remoteHz;
@@ -784,6 +785,7 @@ public class SinksTest extends PipelineTestSupport {
     }
 
     @Test
+    @Category(SlowTest.class)
     public void mapWithEntryProcessor_testBackpressure() {
         /*
         NOTE TO THE TEST

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SortBatchStageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SortBatchStageTest.java
@@ -16,16 +16,21 @@
 
 package com.hazelcast.jet.pipeline;
 
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.junit.Test;
 
 import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertOrdered;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SortBatchStageTest extends PipelineTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourceBuilder_TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourceBuilder_TopologyChangeTest.java
@@ -28,7 +28,10 @@ import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.datamodel.WindowResult;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
@@ -44,6 +47,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SourceBuilder_TopologyChangeTest extends JetTestSupport {
 
     private static volatile boolean stateRestored;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -27,10 +27,12 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projections;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -56,6 +58,7 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@Category(QuickTest.class)
 public class SourcesTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -27,13 +27,10 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projections;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -59,7 +56,6 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class SourcesTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -27,10 +27,13 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projections;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -56,6 +59,7 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SourcesTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -54,7 +53,7 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Category({SlowTest.class, ParallelJVMTest.class})
+@Category({SlowTest.class})
 public class Sources_withEventJournalTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -53,7 +53,7 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Category({SlowTest.class})
+@Category({QuickTest.class})
 public class Sources_withEventJournalTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.jet.pipeline;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.EventJournalCacheEvent;
+import com.hazelcast.cache.ICache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.collection.IList;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -27,11 +27,14 @@ import com.hazelcast.function.PredicateEx;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
-import com.hazelcast.map.IMap;
 import com.hazelcast.map.EventJournalMapEvent;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -51,6 +54,7 @@ import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class Sources_withEventJournalTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTest.java
@@ -28,6 +28,8 @@ import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,6 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamSourceStageTest extends StreamSourceStageTestBase {
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StreamSourceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StreamSourceTest.java
@@ -18,7 +18,10 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.Processor.Context;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
 import static com.hazelcast.jet.core.EventTimePolicy.DEFAULT_IDLE_TIMEOUT;
@@ -26,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamSourceTest extends PipelineTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/file/WildcardMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/file/WildcardMatcherTest.java
@@ -16,11 +16,18 @@
 
 package com.hazelcast.jet.pipeline.file;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.pipeline.file.WildcardMatcher.hasWildcard;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class WildcardMatcherTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/AssertionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/AssertionsTest.java
@@ -20,8 +20,11 @@ import com.hazelcast.jet.aggregate.AggregateOperations;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
@@ -41,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class AssertionsTest extends PipelineTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.pipeline.test;
 
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
@@ -32,6 +35,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class TestSourcesTest extends PipelineTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/jet/retry/impl/IntervalFunctionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/retry/impl/IntervalFunctionTest.java
@@ -17,10 +17,17 @@
 package com.hazelcast.jet.retry.impl;
 
 import com.hazelcast.jet.retry.IntervalFunction;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class IntervalFunctionTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/retry/impl/RetryTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/retry/impl/RetryTrackerTest.java
@@ -19,7 +19,12 @@ package com.hazelcast.jet.retry.impl;
 import com.hazelcast.jet.retry.IntervalFunction;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.retry.RetryStrategy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.function.LongSupplier;
 
@@ -27,6 +32,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RetryTrackerTest {
 
     private final NanoTimeSupplier timeSupplier = new NanoTimeSupplier();

--- a/hazelcast/src/test/java/com/hazelcast/jet/server/JetCommandLineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/server/JetCommandLineTest.java
@@ -31,12 +31,15 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -62,6 +65,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class JetCommandLineTest extends JetTestSupport {
 
     private static final String SOURCE_NAME = "source";

--- a/hazelcast/src/test/java/com/hazelcast/map/MapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapLockTest.java
@@ -199,7 +199,7 @@ public class MapLockTest extends HazelcastTestSupport {
 
     @Category(NightlyTest.class)
     @Test
-    public void testLockEvictionWithMigration() throws Exception {
+    public void testLockEvictionWithMigration() {
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
         final Config config = getConfig();
         final HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
                                 <configuration combine.self="override">
                                     <useFile>false</useFile>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <!-- 1C means 1 process per cpu core -->
+                                    <!-- 0.5C means half as many forks as cpu cores -->
                                     <forkCount>0.5C</forkCount>
                                     <reuseForks>true</reuseForks>
                                     <argLine>


### PR DESCRIPTION
Jet tests needs to be set up with the appropriate categories and runners in order for the Platform surefire configs to run them properly.