### PR TITLE
Fix MetricsTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JmxMetricsChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JmxMetricsChecker.java
@@ -52,7 +52,7 @@ class JmxMetricsChecker {
         Set<ObjectName> publishedDescriptors = platformMBeanServer
                 .queryMBeans(new ObjectName(PREFIX + ":*"), null)
                 .stream().map(ObjectInstance::getObjectName).collect(toSet());
-        assertTrue("name: " + metricName + " not published", publishedDescriptors.contains(descriptor));
+        assertTrue("metric '" + metricName + "' not published", publishedDescriptors.contains(descriptor));
         return (long) platformMBeanServer.getAttribute(descriptor, metricName);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
@@ -71,13 +71,14 @@ public class MetricsTest extends JetTestSupport {
 
     private final Pipeline pipeline = Pipeline.create();
     private JetInstance instance;
+    private Config config;
 
     @Before
     public void before() {
-        Config config = new Config();
+        config = smallInstanceConfig();
         config.setProperty("hazelcast.jmx", "true");
         config.getMetricsConfig().setCollectionFrequencySeconds(1);
-        instance = createJetMembers(config, 1)[0];
+        instance = createJetMember(config);
 
         TestProcessors.reset(1);
     }
@@ -415,7 +416,7 @@ public class MetricsTest extends JetTestSupport {
 
         String instanceName = instance.getHazelcastInstance().getName();
         long sum = 0;
-        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int availableProcessors = config.getJetConfig().getInstanceConfig().getCooperativeThreadCount();
         for (int i = 0; i < availableProcessors; i++) {
             JmxMetricsChecker jmxMetricsChecker = new JmxMetricsChecker(instanceName, job,
                     "vertex=fused(filter, map)", "procType=TransformP", "proc=" + i, "user=true");


### PR DESCRIPTION
I think due to some test setup the `localParallelism != availableProcessors`. This PR makes the test not depend on that equality.

Fixes #18626