### PR TITLE
Fix ExecutionLifecycleTest failures

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -70,9 +70,6 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
             @Nullable Config config,
             @Nullable ClientConfig clientConfig
     ) {
-        if (config == null) {
-            config = new Config();
-        }
         if (clientConfig == null) {
             clientConfig = new ClientConfig();
         }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -91,12 +91,13 @@ import static org.junit.Assert.fail;
 public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
     private static final int MEMBER_COUNT = 2;
-    private static final int PARALLELISM = Runtime.getRuntime().availableProcessors();
 
     private static final Throwable MOCK_ERROR = new AssertionError("mock error");
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    private int parallelism;
 
     @BeforeClass
     public static void beforeClass() {
@@ -105,7 +106,8 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
     @Before
     public void before() {
-        TestProcessors.reset(MEMBER_COUNT * PARALLELISM);
+        parallelism = instance().getConfig().getInstanceConfig().getCooperativeThreadCount();
+        TestProcessors.reset(MEMBER_COUNT * parallelism);
     }
 
     @Test
@@ -702,12 +704,12 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
     }
 
     private void assertPClosedWithoutError() {
-        assertEquals(MEMBER_COUNT * PARALLELISM, MockP.initCount.get());
-        assertEquals(MEMBER_COUNT * PARALLELISM, MockP.closeCount.get());
+        assertEquals(MEMBER_COUNT * parallelism, MockP.initCount.get());
+        assertEquals(MEMBER_COUNT * parallelism, MockP.closeCount.get());
     }
 
     private void assertPClosedWithError() {
-        assertEquals(MEMBER_COUNT * PARALLELISM, MockP.closeCount.get());
+        assertEquals(MEMBER_COUNT * parallelism, MockP.closeCount.get());
     }
 
     private void assertJobSucceeded(Job job) {


### PR DESCRIPTION
The test was using `Runtime.getRuntime().availableProcessors();` to
determine the parallelism. We are now using
`RuntimeAvailableProcessors.get()`.

With the changes, we are now using `smallInstanceConfig()` to configure
the instances and get the configured `cooperativeThreadCount` as the
parallelism.

Fixes https://github.com/hazelcast/hazelcast/issues/18531


Checklist:
- [x] Labels and Milestone set
