### PR TITLE
Disable Multicast setInterface calls in Solaris

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -47,6 +47,7 @@ import java.util.Properties;
 
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static com.hazelcast.test.TestEnvironment.isSolaris;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -171,6 +172,9 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
 
         try {
             Config config = new Config();
+            if (isSolaris()) {
+                config.setProperty(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE.getName(), "false");
+            }
             CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
                     .setName(CACHE_NAME)
                     .setBackupCount(1); // Be sure that cache put operation is mirrored to backup node

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.TestEnvironment.isSolaris;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ClientAutoDetectionDiscoveryTest extends HazelcastTestSupport {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,8 +41,13 @@ public class ClientAutoDetectionDiscoveryTest extends HazelcastTestSupport {
 
     @Test
     public void defaultDiscovery() {
-        Hazelcast.newHazelcastInstance();
-        Hazelcast.newHazelcastInstance();
+        Config c = new Config();
+        if (isSolaris()) {
+            c.setProperty(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE.getName(), "false");
+        }
+
+        Hazelcast.newHazelcastInstance(c);
+        Hazelcast.newHazelcastInstance(c);
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
         assertClusterSizeEventually(2, client);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.cluster;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.isSolaris;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -30,6 +31,7 @@ import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.nio.ByteBuffer;
 
+import com.hazelcast.spi.properties.ClusterProperty;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -121,6 +123,9 @@ public class MulticastDeserializationTest {
                 .setMulticastPort(MULTICAST_PORT)
                 .setMulticastGroup(MULTICAST_GROUP)
                 .setMulticastTimeToLive(MULTICAST_TTL);
+        if (isSolaris()) {
+            config.setProperty(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE.getName(), "false");
+        }
         return config;
     }
 
@@ -136,7 +141,9 @@ public class MulticastDeserializationTest {
         MulticastSocket multicastSocket = null;
         try {
             multicastSocket = new MulticastSocket(MULTICAST_PORT);
-            multicastSocket.setInterface(InetAddress.getByName("127.0.0.1"));
+            if (!isSolaris()) {
+                multicastSocket.setInterface(InetAddress.getByName("127.0.0.1"));
+            }
             multicastSocket.setTimeToLive(MULTICAST_TTL);
             InetAddress group = InetAddress.getByName(MULTICAST_GROUP);
             multicastSocket.joinGroup(group);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -18,8 +18,8 @@ package com.hazelcast.cluster;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.HazelcastTestSupport.isSolaris;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static com.hazelcast.test.TestEnvironment.isSolaris;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1684,8 +1684,4 @@ public abstract class HazelcastTestSupport {
             object.destroy();
         }
     }
-
-    public static boolean isSolaris() {
-        return System.getProperty("os.name").startsWith("SunOS");
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1684,4 +1684,8 @@ public abstract class HazelcastTestSupport {
             object.destroy();
         }
     }
+
+    public static boolean isSolaris() {
+        return System.getProperty("os.name").startsWith("SunOS");
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
@@ -59,4 +59,8 @@ public final class TestEnvironment {
     public static String getSerializedClassNamesPath() {
         return System.getProperty(SAMPLE_SERIALIZED_OBJECTS);
     }
+
+    public static boolean isSolaris() {
+        return System.getProperty("os.name").startsWith("SunOS");
+    }
 }


### PR DESCRIPTION
Disable Multicast setInterface calls in Solaris

Fixes #17834 

