### PR TITLE
Don't remove backup listeners on connection problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -158,7 +158,7 @@ public interface ClientEngine extends Consumer<ClientMessage> {
 
     void addBackupListener(UUID clientUUID, Consumer<Long> backupListener);
 
-    boolean deregisterBackupListener(UUID clientUUID);
+    boolean deregisterBackupListener(UUID clientUUID, Consumer<Long> backupListener);
 
     void dispatchBackupEvent(UUID clientUUID, long clientCorrelationId);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -523,8 +523,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     }
 
     @Override
-    public boolean deregisterBackupListener(UUID clientUUID) {
-        return backupListeners.remove(clientUUID) != null;
+    public boolean deregisterBackupListener(UUID clientUUID, Consumer<Long> backupListener) {
+        return backupListeners.remove(clientUUID, backupListener);
     }
 
     public Map<UUID, Consumer<Long>> getBackupListeners() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -168,7 +168,7 @@ public class NoOpClientEngine implements ClientEngine {
     }
 
     @Override
-    public boolean deregisterBackupListener(UUID clientUUID) {
+    public boolean deregisterBackupListener(UUID clientUUID, Consumer<Long> backupListener) {
         return false;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
@@ -55,7 +55,7 @@ public class AddBackupListenerMessageTask
 
     @Override
     protected void addDestroyAction(UUID registrationId) {
-        endpoint.addDestroyAction(registrationId, () -> clientEngine.deregisterBackupListener(registrationId));
+        endpoint.addDestroyAction(registrationId, () -> clientEngine.deregisterBackupListener(registrationId, this));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/BackupListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/BackupListenerLeakTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.listeners.leak;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.ClientEngineImpl;
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.tcp.TcpClientConnectionManager;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
+import static com.hazelcast.test.Accessors.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class BackupListenerLeakTest {
+
+    protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testBackupListenerRemoved_afterClientShutdown() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
+        HazelcastInstance hazelcast = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        client.shutdown();
+        Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
+        assertTrueEventually(() -> assertEquals(0, backupListeners.size()));
+    }
+
+    @Test
+    public void testBackupListenerIsNotRemoved_afterClientRestart() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
+        HazelcastInstance hazelcast = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        TcpClientConnectionManager connectionManager = (TcpClientConnectionManager) clientImpl.getConnectionManager();
+
+        connectionManager.reset();
+
+        Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
+        assertTrueEventually(() -> assertEquals(1, backupListeners.size()));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.listeners.leak;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.ClientEndpoint;
-import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.clientside.ClientTestUtil;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.spi.impl.listener.ClientConnectionRegistration;
@@ -51,9 +50,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static com.hazelcast.test.Accessors.getNode;
 import static java.util.Arrays.asList;
@@ -252,19 +249,6 @@ public class ListenerLeakTest extends ClientTestSupport {
         hazelcast.shutdown();
 
         assertTrueEventually(() -> assertEquals(0, getAllEventHandlers(client).size()));
-    }
-
-    @Test
-    public void testBackupListenerRemoved_afterClientShutdown() {
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setSmartRouting(smartRouting);
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
-        HazelcastInstance hazelcast = hazelcastFactory.newHazelcastInstance();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-
-        client.shutdown();
-        Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
-        assertTrueEventually(() -> assertEquals(0, backupListeners.size()));
     }
 
     @Test


### PR DESCRIPTION
The client backup listeners are kept per endpoint(connection) as
all listeners are.

When an endpoint is gone, the removal of related listeners
done automatically.

In the problematic scenario, even though the client is connected
back, we remove the backup listener anyway. This is because we
use `clientUuid` as the key for backup listener.

I have changed removal so that it takes the `value` into account.
This way, an old scheduled automatic removal can not delete a more
up-to-date listener from backupListeners map.

fixes https://github.com/hazelcast/hazelcast/issues/18596
back-port of https://github.com/hazelcast/hazelcast/pull/18598
(cherry picked from commit 4b78b4e74c0bed08ed1610521d6b493fd966b099)
