### PR TITLE
Support dynamic parameters in file table functions

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlBackend.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlBackend.java
@@ -116,9 +116,10 @@ class JetSqlBackend implements SqlBackend {
     public SqlValidator validator(
             CatalogReader catalogReader,
             HazelcastTypeFactory typeFactory,
-            SqlConformance sqlConformance
+            SqlConformance sqlConformance,
+            List<Object> arguments
     ) {
-        return new JetSqlValidator(catalogReader, typeFactory, sqlConformance);
+        return new JetSqlValidator(catalogReader, typeFactory, sqlConformance, arguments);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlOperatorTable.java
@@ -28,6 +28,7 @@ import com.hazelcast.jet.sql.impl.connector.file.FileTableFunction;
 import com.hazelcast.jet.sql.impl.connector.generator.SeriesGeneratorTableFunction;
 import com.hazelcast.jet.sql.impl.connector.generator.StreamGeneratorTableFunction;
 import com.hazelcast.jet.sql.impl.validate.operators.HazelcastCollectionTableOperator;
+import com.hazelcast.jet.sql.impl.validate.operators.HazelcastMapValueConstructor;
 import com.hazelcast.jet.sql.impl.validate.operators.HazelcastRowOperator;
 import com.hazelcast.jet.sql.impl.validate.operators.HazelcastValuesOperator;
 import org.apache.calcite.sql.SqlFunction;
@@ -37,7 +38,6 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlSyntax;
-import org.apache.calcite.sql.fun.SqlMapValueConstructor;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
 import org.apache.calcite.sql.validate.SqlNameMatcher;
@@ -50,6 +50,7 @@ public final class JetSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlSpecialOperator VALUES = new HazelcastValuesOperator();
     public static final SqlSpecialOperator ROW = new HazelcastRowOperator();
     public static final SqlSpecialOperator COLLECTION_TABLE = new HazelcastCollectionTableOperator("TABLE");
+    public static final SqlSpecialOperator MAP_VALUE_CONSTRUCTOR = new HazelcastMapValueConstructor();
 
     // We use an operator that doesn't implement the HazelcastOperandTypeCheckerAware interface.
     // The reason is that HazelcastOperandTypeCheckerAware.prepareBinding() gets the operand type for
@@ -57,9 +58,6 @@ public final class JetSqlOperatorTable extends ReflectiveSqlOperatorTable {
     // an SQL identifier and Calcite tries to resolve it as a column name. The other parameter accepts
     // ANY type so there's no need for this
     public static final SqlSpecialOperator ARGUMENT_ASSIGNMENT = SqlStdOperatorTable.ARGUMENT_ASSIGNMENT;
-
-    // TODO [viliam] this seems to work, but it doesn't extend the hz-specific classes
-    public static final SqlMapValueConstructor MAP_VALUE_CONSTRUCTOR = new SqlMapValueConstructor();
 
     public static final SqlFunction SUM = new HazelcastSumAggFunction();
     public static final SqlFunction COUNT = new HazelcastCountAggFunction();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlValidator.java
@@ -38,6 +38,8 @@ import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.sql.validate.SqlValidatorTable;
 
+import java.util.List;
+
 import static com.hazelcast.jet.sql.impl.connector.SqlConnectorUtil.getJetSqlConnector;
 import static com.hazelcast.jet.sql.impl.validate.ValidatorResource.RESOURCE;
 import static org.apache.calcite.sql.SqlKind.AGGREGATE;
@@ -51,9 +53,10 @@ public class JetSqlValidator extends HazelcastSqlValidator {
     public JetSqlValidator(
             SqlValidatorCatalogReader catalogReader,
             HazelcastTypeFactory typeFactory,
-            SqlConformance conformance
+            SqlConformance conformance,
+            List<Object> arguments
     ) {
-        super(JetSqlOperatorTable.instance(), catalogReader, typeFactory, conformance);
+        super(JetSqlOperatorTable.instance(), catalogReader, typeFactory, conformance, arguments);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/HazelcastMapValueConstructor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/HazelcastMapValueConstructor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.validate.operators;
+
+import com.hazelcast.sql.impl.calcite.validate.HazelcastCallBinding;
+import com.hazelcast.sql.impl.calcite.validate.operand.TypedOperandChecker;
+import com.hazelcast.sql.impl.calcite.validate.operators.ReplaceUnknownOperandTypeInference;
+import com.hazelcast.sql.impl.calcite.validate.operators.common.HazelcastSpecialOperator;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.fun.SqlMapValueConstructor;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+import java.util.List;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Hazelcast equivalent of {@link SqlMapValueConstructor}.
+ */
+public class HazelcastMapValueConstructor extends HazelcastSpecialOperator {
+
+    public HazelcastMapValueConstructor() {
+        super(
+                "MAP",
+                SqlKind.MAP_VALUE_CONSTRUCTOR,
+                MDX_PRECEDENCE,
+                false,
+                HazelcastMapValueConstructor::inferReturnType0,
+                new ReplaceUnknownOperandTypeInference(SqlTypeName.ANY)
+        );
+    }
+
+    private static RelDataType inferReturnType0(SqlOperatorBinding binding) {
+        Pair<RelDataType, RelDataType> entryType = findEntryType(binding.getTypeFactory(), binding.collectOperandTypes());
+        return SqlTypeUtil.createMapType(binding.getTypeFactory(), entryType.left, entryType.right, false);
+    }
+
+    @Override
+    public SqlOperandCountRange getOperandCountRange() {
+        return SqlOperandCountRanges.any();
+    }
+
+    @Override
+    protected boolean checkOperandTypes(HazelcastCallBinding callBinding, boolean throwOnFailure) {
+        // do not throwOnFailure as MAP is not really supported - user either will get
+        // 'MAP VALUE CONSTRUCTOR not supported' (UnsupportedOperationVisitor) or
+        // JetDynamicTableFunction validation will kick in and reject non-VARCHARs
+        // obviously fix it when MAP/MAP_VALUE_CONSTRUCTOR gets proper support
+        boolean result = checkOperandTypes(callBinding);
+
+        List<RelDataType> argTypes = SqlTypeUtil.deriveAndCollectTypes(
+                callBinding.getValidator(),
+                callBinding.getScope(),
+                callBinding.operands()
+        );
+        if (argTypes.size() == 0) {
+            throw callBinding.newValidationError(RESOURCE.mapRequiresTwoOrMoreArgs());
+        }
+        if (argTypes.size() % 2 > 0) {
+            throw callBinding.newValidationError(RESOURCE.mapRequiresEvenArgCount());
+        }
+        Pair<RelDataType, RelDataType> entryType = findEntryType(callBinding.getTypeFactory(), argTypes);
+        if (entryType.left == null || entryType.right == null) {
+            if (throwOnFailure) {
+                throw callBinding.newValidationError(RESOURCE.needSameTypeParameter());
+            }
+            return false;
+        }
+
+        return result;
+    }
+
+    private static boolean checkOperandTypes(HazelcastCallBinding callBinding) {
+        boolean result = true;
+        for (int i = 0; i < callBinding.getOperandCount(); i++) {
+            // supporting just VARCHARs now
+            result &= TypedOperandChecker.VARCHAR.check(callBinding, false, i);
+        }
+        return result;
+    }
+
+    private static Pair<RelDataType, RelDataType> findEntryType(
+            RelDataTypeFactory typeFactory,
+            List<RelDataType> argTypes
+    ) {
+        return Pair.of(
+                typeFactory.leastRestrictive(Util.quotientList(argTypes, 2, 0)),
+                typeFactory.leastRestrictive(Util.quotientList(argTypes, 2, 1))
+        );
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/HazelcastOperandTypeInference.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/HazelcastOperandTypeInference.java
@@ -73,7 +73,7 @@ public class HazelcastOperandTypeInference implements SqlOperandTypeInference {
 
     private static RelDataType toType(SqlTypeName parameterType, RelDataTypeFactory typeFactory) {
         if (parameterType == SqlTypeName.MAP) {
-            RelDataType sqlType = typeFactory.createSqlType(SqlTypeName.ANY);
+            RelDataType sqlType = typeFactory.createUnknownType();
             return typeFactory.createMapType(sqlType, sqlType);
         } else {
             RelDataType sqlType = typeFactory.createSqlType(parameterType);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/CalciteSqlOptimizer.java
@@ -117,6 +117,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
         OptimizerContext context = OptimizerContext.create(
                 task.getSchema(),
                 task.getSearchPaths(),
+                task.getArguments(),
                 memberCount,
                 sqlBackend,
                 jetSqlBackend

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlBackend.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlBackend.java
@@ -72,9 +72,10 @@ public class HazelcastSqlBackend implements SqlBackend {
     public SqlValidator validator(
             CatalogReader catalogReader,
             HazelcastTypeFactory typeFactory,
-            SqlConformance conformance
+            SqlConformance conformance,
+            List<Object> arguments
     ) {
-        return new HazelcastSqlValidator(catalogReader, typeFactory, conformance);
+        return new HazelcastSqlValidator(catalogReader, typeFactory, conformance, arguments);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/OptimizerContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/OptimizerContext.java
@@ -93,6 +93,7 @@ public final class OptimizerContext {
     public static OptimizerContext create(
             SqlCatalog schema,
             List<List<String>> searchPaths,
+            List<Object> arguments,
             int memberCount,
             @Nonnull SqlBackend sqlBackend,
             @Nullable SqlBackend jetSqlBackend
@@ -100,12 +101,13 @@ public final class OptimizerContext {
         // Resolve tables.
         HazelcastSchema rootSchema = HazelcastSchemaUtils.createRootSchema(schema);
 
-        return create(rootSchema, searchPaths, memberCount, sqlBackend, jetSqlBackend);
+        return create(rootSchema, searchPaths, arguments, memberCount, sqlBackend, jetSqlBackend);
     }
 
     public static OptimizerContext create(
             HazelcastSchema rootSchema,
             List<List<String>> schemaPaths,
+            List<Object> arguments,
             int memberCount,
             @Nonnull SqlBackend sqlBackend,
             @Nullable SqlBackend jetSqlBackend
@@ -118,7 +120,7 @@ public final class OptimizerContext {
         VolcanoPlanner volcanoPlanner = createPlanner(CONNECTION_CONFIG, distributionTraitDef);
         HazelcastRelOptCluster cluster = createCluster(volcanoPlanner, typeFactory, distributionTraitDef);
 
-        QueryParser parser = new QueryParser(typeFactory, catalogReader, conformance, sqlBackend, jetSqlBackend);
+        QueryParser parser = new QueryParser(typeFactory, catalogReader, conformance, arguments, sqlBackend, jetSqlBackend);
         QueryConverter converter = new QueryConverter(catalogReader, cluster);
         QueryPlanner planner = new QueryPlanner(volcanoPlanner);
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/SqlBackend.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/SqlBackend.java
@@ -32,6 +32,8 @@ import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.SqlToRelConverter.Config;
 
+import java.util.List;
+
 /**
  * Provides various customization points for the optimization engine.
  */
@@ -42,7 +44,8 @@ public interface SqlBackend {
     SqlValidator validator(
             CatalogReader catalogReader,
             HazelcastTypeFactory typeFactory,
-            SqlConformance conformance
+            SqlConformance conformance,
+            List<Object> arguments
     );
 
     SqlVisitor<Void> unsupportedOperationVisitor(

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/QueryParser.java
@@ -36,6 +36,7 @@ import org.apache.calcite.sql.validate.SqlConformance;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Performs syntactic and semantic validation of the query.
@@ -45,6 +46,7 @@ public class QueryParser {
     private final HazelcastTypeFactory typeFactory;
     private final CatalogReader catalogReader;
     private final SqlConformance conformance;
+    private final List<Object> arguments;
 
     private final SqlBackend sqlBackend;
     private final SqlBackend jetSqlBackend;
@@ -53,12 +55,14 @@ public class QueryParser {
             HazelcastTypeFactory typeFactory,
             CatalogReader catalogReader,
             SqlConformance conformance,
+            List<Object> arguments,
             @Nonnull SqlBackend sqlBackend,
             @Nullable SqlBackend jetSqlBackend
     ) {
         this.typeFactory = typeFactory;
         this.catalogReader = catalogReader;
         this.conformance = conformance;
+        this.arguments = arguments;
 
         this.sqlBackend = sqlBackend;
         this.jetSqlBackend = jetSqlBackend;
@@ -94,7 +98,8 @@ public class QueryParser {
         SqlParser parser = SqlParser.create(sql, config);
         SqlNode topNode = parser.parseStmt();
 
-        HazelcastSqlValidator validator = (HazelcastSqlValidator) sqlBackend.validator(catalogReader, typeFactory, conformance);
+        HazelcastSqlValidator validator =
+                (HazelcastSqlValidator) sqlBackend.validator(catalogReader, typeFactory, conformance, arguments);
         SqlNode node = validator.validate(topNode);
 
         SqlVisitor<Void> visitor = sqlBackend.unsupportedOperationVisitor(catalogReader);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
@@ -79,4 +79,12 @@ public class SqlUnsupportedFeaturesTest extends SqlTestSupport {
                 .hasCauseInstanceOf(QueryException.class)
                 .hasMessageContaining("Function 'EXISTS' does not exist");
     }
+
+    @Test
+    public void test_mapValueConstructor() {
+        TestBatchSqlConnector.create(sqlService, "b", 1);
+
+        assertThatThrownBy(() -> sqlService.execute("SELECT MAP[1, 2] FROM b"))
+                .hasMessageContaining("MAP VALUE CONSTRUCTOR not supported");
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/JetSqlBackendTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/JetSqlBackendTest.java
@@ -135,7 +135,7 @@ public class JetSqlBackendTest {
     }
 
     private static OptimizationTask task() {
-        return new OptimizationTask("", emptyList(), null);
+        return new OptimizationTask("", emptyList(), emptyList(), null);
     }
 
     private static SqlOption option(String key, String value) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlCsvTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlCsvTest.java
@@ -286,15 +286,27 @@ public class SqlCsvTest extends SqlTestSupport {
                 "SELECT CAST(long AS BIGINT) - ?"
                         + " FROM TABLE ("
                         + "csv_file ("
-                        + "path => '" + RESOURCES_PATH + "'"
-                        + ", glob => 'file.csv'"
-                        + ", options => MAP['key', 'value']"
+                        + "path => ?"
+                        + ", glob => ?"
+                        + ", options => MAP[?, ?]"
                         + ")"
                         + ")"
                         + "WHERE byte = ?",
-                asList(6, "127"),
+                asList(6, RESOURCES_PATH, "file.csv", "key", "value", "127"),
                 singletonList(new Row(9223372036854775801L))
         );
+    }
+
+    @Test
+    public void test_tableFunctionWithDynamicParametersAndArgumentTypeMismatch() {
+        assertThatThrownBy(() -> sqlService.execute("SELECT *"
+                + " FROM TABLE ("
+                + "csv_file ("
+                + "path => '" + RESOURCES_PATH + "'"
+                + ", glob => ?"
+                + ")"
+                + ")", 1
+        )).hasMessageContaining("Parameter at position 0 must be of VARCHAR type, but INTEGER was found");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/OptimizerTestSupport.java
@@ -44,7 +44,6 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.SqlExplainLevel;
@@ -53,9 +52,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +60,7 @@ import java.util.Map;
 
 import static com.hazelcast.sql.impl.QueryUtils.SCHEMA_NAME_PARTITIONED;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
+import static java.util.Collections.emptyList;
 import static junit.framework.TestCase.assertEquals;
 
 /**
@@ -75,10 +73,6 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
 
     protected RelNode optimizePhysical(String sql, QueryDataType... parameterTypes) {
         return optimize(sql, 1, true, parameterTypes).getPhysical();
-    }
-
-    protected RelNode optimizeLogical(String sql, int nodeCount, QueryDataType... parameterTypes) {
-        return optimize(sql, nodeCount, false, parameterTypes).getLogical();
     }
 
     protected RelNode optimizePhysical(String sql, int nodeCount, QueryDataType... parameterTypes) {
@@ -122,6 +116,7 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
         OptimizerContext context = OptimizerContext.create(
                 HazelcastSchemaUtils.createCatalog(schema),
                 QueryUtils.prepareSearchPaths(null, null),
+                emptyList(),
                 nodeCount,
                 new HazelcastSqlBackend(null),
                 null
@@ -320,16 +315,6 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
 
     private static String planErrorMessage(String message, PlanRows expected, PlanRows actual) {
         return message + "\n\n>>> EXPECTED PLAN:\n" + expected + "\n>>> ACTUAL PLAN:\n" + actual;
-    }
-
-    public static void dump(RelNode node) {
-        VolcanoPlanner planner = (VolcanoPlanner) node.getCluster().getPlanner();
-
-        StringWriter sw = new StringWriter();
-
-        planner.dump(new PrintWriter(sw));
-
-        System.out.println(sw);
     }
 
     /**

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/index/PhysicalIndexScanTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/opt/physical/index/PhysicalIndexScanTest.java
@@ -72,6 +72,7 @@ import java.util.Map;
 
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.calcite.rel.RelFieldCollation.Direction.ASCENDING;
 import static org.apache.calcite.rel.RelFieldCollation.Direction.DESCENDING;
@@ -474,6 +475,7 @@ public class PhysicalIndexScanTest extends IndexOptimizerTestSupport {
         OptimizerContext context = OptimizerContext.create(
                 HazelcastSchemaUtils.createCatalog(schema),
                 QueryUtils.prepareSearchPaths(null, null),
+                emptyList(),
                 2,
                 new HazelcastSqlBackend(null),
                 null

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserNameResolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserNameResolutionTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.sql.impl.calcite.parse;
 
-import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.calcite.HazelcastSqlBackend;
 import com.hazelcast.sql.impl.calcite.OptimizerContext;
 import com.hazelcast.sql.impl.calcite.TestMapTable;
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.hazelcast.sql.impl.QueryUtils.CATALOG;
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -188,7 +189,7 @@ public class ParserNameResolutionTest {
         List<TableResolver> tableResolvers = Arrays.asList(resolverWithoutSearchPath, resolverWithSearchPath);
 
         List<List<String>> additionalSearchPaths = additionalSearchPath != null
-                ? Collections.singletonList(Arrays.asList(CATALOG, additionalSearchPath)) : Collections.emptyList();
+                ? Collections.singletonList(Arrays.asList(CATALOG, additionalSearchPath)) : emptyList();
 
         List<List<String>> searchPaths = QueryUtils.prepareSearchPaths(
                 additionalSearchPaths,
@@ -198,6 +199,7 @@ public class ParserNameResolutionTest {
         return OptimizerContext.create(
                 new SqlCatalog(tableResolvers),
                 searchPaths,
+                emptyList(),
                 1,
                 new HazelcastSqlBackend(null),
                 null

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.sql.impl.calcite.parse;
 
-import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.QueryUtils;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.calcite.HazelcastSqlBackend;
 import com.hazelcast.sql.impl.calcite.OptimizerContext;
 import com.hazelcast.sql.impl.calcite.TestMapTable;
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -182,13 +183,14 @@ public class ParserOperationsTest {
         List<TableResolver> tableResolvers = Collections.singletonList(resolver);
 
         List<List<String>> searchPaths = QueryUtils.prepareSearchPaths(
-                Collections.emptyList(),
+                emptyList(),
                 tableResolvers
         );
 
         return OptimizerContext.create(
                 new SqlCatalog(tableResolvers),
                 searchPaths,
+                emptyList(),
                 1,
                 new HazelcastSqlBackend(null),
                 null

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/QueryParserTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/QueryParserTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -78,10 +79,10 @@ public class QueryParserTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        parser = new QueryParser(HazelcastTypeFactory.INSTANCE, catalogReader, conformance, sqlBackend, jetSqlBackend);
+        parser = new QueryParser(HazelcastTypeFactory.INSTANCE, catalogReader, conformance, emptyList(), sqlBackend, jetSqlBackend);
 
-        given(sqlBackend.validator(catalogReader, HazelcastTypeFactory.INSTANCE, conformance)).willReturn(sqlValidator);
-        given(jetSqlBackend.validator(catalogReader, HazelcastTypeFactory.INSTANCE, conformance)).willReturn(jetSqlValidator);
+        given(sqlBackend.validator(catalogReader, HazelcastTypeFactory.INSTANCE, conformance, emptyList())).willReturn(sqlValidator);
+        given(jetSqlBackend.validator(catalogReader, HazelcastTypeFactory.INSTANCE, conformance, emptyList())).willReturn(jetSqlValidator);
     }
 
     @Test
@@ -115,7 +116,7 @@ public class QueryParserTest {
     @Test(expected = QueryException.class)
     public void when_imdgCantHandleSqlAndJetIsNotAvailable_then_throwsException() {
         // given
-        parser = new QueryParser(HazelcastTypeFactory.INSTANCE, catalogReader, conformance, sqlBackend, null);
+        parser = new QueryParser(HazelcastTypeFactory.INSTANCE, catalogReader, conformance, emptyList(), sqlBackend, null);
 
         given(sqlValidator.validate(isA(SqlNode.class))).willThrow(new CalciteException("expected test exception", null));
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -243,7 +243,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
         QueryId queryId,
         String schema,
         String sql,
-        List<Object> params,
+        List<Object> args,
         long timeout,
         int pageSize,
         SqlExpectedResultType expectedResultType,
@@ -254,7 +254,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
             throw QueryException.error("SQL statement cannot be empty.");
         }
 
-        List<Object> params0 = new ArrayList<>(params);
+        List<Object> args0 = new ArrayList<>(args);
 
         if (timeout < 0) {
             throw QueryException.error("Timeout cannot be negative: " + timeout);
@@ -265,16 +265,16 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
         }
 
         // Prepare and execute
-        SqlPlan plan = prepare(schema, sql, expectedResultType);
+        SqlPlan plan = prepare(schema, sql, args0, expectedResultType);
 
         if (securityContext.isSecurityEnabled()) {
             plan.checkPermissions(securityContext);
         }
 
-        return execute(queryId, plan, params0, timeout, pageSize);
+        return execute(queryId, plan, args0, timeout, pageSize);
     }
 
-    private SqlPlan prepare(String schema, String sql, SqlExpectedResultType expectedResultType) {
+    private SqlPlan prepare(String schema, String sql, List<Object> arguments, SqlExpectedResultType expectedResultType) {
         List<List<String>> searchPaths = prepareSearchPaths(schema);
 
         PlanKey planKey = new PlanKey(searchPaths, sql);
@@ -284,7 +284,7 @@ public class SqlServiceImpl implements SqlService, Consumer<Packet> {
         if (plan == null) {
             SqlCatalog catalog = new SqlCatalog(tableResolvers);
 
-            plan = optimizer.prepare(new OptimizationTask(sql, searchPaths, catalog));
+            plan = optimizer.prepare(new OptimizationTask(sql, arguments, searchPaths, catalog));
 
             if (plan.isCacheable()) {
                 planCache.put(planKey, plan);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/optimizer/OptimizationTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/optimizer/OptimizationTask.java
@@ -27,20 +27,28 @@ public final class OptimizationTask {
     /** The query. */
     private final String sql;
 
+    /** Query parameter values. */
+    private final List<Object> arguments;
+
     /** The scopes for object lookup in addition to the default ones. */
     private final List<List<String>> searchPaths;
 
     /** The resolved schema. */
     private final SqlCatalog schema;
 
-    public OptimizationTask(String sql, List<List<String>> searchPaths, SqlCatalog schema) {
+    public OptimizationTask(String sql, List<Object> arguments, List<List<String>> searchPaths, SqlCatalog schema) {
         this.sql = sql;
+        this.arguments = arguments;
         this.searchPaths = searchPaths;
         this.schema = schema;
     }
 
     public String getSql() {
         return sql;
+    }
+
+    public List<Object> getArguments() {
+        return arguments;
     }
 
     public List<List<String>> getSearchPaths() {


### PR DESCRIPTION
Added statement arguments to `HazelcastSqlValidator` so they are available during validation phase - required by `JetDynamicTableFunction`s.
Created `HazelcastMapValueConstructor` which adds type inference for `MAP` arguments.