### PR TITLE
Fix map reader/writer processor issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -200,13 +200,13 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
             partitionReadCount--;
 
             IterationPointer[] pointers = reader.toNextPointer(result);
+            currentBatch = reader.toRecordSet(result);
             if (isDone(pointers)) {
                 numCompletedPartitions++;
             } else {
                 assert !currentBatch.isEmpty() : "empty but not terminal batch";
             }
 
-            currentBatch = reader.toRecordSet(result);
             currentBatchPosition = 0;
             readPointers[currentPartitionIndex] = pointers;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
@@ -16,15 +16,22 @@
 
 package com.hazelcast.jet.impl.connector;
 
+import com.hazelcast.client.impl.proxy.ClientMapProxy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.function.FunctionEx;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.config.EdgeConfig;
 import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.impl.connector.HazelcastWriters.ArrayMap;
+import com.hazelcast.jet.impl.serialization.DelegatingSerializationService;
 import com.hazelcast.map.IMap;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.partition.PartitioningStrategy;
 
 import javax.annotation.Nonnull;
 import java.util.AbstractMap.SimpleEntry;
@@ -37,22 +44,25 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
     private static final int BUFFER_LIMIT = 1024;
 
     private final String mapName;
+    private final SerializationService serializationService;
     private final FunctionEx<? super T, ? extends K> toKeyFn;
     private final FunctionEx<? super T, ? extends V> toValueFn;
 
-    private ArrayMap<K, V> buffer;
-    private IMap<K, V> map;
+    private ArrayMap<Object, Object> buffer;
+    private IMap<Object, Object> map;
     private Consumer<T> addToBuffer;
 
     private WriteMapP(
             @Nonnull HazelcastInstance instance,
             int maxParallelAsyncOps,
             String mapName,
+            @Nonnull SerializationService serializationService,
             @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
             @Nonnull FunctionEx<? super T, ? extends V> toValueFn
     ) {
         super(instance, maxParallelAsyncOps);
         this.mapName = mapName;
+        this.serializationService = serializationService;
         this.toKeyFn = toKeyFn;
         this.toValueFn = toValueFn;
 
@@ -62,8 +72,43 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
     @Override
     public void init(@Nonnull Outbox outbox, @Nonnull Context context) {
         map = instance().getMap(mapName);
-        addToBuffer = item -> buffer.add(
-                new SimpleEntry<>(toKeyFn.apply(item), toValueFn.apply(item)));
+
+        boolean hasCustomSerializers = ((DelegatingSerializationService) serializationService).hasAddedSerializers();
+        boolean hasNearCache = map instanceof NearCachedMapProxyImpl;
+        if (hasNearCache && hasCustomSerializers) {
+            // To invalidate NearCache, the `putAll` method would need a deserialized key. It can't deserialize
+            // because it doesn't know the job-specific serializers.
+            // See https://github.com/hazelcast/hazelcast-jet/issues/3046
+            throw new JetException("Writing into IMap with both near cache and custom serializers not supported");
+        }
+
+        if (!hasCustomSerializers) {
+            addToBuffer = item -> buffer.add(new SimpleEntry<>(key(item), value(item)));
+        } else if (map instanceof MapProxyImpl) {
+            PartitioningStrategy<?> partitionStrategy = ((MapProxyImpl<K, V>) map).getPartitionStrategy();
+            addToBuffer = item -> {
+                Data key = serializationService.toData(key(item), partitionStrategy);
+                Data value = serializationService.toData(value(item));
+                buffer.add(new SimpleEntry<>(key, value));
+            };
+        } else if (map instanceof ClientMapProxy) {
+            // TODO: add strategy/unify after https://github.com/hazelcast/hazelcast/issues/13950 is fixed
+            addToBuffer = item -> {
+                Data key = serializationService.toData(key(item));
+                Data value = serializationService.toData(value(item));
+                buffer.add(new SimpleEntry<>(key, value));
+            };
+        } else {
+            throw new RuntimeException("Unexpected map class: " + map.getClass().getName());
+        }
+    }
+
+    private K key(T item) {
+        return toKeyFn.apply(item);
+    }
+
+    private V value(T item) {
+        return toValueFn.apply(item);
     }
 
     @Override
@@ -127,7 +172,7 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
 
         @Override
         protected Processor createProcessor(HazelcastInstance instance, SerializationService serializationService) {
-            return new WriteMapP<>(instance, maxParallelAsyncOps, mapName, toKeyFn, toValueFn);
+            return new WriteMapP<>(instance, maxParallelAsyncOps, mapName, serializationService, toKeyFn, toValueFn);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
@@ -73,7 +73,8 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
     public void init(@Nonnull Outbox outbox, @Nonnull Context context) {
         map = instance().getMap(mapName);
 
-        boolean hasCustomSerializers = ((DelegatingSerializationService) serializationService).hasAddedSerializers();
+        boolean hasCustomSerializers = serializationService instanceof DelegatingSerializationService
+                && ((DelegatingSerializationService) serializationService).hasAddedSerializers();
         boolean hasNearCache = map instanceof NearCachedMapProxyImpl;
         if (hasNearCache && hasCustomSerializers) {
             // To invalidate NearCache, the `putAll` method would need a deserialized key. It can't deserialize

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.client.impl.proxy.ClientMapProxy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.jet.config.EdgeConfig;
 import com.hazelcast.jet.core.Inbox;
@@ -27,8 +25,6 @@ import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.impl.connector.HazelcastWriters.ArrayMap;
 import com.hazelcast.map.IMap;
-import com.hazelcast.map.impl.proxy.MapProxyImpl;
-import com.hazelcast.partition.PartitioningStrategy;
 
 import javax.annotation.Nonnull;
 import java.util.AbstractMap.SimpleEntry;
@@ -41,58 +37,33 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
     private static final int BUFFER_LIMIT = 1024;
 
     private final String mapName;
-    private final SerializationService serializationService;
-    private final ArrayMap<Data, Data> buffer = new ArrayMap<>(EdgeConfig.DEFAULT_QUEUE_SIZE);
     private final FunctionEx<? super T, ? extends K> toKeyFn;
     private final FunctionEx<? super T, ? extends V> toValueFn;
 
-    private IMap<Data, Data> map;
+    private ArrayMap<K, V> buffer;
+    private IMap<K, V> map;
     private Consumer<T> addToBuffer;
 
     private WriteMapP(
             @Nonnull HazelcastInstance instance,
             int maxParallelAsyncOps,
             String mapName,
-            @Nonnull SerializationService serializationService,
             @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
             @Nonnull FunctionEx<? super T, ? extends V> toValueFn
     ) {
         super(instance, maxParallelAsyncOps);
         this.mapName = mapName;
-        this.serializationService = serializationService;
         this.toKeyFn = toKeyFn;
         this.toValueFn = toValueFn;
+
+        resetBuffer();
     }
 
     @Override
     public void init(@Nonnull Outbox outbox, @Nonnull Context context) {
         map = instance().getMap(mapName);
-
-        if (map instanceof MapProxyImpl) {
-            PartitioningStrategy<?> partitionStrategy = ((MapProxyImpl<K, V>) map).getPartitionStrategy();
-            addToBuffer = item -> {
-                Data key = serializationService.toData(key(item), partitionStrategy);
-                Data value = serializationService.toData(value(item));
-                buffer.add(new SimpleEntry<>(key, value));
-            };
-        } else if (map instanceof ClientMapProxy) {
-            // TODO: add strategy/unify after https://github.com/hazelcast/hazelcast/issues/13950 is fixed
-            addToBuffer = item -> {
-                Data key = serializationService.toData(key(item));
-                Data value = serializationService.toData(value(item));
-                buffer.add(new SimpleEntry<>(key, value));
-            };
-        } else {
-            throw new RuntimeException("Unexpected map class: " + map.getClass().getName());
-        }
-    }
-
-    private K key(T item) {
-        return toKeyFn.apply(item);
-    }
-
-    private V value(T item) {
-        return toValueFn.apply(item);
+        addToBuffer = item -> buffer.add(
+                new SimpleEntry<>(toKeyFn.apply(item), toValueFn.apply(item)));
     }
 
     @Override
@@ -116,8 +87,12 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
             return false;
         }
         setCallback(map.putAllAsync(buffer));
-        buffer.clear();
+        resetBuffer();
         return true;
+    }
+
+    private void resetBuffer() {
+        buffer = new ArrayMap<>(EdgeConfig.DEFAULT_QUEUE_SIZE);
     }
 
     public static class Supplier<T, K, V> extends AbstractHazelcastConnectorSupplier {
@@ -152,7 +127,7 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
 
         @Override
         protected Processor createProcessor(HazelcastInstance instance, SerializationService serializationService) {
-            return new WriteMapP<>(instance, maxParallelAsyncOps, mapName, serializationService, toKeyFn, toValueFn);
+            return new WriteMapP<>(instance, maxParallelAsyncOps, mapName, toKeyFn, toValueFn);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/serialization/DelegatingSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/serialization/DelegatingSerializationService.java
@@ -172,6 +172,10 @@ public class DelegatingSerializationService extends AbstractSerializationService
                 + "or between clients and members.");
     }
 
+    public boolean hasAddedSerializers() {
+        return !serializersByClass.isEmpty();
+    }
+
     @Override
     public void dispose() {
         active = false;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1004,7 +1004,13 @@ abstract class MapProxySupport<K, V>
                     resultFuture.completeExceptionally(t);
                 }
                 if (counter.decrementAndGet() == 0) {
-                    finalizePutAll(map);
+                    try {
+                        // don't ignore errors here, see https://github.com/hazelcast/hazelcast-jet/issues/3046
+                        finalizePutAll(map);
+                    } catch (Throwable e) {
+                        resultFuture.completeExceptionally(e);
+                        return;
+                    }
                     if (!resultFuture.isDone()) {
                         resultFuture.complete(null);
                     }


### PR DESCRIPTION
Issues with IMap writer:
- we used Map<Data, Data> with putAll, that's not supported
- when we did that, the error wasn't reported, but instead the operation got stuck
- we cleared the buffer right after putAllAsync returned, but it was used
  concurrently, which hid the error

Issue with IMap reader:
- bad assert, checked the `currentBatch` before it was assigned. Failed only with larger data set.

Fixes hazelcast/hazelcast-jet#3046
