### PR TITLE
Member start should fail on SSL errors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -247,7 +247,7 @@ public class TcpServerConnection implements ServerConnection {
             logger.warning(e);
         }
 
-        lifecycleListener.onConnectionClose(this, null, false);
+        lifecycleListener.onConnectionClose(this, cause, false);
         serverContext.onDisconnect(remoteAddress, cause);
 
         LoginContext lc = (LoginContext) attributeMap.remove(LoginContext.class);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -34,7 +34,6 @@ import com.hazelcast.internal.util.executor.StripedRunnable;
 import com.hazelcast.logging.ILogger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import javax.net.ssl.SSLException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -295,11 +294,9 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
                 }
             }
 
-            if (!(cause instanceof SSLException)) {
-                serverContext.onFailedConnection(remoteAddress);
-                if (!silent && plane != null) {
-                    getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
-                }
+            serverContext.onFailedConnection(remoteAddress);
+            if (!silent && plane != null) {
+                getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -294,9 +294,13 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
                 }
             }
 
-            serverContext.onFailedConnection(remoteAddress);
-            if (!silent && plane != null) {
-                getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
+            long lastReadTime = connection.getChannel().lastReadTimeMillis();
+            boolean hadNoDataTraffic = lastReadTime < 0;
+            if (hadNoDataTraffic) {
+                serverContext.onFailedConnection(remoteAddress);
+                if (!silent && plane != null) {
+                    getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -34,6 +34,7 @@ import com.hazelcast.internal.util.executor.StripedRunnable;
 import com.hazelcast.logging.ILogger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.net.ssl.SSLException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -294,9 +295,11 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
                 }
             }
 
-            serverContext.onFailedConnection(remoteAddress);
-            if (!silent && plane != null) {
-                getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
+            if (!(cause instanceof SSLException)) {
+                serverContext.onFailedConnection(remoteAddress);
+                if (!silent && plane != null) {
+                    getErrorHandler(remoteAddress, plane.errorHandlers).onError(cause);
+                }
             }
         }
     }


### PR DESCRIPTION
The recent fixes done to solve reconnection floods ([PR 18673](https://github.com/hazelcast/hazelcast/pull/18673)) broke behavior related to SSL functionality in EE. This PR attempt to restore that functionality.