### PR TITLE
Fix SnapshotContext creation for light jobs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -181,7 +181,10 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
             // create StoreSnapshotTasklet and the queues to it
             ConcurrentConveyor<Object> ssConveyor = null;
-            if (snapshotContext.processingGuarantee() != ProcessingGuarantee.NONE) {
+            if (!isLightJob) {
+                // Note that we create the snapshot queues for all non-light jobs, even if they don't have
+                // processing guarantee enabled, because in EE one can request a snapshot also for
+                // non-snapshotted jobs.
                 @SuppressWarnings("unchecked")
                 QueuedPipe<Object>[] snapshotQueues = new QueuedPipe[vertex.localParallelism()];
                 Arrays.setAll(snapshotQueues, i -> new OneToOneConcurrentArrayQueue<>(SNAPSHOT_QUEUE_SIZE));


### PR DESCRIPTION
With light jobs (#18619) we avoided creating the SnapshotContext for
non-snapshotted jobs. However, in Hazelcast EE, it's allowed to create a
snapshot also for a non-snapshotted job.

The fix is to avoid creating the SnapshotContext only for light jobs.

Fixes hazelcast/hazelcast-enterprise#4043
