### PR TITLE
Move the hazelcast.multicast.group system property to ClusterProperty class

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -54,11 +54,6 @@ import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 public final class MulticastService implements Runnable {
 
-    /**
-     * IP address of a multicast group. If not set, configuration is read from the {@link MulticastConfig} configuration.
-     */
-    public static final String SYSTEM_PROPERTY_MULTICAST_GROUP = "hazelcast.multicast.group";
-
     private static final int SEND_OUTPUT_SIZE = 1024;
     private static final int DATAGRAM_BUFFER_SIZE = 64 * 1024;
     private static final int SOCKET_BUFFER_SIZE = 64 * 1024;
@@ -166,7 +161,7 @@ public final class MulticastService implements Runnable {
         }
         multicastSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         multicastSocket.setSendBufferSize(SOCKET_BUFFER_SIZE);
-        String multicastGroup = System.getProperty(SYSTEM_PROPERTY_MULTICAST_GROUP);
+        String multicastGroup = hzProperties.getString(ClusterProperty.MULTICAST_GROUP);
         if (multicastGroup == null) {
             multicastGroup = multicastConfig.getMulticastGroup();
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -51,7 +51,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Defines the name and default value for Hazelcast properties.
  */
-@SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:magicnumber"})
+@SuppressWarnings({"checkstyle:magicnumber"})
 public final class ClusterProperty {
     /*
      * NETWORKING / TCP PROPERTIES
@@ -383,6 +383,13 @@ public final class ClusterProperty {
      */
     public static final HazelcastProperty MULTICAST_SOCKET_SET_INTERFACE
             = new HazelcastProperty("hazelcast.multicast.socket.set.interface");
+
+    /**
+     * IP address of a multicast group. If not set, then the configuration is read from the
+     * {@link com.hazelcast.config.MulticastConfig} configuration.
+     */
+    public static final HazelcastProperty MULTICAST_GROUP
+            = new HazelcastProperty("hazelcast.multicast.group");
 
     /**
      * Timeout to connect all other cluster members when a member is joining to a cluster.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -44,7 +44,6 @@ import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
-import com.hazelcast.internal.cluster.impl.MulticastService;
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -67,7 +66,7 @@ public class MulticastDeserializationTest {
 
     @Rule
     public OverridePropertyRule multicastGroupOverride = OverridePropertyRule
-            .clear(MulticastService.SYSTEM_PROPERTY_MULTICAST_GROUP);
+            .clear(ClusterProperty.MULTICAST_GROUP.getName());
 
     @Before
     public void before() {

--- a/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
@@ -21,14 +21,11 @@ import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
-import com.hazelcast.internal.cluster.impl.MulticastService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -54,10 +51,6 @@ public class MulticastLoopbackModeTest extends HazelcastTestSupport {
 
     private HazelcastInstance hz1;
     private HazelcastInstance hz2;
-
-    @Rule
-    public OverridePropertyRule multicastGroupOverride = OverridePropertyRule
-            .clear(MulticastService.SYSTEM_PROPERTY_MULTICAST_GROUP);
 
     @Before
     public void setUpTests() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MulticastServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MulticastServiceTest.java
@@ -116,6 +116,22 @@ public class MulticastServiceTest {
         verify(multicastSocket).joinGroup(InetAddress.getByName(multicastConfig.getMulticastGroup()));
     }
 
+    @Test
+    public void testMulticastGroupProperty() throws Exception {
+        Config config = createConfig(null);
+        String customMulticastGroup = "225.225.225.225";
+        config.setProperty(ClusterProperty.MULTICAST_GROUP.getName(), customMulticastGroup);
+        MulticastConfig multicastConfig = config.getNetworkConfig().getJoin().getMulticastConfig();
+        MulticastSocket multicastSocket = mock(MulticastSocket.class);
+        Address address = new Address("10.0.0.2",  5701);
+        HazelcastProperties hzProperties = new HazelcastProperties(config);
+        MulticastService.configureMulticastSocket(multicastSocket, address, hzProperties , multicastConfig, mock(ILogger.class));
+        verify(multicastSocket).bind(new InetSocketAddress(multicastConfig.getMulticastPort()));
+        verify(multicastSocket).setTimeToLive(multicastConfig.getMulticastTimeToLive());
+        verify(multicastSocket).setLoopbackMode(!multicastConfig.isLoopbackModeEnabled());
+        verify(multicastSocket).joinGroup(InetAddress.getByName(customMulticastGroup));
+    }
+
     private Config createConfig(Boolean callSetInterface) {
         Config config = new Config();
         if (callSetInterface != null) {


### PR DESCRIPTION
This PR aligns handling of `hazelcast.multicast.group` property to other Hazelcast properties.

The property `hazelcast.multicast.group` configuration was only possible through system properties. The other standard way through Hazelcast properties was not possible. This PR fixes it.
