### PR TITLE
Fix NoMandatoryDependencyDeclared tests failing on EE

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -55,7 +55,6 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
             // as it contains e.g. javax.servlet which is not part of the SE platform!
             "javax.annotation",
             "javax.crypto",
-            "javax.jms",
             "javax.management",
             "javax.naming",
             "javax.net.ssl",

--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -53,15 +53,17 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
 
             // with the "javax" package we have to be more specific - do not use just "javax."
             // as it contains e.g. javax.servlet which is not part of the SE platform!
+            "javax.annotation",
             "javax.crypto",
+            "javax.jms",
             "javax.management",
+            "javax.naming",
             "javax.net.ssl",
             "javax.script",
             "javax.security.auth",
             "javax.sql",
             "javax.transaction.xa",
             "javax.xml",
-            "javax.naming",
 
             // these 2 XML-related packages are part of the platform since Java SE 6
             "org.xml.sax",


### PR DESCRIPTION
This pr adds `javax.annotation` ~~and `javax.jms`~~ to the whitelist

Checklist:
- [x] Labels and Milestone set
