### PR TITLE
Fix race in phase2 coordination

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ProcessorState.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ProcessorState.java
@@ -89,7 +89,7 @@ enum ProcessorState {
      * Making calls to {@link Processor#snapshotCommitFinish(boolean)} until it
      * returns {@code true} and then proceed to {@link #EMIT_DONE_ITEM}. Used
      * when phase-2 was initiated after {@code Processor.complete()} returned
-     * true.
+     * {@code true}.
      */
     SNAPSHOT_COMMIT_FINISH__FINAL,
 
@@ -99,6 +99,11 @@ enum ProcessorState {
      * waiting for a snapshot phase 2.
      */
     WAITING_FOR_SNAPSHOT_COMPLETED,
+
+    /**
+     * A phase before emitting the {@code DONE_ITEM}.
+     */
+    PRE_EMIT_DONE_ITEM,
 
     /**
      * Waiting for the outbox to accept the {@code DONE_ITEM}.

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -71,6 +71,7 @@ import static com.hazelcast.jet.impl.execution.ProcessorState.COMPLETE_EDGE;
 import static com.hazelcast.jet.impl.execution.ProcessorState.EMIT_BARRIER;
 import static com.hazelcast.jet.impl.execution.ProcessorState.EMIT_DONE_ITEM;
 import static com.hazelcast.jet.impl.execution.ProcessorState.END;
+import static com.hazelcast.jet.impl.execution.ProcessorState.PRE_EMIT_DONE_ITEM;
 import static com.hazelcast.jet.impl.execution.ProcessorState.NULLARY_PROCESS;
 import static com.hazelcast.jet.impl.execution.ProcessorState.PROCESS_INBOX;
 import static com.hazelcast.jet.impl.execution.ProcessorState.PROCESS_WATERMARK;
@@ -352,7 +353,7 @@ public class ProcessorTasklet implements Tasklet {
                             state = COMPLETE;
                             break;
                         case SNAPSHOT_COMMIT_FINISH__FINAL:
-                            state = EMIT_DONE_ITEM;
+                            state = PRE_EMIT_DONE_ITEM;
                             break;
                         default:
                             throw new RuntimeException("unexpected state: " + state);
@@ -372,9 +373,14 @@ public class ProcessorTasklet implements Tasklet {
                 complete();
                 return;
 
+            case PRE_EMIT_DONE_ITEM:
+                ssContext.processorTaskletDone(pendingSnapshotId2 - 1);
+                state = EMIT_DONE_ITEM;
+                stateMachineStep();
+                return;
+
             case EMIT_DONE_ITEM:
                 if (outbox.offerToEdgesAndSnapshot(DONE_ITEM)) {
-                    ssContext.processorTaskletDone();
                     progTracker.madeProgress();
                     state = CLOSE;
                     stateMachineStep();
@@ -441,7 +447,7 @@ public class ProcessorTasklet implements Tasklet {
     }
 
     private void complete() {
-        // check ssContext to see if snapshot phase should be executed
+        // check ssContext to see if a snapshot phase should be executed
         if (pendingSnapshotId1 == pendingSnapshotId2) {
             long currSnapshotId1 = ssContext.activeSnapshotIdPhase1();
             assert currSnapshotId1 + 1 == pendingSnapshotId1 || currSnapshotId1 == pendingSnapshotId1
@@ -473,7 +479,7 @@ public class ProcessorTasklet implements Tasklet {
             progTracker.madeProgress();
             state = pendingSnapshotId2 < pendingSnapshotId1
                     ? WAITING_FOR_SNAPSHOT_COMPLETED
-                    : EMIT_DONE_ITEM;
+                    : PRE_EMIT_DONE_ITEM;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -329,8 +329,16 @@ public class SnapshotContext {
         }
     }
 
-    synchronized void processorTaskletDone() {
+    /**
+     * This method is called when a processor tasklet completes.
+     *
+     * @param lastCompletedPhase2SnapshotId the last snapshotId for
+     *     which the processor did the phase2
+     */
+    synchronized void processorTaskletDone(long lastCompletedPhase2SnapshotId) {
         assert numPTasklets > 0 : "numPTasklets=" + numPTasklets;
+        assert lastCompletedPhase2SnapshotId == activeSnapshotIdPhase2
+                : "phase2 was initiated, processor completed without doing it";
         numPTasklets--;
     }
 
@@ -351,9 +359,8 @@ public class SnapshotContext {
     }
 
     /**
-     * Called when current snapshot is done in {@link StoreSnapshotTasklet}
-     * (it received barriers from all its processors and all async flush
-     * operations are done).
+     * Called when current snapshot phase 2 is done in {@link
+     * ProcessorTasklet}. All processors do it concurrently.
      */
     void phase2DoneForTasklet() {
         int newRemainingTasklets = numRemainingTasklets.decrementAndGet();

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -455,7 +455,7 @@ public class ProcessorTaskletTest_Snapshots {
         boolean isStreaming;
         private Outbox outbox;
 
-        private Queue<Map.Entry> snapshotQueue = new ArrayDeque<>();
+        private final Queue<Map.Entry> snapshotQueue = new ArrayDeque<>();
 
         @Override
         public void init(@Nonnull Outbox outbox, @Nonnull Context context) {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -150,7 +151,17 @@ public class SnapshotContextSimpleTest {
         ssContext.initTaskletCount(1, 1, 0);
         CompletableFuture<SnapshotPhase1Result> future = ssContext.startNewSnapshotPhase1(10, null, 0);
         ssContext.storeSnapshotTaskletDone(9, false);
-        ssContext.processorTaskletDone();
+        ssContext.processorTaskletDone(9);
         assertTrue(future.isDone());
+    }
+
+    @Test
+    public void test_taskletDoneWhileInPhase2() {
+        ssContext.initTaskletCount(1, 1, 0);
+        ssContext.startNewSnapshotPhase1(10, "map", 0);
+        ssContext.phase1DoneForTasklet(1, 2, 3);
+        ssContext.startNewSnapshotPhase2(10, true);
+        assertThatThrownBy(() -> ssContext.processorTaskletDone(9))
+                .isInstanceOf(AssertionError.class);
     }
 }


### PR DESCRIPTION
The failure scenario:

- snapshot phase 1 is started in `SnapshotContext`

- Before P1 does phase1, it completes. This is normal. It emits
DONE_ITEM to snapshotOutbox

- `StoreSnapshotTasklet` receives the DONE_ITEM and calls
`SnapshotContext.storeSnapshotTaskletDone()`. Because it does so before
phase1 was done, it marks the phase1 as done for the processor.

- we respond to master that phase1 is done on member, master initiates
phase2

- Note that the P1 didn't yet call
`SnapshotContext.processorTaskletDone()` so `numPTasklets` isn't
decremented

- phase2 is initiated with non-decremented `numPTasklets`. We expect
this number of processors to do the phase2.

- now the processor thread calls
`SnapshotContext.processorTaskletDone()` and decrements `numPTasklets`.
Since it didn't do the phase1, it completes and never does the phase2
and the execution is stuck waiting for that.

This scenario is very unlikely because another threads have a lot more
work to do than the processor's thread: send the DONE_ITEM to snapshot
queue, handle it in another thread, complete a future, respond to an
operation in yet another thread, handle the response and issue a the
phase2 operation, handle the phase 2 operation, all in a time while the
processor thread proceeds to the very next line. It's easily
reproducible by inserting a sleep after
`outbox.offerToEdgesAndSnapshot(DONE_ITEM)` in `ProcessorTasklet`.

The fix is to ensure we first call `SnapshotContext.processorTaskletDone()`
before adding the DONE_ITEM to snapshotQueue to ensure it's called
before `SnapshotContext.storeSnapshotTaskletDone()`.

We also add an assert that a tasklet isn't done without doing phase2, if
phase2 was initiated.

Fixes hazelcast/hazelcast-jet#3027