### PR TITLE
Update distribution zip contents

### DIFF
--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -14,9 +14,9 @@
   ~ limitations under the License.
   -->
 
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+
     <id>slim</id>
     <formats>
         <format>zip</format>

--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -35,6 +35,7 @@
                 <include>com.hazelcast:hazelcast-gcp</include>
                 <include>com.hazelcast:hazelcast-azure</include>
                 <include>com.hazelcast:hazelcast-hibernate53</include>
+                <include>com.hazelcast:hazelcast-wm</include>
                 <include>org.apache.logging.log4j:*</include>
                 <include>org.slf4j:*</include>
                 <include>info.picocli:picocli</include>

--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -30,6 +30,11 @@
             <includes>
                 <include>com.hazelcast:hazelcast</include>
                 <include>com.hazelcast.jet:hazelcast-jet-sql</include>
+                <include>com.hazelcast:hazelcast-aws</include>
+                <include>com.hazelcast:hazelcast-kubernetes</include>
+                <include>com.hazelcast:hazelcast-gcp</include>
+                <include>com.hazelcast:hazelcast-azure</include>
+                <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>org.apache.logging.log4j:*</include>
                 <include>org.slf4j:*</include>
                 <include>info.picocli:picocli</include>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -34,6 +34,7 @@
                 <include>com.hazelcast:hazelcast-gcp</include>
                 <include>com.hazelcast:hazelcast-azure</include>
                 <include>com.hazelcast:hazelcast-hibernate53</include>
+                <include>com.hazelcast:hazelcast-wm</include>
                 <include>org.apache.logging.log4j:*</include>
                 <include>org.slf4j:*</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -34,8 +34,6 @@
                 <include>com.hazelcast:hazelcast-gcp</include>
                 <include>com.hazelcast:hazelcast-azure</include>
                 <include>com.hazelcast:hazelcast-hibernate53</include>
-                <include>com.hazelcast:hazelcast-spring</include>
-                <include>com.hazelcast:hazelcast-wm</include>
                 <include>org.apache.logging.log4j:*</include>
                 <include>org.slf4j:*</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>


### PR DESCRIPTION
Based on the discussion we want to have the aws, azure, gcp and kubernetes modules in both distributions.

The spring and wm modules are not required on the server side, so they re removed from the fat distribution.
(hibernate module is required for certain scenarios).
