### PR TITLE
Get jvmName once pr jvm to speed up tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -46,6 +46,7 @@ import static com.hazelcast.client.HazelcastClientUtil.getInstanceName;
 public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
     public static final String TEST_JVM_PREFIX = "test-jvm-";
+    private static final String jvmName = ManagementFactory.getRuntimeMXBean().getName();
     private final boolean mockNetwork = TestEnvironment.isMockNetwork();
     private final ConcurrentMap<String, HazelcastClientInstanceImpl> clients = new ConcurrentHashMap<>(10);
     private final TestClientRegistry clientRegistry = new TestClientRegistry(getRegistry());
@@ -104,8 +105,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     }
 
     private void registerJvmNameAndPidMetric(HazelcastClientInstanceImpl client) {
-        String jvmName = ManagementFactory.getRuntimeMXBean().getName();
-        int pid = Integer.valueOf(jvmName.substring(0, jvmName.indexOf("@")));
+        int pid = Integer.parseInt(jvmName.substring(0, jvmName.indexOf("@")));
         MetricsRegistryImpl metricsRegistry = client.getMetricsRegistry();
         metricsRegistry.registerDynamicMetricsProvider(
                 (descriptor, context) -> context


### PR DESCRIPTION
apparently
```ManagementFactory.getRuntimeMXBean().getName()```
This is an expensive call which can wait up to 5 to 6 seconds.

Since this will not change ever per jvm, I have moved it to static
the field in order not to pay 5 seconds per client start.