### PR TITLE
Remove jackson-core from root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1412,13 +1412,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.snakeyaml</groupId>
             <artifactId>snakeyaml-engine</artifactId>
             <version>${snakeyaml.engine.version}</version>


### PR DESCRIPTION
Maybe the `jackson-core` dependency definition with provided/optional should be moved to some of the submodules.

It definitely breaks the extensions which depend on jackson.