### PR TITLE
Replace usage of hasMessageEndingWith() with hasMessageContaining() in SQL tests

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlAvroTest.java
@@ -240,7 +240,7 @@ public class SqlAvroTest extends SqlTestSupport {
         );
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name).iterator().hasNext())
-                .hasMessageEndingWith("Cannot parse VARCHAR value to INTEGER");
+                .hasMessageContaining("Cannot parse VARCHAR value to INTEGER");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlCsvTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlCsvTest.java
@@ -322,7 +322,7 @@ public class SqlCsvTest extends SqlTestSupport {
         );
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name).iterator().hasNext())
-                .hasMessageEndingWith("Cannot parse VARCHAR value to INTEGER");
+                .hasMessageContaining("Cannot parse VARCHAR value to INTEGER");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlJsonTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlJsonTest.java
@@ -240,7 +240,7 @@ public class SqlJsonTest extends SqlTestSupport {
         );
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name).iterator().hasNext())
-                .hasMessageEndingWith("Cannot parse VARCHAR value to INTEGER");
+                .hasMessageContaining("Cannot parse VARCHAR value to INTEGER");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/PositionFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/string/PositionFunctionIntegrationTest.java
@@ -166,7 +166,7 @@ public class PositionFunctionIntegrationTest extends ExpressionTestSupport {
                     fail("did not throw exception");
                 })
                 .isInstanceOf(HazelcastSqlException.class)
-                .hasMessageEndingWith(expectedError);
+                .hasMessageContaining(expectedError);
     }
 
     private String sql(Object text, Object search) {


### PR DESCRIPTION
There are cases when the cause a failed job is _stringified_ before reported to the user ([here](https://github.com/hazelcast/hazelcast/blob/d2bb75149610df5272651296a1d5c4f214af208a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java#L651)).
Replaces usage of `hasMessageEndingWith()` with `hasMessageContaining()` to avoid false negatives.