### PR TITLE
Add address info on connection failure messages

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1088,7 +1088,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                         }
                         getOrConnectToMember(member);
                     } catch (Exception e) {
-                        EmptyStatement.ignore(e);
+                        logger.warning("Could not connect to member " + uuid + ", reason " + e);
                     } finally {
                         connectingAddresses.remove(uuid);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractChannel.java
@@ -18,15 +18,14 @@ package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelCloseListener;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.SocketException;
 import java.nio.channels.SocketChannel;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -128,17 +127,10 @@ public abstract class AbstractChannel implements Channel {
             // since the connect method is blocking, we need to configure blocking.
             socketChannel.configureBlocking(true);
 
-            try {
-                if (timeoutMillis > 0) {
-                    socketChannel.socket().connect(address, timeoutMillis);
-                } else {
-                    socketChannel.connect(address);
-                }
-            } catch (SocketException ex) {
-                //we want to include the address in the exception.
-                SocketException newEx = new SocketException(ex.getMessage() + " to address " + address);
-                newEx.setStackTrace(ex.getStackTrace());
-                throw newEx;
+            if (timeoutMillis > 0) {
+                socketChannel.socket().connect(address, timeoutMillis);
+            } else {
+                socketChannel.connect(address);
             }
 
             if (logger.isFinestEnabled()) {
@@ -149,7 +141,10 @@ public abstract class AbstractChannel implements Channel {
             throw e;
         } catch (IOException e) {
             IOUtil.closeResource(this);
-            throw e;
+            //we want to include the address in the exception.
+            IOException newEx = new IOException(e.getMessage() + " to address " + address);
+            newEx.setStackTrace(e.getStackTrace());
+            throw newEx;
         }
     }
 
@@ -169,7 +164,7 @@ public abstract class AbstractChannel implements Channel {
 
     /**
      * Template method that is called when the Channel is closed.
-     *
+     * <p>
      * It will be called only once.
      */
     protected void close0() throws IOException {


### PR DESCRIPTION
Added a warning log the the client connection problems

AbstractChannel.connect has a logic to add address to the SocketException.
Made it more generic so that it is applied to all IOExceptions thrown from this method.

backport of https://github.com/hazelcast/hazelcast/pull/18560

fixes #18559

(cherry picked from commit 550703a83b9cc57f6e1c9524c64bc483ba780a57)
