### PR TITLE
Rename params to arguments or "param values"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -116,12 +116,14 @@ import java.util.List;
 @Beta
 public interface SqlService {
     /**
-     * Convenient method to execute a distributed query with the given parameters.
+     * Convenient method to execute a distributed query with the given
+     * parameter values.
      * <p>
-     * Converts passed SQL string and parameters into an {@link SqlStatement} object and invokes {@link #execute(SqlStatement)}.
+     * Converts passed SQL string and parameter values into an {@link
+     * SqlStatement} object and invokes {@link #execute(SqlStatement)}.
      *
      * @param sql SQL string
-     * @param params query parameters that will be passed to {@link SqlStatement#setParameters(List)}
+     * @param arguments query parameter values that will be passed to {@link SqlStatement#setParameters(List)}
      * @return result
      * @throws NullPointerException if the SQL string is null
      * @throws IllegalArgumentException if the SQL string is empty
@@ -132,12 +134,12 @@ public interface SqlService {
      * @see #execute(SqlStatement)
      */
     @Nonnull
-    default SqlResult execute(@Nonnull String sql, Object... params) {
+    default SqlResult execute(@Nonnull String sql, Object... arguments) {
         SqlStatement statement = new SqlStatement(sql);
 
-        if (params != null) {
-            for (Object param : params) {
-                statement.addParameter(param);
+        if (arguments != null) {
+            for (Object arg : arguments) {
+                statement.addParameter(arg);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
@@ -45,7 +45,7 @@ public final class SqlStatement {
     public static final int DEFAULT_CURSOR_BUFFER_SIZE = 4096;
 
     private String sql;
-    private List<Object> parameters = new ArrayList<>();
+    private List<Object> arguments = new ArrayList<>();
     private long timeout = DEFAULT_TIMEOUT;
     private int cursorBufferSize = DEFAULT_CURSOR_BUFFER_SIZE;
     private String schema;
@@ -60,14 +60,14 @@ public final class SqlStatement {
      */
     private SqlStatement(
         String sql,
-        List<Object> parameters,
+        List<Object> arguments,
         long timeout,
         int cursorBufferSize,
         String schema,
         SqlExpectedResultType expectedResultType
     ) {
         this.sql = sql;
-        this.parameters = parameters;
+        this.arguments = arguments;
         this.timeout = timeout;
         this.cursorBufferSize = cursorBufferSize;
         this.schema = schema;
@@ -140,22 +140,20 @@ public final class SqlStatement {
     }
 
     /**
-     * Gets the statement parameters.
-     *
-     * @return statement parameters
+     * Gets the statement parameter values.
      */
     @Nonnull
     public List<Object> getParameters() {
-        return parameters;
+        return arguments;
     }
 
     /**
-     * Sets the statement parameters.
+     * Sets the values for statement parameters.
      * <p>
-     * You may define parameter placeholders in the statement with the {@code "?"} character. For every placeholder, a parameter
+     * You may define parameter placeholders in the statement with the {@code "?"} character. For every placeholder, a
      * value must be provided.
      * <p>
-     * When the method is called, the content of the parameters list is copied. Subsequent changes to the original list don't
+     * When the method is called, the contents of the list are copied. Subsequent changes to the original list don't
      * change the statement parameters.
      *
      * @param parameters statement parameters
@@ -167,32 +165,32 @@ public final class SqlStatement {
     @Nonnull
     public SqlStatement setParameters(List<Object> parameters) {
         if (parameters == null || parameters.isEmpty()) {
-            this.parameters = new ArrayList<>();
+            this.arguments = new ArrayList<>();
         } else {
-            this.parameters = new ArrayList<>(parameters);
+            this.arguments = new ArrayList<>(parameters);
         }
 
         return this;
     }
 
     /**
-     * Adds a single parameter to the end of the parameters list.
+     * Adds a single parameter value to the end of the parameter values list.
      *
-     * @param parameter parameter
+     * @param value parameter value
      * @return this instance for chaining
      *
      * @see #setParameters(List)
      * @see #clearParameters()
      */
     @Nonnull
-    public SqlStatement addParameter(Object parameter) {
-        parameters.add(parameter);
+    public SqlStatement addParameter(Object value) {
+        arguments.add(value);
 
         return this;
     }
 
     /**
-     * Clears statement parameters.
+     * Clears statement parameter values.
      *
      * @return this instance for chaining
      *
@@ -201,7 +199,7 @@ public final class SqlStatement {
      */
     @Nonnull
     public SqlStatement clearParameters() {
-        this.parameters = new ArrayList<>();
+        this.arguments.clear();
 
         return this;
     }
@@ -316,7 +314,7 @@ public final class SqlStatement {
      */
     @Nonnull
     public SqlStatement copy() {
-        return new SqlStatement(sql, new ArrayList<>(parameters), timeout, cursorBufferSize, schema, expectedResultType);
+        return new SqlStatement(sql, new ArrayList<>(arguments), timeout, cursorBufferSize, schema, expectedResultType);
     }
 
     @Override
@@ -332,7 +330,7 @@ public final class SqlStatement {
         SqlStatement sqlStatement = (SqlStatement) o;
 
         return Objects.equals(sql, sqlStatement.sql)
-            && Objects.equals(parameters, sqlStatement.parameters)
+            && Objects.equals(arguments, sqlStatement.arguments)
             && timeout == sqlStatement.timeout
             && cursorBufferSize == sqlStatement.cursorBufferSize
             && Objects.equals(schema, sqlStatement.schema)
@@ -343,7 +341,7 @@ public final class SqlStatement {
     public int hashCode() {
         int result = sql != null ? sql.hashCode() : 0;
 
-        result = 31 * result + parameters.hashCode();
+        result = 31 * result + arguments.hashCode();
         result = 31 * result + (int) (timeout ^ (timeout >>> 32));
         result = 31 * result + cursorBufferSize;
         result = 31 * result + (schema != null ? schema.hashCode() : 0);
@@ -357,7 +355,7 @@ public final class SqlStatement {
         return "SqlStatement{"
             + "schema=" + schema
             + ", sql=" + sql
-            + ", parameters=" + parameters
+            + ", arguments=" + arguments
             + ", timeout=" + timeout
             + ", cursorBufferSize=" + cursorBufferSize
             + ", expectedResultType=" + expectedResultType

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlStatementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlStatementTest.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -149,19 +148,6 @@ public class SqlStatementTest extends SqlTestSupport {
 
         another = query.copy().setSchema("schema");
         checkEquals(query, another, false);
-    }
-
-    @Test
-    public void testToString() {
-        SqlStatement query = create().setSchema("schema").setParameters(Arrays.asList(1, 2)).setTimeoutMillis(3L).setCursorBufferSize(4);
-
-        String string = query.toString();
-
-        assertTrue(string.contains("schema="));
-        assertTrue(string.contains("sql="));
-        assertTrue(string.contains("parameters="));
-        assertTrue(string.contains("timeout="));
-        assertTrue(string.contains("cursorBufferSize="));
     }
 
     private static SqlStatement create() {


### PR DESCRIPTION
This is to unify terminology: query has parameters, and for each
parameter we provide an argument or a value.

Nothing in the public API is changed, except for the method parameter names.