### PR TITLE
[PLAT-78] Cooperative threads run only if tasklets are available

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -361,7 +361,8 @@ public class TaskletExecutionService {
                             try {
                                 newTaskletSemaphore.acquire();
                             } catch (InterruptedException e) {
-                                logger.fine(e.getMessage());
+                                logger.severe("Cooperative worker interrupted", e);
+                                return;
                             }
                         }
                     } else {


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/PLAT-78

This PR tries to solve the above mentioned problem by doing the following:

- ~Do not start cooperative threads at the startup~
- ~If any job submitted to the Platform start the cooperative threads~
- ~Cooperative threads stay active until shutdown~
- Cooperative threads sleep if there are no available tasklets
- Cooperative threads wake up if a new job submitted

This is an alternative approach to [this PR](https://github.com/hazelcast/hazelcast/pull/18574) using semaphores. It should be either that or this should be merged.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
