### PR TITLE
 Add pr-builder profile excluding assembly/shade executions

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>co.leantechniques</groupId>
+        <artifactId>maven-buildtime-extension</artifactId>
+        <version>3.0.0</version>
+    </extension>
+</extensions>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -108,7 +108,7 @@
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-sql</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <!-- JetCommandLine dependencies-->
         <dependency>
@@ -193,43 +193,43 @@
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-avro</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-cdc-debezium</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-cdc-mysql</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-cdc-postgres</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-csv</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-elasticsearch-7</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-elasticsearch-6</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
             <exclusions>
                 <!--
                 Exclude the elastic client for version 6 reported by enforcer plugin
@@ -246,61 +246,61 @@
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-grpc</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-files-azure</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-files-gcs</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-files-s3</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-hadoop-all</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-kafka</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-kinesis</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-protobuf</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-python</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-s3</artifactId>
             <version>${project.version}</version>
-            <classifier>jar-with-dependencies</classifier>
+            <classifier>${fat.dependency.classifier}</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -49,20 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
-                    <createSourcesJar>true</createSourcesJar>
-                    <shadeSourcesContent>true</shadeSourcesContent>
-                    <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                     <relocations>
                         <relocation>
                             <pattern>com.fasterxml.jackson.core</pattern>
@@ -77,20 +64,6 @@
                             <shadedPattern>com.hazelcast.com.fasterxml.jackson.dataformat</shadedPattern>
                         </relocation>
                     </relocations>
-                    <transformers>
-                        <transformer
-                            implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
                 </configuration>
             </plugin>
 

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -64,20 +64,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
-                        <createSourcesJar>true</createSourcesJar>
-                        <shadeSourcesContent>true</shadeSourcesContent>
-                        <createDependencyReducedPom>true</createDependencyReducedPom>
-                        <shadedArtifactAttached>true</shadedArtifactAttached>
-                        <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                         <!--
                         We actually don't shade these in here in Hadoop module, they are already part of core
                         But we need to relocate the usage in the Hadoop module
@@ -100,20 +87,6 @@
                                 <shadedPattern>com.hazelcast.com.fasterxml.jackson.dataformat</shadedPattern>
                             </relocation>
                         </relocations>
-                        <transformers>
-                            <transformer
-                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        </transformers>
-                        <filters>
-                            <filter>
-                                <artifact>*:*</artifact>
-                                <excludes>
-                                    <exclude>META-INF/*.SF</exclude>
-                                    <exclude>META-INF/*.DSA</exclude>
-                                    <exclude>META-INF/*.RSA</exclude>
-                                </excludes>
-                            </filter>
-                        </filters>
                     </configuration>
                 </plugin>
             </plugins>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -53,44 +53,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
-                    <createSourcesJar>true</createSourcesJar>
-                    <shadeSourcesContent>true</shadeSourcesContent>
-                    <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                     <relocations>
                         <relocation>
                             <pattern>com.amazonaws</pattern>
                             <shadedPattern>com.hazelcast.com.amazonaws</shadedPattern>
                         </relocation>
                     </relocations>
-                    <transformers>
-                        <transformer
-                            implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                        <transformer
-                            implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
-                        <transformer
-                            implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -97,4 +97,49 @@
             <classifier>tests</classifier>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>jar-with-dependencies</id>
+                            <phase>${shade.jar-with-dependencies.phase}</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <createSourcesJar>true</createSourcesJar>
+                        <shadeSourcesContent>true</shadeSourcesContent>
+                        <createDependencyReducedPom>true</createDependencyReducedPom>
+                        <shadedArtifactAttached>true</shadedArtifactAttached>
+                        <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                        <transformers>
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                        </transformers>
+                        <filters>
+                            <filter>
+                                <artifact>*:*</artifact>
+                                <excludes>
+                                    <exclude>META-INF/*.SF</exclude>
+                                    <exclude>META-INF/*.DSA</exclude>
+                                    <exclude>META-INF/*.RSA</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/hazelcast-jet-sql/pom.xml
+++ b/hazelcast-jet-sql/pom.xml
@@ -364,7 +364,8 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>jar-with-dependencies</id>
+                        <phase>${shade.jar-with-dependencies.phase}</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -91,8 +91,8 @@
                 <version>${maven.shade.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>fat-shaded-jar</id>
-                        <phase>package</phase>
+                        <id>jar-with-dependencies</id>
+                        <phase>${shade.jar-with-dependencies.phase}</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,9 @@
         <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle.xml</checkstyle.configLocation>
         <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions.xml</checkstyle.supressionsLocation>
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeader.txt</checkstyle.headerLocation>
+
+        <shade.jar-with-dependencies.phase>package</shade.jar-with-dependencies.phase>
+        <fat.dependency.classifier>jar-with-dependencies</fat.dependency.classifier>
     </properties>
     <licenses>
         <license>
@@ -546,6 +549,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>pr-builder</id>
+            <properties>
+                <assembly.skipAssembly>true</assembly.skipAssembly>
+                <!-- Set the classifier to empty in this profile to use regular jar-->
+                <fat.dependency.classifier/>
+                <shade.jar-with-dependencies.phase>none</shade.jar-with-dependencies.phase>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
Some assembly/shade plugin executions for modules with many transitive
dependencies may take over a minute. This disables the assembly/shade
plugins in a new pr-builder profile in the following way:

- set `assembly.skipAssembly` property to disable the assembly plugin

- introduce a new property `shade.jar-with-dependencies.phase` to set
the phase on which the shade plugin runs. Setting this to `none`
disables the plugin.

Disabling the assembly/shade plugins create a dependency issue in the
distribution module which needs those dependencies for license check and
dependency resolution tasks.

We override the classifier by using another property
`fat.dependency.classifier`. Using empty value results in using the
regular (non-fat) jar, which is enough for license/dependency checks.
Because we also disable the assembly plugin in this module don't need
the fat jars. (Note that it is not possible to override the classifier
of a dependency in a profile because defining a dependency with a
classifier and without is considered a different dependency. Therefore
the property is used).

Fixes #18506