### PR TITLE
Create test-jar for hazelcast-sql-core

### DIFF
--- a/hazelcast-sql-core/pom.xml
+++ b/hazelcast-sql-core/pom.xml
@@ -40,6 +40,23 @@
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
This reverts the removal of the test jar in
Remove SQL core tests re-run from Jet SQL module (#18472) ca9d9b73

The test-jar is used in hazelcast-enterprise.