### PR TITLE
Read, filter & project Kafka records in a single processor

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
@@ -37,6 +37,9 @@ import java.util.Properties;
  */
 public final class KafkaProcessors {
 
+    /**
+     * Preferred local parallelism for Kafka processors.
+     */
     public static final int PREFERRED_LOCAL_PARALLELISM = 4;
 
     private KafkaProcessors() {

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
@@ -37,7 +37,7 @@ import java.util.Properties;
  */
 public final class KafkaProcessors {
 
-    private static final int PREFERRED_LOCAL_PARALLELISM = 4;
+    public static final int PREFERRED_LOCAL_PARALLELISM = 4;
 
     private KafkaProcessors() {
     }

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
@@ -29,6 +29,8 @@ import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Properties;
 
+import static com.hazelcast.jet.kafka.impl.StreamKafkaP.PREFERRED_LOCAL_PARALLELISM;
+
 /**
  * Static utility class with factories of Apache Kafka source and sink
  * processors.
@@ -36,11 +38,6 @@ import java.util.Properties;
  * @since 3.0
  */
 public final class KafkaProcessors {
-
-    /**
-     * Preferred local parallelism for Kafka processors.
-     */
-    public static final int PREFERRED_LOCAL_PARALLELISM = 4;
 
     private KafkaProcessors() {
     }

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -82,7 +82,7 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
     private int processorIndex;
     private Traverser<Object> traverser = Traversers.empty();
 
-    StreamKafkaP(
+    public StreamKafkaP(
             @Nonnull Properties properties,
             @Nonnull List<String> topics,
             @Nonnull FunctionEx<? super ConsumerRecord<K, V>, ? extends T> projectionFn,

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -58,6 +58,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
 
+    public static final int PREFERRED_LOCAL_PARALLELISM = 4;
     private static final long METADATA_CHECK_INTERVAL_NANOS = SECONDS.toNanos(5);
     private static final String PARTITION_COUNTS_SNAPSHOT_KEY = "partitionCounts";
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SimpleExpressionEvalContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SimpleExpressionEvalContext.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.sql.impl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.execution.init.Contexts;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 
 import javax.annotation.Nonnull;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SimpleExpressionEvalContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SimpleExpressionEvalContext.java
@@ -19,13 +19,19 @@ package com.hazelcast.jet.sql.impl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.execution.init.Contexts;
+import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * An immutable and thread-safe context of a running query.
+ */
+@ThreadSafe
 public final class SimpleExpressionEvalContext implements ExpressionEvalContext {
 
     public static final String SQL_ARGUMENTS_KEY_NAME = "__sql.arguments";

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.kafka.KafkaProcessors;
+import com.hazelcast.jet.kafka.impl.StreamKafkaP;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadata;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataAvroResolver;
@@ -125,7 +126,7 @@ public class KafkaSqlConnector implements SqlConnector {
         return dag.newUniqueVertex(
                 table.toString(),
                 ProcessorMetaSupplier.of(
-                        KafkaProcessors.PREFERRED_LOCAL_PARALLELISM,
+                        StreamKafkaP.PREFERRED_LOCAL_PARALLELISM,
                         new RowProjectorProcessorSupplier(
                                 table.kafkaConsumerProperties(),
                                 table.topicName(),

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/RowProjectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/RowProjectorProcessorSupplier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.sql.impl.connector.kafka;
 
 import com.hazelcast.jet.core.EventTimePolicy;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/RowProjectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/RowProjectorProcessorSupplier.java
@@ -1,0 +1,109 @@
+package com.hazelcast.jet.sql.impl.connector.kafka;
+
+import com.hazelcast.jet.core.EventTimePolicy;
+import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.kafka.impl.StreamKafkaP;
+import com.hazelcast.jet.sql.impl.SimpleExpressionEvalContext;
+import com.hazelcast.jet.sql.impl.connector.keyvalue.KvRowProjector;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.extract.QueryPath;
+import com.hazelcast.sql.impl.extract.QueryTargetDescriptor;
+import com.hazelcast.sql.impl.type.QueryDataType;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import static java.util.Collections.singletonList;
+
+@SuppressFBWarnings(
+        value = {"SE_BAD_FIELD", "SE_NO_SERIALVERSIONID"},
+        justification = "the class is never java-serialized"
+)
+final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSerializable {
+
+    private Properties properties;
+    private String topic;
+    private EventTimePolicy<Object[]> eventTimePolicy;
+    private KvRowProjector.Supplier projectorSupplier;
+
+    private transient ExpressionEvalContext evalContext;
+    private transient Extractors extractors;
+
+    @SuppressWarnings("unused")
+    private RowProjectorProcessorSupplier() {
+    }
+
+    RowProjectorProcessorSupplier(
+            Properties properties,
+            String topic,
+            EventTimePolicy<Object[]> eventTimePolicy,
+            QueryPath[] paths,
+            QueryDataType[] types,
+            QueryTargetDescriptor keyDescriptor,
+            QueryTargetDescriptor valueDescriptor,
+            Expression<Boolean> predicate,
+            List<Expression<?>> projection
+    ) {
+        this.properties = properties;
+        this.topic = topic;
+        this.eventTimePolicy = eventTimePolicy;
+        this.projectorSupplier = KvRowProjector.supplier(
+                paths,
+                types,
+                keyDescriptor,
+                valueDescriptor,
+                predicate,
+                projection
+        );
+    }
+
+    @Override
+    public void init(@Nonnull Context context) {
+        evalContext = SimpleExpressionEvalContext.from(context);
+        extractors = Extractors.newBuilder(evalContext.getSerializationService()).build();
+    }
+
+    @Nonnull
+    @Override
+    public Collection<? extends Processor> get(int count) {
+        List<Processor> processors = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            KvRowProjector projector = projectorSupplier.get(evalContext, extractors);
+            Processor processor = new StreamKafkaP<>(
+                    properties,
+                    singletonList(topic),
+                    record -> projector.project(record.key(), record.value()),
+                    eventTimePolicy
+            );
+            processors.add(processor);
+        }
+        return processors;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(properties);
+        out.writeString(topic);
+        out.writeObject(projectorSupplier);
+        out.writeObject(eventTimePolicy);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        properties = in.readObject();
+        topic = in.readString();
+        projectorSupplier = in.readObject();
+        eventTimePolicy = in.readObject();
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjector.java
@@ -37,7 +37,7 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.jet.sql.impl.ExpressionUtil.evaluate;
 
 /**
- * An utility to convert a key-value entry to a row represented as
+ * A utility to convert a key-value entry to a row represented as
  * {@code Object[]}. As a convenience, it also contains a
  * {@link #predicate} - it is applied before projecting.
  * <p>

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjector.java
@@ -32,16 +32,14 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map.Entry;
 
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.jet.sql.impl.ExpressionUtil.evaluate;
 
 /**
- * A utility to convert a key-value entry represented as {@code
- * Entry<Object, Object>} to a row represented as {@code Object[]}. As a
- * convenience, it also contains a {@link #predicate} - it is applied
- * before projecting.
+ * An utility to convert a key-value entry to a row represented as
+ * {@code Object[]}. As a convenience, it also contains a
+ * {@link #predicate} - it is applied before projecting.
  * <p>
  * {@link KvProjector} does the reverse.
  */
@@ -94,9 +92,9 @@ public class KvRowProjector implements Row {
         return extractors;
     }
 
-    public Object[] project(Entry<Object, Object> entry) {
-        keyTarget.setTarget(entry.getKey(), null);
-        valueTarget.setTarget(entry.getValue(), null);
+    public Object[] project(Object key, Object value) {
+        keyTarget.setTarget(key, null);
+        valueTarget.setTarget(value, null);
 
         if (!Boolean.TRUE.equals(evaluate(predicate, this, evalContext))) {
             return null;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -143,7 +143,8 @@ public class IMapSqlConnector implements SqlConnector {
             @Nonnull DAG dag,
             @Nonnull Table table0,
             @Nullable Expression<Boolean> filter,
-            @Nonnull List<Expression<?>> projection) {
+            @Nonnull List<Expression<?>> projection
+    ) {
         PartitionedMapTable table = (PartitionedMapTable) table0;
         MapScanMetadata mapScanMetadata = new MapScanMetadata(
                 table.getMapName(),

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByEquiJoinProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByEquiJoinProcessorSupplier.java
@@ -167,7 +167,7 @@ final class JoinByEquiJoinProcessorSupplier implements ProcessorSupplier, DataSe
     ) {
         List<Object[]> rows = new ArrayList<>();
         for (Entry<Object, Object> entry : entries) {
-            Object[] right = rightRowProjector.project(entry);
+            Object[] right = rightRowProjector.project(entry.getKey(), entry.getValue());
             if (right == null) {
                 continue;
             }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByPrimitiveKeyProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByPrimitiveKeyProcessorSupplier.java
@@ -40,7 +40,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.jet.Traversers.singleton;
-import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.impl.util.Util.extendArray;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -129,7 +128,7 @@ final class JoinByPrimitiveKeyProcessorSupplier implements ProcessorSupplier, Da
             return null;
         }
 
-        Object[] right = rightRowProjector.project(entry(key, value));
+        Object[] right = rightRowProjector.project(key, value);
         if (right == null) {
             return null;
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
@@ -124,7 +124,7 @@ final class QueryUtil {
 
         @Override
         public Object[] transform(Entry<Object, Object> entry) {
-            return rightRowProjectorSupplier.get(evalContext, extractors).project(entry);
+            return rightRowProjectorSupplier.get(evalContext, extractors).project(entry.getKey(), entry.getValue());
         }
 
         @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
@@ -82,16 +82,16 @@ public class SqlPrimitiveTest extends SqlTestSupport {
         );
 
         String from = randomName();
-        TestBatchSqlConnector.create(sqlService, from, 2);
+        TestBatchSqlConnector.create(sqlService, from, 4);
 
         assertTopicEventually(
                 name,
                 "INSERT INTO " + name + " SELECT v, 'value-' || v FROM " + from,
-                createMap(0, "value-0", 1, "value-1")
+                createMap(0, "value-0", 1, "value-1", 2, "value-2", 3, "value-3")
         );
         assertRowsEventuallyInAnyOrder(
-                "SELECT * FROM " + name,
-                asList(new Row(0, "value-0"), new Row(1, "value-1"))
+                "SELECT * FROM " + name + " WHERE __key > 0 AND __key < 3",
+                asList(new Row(1, "value-1"), new Row(2, "value-2"))
         );
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvRowProjectorTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.sql.impl.ExpressionUtil.NOT_IMPLEMENTED_ARGUMENTS_CONTEXT;
 import static com.hazelcast.sql.impl.type.QueryDataType.BOOLEAN;
 import static com.hazelcast.sql.impl.type.QueryDataType.INT;
@@ -63,7 +62,7 @@ public class KvRowProjectorTest {
                 NOT_IMPLEMENTED_ARGUMENTS_CONTEXT
         );
 
-        Object[] row = projector.project(entry(1, 8));
+        Object[] row = projector.project(1, 8);
 
         assertThat(row).isEqualTo(new Object[]{2, 4});
     }
@@ -81,7 +80,7 @@ public class KvRowProjectorTest {
                 NOT_IMPLEMENTED_ARGUMENTS_CONTEXT
         );
 
-        Object[] row = projector.project(entry(1, 8));
+        Object[] row = projector.project(1, 8);
 
         assertThat(row).isNull();
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPrimitiveTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPrimitiveTest.java
@@ -77,18 +77,18 @@ public class SqlPrimitiveTest extends SqlTestSupport {
         sqlService.execute(javaSerializableMapDdl(name, Integer.class, String.class));
 
         String from = randomName();
-        TestBatchSqlConnector.create(sqlService, from, 2);
+        TestBatchSqlConnector.create(sqlService, from, 4);
 
         assertMapEventually(
                 name,
                 "SINK INTO " + name + " SELECT v, 'value-' || v FROM " + from,
-                createMap(0, "value-0", 1, "value-1")
+                createMap(0, "value-0", 1, "value-1", 2, "value-2", 3, "value-3")
         );
         assertRowsAnyOrder(
-                "SELECT * FROM " + name,
+                "SELECT * FROM " + name + " WHERE __key > 0 AND __key < 3",
                 asList(
-                        new Row(0, "value-0"),
-                        new Row(1, "value-1")
+                        new Row(1, "value-1"),
+                        new Row(2, "value-2")
                 )
         );
     }


### PR DESCRIPTION
To support watermarks from SQL we need the row (`Object[]`) to be accessible while applying event time policy.