### PR TITLE
Remove printing the license key while starting instance with overriding config

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -121,6 +121,7 @@
               files="com[\\/]hazelcast[\\/]config[\\/]MapConfig"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]SerializationConfig"/>
     <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]internal[\\/]config[\\/]MemberDomConfigProcessor"/>
+    <suppress checks="MagicNumber" files="com[\\/]hazelcast[\\/]internal[\\/]config[\\/]override[\\/]ExternalConfigurationOverride"/>
 
     <!-- YAML -->
     <suppress checks="BooleanExpressionComplexity" files="com[\\/]hazelcast[\\/]internal[\\/]yaml[\\/]YamlUtil"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
@@ -82,7 +82,13 @@ public class ExternalConfigurationOverride {
                   configProvider.name(),
                   properties.entrySet().stream()
                     .filter(e -> !unprocessed.containsKey(e.getKey()))
-                    .map(e -> e.getKey() + "=" + e.getValue())
+                    .map(e -> {
+                        if (e.getKey().equals("hazelcast.licensekey")) {
+                            return e.getKey() + "=*********";
+                        } else {
+                            return e.getKey() + "=" + e.getValue();
+                        }
+                    })
                     .collect(joining(","))));
 
                 if (!unprocessed.isEmpty()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
@@ -84,7 +84,10 @@ public class ExternalConfigurationOverride {
                     .filter(e -> !unprocessed.containsKey(e.getKey()))
                     .map(e -> {
                         if (e.getKey().equals("hazelcast.licensekey")) {
-                            return e.getKey() + "=*********";
+                            String[] licenceKeyParts = e.getValue().split("#");
+                            String originalKeyPart = licenceKeyParts[licenceKeyParts.length - 1];
+                            return e.getKey() + "=" + originalKeyPart.substring(0, 5) + "*********"
+                                    + originalKeyPart.substring(originalKeyPart.length() - 5) ;
                         } else {
                             return e.getKey() + "=" + e.getValue();
                         }


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-docker/issues/248

Here is the fixed version of related log:
```
Detected external configuration entries in system properties:[hazelcast.clustername=test,hazelcast.licensekey=*********]
```