### PR TITLE
Replace MetaSupplierCtx.processingGuarantee with a call to JobConfig.getProcessingGuarantee()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -70,7 +70,6 @@ public final class Contexts {
         private final int localParallelism;
         private final int totalParallelism;
         private final int memberCount;
-        private final ProcessingGuarantee processingGuarantee;
 
         MetaSupplierCtx(
                 JetInstance jetInstance,
@@ -81,8 +80,7 @@ public final class Contexts {
                 String vertexName,
                 int localParallelism,
                 int totalParallelism,
-                int memberCount,
-                ProcessingGuarantee processingGuarantee
+                int memberCount
         ) {
             this.jetInstance = jetInstance;
             this.jobId = jobId;
@@ -93,7 +91,6 @@ public final class Contexts {
             this.totalParallelism = totalParallelism;
             this.localParallelism = localParallelism;
             this.memberCount = memberCount;
-            this.processingGuarantee = processingGuarantee;
         }
 
         @Nonnull @Override
@@ -143,7 +140,7 @@ public final class Contexts {
 
         @Override
         public ProcessingGuarantee processingGuarantee() {
-            return processingGuarantee;
+            return jobConfig.getProcessingGuarantee();
         }
     }
 
@@ -165,12 +162,11 @@ public final class Contexts {
                 int totalParallelism,
                 int memberIndex,
                 int memberCount,
-                ProcessingGuarantee processingGuarantee,
                 ConcurrentHashMap<String, File> tempDirectories,
                 InternalSerializationService serializationService
         ) {
             super(jetInstance, jobId, executionId, jobConfig, logger, vertexName, localParallelism, totalParallelism,
-                    memberCount, processingGuarantee);
+                    memberCount);
             this.memberIndex = memberIndex;
             this.tempDirectories = tempDirectories;
             this.serializationService = serializationService;
@@ -293,14 +289,13 @@ public final class Contexts {
                        String vertexName,
                        int localProcessorIndex,
                        int globalProcessorIndex,
-                       ProcessingGuarantee processingGuarantee,
                        int localParallelism,
                        int memberIndex,
                        int memberCount,
                        ConcurrentHashMap<String, File> tempDirectories,
                        InternalSerializationService serializationService) {
             super(instance, jobId, executionId, jobConfig, logger, vertexName, localParallelism,
-                    memberCount * localParallelism, memberIndex, memberCount, processingGuarantee,
+                    memberCount * localParallelism, memberIndex, memberCount,
                     tempDirectories, serializationService);
             this.localProcessorIndex = localProcessorIndex;
             this.globalProcessorIndex = globalProcessorIndex;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -202,7 +202,6 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         vertex.name(),
                         localProcessorIdx,
                         globalProcessorIndex,
-                        jobConfig.getProcessingGuarantee(),
                         vertex.localParallelism(),
                         memberIndex,
                         memberCount,
@@ -327,7 +326,6 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         vertex.localParallelism() * memberCount,
                         memberIndex,
                         memberCount,
-                        jobConfig.getProcessingGuarantee(),
                         tempDirectories,
                         jobSerializationService
                 ));

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -93,8 +93,7 @@ public final class ExecutionPlanBuilder {
             ILogger logger = prefixedLogger(nodeEngine.getLogger(metaSupplier.getClass()), prefix);
             try {
                 metaSupplier.init(new MetaSupplierCtx(instance, jobId, executionId, jobConfig, logger,
-                        vertex.getName(), localParallelism, totalParallelism, clusterSize,
-                        jobConfig.getProcessingGuarantee()));
+                        vertex.getName(), localParallelism, totalParallelism, clusterSize));
             } catch (Exception e) {
                 throw sneakyThrow(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/ProcessorWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/ProcessorWrapper.java
@@ -78,7 +78,7 @@ public abstract class ProcessorWrapper implements Processor, DynamicMetricsProvi
             String prefix = prefix(c.jobConfig().getName(), c.jobId(), c.vertexName(), c.globalProcessorIndex());
             ILogger newLogger = prefixedLogger(loggingService.getLogger(wrapped.getClass()), prefix);
             context = new ProcCtx(c.jetInstance(), c.jobId(), c.executionId(), c.jobConfig(),
-                    newLogger, c.vertexName(), c.localProcessorIndex(), c.globalProcessorIndex(), c.processingGuarantee(),
+                    newLogger, c.vertexName(), c.localProcessorIndex(), c.globalProcessorIndex(),
                     c.localParallelism(), c.memberIndex(), c.memberCount(), c.tempDirectories(), c.serializationService());
         }
         return context;

--- a/hazelcast/src/test/java/com/hazelcast/jet/TestContextSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/TestContextSupport.java
@@ -97,7 +97,7 @@ public final class TestContextSupport {
                 TestProcessorSupplierContext c = (TestProcessorSupplierContext) context;
                 NodeEngine nodeEngine = ((HazelcastInstanceImpl) c.jetInstance().getHazelcastInstance()).node.nodeEngine;
                 context = new ProcCtx(c.jetInstance(), c.jobId(), c.executionId(), c.jobConfig(),
-                        c.logger(), c.vertexName(), 1, 1, c.processingGuarantee(),
+                        c.logger(), c.vertexName(), 1, 1,
                         c.localParallelism(), 1, c.memberCount(), new ConcurrentHashMap<>(),
                         (InternalSerializationService) nodeEngine.getSerializationService());
             }
@@ -119,8 +119,8 @@ public final class TestContextSupport {
                 NodeEngine nodeEngine = ((HazelcastInstanceImpl) c.jetInstance().getHazelcastInstance()).node.nodeEngine;
                 context = new ProcCtx(c.jetInstance(), c.jobId(), c.executionId(), c.jobConfig(),
                         c.logger(), c.vertexName(), c.localProcessorIndex(), c.globalProcessorIndex(),
-                        c.processingGuarantee(), c.localParallelism(), c.memberIndex(), c.memberCount(),
-                        new ConcurrentHashMap<>(), (InternalSerializationService) nodeEngine.getSerializationService());
+                        c.localParallelism(), c.memberIndex(), c.memberCount(), new ConcurrentHashMap<>(),
+                        (InternalSerializationService) nodeEngine.getSerializationService());
             }
             return context;
         }


### PR DESCRIPTION
`MetaSupplierCtx.processingGuarantee` always comes from `JobConfig.getProcessingGuarantee()` - removed the separate field to store it.