### PR TITLE
Share cluster in ExpressionTestSupport

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.sql.impl.type.converter.LocalDateTimeConverter;
 import com.hazelcast.sql.impl.type.converter.LocalTimeConverter;
 import com.hazelcast.sql.impl.type.converter.OffsetDateTimeConverter;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -55,7 +55,7 @@ import static com.hazelcast.sql.impl.SqlErrorCode.DATA_EXCEPTION;
 import static com.hazelcast.sql.impl.SqlErrorCode.PARSING;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CastFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ColumnIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ColumnIntegrationTest.java
@@ -23,9 +23,10 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionType;
 import com.hazelcast.sql.support.expressions.ExpressionTypes;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,11 +51,11 @@ import static com.hazelcast.sql.SqlColumnType.TINYINT;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ColumnIntegrationTest extends ExpressionTestSupport {
-    @Override
-    protected void before0() {
+    @Before
+    public void before() {
         put(1);
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -96,8 +96,8 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         }
         // after each test ditch all jobs and objects
         List<Job> jobs = member.getJetInstance().getJobs();
-        SUPPORT_LOGGER.info("Ditching " + jobs.size() + " jobs in SimpleTestInClusterSupport.@After: " +
-                jobs.stream().map(j -> idToString(j.getId())).collect(joining(", ", "[", "]")));
+        SUPPORT_LOGGER.info("Ditching " + jobs.size() + " jobs in SimpleTestInClusterSupport.@After: "
+                + jobs.stream().map(j -> idToString(j.getId())).collect(joining(", ", "[", "]")));
         for (Job job : jobs) {
             ditchJob(job, member);
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -96,7 +96,7 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         }
         // after each test ditch all jobs and objects
         List<Job> jobs = member.getJetInstance().getJobs();
-        SUPPORT_LOGGER.info("Ditching " + jobs.size() + " jobs in SimpleTestInClusterSupport.@After: "
+        SUPPORT_LOGGER.info("Ditching " + jobs.size() + " jobs in ExpressionTestSupport.@After: "
                 + jobs.stream().map(j -> idToString(j.getId())).collect(joining(", ", "[", "]")));
         for (Job job : jobs) {
             ditchJob(job, member);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -17,7 +17,11 @@
 package com.hazelcast.sql.impl.expression;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlColumnType;
@@ -27,7 +31,8 @@ import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
 import junit.framework.TestCase;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -36,11 +41,16 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
+import static com.hazelcast.jet.Util.idToString;
+import static com.hazelcast.jet.core.JetTestSupport.ditchJob;
+import static java.util.stream.Collectors.joining;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -48,6 +58,7 @@ import static org.junit.Assert.fail;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 public abstract class ExpressionTestSupport extends SqlTestSupport {
+    private static final ILogger SUPPORT_LOGGER = Logger.getLogger(ExpressionTestSupport.class);
 
     public static final Character CHAR_VAL = 'f';
     public static final String STRING_VAL = "foo";
@@ -67,27 +78,42 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
     public static final ExpressionValue OBJECT_VAL = new ExpressionValue.ObjectVal();
 
     protected static final Object SKIP_VALUE_CHECK = new Object();
-    protected HazelcastInstance member;
+    protected static HazelcastInstance member;
 
-    private final TestHazelcastFactory factory = new TestHazelcastFactory();
-    protected IMap map;
+    private static final TestHazelcastFactory factory = new TestHazelcastFactory();
+    protected static IMap map;
 
-    @Before
-    public void before() {
+    @BeforeClass
+    public static void beforeClass() {
         member = factory.newHazelcastInstance();
-
         map = member.getMap("map");
-
-        before0();
-    }
-
-    protected void before0() {
-        // No-op
     }
 
     @After
-    public void after() {
-        factory.shutdownAll();
+    public void supportAfter() {
+        if (member == null) {
+            return;
+        }
+        // after each test ditch all jobs and objects
+        List<Job> jobs = member.getJetInstance().getJobs();
+        SUPPORT_LOGGER.info("Ditching " + jobs.size() + " jobs in SimpleTestInClusterSupport.@After: " +
+                jobs.stream().map(j -> idToString(j.getId())).collect(joining(", ", "[", "]")));
+        for (Job job : jobs) {
+            ditchJob(job, member);
+        }
+        Collection<DistributedObject> objects = member.getDistributedObjects();
+        SUPPORT_LOGGER.info("Destroying " + objects.size()
+                + " distributed objects in SimpleTestInClusterSupport.@After: "
+                + objects.stream().map(o -> o.getServiceName() + "/" + o.getName())
+                .collect(Collectors.joining(", ", "[", "]")));
+        for (DistributedObject o : objects) {
+            o.destroy();
+        }
+    }
+
+    @AfterClass
+    public static void after() {
+        factory.terminateAll();
     }
 
     protected void put(Object value) {
@@ -105,15 +131,11 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
         if (values == null || values.length == 0) {
             return;
         }
-
         Map<Integer, Object> entries = new HashMap<>();
-
         int key = 0;
-
         for (Object value : values) {
             entries.put(key++, value);
         }
-
         putAll(entries);
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
@@ -18,10 +18,11 @@ package com.hazelcast.sql.impl.expression;
 
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.impl.calcite.validate.HazelcastSqlOperatorTable;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.calcite.sql.SqlOperator;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -43,10 +44,10 @@ import static junit.framework.TestCase.fail;
  * <p>
  * Also ensures that function names are case-insensitive.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class NestingAndCasingExpressionTest extends ExpressionTestSupport {
-    @Override
+    @Before
     public void before0() {
         put(1);
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/AbsFunctionIntegrationTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -47,7 +47,7 @@ import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.SqlColumnType.TINYINT;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class AbsFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DivideOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DivideOperatorIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.expression.math;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -45,7 +45,7 @@ import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 import static com.hazelcast.sql.impl.SqlErrorCode.DATA_EXCEPTION;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DivideOperatorIntegrationTest extends ArithmeticOperatorIntegrationTest {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleBiFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleBiFunctionIntegrationTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -47,7 +47,7 @@ import static com.hazelcast.sql.impl.expression.math.DoubleBiFunction.ATAN2;
 import static com.hazelcast.sql.impl.expression.math.DoubleBiFunction.POWER;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DoubleBiFunctionIntegrationTest extends ExpressionTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/DoubleFunctionIntegrationTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -47,7 +47,7 @@ import static com.hazelcast.sql.impl.expression.math.DoubleFunction.COS;
 import static com.hazelcast.sql.impl.expression.math.DoubleFunction.SIN;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DoubleFunctionIntegrationTest extends ExpressionTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorCeilFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/FloorCeilFunctionIntegrationTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -56,7 +56,7 @@ import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class FloorCeilFunctionIntegrationTest extends ExpressionTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/MinusOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/MinusOperatorIntegrationTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -57,7 +57,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.time.temporal.ChronoUnit.YEARS;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MinusOperatorIntegrationTest extends ArithmeticOperatorIntegrationTest {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/MultiplyOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/MultiplyOperatorIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.expression.math;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -45,7 +45,7 @@ import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 import static com.hazelcast.sql.impl.SqlErrorCode.DATA_EXCEPTION;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MultiplyOperatorIntegrationTest extends ArithmeticOperatorIntegrationTest {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/PlusOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/PlusOperatorIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -57,7 +57,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.time.temporal.ChronoUnit.YEARS;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PlusOperatorIntegrationTest extends ArithmeticOperatorIntegrationTest {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RandFunctionIntegrationTest.java
@@ -17,14 +17,14 @@
 package com.hazelcast.sql.impl.expression.math;
 
 import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.SqlErrorCode;
-import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RandFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RemainderOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RemainderOperatorIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.expression.math;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -48,7 +48,7 @@ import static com.hazelcast.sql.impl.SqlErrorCode.DATA_EXCEPTION;
 import static com.hazelcast.sql.impl.expression.ConstantExpression.create;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RemainderOperatorIntegrationTest extends ArithmeticOperatorIntegrationTest {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.sql.support.expressions.ExpressionValue.ByteVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.IntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.LongVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.ShortVal;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -63,7 +63,7 @@ import static com.hazelcast.sql.support.expressions.ExpressionBiValue.DoubleVal;
 import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatIntegerVal;
 import static com.hazelcast.sql.support.expressions.ExpressionBiValue.FloatVal;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RoundFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/SignFunctionIntegrationTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -44,7 +44,7 @@ import static com.hazelcast.sql.SqlColumnType.TIMESTAMP;
 import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SignFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.sql.support.expressions.ExpressionValue.ByteVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.IntegerVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.LongVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.ShortVal;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -61,7 +61,7 @@ import static com.hazelcast.sql.support.expressions.ExpressionValue.BigDecimalVa
 import static com.hazelcast.sql.support.expressions.ExpressionValue.DoubleVal;
 import static com.hazelcast.sql.support.expressions.ExpressionValue.FloatVal;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class TruncateFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/UnaryMinusIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/UnaryMinusIntegrationTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -49,7 +49,7 @@ import static com.hazelcast.sql.SqlColumnType.TINYINT;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class UnaryMinusIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/UnaryPlusIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/math/UnaryPlusIntegrationTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -45,7 +45,7 @@ import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.SqlColumnType.TINYINT;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class UnaryPlusIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/AndOrPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/AndOrPredicateIntegrationTest.java
@@ -35,7 +35,7 @@ import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanOffsetDate
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanShortVal;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanStringVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -54,7 +54,7 @@ import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanFlo
 import static com.hazelcast.sql.support.expressions.ExpressionBiValue.BooleanIntegerVal;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class AndOrPredicateIntegrationTest extends ExpressionTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/BetweenOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/BetweenOperatorIntegrationTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionType;
 import com.hazelcast.sql.support.expressions.ExpressionTypes;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Ignore;
@@ -86,7 +86,7 @@ import static org.junit.Assert.assertNull;
  * @see #betweenAsymmetricPredicateTypeCheckTest()
  * @see #betweenSymmetricPredicateTypeCheckTest()
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class BetweenOperatorIntegrationTest extends ExpressionTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/ComparisonPredicateIntegrationTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionType;
 import com.hazelcast.sql.support.expressions.ExpressionTypes;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -48,7 +48,7 @@ import java.util.Collection;
 
 @SuppressWarnings("rawtypes")
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ComparisonPredicateIntegrationTest extends ExpressionTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/InOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/InOperatorIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.expression.predicate;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Ignore;
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
 
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class InOperatorIntegrationTest extends ExpressionTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsNullPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsNullPredicateIntegrationTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -62,7 +62,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for IS (NOT) NULL predicates.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class IsNullPredicateIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsTrueFalsePredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/IsTrueFalsePredicateIntegrationTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for IS (NOT) TRUE/FALSE predicates.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class IsTrueFalsePredicateIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/NotPredicateIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/NotPredicateIntegrationTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for NOT predicate.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class NotPredicateIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/AsciiFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/AsciiFunctionIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.support.expressions.ExpressionValue.CharacterVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.StringVal;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class AsciiFunctionIntegrationTest extends StringFunctionIntegrationTestSupport {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/CharLengthFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/CharLengthFunctionIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.support.expressions.ExpressionValue.CharacterVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.StringVal;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -35,7 +35,7 @@ import java.util.Collection;
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CharLengthFunctionIntegrationTest extends StringFunctionIntegrationTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/ConcatFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/ConcatFunctionIntegrationTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.support.expressions.ExpressionBiValue;
 import com.hazelcast.sql.support.expressions.ExpressionType;
 import com.hazelcast.sql.support.expressions.ExpressionTypes;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ConcatFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/InitcapFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/InitcapFunctionIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.support.expressions.ExpressionValue.CharacterVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.StringVal;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class InitcapFunctionIntegrationTest extends StringFunctionIntegrationTestSupport {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/LikeFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/LikeFunctionIntegrationTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LikeFunctionIntegrationTest extends ExpressionTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/LowerFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/LowerFunctionIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.support.expressions.ExpressionValue.CharacterVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.StringVal;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LowerFunctionIntegrationTest extends StringFunctionIntegrationTestSupport {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/PositionFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/PositionFunctionIntegrationTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PositionFunctionIntegrationTest extends ExpressionTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/ReplaceFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/ReplaceFunctionIntegrationTest.java
@@ -23,7 +23,12 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
@@ -31,6 +36,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ReplaceFunctionIntegrationTest extends ExpressionTestSupport {
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/StringFunctionIntegrationTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/StringFunctionIntegrationTestSupport.java
@@ -40,7 +40,6 @@ import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.SqlColumnType.TINYINT;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 
-
 public abstract class StringFunctionIntegrationTestSupport extends ExpressionTestSupport {
 
     protected abstract String functionName();

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/SubstringFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/SubstringFunctionIntegrationTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -54,7 +54,7 @@ import static java.util.Arrays.asList;
 
 @SuppressWarnings("SpellCheckingInspection")
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SubstringFunctionIntegrationTest extends ExpressionTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/TrimFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/TrimFunctionIntegrationTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.sql.support.expressions.ExpressionValue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -50,7 +50,7 @@ import static com.hazelcast.sql.SqlColumnType.VARCHAR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class TrimFunctionIntegrationTest extends ExpressionTestSupport {
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/TrimSimpleFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/TrimSimpleFunctionIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.sql.impl.expression.string;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.support.expressions.ExpressionValue.CharacterVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.StringVal;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class TrimSimpleFunctionIntegrationTest extends StringFunctionIntegrationTestSupport {
     @Parameterized.Parameter

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/UpperFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/UpperFunctionIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.support.expressions.ExpressionValue.CharacterVal;
 import com.hazelcast.sql.support.expressions.ExpressionValue.StringVal;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class UpperFunctionIntegrationTest extends StringFunctionIntegrationTestSupport {
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/ComparisonPredicateIntegrationSlowTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/ComparisonPredicateIntegrationSlowTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql_slow;
 
 import com.hazelcast.sql.impl.expression.predicate.ComparisonPredicateIntegrationTest;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.experimental.categories.Category;
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({SlowTest.class, ParallelJVMTest.class})
 public class ComparisonPredicateIntegrationSlowTest extends ComparisonPredicateIntegrationTest {
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
@@ -279,6 +280,10 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
                 + snapshotId[0] + ", previous id=" + originalSnapshotId + ")");
     }
 
+    public void cleanUpCluster(JetInstance... instances) {
+        cleanUpCluster(Arrays.stream(instances).map(i -> i.getHazelcastInstance()).toArray(HazelcastInstance[]::new));
+    }
+
     /**
      * Clean up the cluster and make it ready to run a next test. If we fail
      * to, shut it down so that next tests don't run on a messed-up cluster.
@@ -286,13 +291,17 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
      * @param instances cluster instances, must contain at least
      *                            one instance
      */
-    public void cleanUpCluster(JetInstance ... instances) {
-        for (Job job : instances[0].getJobs()) {
+    public void cleanUpCluster(HazelcastInstance ... instances) {
+        for (Job job : instances[0].getJetInstance().getJobs()) {
             ditchJob(job, instances);
         }
-        for (DistributedObject o : instances[0].getHazelcastInstance().getDistributedObjects()) {
+        for (DistributedObject o : instances[0].getDistributedObjects()) {
             o.destroy();
         }
+    }
+
+    public static void ditchJob(@Nonnull Job job, @Nonnull JetInstance... instancesToShutDown) {
+        ditchJob(job, Arrays.stream(instancesToShutDown).map(i -> i.getHazelcastInstance()).toArray(HazelcastInstance[]::new));
     }
 
     /**
@@ -300,7 +309,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
      * will ignore if it's not running. If the cancellation fails, it will
      * retry.
      */
-    public void ditchJob(@Nonnull Job job, @Nonnull JetInstance... instancesToShutDown) {
+    public static void ditchJob(@Nonnull Job job, @Nonnull HazelcastInstance... instancesToShutDown) {
         int numAttempts;
         for (numAttempts = 0; numAttempts < 10; numAttempts++) {
             JobStatus status = null;
@@ -333,8 +342,8 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
         }
         // if we got here, 10 attempts to cancel the job have failed. Cluster is in bad shape probably, shut it down
         try {
-            for (JetInstance instance : instancesToShutDown) {
-                instance.getHazelcastInstance().getLifecycleService().terminate();
+            for (HazelcastInstance instance : instancesToShutDown) {
+                instance.getLifecycleService().terminate();
             }
         } catch (Exception e) {
             // ignore, proceed to throwing RuntimeException

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteFilePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteFilePTest.java
@@ -416,7 +416,7 @@ public class WriteFilePTest extends SimpleTestInClusterSupport {
         } while (System.nanoTime() < endTime);
 
         waitForNextSnapshot(new JobRepository(instance()), job.getId(), 10, true);
-        ditchJob(job);
+        ditchJob(job, instances());
         // when the job is cancelled, there should be no temporary files
         checkFileContents(0, numItems, exactlyOnce, false, false);
     }


### PR DESCRIPTION
Reduces the affected tests form 69 seconds to about 44 seconds on my machine.
Also makes the laptop more quiet during that.
