### PR TITLE
Update hazelcast.yaml in distribution

### DIFF
--- a/distribution/src/root/config/hazelcast.yaml
+++ b/distribution/src/root/config/hazelcast.yaml
@@ -5,31 +5,36 @@ hazelcast:
   cluster-name: dev
   network:
     port:
-      # The preferred port number where the Jet instance will listen. The
+      # The preferred port number where the Hazelcast instance will listen. The
       # convention is to use 5701 and it is the default both here and in
-      # various tools connecting to Jet.
+      # various tools connecting to Hazelcast.
       port: 5701
       # Whether to automatically try higher port numbers when the preferred
       # one is taken.
       auto-increment: true
     # Which network interface to listen on. With "enabled" set to false
-    # Jet will listen on all available interfaces.
+    # Hazelcast will listen on all available interfaces.
     interfaces:
       enabled: false
       interfaces:
         - 127.0.0.1
-    # Hazelcast Jet has several techniques that simplify the formation of the
+    # Hazelcast has several techniques that simplify the formation of the
     # cluster by automatically discovering the other nodes. This config section
-    # lists some. Jet will form a cluster only with nodes using the same discovery
+    # lists some. Hazelcast will form a cluster only with nodes using the same discovery
     # mechanism, so make sure to enable only one.
     join:
-      # The default way to discover nodes: using the IP multicast. This is the
+      # The default way to discover nodes: autodetection. This checks if cloud
+      # discovery plugins are installed and uses them. If they are not present
+      # then the multicast discovery is used.
+      auto-detection:
+        enabled: true
+      # Uses the IP multicast to send and receive join messages. This is the
       # simplest technique, but in a cloud setting the network usually doesn't
       # allow multicast.
       multicast:
-        enabled: true
+        enabled: false
         multicast-group: 224.2.2.3
-        multicast-port: 54328
+        multicast-port: 54327
       # This technique doesn't attempt any auto-discovery, you directly list all
       # the candidate IPs to check.
       tcp-ip:
@@ -42,8 +47,7 @@ hazelcast:
       # parameters work as filtering criteria that narrow down the list of
       # IPs to check. You can get more information on the AWS plugin's GitHub
       # page: https://github.com/hazelcast/hazelcast-aws
-      # This plugin is built into the main Hazelcast Jet JAR found in the
-      # distribution package.
+      # This plugin is included as a JAR in the distribution package.
       aws:
         enabled: false
         access-key: my-access-key
@@ -57,17 +61,15 @@ hazelcast:
       # Uses the GCP API to get a list of candidate IPs to check. For more
       # details go to the plugin's GitHub page:
       # https://github.com/hazelcast/hazelcast-gcp
-      # This plugin is built into the main Hazelcast Jet JAR found in the
-      # distribution package.
+      # This plugin is included as a JAR in the distribution package.
       gcp:
         enabled: false
-        label: application=hazelcast-jet
+        label: application=hazelcast
         zones: us-east1-b,us-east1-c
       # Uses the Azure REST API to get a list of candidate IPs to check. For more
       # details go to the plugin's GitHub page:
       # https://github.com/hazelcast/hazelcast-azure
-      # This plugin is built into the main Hazelcast Jet JAR found in the
-      # distribution package.
+      # This plugin is included as a JAR in the distribution package.
       azure:
         enabled: false
         instance-metadata-available: false
@@ -78,12 +80,12 @@ hazelcast:
         resource-group: RESOURCE-GROUP-NAME
         scale-set: SCALE-SET-NAME
         use-public-ip: true
-    # Selectively opens some of Hazelcast Jet's REST API endpoints.
+    # Selectively opens some of Hazelcast's REST API endpoints.
     # The "jet-cluster-admin" command-line tool uses REST and you may get an
     # error message telling you which endpoint group you must enable for the
     # operation to be allowed. Here's the place to add it.
     rest-api:
-      enabled: true
+      enabled: false
       endpoint-groups:
         CLUSTER_READ:
           enabled: true
@@ -91,7 +93,7 @@ hazelcast:
           enabled: true
         CP:
           enabled: true
-  # Configures Jet's background collection of performance and health
+  # Configures Hazelcast's background collection of performance and health
   # monitoring metrics.
   metrics:
     enabled: true
@@ -102,9 +104,9 @@ hazelcast:
       enabled: true
     collection-frequency-seconds: 5
 
-  # Some features of Hazelcast Jet are configured through the system properties.
+  # Some features of Hazelcast are configured through the system properties.
   # You can configure the same properties here. This configuration overrides the
   # system properties. For a full list of recognized properties see
-  # https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties
+  # https://docs.hazelcast.com/imdg/latest/system-properties.html
 #  properties:
 #    property.name: value


### PR DESCRIPTION
This PR fixes the multicast port number in the `hazelcast.yaml`. It also updates some other leftovers after the Jet merge.

Original port number was used by Jet cluster discovery, the updated is the default for (former IMDG) Hazelcast clusters.