### PR TITLE
Always set `dbConnectionUrl` as a first thing of the test class initialization

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
@@ -50,8 +50,8 @@ public class ReadJdbcPTest extends SimpleTestInClusterSupport {
 
     @BeforeClass
     public static void setupClass() throws SQLException {
-        initialize(2, null);
         dbConnectionUrl = "jdbc:h2:mem:" + ReadJdbcPTest.class.getSimpleName() + ";DB_CLOSE_DELAY=-1";
+        initialize(2, null);
         // create and fill a table
         try (Connection conn = DriverManager.getConnection(dbConnectionUrl);
              Statement stmt = conn.createStatement()


### PR DESCRIPTION
Reasoning:
Previously an exception in the `initialize(2, null);` meant `dbConnectionUrl`
was left as a NULL. But `afterClass()` does not expect `dbConnectionUrl` to be null
and `DriverManager.getConnection()` would throw an exception obfustacting the original
root cause: a failure in `initialize(2, null);`