### PR TITLE
Downgrade Testcontainers version for CDC extensions

### DIFF
--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -33,7 +33,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import javax.annotation.Nonnull;
 import java.sql.Connection;
@@ -52,11 +51,9 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    private static final DockerImageName MYSQL_IMAGE =
-            DockerImageName.parse("debezium/example-mysql:1.3").asCompatibleSubstituteFor("mysql");
+    private static final String MYSQL_IMAGE = "debezium/example-mysql:1.3";
 
-    private static final DockerImageName POSTGRES_IMAGE =
-            DockerImageName.parse("debezium/example-postgres:1.3").asCompatibleSubstituteFor("postgres");
+    private static final String POSTGRES_IMAGE = "debezium/example-postgres:1.3";
 
     @Test
     public void mysql() throws Exception {

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -27,7 +27,6 @@ import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -39,9 +38,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.3")
-            .asCompatibleSubstituteFor("mysql");
-
+    public static final String DOCKER_IMAGE = "debezium/example-mysql:1.3";
     @Rule
     public MySQLContainer<?> mysql = namedTestContainer(
             new MySQLContainer<>(DOCKER_IMAGE)

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -26,7 +26,6 @@ import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.io.Serializable;
 import java.sql.Connection;
@@ -42,8 +41,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.3")
-            .asCompatibleSubstituteFor("postgres");
+    public static final String DOCKER_IMAGE = "debezium/example-postgres:1.3";
 
     protected static final String DATABASE_NAME = "postgres";
     protected static final String REPLICATION_SLOT_NAME = "debezium";

--- a/extensions/elasticsearch/elasticsearch-5/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-5/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.function.Supplier;
 
@@ -30,8 +29,7 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 
 public final class ElasticSupport {
 
-    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:6.8.14")
-            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
+    public static final String ELASTICSEARCH_IMAGE = "elasticsearch:6.8.14";
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.function.Supplier;
 
@@ -30,8 +29,7 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 
 public final class ElasticSupport {
 
-    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:7.10.1")
-            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
+    public static final String ELASTICSEARCH_IMAGE = "elasticsearch:7.10.1";
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -33,7 +33,6 @@
     </parent>
 
     <properties>
-        <testcontainers.version>1.15.2</testcontainers.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
     </properties>
 

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -51,7 +51,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.repeat;
-import static org.testcontainers.utility.DockerImageName.parse;
 
 public class KinesisFailureTest extends AbstractKinesisTest {
 
@@ -59,14 +58,12 @@ public class KinesisFailureTest extends AbstractKinesisTest {
     public static final Network NETWORK = Network.newNetwork();
 
     @ClassRule
-    public static final LocalStackContainer LOCALSTACK = new LocalStackContainer(parse("localstack/localstack")
-            .withTag("0.12.3"))
+    public static final LocalStackContainer LOCALSTACK = new LocalStackContainer("localstack/localstack:0.12.3")
             .withNetwork(NETWORK)
             .withServices(Service.KINESIS);
 
     @ClassRule
-    public static final ToxiproxyContainer TOXIPROXY = new ToxiproxyContainer(parse("shopify/toxiproxy")
-            .withTag("2.1.0"))
+    public static final ToxiproxyContainer TOXIPROXY = new ToxiproxyContainer("shopify/toxiproxy:2.1.0")
             .withNetwork(NETWORK)
             .withNetworkAliases("toxiproxy");
 

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
@@ -63,13 +63,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.testcontainers.utility.DockerImageName.parse;
 
 public class KinesisIntegrationTest extends AbstractKinesisTest {
 
     @ClassRule
-    public static final LocalStackContainer LOCALSTACK = new LocalStackContainer(parse("localstack/localstack")
-            .withTag("0.12.3"))
+    public static final LocalStackContainer LOCALSTACK = new LocalStackContainer("0.12.3")
             .withServices(Service.KINESIS);
 
     private static AwsConfig AWS_CONFIG;

--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>rabbitmq</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -640,7 +640,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>rabbitmq</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -660,7 +660,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,8 +139,8 @@
         <mockito.version>3.6.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
-        <zookeeper.version>3.5.8</zookeeper.version>
         <testcontainers.version>1.14.3</testcontainers.version>
+        <zookeeper.version>3.5.8</zookeeper.version>
 
         <sonar.jacoco.jar>${basedir}/lib/jacocoagent.jar</sonar.jacoco.jar>
         <!--<sonar.phase>post-integration-test</sonar.phase>-->

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <zookeeper.version>3.5.8</zookeeper.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
 
         <sonar.jacoco.jar>${basedir}/lib/jacocoagent.jar</sonar.jacoco.jar>
         <!--<sonar.phase>post-integration-test</sonar.phase>-->


### PR DESCRIPTION
The occasional failures we are getting for CDC tests are all failures like this:

```
org.junit.runners.model.TestTimedOutException: test timed out after 900 seconds
	...
	at org.testcontainers.utility.ResourceReaper.start(ResourceReaper.java:205)
	at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:205)
	at org.testcontainers.LazyDockerClient.getDockerClient(LazyDockerClient.java:14)
	at org.testcontainers.LazyDockerClient.authConfig(LazyDockerClient.java:12)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:310)
	at org.testcontainers.containers.GenericContainer.starting(GenericContainer.java:1029)
	...
```

I've found some clues about this being an issue in version `1.15` of Testcontainers (to which we've upgraded recently): https://github.com/testcontainers/testcontainers-java/issues/3531

I can't be sure but let's try it.

This PR downgrades the version we use to latest `1.14`.

Fixes #18453
Fixes #18451
