### PR TITLE
Fix #18668: set interfaces must not be added when loopback mode nor loopback interface are used

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -124,7 +124,7 @@ public final class MulticastService implements Runnable {
                 multicastSocket.setLoopbackMode(!multicastConfig.isLoopbackModeEnabled());
                 if (!bindAddress.getInetAddress().isLoopbackAddress() || !multicastConfig.isLoopbackModeEnabled()) {
                     multicastSocket.setInterface(bindAddress.getInetAddress());
-                } else if (multicastConfig.isLoopbackModeEnabled()){
+                } else if (multicastConfig.isLoopbackModeEnabled()) {
                     // If LoopBack is not enabled but its the selected interface from the given
                     // bind address, then we rely on Default Network Interface.
                     logger.warning("Hazelcast is bound to " + bindAddress.getHost() + " and loop-back mode is "

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -118,6 +118,7 @@ public class MulticastDeserializationTest {
                 .setEnabled(false);
         join.getMulticastConfig()
                 .setEnabled(true)
+                .setLoopbackModeEnabled(true)
                 .setMulticastPort(MULTICAST_PORT)
                 .setMulticastGroup(MULTICAST_GROUP)
                 .setMulticastTimeToLive(MULTICAST_TTL);


### PR DESCRIPTION
Fix #18668: set interfaces must not be added when loopback mode nor loopback interface are used

Restores old code of adding setInterfaces, without modification of other branches.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
