### PR TITLE
Remove snapshot repository declaration from hazelcast-all pom.xml

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -29,14 +29,6 @@
     <artifactId>hazelcast-all</artifactId>
     <packaging>jar</packaging>
 
-    <repositories>
-        <repository>
-            <id>snapshot-repository</id>
-            <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
-
     <properties>
         <!-- needed for CheckStyle -->
         <main.basedir>${project.parent.basedir}</main.basedir>


### PR DESCRIPTION
Removes snapshot repository configuration from `hazelcast-all`. The declaration is already in the parent POM and in hazelcast-all it didn't have correct flags set (i.e. snapshot-only).

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
