### PR TITLE
Check for leftover HazelcastClient instances

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
@@ -35,6 +35,7 @@ public class ClientAutoDetectionDiscoveryTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
+        HazelcastClient.shutdownAll();
         Hazelcast.shutdownAll();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -17,6 +17,7 @@
 package com.hazelcast.test;
 
 import com.hazelcast.cache.jsr.JsrTestUtil;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.util.ConcurrencyUtil;
@@ -44,6 +45,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -310,6 +312,12 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
                 if (!instances.isEmpty()) {
                     String message = "Instances haven't been shut down: " + instances;
                     Hazelcast.shutdownAll();
+                    throw new IllegalStateException(message);
+                }
+                Collection<HazelcastInstance> clientInstances = HazelcastClient.getAllHazelcastClients();
+                if (!clientInstances.isEmpty()) {
+                    String message = "Client instances haven't been shut down: " + clientInstances;
+                    HazelcastClient.shutdownAll();
                     throw new IllegalStateException(message);
                 }
 


### PR DESCRIPTION
Similarly to existing check for leftover
Hazelcast members, after each test class execution
check for leftover hazelcast clients and
throw an exception if any are found.

A leftover client instance was observed attempting to connect to members in unrelated test log files of failed PR builder run 5077, see https://github.com/hazelcast/hazelcast/issues/18694#issuecomment-842945056

Fixes #18694 
