### PR TITLE
Convert IOUtilTest back to serial-class-runner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -18,10 +18,9 @@ package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.test.JetAssert;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,7 +45,7 @@ import static com.hazelcast.jet.impl.util.IOUtil.unzip;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class IOUtilTest extends JetTestSupport {
 
@@ -57,7 +56,6 @@ public class IOUtilTest extends JetTestSupport {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
-    @Ignore // https://github.com/hazelcast/hazelcast/issues/18541
     public void test_zipAndUnzipNestedFolder_then_contentsShouldBeSame() throws Exception {
         Path originalPath = Paths.get(this.getClass().getResource("/nested").toURI());
         test(originalPath);


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/18541

other method in the test creates a random directory which affects this test if run in parallel.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
