### PR TITLE
Fix Jet related RU compatibility issue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -44,7 +44,6 @@ import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.TextCommandServiceImpl;
 import com.hazelcast.internal.cluster.ClusterStateListener;
 import com.hazelcast.internal.cluster.ClusterVersionListener;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
 import com.hazelcast.internal.diagnostics.BuildInfoPlugin;

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
@@ -99,7 +99,7 @@ public class JetExtension {
             setActivated(true);
             logger.info("Jet extension is enabled");
         } else {
-            logger.info("Jet extension is disabled due to the current cluster version is lower than 5.0.");
+            logger.info("Jet extension is disabled due to current cluster version being less than 5.0.");
         }
     }
 


### PR DESCRIPTION
This PR partly resolves the RU incompatibility issue described in [here](https://github.com/hazelcast/hazelcast-enterprise/issues/4028) by restricting Jet access with preventing getting a `JetInstance` when the node is running in a cluster version smaller than 5.0, and also removing the internal `JetService` accesses such as job scanning, shutdown operations etc in this condition. We re-enable these accesses after cluster version is upgraded to version 5.0 or higher. 

Note: I didn't consider the accesses to jet service with using SQL API

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4028

Related EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4030

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

