### PR TITLE
Remove client endpoint on connection remove 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -70,8 +70,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
         return replicatedMap.removeEntryListener(registrationId);
     }
 
-    @Override
-    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory) {
+    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory, int expected) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -80,7 +79,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
                     NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
                     EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
                     EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
-                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == 1) {
+                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == expected) {
                         found = true;
                     }
                 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -48,7 +48,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.hazelcast.client.impl.management.ManagementCenterService.MC_CLIENT_MODE_PROP;
-import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
@@ -344,14 +343,8 @@ class TestClientRegistry {
             super(localEndpoint, remoteEndpoint, nodeEngine);
             this.responseConnection = responseConnection;
             this.connectionId = connectionId;
-            register();
             lastReadTimeMillis = System.currentTimeMillis();
             lastWriteTimeMillis = System.currentTimeMillis();
-        }
-
-        private void register() {
-            Node node = remoteNodeEngine.getNode();
-            node.getServer().getConnectionManager(CLIENT).register(getRemoteAddress(), this);
         }
 
         @Override


### PR DESCRIPTION
Client endpoints were not destroyed on connection remove but
instead a periodic task was cleaning them up(every 10 seconds)
This was causing some tests to take long.
Added client connections to server connection manager so that
connectionRemoved can be called and related endpoint is
removed as soon as the connection is removed.

While adding the test, I have realized that we were registering
client connection to the server on the mock connection manager.
This behaviour is different than actual one. This was hiding the
bug on mock tests. Removed that registration. The actual
registration is done while authentication.

fixes #18318
backport of https://github.com/hazelcast/hazelcast/pull/18562
(cherry picked from commit 93b9c37365bcc41c3cd921c37cd16562107ed018)
