### PR TITLE
Add OWASP dependency checker configuration

### DIFF
--- a/owasp-check-suppressions.xml
+++ b/owasp-check-suppressions.xml
@@ -2,28 +2,28 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
-      False positive. No known CVEs in hazelcast-gcp.
+      False positive. The hazelcast:hazelcast component vulnerabilities are related to Hazelcast IMDG version and not the integration - hazelcast-gcp.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-gcp@.*$</packageUrl>
         <cpe>cpe:/a:hazelcast:hazelcast</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-      False positive. No known CVEs in hazelcast-azure.
+      False positive. The hazelcast:hazelcast component vulnerabilities are related to Hazelcast IMDG version and not the integration - hazelcast-azure.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-azure@.*$</packageUrl>
         <cpe>cpe:/a:hazelcast:hazelcast</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-      False positive. No known CVEs in hazelcast-hibernate.
+      False positive. The hazelcast:hazelcast component vulnerabilities are related to Hazelcast IMDG version and not the integration - hazelcast-hibernate.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-hibernate.*$</packageUrl>
         <cpe>cpe:/a:hazelcast:hazelcast</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-      False positive. No known CVEs in hazelcast-wm.
+      False positive. The hazelcast:hazelcast component vulnerabilities are related to Hazelcast IMDG version and not the integration - hazelcast-wm.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-wm@.*$</packageUrl>
         <cpe>cpe:/a:hazelcast:hazelcast</cpe>

--- a/owasp-check-suppressions.xml
+++ b/owasp-check-suppressions.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+      False positive. No known CVEs in hazelcast-gcp.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-gcp@.*$</packageUrl>
+        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+      False positive. No known CVEs in hazelcast-azure.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-azure@.*$</packageUrl>
+        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+      False positive. No known CVEs in hazelcast-hibernate.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-hibernate.*$</packageUrl>
+        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+      False positive. No known CVEs in hazelcast-wm.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-wm@.*$</packageUrl>
+        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+      False positive. The Avatica version is not related to the Calcite version.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/avatica\-core@.*$</packageUrl>
+       <cpe>cpe:/a:apache:calcite</cpe>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <maven.os.plugin.version>1.6.2</maven.os.plugin.version>
         <maven.protobuf.plugin.version>0.6.1</maven.protobuf.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
+        <owasp.dependency-check.version>6.1.5</owasp.dependency-check.version>
         <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
 
         <!-- External Hazelcast modules -->
@@ -405,6 +406,18 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${owasp.dependency-check.version}</version>
+                <configuration>
+                    <format>ALL</format>
+                    <skipProvidedScope>true</skipProvidedScope>
+                    <nodeAuditAnalyzerEnabled>false</nodeAuditAnalyzerEnabled>
+                    <failBuildOnCVSS>10</failBuildOnCVSS>
+                    <suppressionFiles>owasp-check-suppressions.xml</suppressionFiles>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>


### PR DESCRIPTION
This PR adds OWASP dependency check Maven plugin configuration.

The check can be executed by:
```
mvn org.owasp:dependency-check-maven:aggregate
```