### PR TITLE
Partition Group API now takes members as method argument

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/SPIAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/SPIAwareMemberGroupFactory.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.partitiongroup.MemberGroup;
+import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 
 import java.util.Collection;
 import java.util.Set;
@@ -62,10 +63,12 @@ public class SPIAwareMemberGroupFactory extends BackupSafeMemberGroupFactory imp
                                 + "check service definitions under META_INF.services folder. ");
                     } else {
                         for (DiscoveryStrategy discoveryStrategy : defaultDiscoveryService.getDiscoveryStrategies()) {
-                            checkNotNull(discoveryStrategy.getPartitionGroupStrategy());
-                            Iterable<MemberGroup> spiGroupsIterator =
-                                    discoveryStrategy.getPartitionGroupStrategy().getMemberGroups();
-                            for (MemberGroup group : spiGroupsIterator) {
+                            PartitionGroupStrategy groupStrategy = discoveryStrategy.getPartitionGroupStrategy(allMembers);
+                            if (groupStrategy == null) {
+                                groupStrategy = discoveryStrategy.getPartitionGroupStrategy();
+                            }
+                            checkNotNull(groupStrategy);
+                            for (MemberGroup group : groupStrategy.getMemberGroups()) {
                                 memberGroups.add(group);
                             }
                             return memberGroups;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.spi.discovery;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.internal.util.StringUtil;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -53,6 +55,11 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
 
     @Override
     public PartitionGroupStrategy getPartitionGroupStrategy() {
+        return null;
+    }
+
+    @Override
+    public PartitionGroupStrategy getPartitionGroupStrategy(Collection<? extends Member> allMembers) {
         return null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.discovery;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -69,12 +70,30 @@ public interface DiscoveryStrategy {
      * default behavior of zone aware backup strategies {@link com.hazelcast.spi.partitiongroup.PartitionGroupMetaData}
      * or to provide a specific behavior in case the discovery environment does not provide
      * information about the infrastructure to be used for automatic configuration.
+     * @param allMembers Current state of Cluster data members, excluding lite members
+     * @return a custom implementation of a <code>PartitionGroupStrategy</code> otherwise <code>null</code>
+     * in case of the default implementation is to be used
+     * @since 4.2.1
+     */
+    default PartitionGroupStrategy getPartitionGroupStrategy(Collection<? extends Member> allMembers) {
+        return null;
+    }
+
+    /**
+     * @deprecated - use the above method that takes allMember arguments
+     * Returns a custom implementation of a {@link PartitionGroupStrategy} to override
+     * default behavior of zone aware backup strategies {@link com.hazelcast.spi.partitiongroup.PartitionGroupMetaData}
+     * or to provide a specific behavior in case the discovery environment does not provide
+     * information about the infrastructure to be used for automatic configuration.
      *
      * @return a custom implementation of a <code>PartitionGroupStrategy</code> otherwise <code>null</code>
      * in case of the default implementation is to be used
      * @since 3.7
      */
-    PartitionGroupStrategy getPartitionGroupStrategy();
+    @Deprecated
+    default PartitionGroupStrategy getPartitionGroupStrategy() {
+        return null;
+    }
 
     /**
      * Returns a map with discovered metadata provided by the runtime environment. Those information

--- a/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,5 +1,7 @@
 com.hazelcast.spi.discovery.DiscoverySpiTest$TestDiscoveryStrategyFactory
+com.hazelcast.spi.discovery.DiscoverySpiTest$DeprecatedTestDiscoveryStrategyFactory
 com.hazelcast.spi.discovery.DiscoverySpiTest$MetadataProvidingDiscoveryStrategyFactory
+com.hazelcast.spi.discovery.DiscoverySpiTest$DeprecatedMetadataProvidingDiscoveryStrategyFactory
 com.hazelcast.spi.discovery.DiscoverySpiTest$ParametrizedDiscoveryStrategyFactory
 com.hazelcast.client.impl.spi.impl.discovery.ClientDiscoverySpiTest$TestDiscoveryStrategyFactory
 com.hazelcast.spi.discovery.impl.AutoDetectionDefaultDiscoveryServiceTest$TestDiscoveryStrategyFactory


### PR DESCRIPTION
<PR description here>

Fixes #18795

Introduces new method that can be overridden so that cluster members are available to the implementing code.
This makes it possible to implement useful partitioning strategies.

I have taken great care here to preserve current functionality, so hopefully this can make it into 4.2.1 or 4.2.2 as opposed to having to wait all the way until 5.0

* API
New API introduced in `DiscoveryStrategy`: `PartitionGroupStrategy getPartitionGroupStrategy(Collection<? extends Member> allMembers)`
The older one with no arguments has been marked as deprecated.
I have made effort to make sure that the old API works as previously, and if the new API method is overridden then it will take precedence over the old one.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
