### PR TITLE
Ignore some CDC tests on JDK 16 too (not just 15)

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -60,7 +60,8 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Test
     public void mysql() throws Exception {
-        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623, " +
+                        "https://github.com/hazelcast/hazelcast/issues/18800",
                 System.getProperty("java.version").matches("^1[56].*"));
 
         MySQLContainer<?> container = mySqlContainer();
@@ -146,7 +147,8 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Test
     public void mysql_simpleJson() {
-        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623, " +
+                        "https://github.com/hazelcast/hazelcast/issues/18800",
                 System.getProperty("java.version").matches("^1[56].*"));
 
         MySQLContainer<?> container = mySqlContainer();

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -61,7 +61,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     @Test
     public void mysql() throws Exception {
         Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
-                System.getProperty("java.version").startsWith("15"));
+                System.getProperty("java.version").matches("^1[56].*"));
 
         MySQLContainer<?> container = mySqlContainer();
 
@@ -147,7 +147,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     @Test
     public void mysql_simpleJson() {
         Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
-                System.getProperty("java.version").startsWith("15"));
+                System.getProperty("java.version").matches("^1[56].*"));
 
         MySQLContainer<?> container = mySqlContainer();
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -50,9 +50,9 @@ public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegra
     );
 
     @Before
-    public void ignoreOnJdk15() {
+    public void ignoreOnJdk15OrHigher() {
         Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
-                System.getProperty("java.version").startsWith("15"));
+                System.getProperty("java.version").matches("^1[56].*"));
     }
 
     protected MySqlCdcSources.Builder sourceBuilder(String name) {

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -51,7 +51,8 @@ public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegra
 
     @Before
     public void ignoreOnJdk15OrHigher() {
-        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623, " +
+                        "https://github.com/hazelcast/hazelcast/issues/18800",
                 System.getProperty("java.version").matches("^1[56].*"));
     }
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -99,7 +99,8 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Before
     public void ignoreOnJdk15OrHigher() throws SQLException {
-        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623, " +
+                        "https://github.com/hazelcast/hazelcast/issues/18800",
                 System.getProperty("java.version").matches("^1[56].*"));
     }
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -98,9 +98,9 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
     }
 
     @Before
-    public void ignoreOnJdk15() throws SQLException {
+    public void ignoreOnJdk15OrHigher() throws SQLException {
         Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
-                System.getProperty("java.version").startsWith("15"));
+                System.getProperty("java.version").matches("^1[56].*"));
     }
 
     @After


### PR DESCRIPTION
There are some CDC tests that we ignore on JDK 15. They fail due to a JDK bug. Apparently the same bug persists in JDK 16 too, so we should ignore these tests in that situation too.

Fixes #18800

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
