### PR TITLE
Add address info on connection failure messages

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -1050,7 +1050,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         }
                         getOrConnectToMember(member);
                     } catch (Exception e) {
-                        EmptyStatement.ignore(e);
+                        logger.warning("Could not connect to member " + uuid + ", reason " + e);
                     } finally {
                         connectingAddresses.remove(uuid);
                     }


### PR DESCRIPTION
Added a warning log the the client connection problems

AbstractChannel.connect has a logic to add address to the SocketException.
Made it more generic so that it is applied to all IOExceptions thrown from this method.

backport of https://github.com/hazelcast/hazelcast/pull/18560

fixes #18559

(cherry picked from commit 550703a83b9cc57f6e1c9524c64bc483ba780a57)