### PR TITLE
Do not exclude shade plugin in hazelcast-sql module

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -91,8 +91,8 @@
                 <version>${maven.shade.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>jar-with-dependencies</id>
-                        <phase>${shade.jar-with-dependencies.phase}</phase>
+                        <id>fat-shaded-jar</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>


### PR DESCRIPTION
It is required for the DependencyReducedPomSqlIT.