### PR TITLE
Call shutdown jobs even before setting shuttingDown to true

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -424,6 +424,10 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
 
     @Override
     public void shutdown() {
+    }
+
+    @Override
+    public void afterShutdown() {
         logger.info("Destroying node NodeExtension.");
         if (phoneHome != null) {
             phoneHome.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -87,14 +87,12 @@ import com.hazelcast.internal.server.ServerContext;
 import com.hazelcast.internal.server.tcp.ChannelInitializerFunction;
 import com.hazelcast.internal.server.tcp.PacketDecoder;
 import com.hazelcast.internal.server.tcp.PacketEncoder;
-import com.hazelcast.internal.util.ByteArrayProcessor;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.JVMUtil;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.internal.util.phonehome.PhoneHome;
 import com.hazelcast.internal.util.Preconditions;
-import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.logging.ILogger;
@@ -103,7 +101,6 @@ import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.security.SecurityContext;
-import com.hazelcast.security.SecurityService;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.NodeEngineImpl.JetPacketConsumer;
@@ -118,7 +115,6 @@ import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -276,10 +272,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     }
 
     @Override
-    public void beforeJoin() {
-    }
-
-    @Override
     public void afterStart() {
         if (jetExtension != null) {
             jetExtension.afterStart();
@@ -330,11 +322,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
             throw ExceptionUtil.rethrow(e);
         }
         return ss;
-    }
-
-    @Override
-    public SecurityService getSecurityService() {
-        return null;
     }
 
     protected PartitioningStrategy getPartitioningStrategy(ClassLoader configClassLoader) throws Exception {
@@ -403,14 +390,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     }
 
     @Override
-    public void onThreadStart(Thread thread) {
-    }
-
-    @Override
-    public void onThreadStop(Thread thread) {
-    }
-
-    @Override
     public MemoryStats getMemoryStats() {
         return memoryStats;
     }
@@ -420,10 +399,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
         if (jetExtension != null) {
             jetExtension.beforeShutdown(terminate);
         }
-    }
-
-    @Override
-    public void shutdown() {
     }
 
     @Override
@@ -474,10 +449,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     }
 
     @Override
-    public void afterClusterStateChange(ClusterState oldState, ClusterState newState, boolean isTransient) {
-    }
-
-    @Override
     public void onPartitionStateChange() {
         ClusterViewListenerService service = node.clientEngine.getClusterListenerService();
         if (service != null) {
@@ -491,10 +462,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
         if (service != null) {
             service.onMemberListChange();
         }
-    }
-
-    @Override
-    public void onInitialClusterState(ClusterState initialState) {
     }
 
     @Override
@@ -542,21 +509,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     @Override
     public InternalHotRestartService getInternalHotRestartService() {
         return new NoopInternalHotRestartService();
-    }
-
-    @Override
-    public UUID createMemberUuid() {
-        return UuidUtil.newUnsecureUUID();
-    }
-
-    @Override
-    public ByteArrayProcessor createMulticastInputProcessor(ServerContext serverContext) {
-        return null;
-    }
-
-    @Override
-    public ByteArrayProcessor createMulticastOutputProcessor(ServerContext serverContext) {
-        return null;
     }
 
     // obtain cluster version, if already initialized (not null)
@@ -623,16 +575,6 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
     @Override
     public void sendPhoneHome() {
         phoneHome.check();
-    }
-
-    @Override
-    public void scheduleClusterVersionAutoUpgrade() {
-        // NOP
-    }
-
-    @Override
-    public boolean isClientFailoverSupported() {
-        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -493,12 +493,12 @@ public class Node {
         if (logger.isFinestEnabled()) {
             logger.finest("We are being asked to shutdown when state = " + state);
         }
+        if (nodeExtension != null) {
+            nodeExtension.beforeShutdown(terminate);
+        }
         if (!setShuttingDown()) {
             waitIfAlreadyShuttingDown();
             return;
-        }
-        if (nodeExtension != null) {
-            nodeExtension.beforeShutdown(terminate);
         }
 
         if (!terminate) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -500,6 +500,9 @@ public class Node {
             waitIfAlreadyShuttingDown();
             return;
         }
+        if (nodeExtension != null) {
+            nodeExtension.shutdown();
+        }
 
         if (!terminate) {
             int maxWaitSeconds = properties.getSeconds(GRACEFUL_SHUTDOWN_MAX_WAIT);
@@ -600,7 +603,7 @@ public class Node {
         }
 
         if (nodeExtension != null) {
-            nodeExtension.shutdown();
+            nodeExtension.afterShutdown();
         }
         if (healthMonitor != null) {
             healthMonitor.stop();

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
@@ -92,8 +92,15 @@ public interface NodeExtension {
 
     /**
      * Shutdowns <tt>NodeExtension</tt>. Called on <tt>Node.shutdown()</tt>
+     * right after setting the state to PASSIVE.
      */
     void shutdown();
+
+    /**
+     * Shutdowns <tt>NodeExtension</tt>. Called on <tt>Node.shutdown()</tt>
+     * right before setting the state to SHUT_DOWN.
+     */
+    void afterShutdown();
 
     /**
      * Creates a <tt>SerializationService</tt> instance to be used by this <tt>Node</tt>.

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
@@ -113,7 +113,7 @@ public class GracefulShutdownTest extends JetTestSupport {
 
         // When
         logger.info("Shutting down instance...");
-        instances[shutDownInstance].shutdown();
+        instances[shutDownInstance].getHazelcastInstance().shutdown();
         logger.info("Joining job...");
         job.join();
         logger.info("Joined");
@@ -163,7 +163,7 @@ public class GracefulShutdownTest extends JetTestSupport {
         Future future = spawn(() -> {
             JetInstance nonParticipatingMember = createJetMember();
             sleepSeconds(1);
-            nonParticipatingMember.shutdown();
+            nonParticipatingMember.getHazelcastInstance().shutdown();
         });
         assertTrueAllTheTime(() -> assertEquals(RUNNING, job.getStatus()), 5);
         future.get();
@@ -202,7 +202,7 @@ public class GracefulShutdownTest extends JetTestSupport {
         job.restart();
         assertTrueEventually(() -> assertTrue("blocking did not happen", BlockingMapStore.wasBlocked), 5);
 
-        Future shutdownFuture = spawn(() -> instances[1].shutdown());
+        Future shutdownFuture = spawn(() -> instances[1].getHazelcastInstance().shutdown());
         logger.info("savedCounters=" + EmitIntegersP.savedCounters);
         int minCounter = EmitIntegersP.savedCounters.values().stream().mapToInt(Integer::intValue).min().getAsInt();
         BlockingMapStore.shouldBlock = false;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
@@ -28,16 +28,20 @@ import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.map.MapStore;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,14 +61,27 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(Parameterized.class)
 @Category({SlowTest.class, ParallelJVMTest.class})
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 public class GracefulShutdownTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;
 
     private JetInstance[] instances;
     private JetInstance client;
+
+    /**
+     * If {@code true} shutdown HazelcastInstance otherwise shutdown
+     * JetInstance. See {@link #shutdown(JetInstance)}.
+     */
+    @Parameter
+    public boolean shutdownHazelcastInstance;
+
+    @Parameters(name = "shutdownHazelcastInstance: {0}")
+    public static Collection<Boolean> shutdownFns() {
+        return Arrays.asList(true, false);
+    }
 
     @Before
     public void setup() {
@@ -113,7 +130,7 @@ public class GracefulShutdownTest extends JetTestSupport {
 
         // When
         logger.info("Shutting down instance...");
-        instances[shutDownInstance].getHazelcastInstance().shutdown();
+        shutdown(instances[shutDownInstance]);
         logger.info("Joining job...");
         job.join();
         logger.info("Joined");
@@ -149,7 +166,7 @@ public class GracefulShutdownTest extends JetTestSupport {
         dag.newVertex("v", (SupplierEx<Processor>) NoOutputSourceP::new);
         Job job = instances[0].newJob(dag);
         assertJobStatusEventually(job, JobStatus.RUNNING, 10);
-        Future future = spawn(liteMember::shutdown);
+        Future future = spawn(() -> shutdown(liteMember));
         assertTrueAllTheTime(() -> assertEquals(RUNNING, job.getStatus()), 5);
         future.get();
     }
@@ -163,7 +180,7 @@ public class GracefulShutdownTest extends JetTestSupport {
         Future future = spawn(() -> {
             JetInstance nonParticipatingMember = createJetMember();
             sleepSeconds(1);
-            nonParticipatingMember.getHazelcastInstance().shutdown();
+            shutdown(nonParticipatingMember);
         });
         assertTrueAllTheTime(() -> assertEquals(RUNNING, job.getStatus()), 5);
         future.get();
@@ -173,8 +190,8 @@ public class GracefulShutdownTest extends JetTestSupport {
     public void when_shutdownGracefulWhileRestartGraceful_then_restartsFromTerminalSnapshot() throws Exception {
         MapConfig mapConfig = new MapConfig(JobRepository.SNAPSHOT_DATA_MAP_PREFIX + "*");
         mapConfig.getMapStoreConfig()
-                 .setClassName(BlockingMapStore.class.getName())
-                 .setEnabled(true);
+                .setClassName(BlockingMapStore.class.getName())
+                .setEnabled(true);
         Config config = instances[0].getHazelcastInstance().getConfig();
         ((DynamicConfigurationAwareConfig) config).getStaticConfig().addMapConfig(mapConfig);
         BlockingMapStore.shouldBlock = false;
@@ -202,7 +219,7 @@ public class GracefulShutdownTest extends JetTestSupport {
         job.restart();
         assertTrueEventually(() -> assertTrue("blocking did not happen", BlockingMapStore.wasBlocked), 5);
 
-        Future shutdownFuture = spawn(() -> instances[1].getHazelcastInstance().shutdown());
+        Future shutdownFuture = spawn(() -> shutdown(instances[1]));
         logger.info("savedCounters=" + EmitIntegersP.savedCounters);
         int minCounter = EmitIntegersP.savedCounters.values().stream().mapToInt(Integer::intValue).min().getAsInt();
         BlockingMapStore.shouldBlock = false;
@@ -216,6 +233,14 @@ public class GracefulShutdownTest extends JetTestSupport {
         Map<Integer, Integer> expected = IntStream.range(0, numItems).boxed()
                 .collect(Collectors.toMap(Function.identity(), item -> item < minCounter ? 2 : 1));
         assertEquals(expected, actual);
+    }
+
+    private void shutdown(JetInstance jetInstance) {
+        if (shutdownHazelcastInstance) {
+            jetInstance.getHazelcastInstance().shutdown();
+        } else {
+            jetInstance.shutdown();
+        }
     }
 
     private static final class EmitIntegersP extends AbstractProcessor {

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -115,6 +115,11 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void afterShutdown() {
+        nodeExtension.afterShutdown();
+    }
+
+    @Override
     public SecurityContext getSecurityContext() {
         return nodeExtension.getSecurityContext();
     }


### PR DESCRIPTION
Before the merge we used to call shutdownJobs in `JetInstance#shutdown()`, now we've moved it to `NodeExtension#beforeShutdown()`. But it is called after setting `shuttingDown` to true and this makes some operations(obtaining an IMap proxy to store snapshots for example) to fail when gracefully shutting down the jobs. With this change we call `NodeExtension#beforeShutdown()` then continue with the shutdown.

On the EE side, we shutdown HotRestart and CPPersistense in `NodeExtension#beforeShutdown()`. With this change we call shutdown for these services before setting the state to PASSIVE, to fix this we've added `NodeExtension#afterShutdown()`.

Before the changes:

- Set `shuttingDown` to true and set state to PASSIVE
- Call `NodeExtension#beforeShutdown()` which shutdowns the Jet jobs on OS and shutdowns HotRestart and CPPersistense on EE
- Call `NodeExtension#shutdown()` which shutdowns PhoneHome on OS and sets license to null on EE.
- Set state to SHUT_DOWN and set `shuttingDown` to false.

After the changes:

- Call `NodeExtension#beforeShutdown()` which shutdowns the Jet jobs on OS
- Set `shuttingDown` to true and set state to PASSIVE
- Call `NodeExtension#shutdown()` which shutdowns HotRestart and CPPersistense on EE
- Call `NodeExtension#afterShutdown()` which shutdowns PhoneHome on OS and sets license to null on EE.
- Set state to SHUT_DOWN and set `shuttingDown` to false.


Fixes https://github.com/hazelcast/hazelcast/issues/18625

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4033

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
