### PR TITLE
Fix reconnect flood when members separated by proxy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionErrorHandler.java
@@ -55,11 +55,12 @@ class TcpServerConnectionErrorHandler {
         }
     }
 
-    synchronized void reset() {
+    synchronized TcpServerConnectionErrorHandler reset() {
         String resetMessage = "Resetting connection monitor for endpoint " + endPoint;
         logger.finest(resetMessage);
         faults = 0;
         lastFaultTime = 0L;
+        return this;
     }
 
     private String getCauseDescription(Throwable cause) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -283,7 +283,7 @@ public class TcpServerConnectionManager extends TcpServerConnectionManagerBase
     private int connectionsInProgress() {
         int c = 0;
         for (Plane plane : planes) {
-            c += plane.noOfConnectionsInProgress();
+            c += plane.connectionsInProgressCount();
         }
         return c;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -143,8 +143,9 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
         void removeConnection(TcpServerConnection connection) {
             removeConnectionInProgress(connection.getRemoteAddress());
 
+            // not using removeIf due to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8078645
             Iterator<TcpServerConnection> connections = connectionMap.values().iterator();
-            while (connections.hasNext()) { // not using removeIf due to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8078645
+            while (connections.hasNext()) {
                 TcpServerConnection c = connections.next();
                 if (c.equals(connection)) {
                     connections.remove();
@@ -153,9 +154,10 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
         }
 
         public boolean removeConnectionsWithId(int id) {
+            // not using removeIf due to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8078645
             boolean found = false;
             Iterator<TcpServerConnection> connections = connectionMap.values().iterator();
-            while (connections.hasNext()) { // not using removeIf due to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8078645
+            while (connections.hasNext()) {
                 TcpServerConnection c = connections.next();
                 if (c.getConnectionId() == id) {
                     connections.remove();

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -18,13 +18,7 @@ package com.hazelcast.internal.server.tcp;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.EndpointQualifier;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_ACCEPTED_SOCKET_COUNT;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_ACTIVE_COUNT;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_CLOSED_COUNT;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_CONNECTION_LISTENER_COUNT;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_OPENED_COUNT;
 import com.hazelcast.internal.metrics.Probe;
-import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionLifecycleListener;
@@ -33,23 +27,35 @@ import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.server.NetworkStats;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.server.ServerContext;
-import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.MutableLong;
 import com.hazelcast.internal.util.counters.MwCounter;
-import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import com.hazelcast.internal.util.executor.StripedRunnable;
 import com.hazelcast.logging.ILogger;
-import static com.hazelcast.spi.properties.ClusterProperty.CHANNEL_COUNT;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import static java.util.Collections.newSetFromMap;
+
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_ACCEPTED_SOCKET_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_ACTIVE_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_CLOSED_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_CONNECTION_LISTENER_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_OPENED_COUNT;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.spi.properties.ClusterProperty.CHANNEL_COUNT;
+import static java.util.Collections.newSetFromMap;
 
 /**
  * This base class solely exists for the purpose of simplification of the Manager class
@@ -113,13 +119,87 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
     }
 
     static class Plane {
-        final ConcurrentHashMap<Address, TcpServerConnection> connectionMap = new ConcurrentHashMap<>(100);
-        final Set<Address> connectionsInProgress = newSetFromMap(new ConcurrentHashMap<>());
         final ConcurrentHashMap<Address, TcpServerConnectionErrorHandler> errorHandlers = new ConcurrentHashMap<>(100);
         final int index;
 
+        private final Set<Address> connectionsInProgress = newSetFromMap(new ConcurrentHashMap<>());
+        private final ConcurrentHashMap<Address, TcpServerConnection> connectionMap = new ConcurrentHashMap<>(100);
+
         Plane(int index) {
             this.index = index;
+        }
+
+        TcpServerConnection getConnection(Address address) {
+            return connectionMap.get(address);
+        }
+
+        void putConnection(Address address, TcpServerConnection connection) {
+            connectionMap.put(address, connection);
+        }
+
+        void putConnectionIfAbsent(Address address, TcpServerConnection connection) {
+            connectionMap.putIfAbsent(address, connection);
+        }
+
+        void removeConnection(TcpServerConnection connection) {
+            removeConnectionInProgress(connection.getRemoteAddress());
+            connectionMap.entrySet().removeIf(entry -> entry.getValue().equals(connection));
+        }
+
+        public Set<Address> getAddresses(TcpServerConnection connection) {
+            return connectionMap.entrySet().stream()
+                    .filter(e -> e.getValue().equals(connection))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+        }
+
+        public boolean removeConnectionsWithId(int id) {
+            boolean found = false;
+            Iterator<TcpServerConnection> connections = connectionMap.values().iterator();
+            while (connections.hasNext()) {
+                TcpServerConnection cxn = connections.next();
+                if (cxn.getConnectionId() == id) {
+                    connections.remove();
+                    found = true;
+                }
+            }
+            return found;
+        }
+
+        public void forEachConnection(Consumer<? super TcpServerConnection> consumer) {
+            connectionMap.values().forEach(consumer);
+        }
+
+        public void clearConnections() {
+            connectionMap.clear();
+        }
+
+        public Set<Map.Entry<Address, TcpServerConnection>> connections() {
+            return Collections.unmodifiableSet(connectionMap.entrySet());
+        }
+
+        public int connectionCount() {
+            return (int) connectionMap.values().stream().distinct().count();
+        }
+
+        public boolean hasConnectionInProgress(Address address) {
+            return connectionsInProgress.contains(address);
+        }
+
+        public boolean addConnectionInProgress(Address address) {
+            return connectionsInProgress.add(address);
+        }
+
+        public boolean removeConnectionInProgress(Address address) {
+            return connectionsInProgress.remove(address);
+        }
+
+        public void clearConnectionsInProgress() {
+            connectionsInProgress.clear();
+        }
+
+        public int noOfConnectionsInProgress() {
+            return connectionsInProgress.size();
         }
     }
 
@@ -175,28 +255,26 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
             }
 
             Address remoteAddress = connection.getRemoteAddress();
+            Plane plane = null;
             if (remoteAddress != null) {
                 int planeIndex = connection.getPlaneIndex();
                 if (planeIndex > -1) {
-                    Plane plane = planes[connection.getPlaneIndex()];
-                    plane.connectionsInProgress.remove(remoteAddress);
-                    plane.connectionMap.remove(remoteAddress);
+                    plane = planes[connection.getPlaneIndex()];
+                    plane.removeConnection(connection);
                     fireConnectionRemovedEvent(connection, remoteAddress);
                 } else {
                     // it might be the case that the connection was closed quickly enough
                     // that the planeIndex was not set. Instead look for the connection
                     // by remoteAddress and connectionId over all planes and remove it wherever found.
                     boolean removed = false;
-                    for (Plane plane : planes) {
-                        plane.connectionsInProgress.remove(remoteAddress);
+                    for (Plane p : planes) {
+                        if (p.removeConnectionInProgress(remoteAddress)) {
+                            plane = p;
+                        }
                         // not using removeIf due to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8078645
-                        Iterator<TcpServerConnection> connections = plane.connectionMap.values().iterator();
-                        while (connections.hasNext()) {
-                            TcpServerConnection cxn = connections.next();
-                            if (cxn.getConnectionId() == connection.getConnectionId()) {
-                                connections.remove();
-                                removed = true;
-                            }
+                        if (p.removeConnectionsWithId(connection.getConnectionId())) {
+                            plane = p;
+                            removed = true;
                         }
                     }
                     if (removed) {
@@ -205,11 +283,9 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
                 }
             }
 
-            if (cause != null) {
-                serverContext.onFailedConnection(remoteAddress);
-                if (!silent) {
-                    getErrorHandler(remoteAddress, connection.getPlaneIndex(), false).onError(cause);
-                }
+            serverContext.onFailedConnection(remoteAddress);
+            if (!silent && plane != null) {
+                getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
             }
         }
     }
@@ -242,13 +318,16 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
         return false;
     }
 
-    protected TcpServerConnectionErrorHandler getErrorHandler(Address endpoint, int planeIndex, boolean reset) {
+    protected TcpServerConnectionErrorHandler getErrorHandler(Address endpoint, int planeIndex) {
         ConcurrentHashMap<Address, TcpServerConnectionErrorHandler> errorHandlers = planes[planeIndex].errorHandlers;
-        TcpServerConnectionErrorHandler handler = getOrPutIfAbsent(errorHandlers, endpoint, errorHandlerConstructor);
-        if (reset) {
-            handler.reset();
-        }
-        return handler;
+        return getErrorHandler(endpoint, errorHandlers);
+    }
+
+    private TcpServerConnectionErrorHandler getErrorHandler(
+            Address endpoint,
+            ConcurrentHashMap<Address, TcpServerConnectionErrorHandler> errorHandlers
+    ) {
+        return getOrPutIfAbsent(errorHandlers, endpoint, errorHandlerConstructor);
     }
 
     private class NetworkStatsImpl implements NetworkStats {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerContext.java
@@ -200,13 +200,13 @@ public class TcpServerContext implements ServerContext {
     @Override
     public void onFailedConnection(final Address address) {
         ClusterService clusterService = node.clusterService;
-        if (!clusterService.isJoined()) {
-            node.getJoiner().blacklist(address, false);
-        } else {
+        if (clusterService.isJoined()) {
             if (clusterService.getMember(address) != null) {
                 nodeEngine.getExecutionService().schedule(ExecutionService.IO_EXECUTOR, new ReconnectionTask(address),
                         getConnectionMonitorInterval(), TimeUnit.MILLISECONDS);
             }
+        } else {
+            node.getJoiner().blacklist(address, false);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
@@ -131,7 +131,7 @@ public final class TcpServerControl {
      * Performs the processing of the handshake (sets the endpoint on the Connection, registers the connection)
      * without any spoofing or other validation checks.
      * When executed on the connection initiator side, the connection is registered on the remote address
-     * with which it was registered in {@link TcpServerConnectionManager#connectionsInProgressArray},
+     * with which it was registered in {@link TcpServerConnectionManager#planes},
      * ignoring the {@code remoteEndpoint} argument.
      *
      * @param connection           the connection that send the handshake
@@ -146,7 +146,7 @@ public final class TcpServerControl {
                                        Collection<Address> remoteAddressAliases,
                                        MemberHandshake handshake) {
         final Address remoteAddress = new Address(connection.getRemoteSocketAddress());
-        if (connectionManager.planes[handshake.getPlaneIndex()].connectionsInProgress.contains(remoteAddress)) {
+        if (connectionManager.planes[handshake.getPlaneIndex()].hasConnectionInProgress(remoteAddress)) {
             // this is the connection initiator side --> register the connection under the address that was requested
             remoteEndpoint = remoteAddress;
         }
@@ -181,13 +181,13 @@ public final class TcpServerControl {
                     logger.finest("Registering connection " + connection + " to address alias " + remoteAddressAlias
                             + " planeIndex:" + handshake.getPlaneIndex());
                 }
-                connectionManager.planes[handshake.getPlaneIndex()].connectionMap.putIfAbsent(remoteAddressAlias, connection);
+                connectionManager.planes[handshake.getPlaneIndex()].putConnectionIfAbsent(remoteAddressAlias, connection);
             }
         }
     }
 
     private boolean checkAlreadyConnected(TcpServerConnection connection, Address remoteEndPoint, int planeIndex) {
-        Connection existingConnection = connectionManager.planes[planeIndex].connectionMap.get(remoteEndPoint);
+        Connection existingConnection = connectionManager.planes[planeIndex].getConnection(remoteEndPoint);
         if (existingConnection != null && existingConnection.isAlive()) {
             if (existingConnection != connection) {
                 if (logger.isFinestEnabled()) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpMemberConnectionLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpMemberConnectionLossTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.test.Accessors;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static com.hazelcast.spi.properties.ClusterProperty.CONNECTION_MONITOR_INTERVAL;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomName;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class TcpIpMemberConnectionLossTest {
+
+    @Before
+    @After
+    public void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.shutdownAll();
+    }
+
+    @Test
+    public void test_whenCanNotReconnect() {
+        Config config = getConfig();
+
+        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
+        assertClusterSize(2, h1, h2);
+
+        //when a member disappears and the other one can't connect to it
+        h1.shutdown();
+        //then it eventually gets dropped from the cluster
+        assertTrueEventually(() -> assertClusterSize(1, h2));
+    }
+
+    @Test
+    public void test_whenConnectionKeepsDying() throws Exception {
+        Config config = getConfig();
+
+        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
+        assertClusterSize(2, h1, h2);
+
+        InetSocketAddress address = Accessors.getNodeEngineImpl(h1).getThisAddress().getInetSocketAddress();
+        RejectionProxy rejectionProxy = new RejectionProxy(address.getHostName(), address.getPort());
+        try {
+            //when a member disappears
+            h1.shutdown();
+            //and connections to it don't succeed (they can be established, but immediately drop)
+            //(for example a TCP proxy might do this)
+            rejectionProxy.start();
+
+            //then it eventually gets dropped from the cluster
+            assertTrueEventually(() -> assertClusterSize(1, h2));
+        } finally {
+            rejectionProxy.stop();
+        }
+    }
+
+    @NotNull
+    private Config getConfig() {
+        Config config = new Config();
+        config.setClusterName(randomName());
+
+        NetworkConfig networkConfig = config.getNetworkConfig();
+        JoinConfig join = networkConfig.getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(true);
+        join.getTcpIpConfig().addMember("127.0.0.1");
+        return config;
+    }
+
+    private static final class RejectionProxy {
+
+        private final String host;
+        private final int port;
+
+        private volatile boolean running;
+        private Thread thread;
+
+        RejectionProxy(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+        void start() {
+            running = true;
+            thread = new Thread(() -> {
+                System.err.println("Starting rejection proxy on port " + port);
+                try {
+                    try (ServerSocket server = new ServerSocket(port)) {
+                        while (running) {
+                            try (Socket socket = server.accept()) {
+                                MILLISECONDS.sleep(Long.parseLong(CONNECTION_MONITOR_INTERVAL.getDefaultValue()));
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    //ignore
+                } finally {
+                    System.err.println("Rejection proxy terminated");
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        void stop() {
+            running = false;
+            while (thread.isAlive()) {
+                //break it out of a potential accept call
+                try {
+                    new Socket(host, port);
+                } catch (IOException e) {
+                    //ignore
+                }
+            }
+        }
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpMemberConnectionLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpMemberConnectionLossTest.java
@@ -50,7 +50,7 @@ public class TcpIpMemberConnectionLossTest {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
     }
 
     @Test
@@ -62,7 +62,7 @@ public class TcpIpMemberConnectionLossTest {
         assertClusterSize(2, h1, h2);
 
         //when a member disappears and the other one can't connect to it
-        h1.shutdown();
+        h1.getLifecycleService().terminate();
         //then it eventually gets dropped from the cluster
         assertTrueEventually(() -> assertClusterSize(1, h2));
     }
@@ -79,7 +79,7 @@ public class TcpIpMemberConnectionLossTest {
         RejectionProxy rejectionProxy = new RejectionProxy(address.getHostName(), address.getPort());
         try {
             //when a member disappears
-            h1.shutdown();
+            h1.getLifecycleService().terminate();
             //and connections to it don't succeed (they can be established, but immediately drop)
             //(for example a TCP proxy might do this)
             rejectionProxy.start();
@@ -120,7 +120,7 @@ public class TcpIpMemberConnectionLossTest {
         void start() {
             running = true;
             thread = new Thread(() -> {
-                System.err.println("Starting rejection proxy on port " + port);
+                System.out.println("Starting rejection proxy on port " + port);
                 try {
                     try (ServerSocket server = new ServerSocket(port)) {
                         while (running) {
@@ -132,7 +132,7 @@ public class TcpIpMemberConnectionLossTest {
                 } catch (Exception e) {
                     //ignore
                 } finally {
-                    System.err.println("Rejection proxy terminated");
+                    System.out.println("Rejection proxy terminated");
                 }
             });
             thread.setDaemon(true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/MemberHandshakeHandlerTest.java
@@ -196,7 +196,7 @@ public class MemberHandshakeHandlerTest {
             for (Address address : expectedAddresses) {
                 boolean found = false;
                 for (TcpServerConnectionManager.Plane plane : planes) {
-                    if (plane.connectionMap.containsKey(address)) {
+                    if (plane.getConnection((address)) != null) {
                         found = true;
                         break;
                     }


### PR DESCRIPTION
Fixes #18320

The root cause of this problem seems to be that, due to the proxy present, not being able to connect from one member to another doesn't behave as expected.

The expected behaviour is that a connection attempt is made, it fails, another one is made, it fails and after a certain number of attempts we give up and behave accordingly.

What happens here instead is that a connection attempt is made, it succeeds connecting to the proxy, the proxy tries to connect to the other side, fails, drops the incoming connection. So instead of an "attempt-fail, attempt-fail, ..." sequence of events we get "attempt-succeed-drop, attempt-succeed-drop, ..." sequence and that's not being handled correctly by the current code.