### PR TITLE
Remove client endpoint on connection remove 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -41,7 +41,6 @@ import com.hazelcast.internal.cluster.impl.AddressCheckerImpl;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.nio.ConnectionType;
-import com.hazelcast.internal.nio.tcp.TcpIpConnection;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.services.CoreService;
 import com.hazelcast.internal.services.ManagedService;
@@ -307,15 +306,21 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
             return false;
         }
 
-        endpointManager.registerEndpoint(endpoint);
-
         Connection conn = endpoint.getConnection();
-        if (conn instanceof TcpIpConnection) {
-            InetSocketAddress socketAddress = conn.getRemoteSocketAddress();
-            //socket address can be null if connection closed before bind
-            if (socketAddress != null) {
-                Address address = new Address(socketAddress);
-                ((TcpIpConnection) conn).setEndPoint(address);
+        InetSocketAddress socketAddress = conn.getRemoteSocketAddress();
+        //socket address can be null if connection closed before bind
+        if (socketAddress != null) {
+            conn.setEndPoint(new Address(socketAddress));
+        }
+
+        if (endpointManager.registerEndpoint(endpoint)) {
+            // remote address can be null if connection closed before bind.
+            // On such a case, `ClientEngine#connectionRemoved` will not be called for this connection since
+            // we did not register the connection.
+            // Endpoint removal logic(inside `ClientEngine#connectionRemoved`) will not be able to run, instead endpoint
+            // will be cleaned up by ClientHearbeatMonitor#cleanupEndpointsWithDeadConnections later.
+            if (conn.getEndPoint() != null) {
+                node.getEndpointManager(CLIENT).registerConnection(conn.getEndPoint(), conn);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnection.java
@@ -116,8 +116,9 @@ public class ClientConnection implements Connection {
         return false;
     }
 
-    public void setRemoteEndpoint(Address remoteEndpoint) {
-        this.remoteEndpoint = remoteEndpoint;
+    @Override
+    public void setEndPoint(Address address) {
+        this.remoteEndpoint = address;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -827,7 +827,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         synchronized (clientStateMutex) {
             checkPartitionCount(response.partitionCount);
             connection.setConnectedServerVersion(response.serverHazelcastVersion);
-            connection.setRemoteEndpoint(response.address);
+            connection.setEndPoint(response.address);
             connection.setRemoteUuid(response.memberUuid);
 
             ClientConnection existingConnection = activeConnections.get(response.memberUuid);

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.networking;
 
-import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ChannelCloseListener;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Connection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Connection.java
@@ -170,4 +170,6 @@ public interface Connection {
      * @return certificate chain (may be empty) or {@code null}
      */
     Certificate[] getRemoteCertificates();
+
+    void setEndPoint(Address address);
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -75,6 +75,30 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         factory.terminateAll();
     }
 
+    //-------------------------- testListenersWhenClientIsGone --------------------- //
+
+    @Test
+    public void testListenersWhenClientIsGone_smart() {
+        testListenersWhenClientIsGone(true);
+    }
+
+    @Test
+    public void testListenersWhenClientIsGone_unisocket() {
+        testListenersWhenClientIsGone(false);
+    }
+
+    private void testListenersWhenClientIsGone(boolean isSmartClient) {
+        factory.newInstances(null, 2);
+        ClientConfig clientConfig = createClientConfig(isSmartClient);
+        client = factory.newHazelcastClient(clientConfig);
+
+        setupListener();
+
+        client.shutdown();
+
+        validateRegistrationsOnMembers(factory, 0);
+    }
+
     //-------------------------- testListenersTerminateRandomNode --------------------- //
     @Test
     public void testListenersTerminateRandomNode_smart() {
@@ -278,7 +302,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         assertOpenEventually(connectedLatch);
         setupListener();
 
-        validateRegistrationsOnMembers(factory);
+        validateRegistrationsOnMembers(factory, 1);
 
         for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
             instance.getLifecycleService().terminate();
@@ -303,13 +327,13 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     private void validateRegistrationsAndListenerFunctionality() {
         assertClusterSizeEventually(clusterSize, client);
-        validateRegistrationsOnMembers(factory);
+        validateRegistrationsOnMembers(factory, 1);
         validateRegistrations(clusterSize, registrationId, getHazelcastClientInstanceImpl(client));
         validateListenerFunctionality();
         assertTrue(removeListener(registrationId));
     }
 
-    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory) {
+    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory, int expected) {
         assertTrueEventually(() -> {
             for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
                 NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
@@ -318,7 +342,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
                 Member member = instance.getCluster().getLocalMember();
                 assertNotNull(member.toString(), serviceSegment);
                 ConcurrentMap registrationIdMap = serviceSegment.getRegistrationIdMap();
-                assertEquals(member.toString() + " Current registrations:" + registrationIdMap, 1,
+                assertEquals(member.toString() + " Current registrations:" + registrationIdMap, expected,
                         registrationIdMap.size());
                 ILogger logger = nodeEngineImpl.getLogger(AbstractListenersOnReconnectTest.class);
                 logger.warning("Current registrations at member " + member.toString() + ": " + registrationIdMap);

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -69,8 +69,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
         return replicatedMap.removeEntryListener(registrationId);
     }
 
-    @Override
-    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory) {
+    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory, int expected) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -79,7 +78,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
                     NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
                     EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
                     EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
-                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == 1) {
+                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == expected) {
                         found = true;
                     }
                 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -49,7 +49,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.hazelcast.client.impl.management.ManagementCenterService.MC_CLIENT_MODE_PROP;
-import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
@@ -359,14 +358,8 @@ class TestClientRegistry {
             super(localEndpoint, remoteEndpoint, nodeEngine);
             this.responseConnection = responseConnection;
             this.connectionId = connectionId;
-            register();
             lastReadTimeMillis = System.currentTimeMillis();
             lastWriteTimeMillis = System.currentTimeMillis();
-        }
-
-        private void register() {
-            Node node = remoteNodeEngine.getNode();
-            node.getEndpointManager(CLIENT).registerConnection(getEndPoint(), this);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/DroppingConnection.java
@@ -122,6 +122,11 @@ class DroppingConnection implements Connection {
     }
 
     @Override
+    public void setEndPoint(Address address) {
+        //no op. The endpoint is already set in the constructor.
+    }
+
+    @Override
     public Address getEndPoint() {
         return endpoint;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -86,6 +86,11 @@ public class MockConnection implements Connection {
     }
 
     @Override
+    public void setEndPoint(Address address) {
+        //no op. The endpoint is already set in the constructor.
+    }
+
+    @Override
     public Address getEndPoint() {
         return remoteEndpoint;
     }


### PR DESCRIPTION
Client endpoints were not destroyed on connection remove but
instead a periodic task was cleaning them up(every 10 seconds)
This was causing some tests to take long.
Added client connections to server connection manager so that
connectionRemoved can be called and related endpoint is
removed as soon as the connection is removed.

While adding the test, I have realized that we were registering
client connection to the server on the mock connection manager.
This behaviour is different than actual one. This was hiding the
bug on mock tests. Removed that registration. The actual
registration is done while authentication.

fixes #18318
backport of https://github.com/hazelcast/hazelcast/pull/18562
(cherry picked from commit 93b9c37365bcc41c3cd921c37cd16562107ed018)

