### PR TITLE
Add null check to client exception factory in JetService initialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -127,7 +127,8 @@ public class JetService implements ManagedService, MembershipAwareService, LiveO
         if (clientExceptionFactory != null) {
             ExceptionUtil.registerJetExceptions(clientExceptionFactory);
         } else {
-            logger.warning("Jet exceptions are not registered since the client exception factory is not accessible.");
+            logger.fine("Jet exceptions are not registered to the ClientExceptionFactory" +
+                    " since the ClientExceptionFactory is not accessible.");
         }
         logger.info("Setting number of cooperative threads and default parallelism to "
                 + config.getInstanceConfig().getCooperativeThreadCount());


### PR DESCRIPTION
ClientExceptionFactory becomes null when ClientEngine is
NoOpClientEngine (ClientEngine can be NoOpClientEngine according to
network config).

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4027 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set

