### PR TITLE
Add includeValue support for MultiMap#addLocalEntryListener

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMultiMapProxy.java
@@ -330,6 +330,12 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
     @Nonnull
     @Override
+    public UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue) {
+        throw new UnsupportedOperationException("Locality for client is ambiguous");
+    }
+
+    @Nonnull
+    @Override
     public UUID addEntryListener(@Nonnull EntryListener<K, V> listener, final boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         ListenerAdapter listenerAdaptor = createListenerAdapter(listener);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -310,6 +310,9 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * If the key2 is owned by member2, then the local listener will be notified
      * for the add/update event. Also note that entries can migrate to other
      * nodes for load balancing and/or membership change.
+     * <p>
+     * Note that event will not contain value. To configure if event should contain value,
+     * use {@link #addLocalEntryListener(EntryListener, boolean)}
      *
      * @param listener entry listener for this multimap
      * @return returns registration ID for the entry listener
@@ -319,10 +322,9 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
     UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener);
 
     /**
-     * Adds a local entry listener for this multimap.
-     * <p>
-     * The listener will be notified for all multimap
-     * add/remove/update events.
+     * {@link #addLocalEntryListener(EntryListener)}
+     * Adds a local entry listener with ability to configure if event should contain the value
+     * for this multimap.
      *
      * @param listener     entry listener for this multimap
      * @param includeValue {@code true} if {@code EntryEvent} should contain the value,

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -319,6 +319,20 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
     UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener);
 
     /**
+     * Adds a local entry listener for this multimap.
+     * <p>
+     * The listener will be notified for all multimap
+     * add/remove/update events.
+     *
+     * @param listener     entry listener for this multimap
+     * @param includeValue {@code true} if {@code EntryEvent} should contain the value,
+     *                     {@code false} otherwise
+     * @return returns registration ID for the entry listener
+     */
+    @Nonnull
+    UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue);
+
+    /**
      * Adds an entry listener for this multimap.
      * <p>
      * The listener will be notified for all multimap

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -330,6 +330,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param includeValue {@code true} if {@code EntryEvent} should contain the value,
      *                     {@code false} otherwise
      * @return returns registration ID for the entry listener
+     * @since 5.0
      */
     @Nonnull
     UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java
@@ -330,7 +330,7 @@ public interface MultiMap<K, V> extends BaseMultiMap<K, V> {
      * @param includeValue {@code true} if {@code EntryEvent} should contain the value,
      *                     {@code false} otherwise
      * @return returns registration ID for the entry listener
-     * @since 5.0
+     * @since 5.1
      */
     @Nonnull
     UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
@@ -280,6 +280,13 @@ public class MultiMapProxyImpl<K, V>
 
     @Nonnull
     @Override
+    public UUID addLocalEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue) {
+        checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        return getService().addLocalListener(name, listener, null, includeValue);
+    }
+
+    @Nonnull
+    @Override
     public UUID addEntryListener(@Nonnull EntryListener<K, V> listener, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         return getService().addListener(name, listener, null, includeValue);

--- a/hazelcast/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
@@ -78,6 +78,13 @@ public class ClientMultiMapListenersTest {
         mm.addLocalEntryListener(myEntryListener);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAddLocalEntryListener_whenValueIncluded() {
+        final MultiMap mm = client.getMultiMap(randomString());
+        MyEntryListener myEntryListener = new CountDownValueNotNullListener(1);
+        mm.addLocalEntryListener(myEntryListener, true);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testAddListener_whenListenerNull() throws InterruptedException {
         final MultiMap mm = client.getMultiMap(randomString());

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapListenerTest.java
@@ -63,6 +63,43 @@ public class MultiMapListenerTest extends HazelcastTestSupport {
         multiMap.addEntryListener(null, true);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testNullLocalEntryListener_whenValueIncluded() {
+        MultiMap<String, String> multiMap = createHazelcastInstance().getMultiMap(randomString());
+        multiMap.addLocalEntryListener(null, true);
+    }
+
+    @Test
+    public void testLocalListenerEntryAddEvent_whenValueIncluded() {
+        int maxKeys = 12;
+        int maxItems = 3;
+        MultiMap<Object, Object> multiMap = createHazelcastInstance().getMultiMap(randomString());
+        MyEntryListener listener = new CountDownValueNotNullListener(maxKeys * maxItems);
+        multiMap.addLocalEntryListener(listener, true);
+        for (int i = 0; i < maxKeys; i++) {
+            for (int j = 0; j < maxItems; j++) {
+                multiMap.put(i, j);
+            }
+        }
+        assertOpenEventually(listener.addLatch);
+    }
+
+    @Test
+    public void testLocalListenerEntryRemoveEvent_whenValueIncluded() {
+        int maxKeys = 12;
+        int maxItems = 3;
+        MultiMap<Object, Object> multiMap = createHazelcastInstance().getMultiMap(randomString());
+        MyEntryListener listener = new CountDownValueNotNullListener(maxKeys * maxItems);
+        multiMap.addLocalEntryListener(listener, true);
+        for (int i = 0; i < maxKeys; i++) {
+            for (int j = 0; j < maxItems; j++) {
+                multiMap.put(i, j);
+                multiMap.remove(i);
+            }
+        }
+        assertOpenEventually(listener.removeLatch);
+    }
+
     @Test
     public void testRemoveListener() {
         MultiMap<Object, Object> multiMap = createHazelcastInstance().getMultiMap(randomString());


### PR DESCRIPTION
Enabled includeValue support for Multimap#addLocalEntryListener, implemented listner in MultiMapProxyImpl and ClientMultiMapProxy.

Fixes #18548

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
