### PR TITLE
Update LICENSE badge used in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hazelcast
 
 [![Slack](https://img.shields.io/badge/slack-chat-green.svg)](https://slack.hazelcast.com/) 
-[![GitHub](https://img.shields.io/github/license/hazelcast/Hazelcast.svg)](https://github.com/hazelcast/Hazelcast/blob/master/LICENSE)
+[![GitHub](https://img.shields.io/badge/license-Apache--2.0-green)](https://github.com/hazelcast/Hazelcast/blob/master/LICENSE)
 [![javadoc](https://javadoc.io/badge2/com.hazelcast/hazelcast/4.0/javadoc.svg)](https://javadoc.io/doc/com.hazelcast/hazelcast/4.0)
 [![Docker pulls](https://img.shields.io/docker/pulls/hazelcast/hazelcast)](https://img.shields.io/docker/pulls/hazelcast/hazelcast)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/hazelcast/hazelcast.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hazelcast/hazelcast/alerts)


### PR DESCRIPTION
Since we changed the contents of the LICENSE file, Github is
unable to identify the license we use. Hence, the badge
showing the license is not being displayed correctly.

Since we say that

```
The default license throughout the repository is Apache License 2.0
unless the header specifies another license.
```

I believe, it would be OK to display the license as Apache-2.0
in the badge.

This PR changes the badge we use for LICENSE information with
a custom one that is identical to a one that a repo with
an identifiable Apache License Version 2.0 would get.
