### PR TITLE
[PLAT-78] Cooperative threads run only if tasklets are available

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -98,7 +98,7 @@ public final class JetProperties {
      * increase latency and very high values (>10000µs) will also limit the
      * throughput.
      * <p>
-     * The default is value is {@code 25µs}.
+     * The default value is {@code 25µs}.
      * <p>
      * Note: the underlying {@link LockSupport#parkNanos(long)} call may
      * actually sleep longer depending on the operating system (up to 15000µs
@@ -120,7 +120,7 @@ public final class JetProperties {
      * increase latency and very high values (>10000µs) will also limit the
      * throughput.
      * <p>
-     * The default is value is {@code 500µs}.
+     * The default value is {@code 500µs}.
      * <p>
      * Note: the underlying {@link LockSupport#parkNanos(long)} call may
      * actually sleep longer depending on the operating system (up to 15000µs on
@@ -134,6 +134,48 @@ public final class JetProperties {
      */
     public static final HazelcastProperty JET_IDLE_COOPERATIVE_MAX_MICROSECONDS
         = new HazelcastProperty("jet.idle.cooperative.max.microseconds", 500, MICROSECONDS);
+
+    /**
+     * The minimum time in milliseconds the cooperative worker threads
+     * will sleep if there is no tasklet to run. Lower values increase
+     * idle CPU usage but may result in decreased latency when starting
+     * the execution of a job. Higher values may add a delay to the
+     * starting the execution of a job.
+     * <p>
+     * The default value is {@code 1ms}.
+     * <p>
+     * Note: the underlying {@link LockSupport#parkNanos(long)} call may
+     * actually sleep longer depending on the operating system (up to 15000µs on
+     * Windows). See the <a
+     * href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
+     * Hazelcast blog post about this subject</a> for more details.
+     * <p>
+     * See also: {@link #JET_IDLE_COOPERATIVE_MIN_MICROSECONDS}, {@link #JET_IDLE_COOPERATIVE_MAX_MICROSECONDS},
+     * {@link #JET_IDLE_COOPERATIVE_NO_TASKLET_MAX_MILLISECONDS}
+     */
+    public static final HazelcastProperty JET_IDLE_COOPERATIVE_NO_TASKLET_MIN_MILLISECONDS
+            = new HazelcastProperty("jet.idle.cooperative.no.tasklet.min.milliseconds", 1, MILLISECONDS);
+
+    /**
+     * The maximum time in milliseconds the cooperative worker threads
+     * will sleep if there is no tasklet to run. Lower values increase
+     * idle CPU usage but may result in decreased latency when starting
+     * the execution of a job. Higher values may add a delay to the
+     * starting the execution of a job.
+     * <p>
+     * The default value is {@code 1000ms}.
+     * <p>
+     * Note: the underlying {@link LockSupport#parkNanos(long)} call may
+     * actually sleep longer depending on the operating system (up to 15000µs on
+     * Windows). See the <a
+     * href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
+     * Hazelcast blog post about this subject</a> for more details.
+     * <p>
+     * See also: {@link #JET_IDLE_COOPERATIVE_MIN_MICROSECONDS}, {@link #JET_IDLE_COOPERATIVE_MAX_MICROSECONDS},
+     * {@link #JET_IDLE_COOPERATIVE_NO_TASKLET_MIN_MILLISECONDS}
+     */
+    public static final HazelcastProperty JET_IDLE_COOPERATIVE_NO_TASKLET_MAX_MILLISECONDS
+            = new HazelcastProperty("jet.idle.cooperative.no.tasklet.max.milliseconds", 1000, MILLISECONDS);
 
     /**
      * The minimum time in microseconds the non-cooperative worker threads will

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -87,6 +87,7 @@ public class TaskletExecutionService {
     private final Thread[] cooperativeThreadPool;
     private final String hzInstanceName;
     private final ILogger logger;
+    private int cooperativeThreadIndex;
     private final AtomicBoolean startCooperativeThreads = new AtomicBoolean(false);
     @Probe(name = "blockingWorkerCount")
     private final Counter blockingWorkerCount = MwCounter.newMwCounter();
@@ -204,7 +205,6 @@ public class TaskletExecutionService {
         // them could happen to not use all threads. When the other one ends,
         // some worker might have no tasklet.
         synchronized (lock) {
-            int cooperativeThreadIndex = 0;
             for (Tasklet t : tasklets) {
                 trackersByThread[cooperativeThreadIndex].add(new TaskletTracker(t, executionTracker, jobClassLoader));
                 cooperativeThreadIndex = (cooperativeThreadIndex + 1) % trackersByThread.length;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -167,6 +167,9 @@ public class TaskletExecutionService {
 
     public void shutdown() {
         isShutdown = true;
+        synchronized (lock) {
+            lock.notifyAll();
+        }
         blockingTaskletExecutor.shutdownNow();
         hzExecutionService.shutdownExecutor(TASKLET_INIT_CLOSE_EXECUTOR_NAME);
     }
@@ -364,7 +367,7 @@ public class TaskletExecutionService {
                     idleCount++;
                     if (trackers.isEmpty()) {
                         synchronized (lock) {
-                            while (trackers.isEmpty()) {
+                            while (trackers.isEmpty() && !isShutdown) {
                                 try {
                                     lock.wait();
                                 } catch (InterruptedException e) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -86,7 +86,7 @@ public class TaskletExecutionService {
     private final String hzInstanceName;
     private final ILogger logger;
     private int cooperativeThreadIndex;
-    private AtomicBoolean startCooperativeThreads = new AtomicBoolean(false);
+    private final AtomicBoolean startCooperativeThreads = new AtomicBoolean(false);
     @Probe(name = "blockingWorkerCount")
     private final Counter blockingWorkerCount = MwCounter.newMwCounter();
     private volatile boolean isShutdown;


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/PLAT-78

This PR tries to solve the above mentioned problem by doing the following:

- Do not start cooperative threads at the startup
- If any job submitted to the Platform start the cooperative threads
- Cooperative threads stay active until shutdown
- Cooperative threads shutdown if there are no available tasklets
- Cooperative threads wake up if a new job submitted

This is an alternative approach to [this PR](https://github.com/hazelcast/hazelcast/pull/18621) using synchronized locks. It should be either that or this should be merged.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
