### PR TITLE
Fix named arguments + dynamic parameters type mismatch handling

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlSeriesGeneratorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlSeriesGeneratorTest.java
@@ -136,6 +136,31 @@ public class SqlSeriesGeneratorTest extends SqlTestSupport {
     }
 
     @Test
+    public void test_generateSeriesWithNamedArgumentsAndDynamicParameters() {
+        assertRowsAnyOrder(
+                "SELECT v * ? FROM TABLE(GENERATE_SERIES(stop => ?, \"start\" => ?)) WHERE v > ? AND v < 5",
+                asList(2, 5, 0, 1),
+                asList(
+                        new Row(4L),
+                        new Row(6L),
+                        new Row(8L)
+                )
+        );
+    }
+
+    @Test
+    public void test_generateSeriesWithDynamicParametersAndArgumentTypeMismatch() {
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(0, ?))", "1"))
+                .hasMessageContaining("Parameter at position 0 must be of INTEGER type, but VARCHAR was found");
+    }
+
+    @Test
+    public void test_generateSeriesWithNamedArgumentsDynamicParametersAndArgumentTypeMismatch() {
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_SERIES(stop => 10, \"start\" => ?))", "1"))
+                .hasMessageContaining("Parameter at position 0 must be of INTEGER type, but VARCHAR was found");
+    }
+
+    @Test
     public void when_startIsGreaterThanStopAndStepIsPositive_then_returnsEmpty() {
         assertRowsAnyOrder(
                 "SELECT * FROM TABLE(GENERATE_SERIES(2, 1, 1))",

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlStreamGeneratorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/generator/SqlStreamGeneratorTest.java
@@ -105,6 +105,32 @@ public class SqlStreamGeneratorTest extends SqlTestSupport {
     }
 
     @Test
+    public void test_generateStreamWithNamedArgumentsAndDynamicParameters() {
+        assertRowsEventuallyInAnyOrder(
+                "SELECT v * ? FROM TABLE(GENERATE_STREAM(rate => ?)) WHERE v > 1 - ? AND v < 5",
+                asList(2, 100, 1),
+                asList(
+                        new Row(2L),
+                        new Row(4L),
+                        new Row(6L),
+                        new Row(8L)
+                )
+        );
+    }
+
+    @Test
+    public void test_generateStreamWithDynamicParametersAndArgumentTypeMismatch() {
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(?))", "1"))
+                .hasMessageContaining("Parameter at position 0 must be of INTEGER type, but VARCHAR was found");
+    }
+
+    @Test
+    public void test_generateStreamWithNamedArgumentsDynamicParametersAndArgumentTypeMismatch() {
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(rate => ?))", "1"))
+                .hasMessageContaining("Parameter at position 0 must be of INTEGER type, but VARCHAR was found");
+    }
+
+    @Test
     public void test_generateEmptyStream() {
         SqlResult result = sqlService.execute("SELECT * FROM TABLE(GENERATE_STREAM(0))");
         Future<Boolean> future = spawn(() -> result.iterator().hasNext());


### PR DESCRIPTION
Fixed named arguments + dynamic parameters handling in `AbstractOperandChecker` to provide proper error message instead of NPE in case of type mismatch.