### PR TITLE
Don't copy HD value if caller of map.get is client 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
@@ -54,6 +54,7 @@ public class MapGetMessageTask
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         MapOperation operation = operationProvider.createGetOperation(parameters.name, parameters.key);
+        operation.setOpSentByClient(true);
         operation.setThreadId(parameters.threadId);
         return operation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -18,8 +18,8 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
-import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.BlockingOperation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
 
@@ -39,13 +39,18 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
     @Override
     protected void runInternal() {
         Object currentValue = recordStore.get(dataKey, false, getCallerAddress());
-        if (!executedLocally() && currentValue instanceof Data) {
+        if (noCopyReadAllowed(currentValue)) {
             // in case of a 'remote' call (e..g a client call) we prevent making an onheap copy of the offheap data
             result = (Data) currentValue;
         } else {
             // in case of a local call, we do make a copy so we can safely share it with e.g. near cache invalidation
             result = mapService.getMapServiceContext().toData(currentValue);
         }
+    }
+
+    private boolean noCopyReadAllowed(Object currentValue) {
+        return (isOpSentByClient() || !super.executedLocally())
+                && currentValue instanceof Data;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
@@ -70,6 +70,7 @@ public abstract class Operation implements DataSerializable, Tenantable {
     static final int BITMASK_CALL_TIMEOUT_64_BIT = 1 << 5;
     static final int BITMASK_SERVICE_NAME_SET = 1 << 6;
     static final int BITMASK_CLIENT_CALL_ID_SET = 1 << 7;
+    static final int BITMASK_OP_SEND_BY_CLIENT = 1 << 8;
 
     private static final AtomicLongFieldUpdater<Operation> CALL_ID =
             AtomicLongFieldUpdater.newUpdater(Operation.class, "callId");
@@ -107,6 +108,14 @@ public abstract class Operation implements DataSerializable, Tenantable {
 
     public long getClientCallId() {
         return clientCallId;
+    }
+
+    public final void setOpSentByClient(boolean value) {
+        setFlag(value, BITMASK_OP_SEND_BY_CLIENT);
+    }
+
+    protected final boolean isOpSentByClient() {
+        return isFlagSet(BITMASK_OP_SEND_BY_CLIENT);
     }
 
     /**


### PR DESCRIPTION
It was intended to work as no copy before but is not working as intended for operations sent by client. This is a performance bug. 