### PR TITLE
Fix SqlNoDeserializationTest client test

### DIFF
--- a/hazelcast-sql-core/src/test/java/com/hazelcast/sql/misc/SqlNoDeserializationTest.java
+++ b/hazelcast-sql-core/src/test/java/com/hazelcast/sql/misc/SqlNoDeserializationTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.sql.misc;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SqlExecuteCodec;
 import com.hazelcast.client.impl.protocol.codec.SqlFetchCodec;
@@ -25,7 +26,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableReader;
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -83,9 +82,7 @@ public class SqlNoDeserializationTest extends SqlTestSupport {
 
     @Before
     public void before() {
-        member = factory.newHazelcastInstance(config());
-        factory.newHazelcastInstance(config());
-
+        member = factory.newInstances(config(), 2)[0];
         client = factory.newHazelcastClient(clientConfig());
 
         prepare();
@@ -149,10 +146,10 @@ public class SqlNoDeserializationTest extends SqlTestSupport {
 
         SqlClientService clientService = (SqlClientService) client.getSql();
 
-        Connection connection = clientService.getRandomConnection();
+        ClientConnection connection = clientService.getRandomConnection();
 
         // Get the first page through the "execute" request
-        QueryId queryId = QueryId.create(UUID.randomUUID());
+        QueryId queryId = QueryId.create(connection.getRemoteUuid());
 
         ClientMessage executeRequest = SqlExecuteCodec.encodeRequest(
                 SQL,

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientService.java
@@ -195,8 +195,8 @@ public class SqlClientService implements SqlService {
     /**
      * For testing only.
      */
-    public Connection getRandomConnection() {
-        Connection connection = client.getConnectionManager().getRandomConnection(false);
+    public ClientConnection getRandomConnection() {
+        ClientConnection connection = client.getConnectionManager().getRandomConnection(true);
 
         if (connection == null) {
             throw rethrow(QueryException.error(


### PR DESCRIPTION
Replaced random UUID with actual member id so the query does not intermittently get cancelled on _member leave_ https://github.com/hazelcast/hazelcast/blob/5ef6f112e19e10346b09cfe4fb7db03a23881ce8/hazelcast/src/main/java/com/hazelcast/sql/impl/state/QueryState.java#L324

Fixes #18135