### PR TITLE
Add more detailed logs from testcontainers to test output

### DIFF
--- a/extensions/cdc-debezium/src/test/resources/log4j2.xml
+++ b/extensions/cdc-debezium/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>

--- a/extensions/cdc-mysql/src/test/resources/log4j2.xml
+++ b/extensions/cdc-mysql/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>

--- a/extensions/cdc-postgres/src/test/resources/log4j2.xml
+++ b/extensions/cdc-postgres/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>

--- a/extensions/elasticsearch/elasticsearch-5/src/test/resources/log4j2.xml
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>

--- a/extensions/elasticsearch/elasticsearch-6/src/test/resources/log4j2.xml
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>

--- a/extensions/elasticsearch/elasticsearch-7/src/test/resources/log4j2.xml
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>

--- a/extensions/s3/src/test/resources/log4j2.xml
+++ b/extensions/s3/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.testcontainers" level="debug"/>
+        <Logger name="org.testcontainers.shaded" level="info"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Increase log level on extensions using the testcontainers. It could help us identify timeouts. If this extension is not enough, we could go further with adding debug logging from dockerjava library (shaded in testcontainers under `org.testcontainers.shaded.com.github.dockerjava` package name).

Related to:
* #18451
* #18453
* #18459

Checklist:
- [x] Labels and Milestone set
