### PR TITLE
Remove client endpoint on connection remove

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -304,14 +304,21 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
             return false;
         }
 
-        endpointManager.registerEndpoint(endpoint);
-
         ServerConnection conn = endpoint.getConnection();
-        if (conn != null) {
-            InetSocketAddress socketAddress = conn.getRemoteSocketAddress();
-            //socket address can be null if connection closed before bind
-            if (socketAddress != null) {
-                conn.setRemoteAddress(new Address(socketAddress));
+        InetSocketAddress socketAddress = conn.getRemoteSocketAddress();
+        //socket address can be null if connection closed before bind
+        if (socketAddress != null) {
+            conn.setRemoteAddress(new Address(socketAddress));
+        }
+
+        if (endpointManager.registerEndpoint(endpoint)) {
+            // remote address can be null if connection closed before bind.
+            // On such a case, `ClientEngine#connectionRemoved` will not be called for this connection since
+            // we did not register the connection.
+            // Endpoint removal logic(inside `ClientEngine#connectionRemoved`) will not be able to run, instead endpoint
+            // will be cleaned up by ClientHearbeatMonitor#cleanupEndpointsWithDeadConnections later.
+            if (conn.getRemoteAddress() != null) {
+                node.getServer().getConnectionManager(CLIENT).register(conn.getRemoteAddress(), conn);
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -70,8 +70,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
         return replicatedMap.removeEntryListener(registrationId);
     }
 
-    @Override
-    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory) {
+    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory, int expected) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -80,7 +79,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
                     NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
                     EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
                     EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
-                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == 1) {
+                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == expected) {
                         found = true;
                     }
                 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -48,7 +48,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.hazelcast.client.impl.management.ManagementCenterService.MC_CLIENT_MODE_PROP;
-import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
@@ -344,14 +343,8 @@ class TestClientRegistry {
             super(localEndpoint, remoteEndpoint, nodeEngine);
             this.responseConnection = responseConnection;
             this.connectionId = connectionId;
-            register();
             lastReadTimeMillis = System.currentTimeMillis();
             lastWriteTimeMillis = System.currentTimeMillis();
-        }
-
-        private void register() {
-            Node node = remoteNodeEngine.getNode();
-            node.getServer().getConnectionManager(CLIENT).register(getRemoteAddress(), this);
         }
 
         @Override


### PR DESCRIPTION
Client endpoints were not destroyed on connection remove but
instead a periodic task was cleaning them up(every 10 seconds)
This was causing some tests to take long.
Added client connections to server connection manager so that
`connectionRemoved` can be called and related endpoint is
removed as soon as the connection is removed.

fixes https://github.com/hazelcast/hazelcast/issues/18318

