### PR TITLE
Change the internal locale to the language neutral one (Locale.ROOT)

### DIFF
--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHdfsMetaSupplierBase.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHdfsMetaSupplierBase.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static java.util.Collections.emptyList;
@@ -204,6 +205,6 @@ public abstract class ReadHdfsMetaSupplierBase<R> implements ProcessorMetaSuppli
         if (hostName == null) {
             return false;
         }
-        return splitLocations.stream().anyMatch(hostName::equalsIgnoreCase);
+        return splitLocations.stream().anyMatch(l -> equalsIgnoreCase(l, hostName));
     }
 }

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -40,6 +40,9 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Time;
+
+import com.hazelcast.internal.util.StringUtil;
+
 import scala.Option;
 import scala.collection.Seq;
 
@@ -146,7 +149,7 @@ public class KafkaTestSupport {
     }
 
     private static boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase().contains("windows");
+        return StringUtil.lowerCaseInternal(System.getProperty("os.name")).contains("windows");
     }
 
     public void createTopic(String topicId, int partitionCount) {

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceConfig.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceConfig.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.StringJoiner;
 
 /**
@@ -188,7 +189,7 @@ public class PythonServiceConfig implements Serializable {
                     "You already set handlerModule, it would be overwritten by setting handlerFile");
         }
         String handlerFileStr = requireNonBlank(handlerFile, "handlerFile");
-        if (!handlerFileStr.toLowerCase().endsWith(".py")) {
+        if (!handlerFileStr.toLowerCase(Locale.ROOT).endsWith(".py")) {
             throw new IllegalArgumentException("The handler file must be a .py file");
         }
         try {

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -250,7 +251,7 @@ class PythonServiceContext {
 
     private static void createParamsScript(@Nonnull Path paramsFile, String... namesAndVals) throws IOException {
         try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(paramsFile))) {
-            String jetToPython = JET_TO_PYTHON_PREFIX.toUpperCase();
+            String jetToPython = JET_TO_PYTHON_PREFIX.toUpperCase(Locale.ROOT);
             for (int i = 0; i < namesAndVals.length; i += 2) {
                 String name = namesAndVals[i];
                 String value = namesAndVals[i + 1];

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -95,7 +96,7 @@ public class HazelcastManifestTransformer extends ManifestResourceTransformer {
 
     @Override
     public boolean canTransformResource(String resource) {
-        return JarFile.MANIFEST_NAME.equalsIgnoreCase(resource);
+        return JarFile.MANIFEST_NAME.equals(resource.toUpperCase(Locale.ROOT));
     }
 
     @Override
@@ -372,7 +373,7 @@ public class HazelcastManifestTransformer extends ManifestResourceTransformer {
         private boolean findResolutionConstraint(String[] tokens) {
             for (String token : tokens) {
                 if (token.startsWith(RESOLUTION_PREFIX)) {
-                    return token.equalsIgnoreCase("resolution:=optional");
+                    return token.toLowerCase(Locale.ROOT).equals("resolution:=optional");
                 }
             }
             return false;

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/jet/JetSpringServiceFactories.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/jet/JetSpringServiceFactories.java
@@ -46,7 +46,7 @@ public final class JetSpringServiceFactories {
      * Pipeline pipeline = Pipeline.create();
      * pipeline.<String>readFrom(Sources.list(LIST_NAME))
      *         .mapUsingService(JetSpringServiceFactories.bean("userDao", UserDao.class),
-     *                 (userDao, item) -> userDao.findByName(item.toLowerCase()))
+     *                 (userDao, item) -> userDao.findByName(item.toLowerCase(Locale.ROOT)))
      *         .writeTo(Sinks.logger());
      * }</pre>
      *
@@ -71,7 +71,7 @@ public final class JetSpringServiceFactories {
      * Pipeline pipeline = Pipeline.create();
      * pipeline.<String>readFrom(Sources.list(LIST_NAME))
      *         .mapUsingService(JetSpringServiceFactories.bean(UserDao.class),
-     *                 (userDao, item) -> userDao.findByName(item.toLowerCase()))
+     *                 (userDao, item) -> userDao.findByName(item.toLowerCase(Locale.ROOT)))
      *         .writeTo(Sinks.logger());
      * }</pre>
      *
@@ -95,7 +95,7 @@ public final class JetSpringServiceFactories {
      * Pipeline pipeline = Pipeline.create();
      * pipeline.<String>readFrom(Sources.list(LIST_NAME))
      *         .mapUsingService(JetSpringServiceFactories.bean("userDao"),
-     *                 (userDao, item) -> userDao.findByName(item.toLowerCase()))
+     *                 (userDao, item) -> userDao.findByName(item.toLowerCase(Locale.ROOT)))
      *         .writeTo(Sinks.logger());
      * }</pre>
      *

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeUtils.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static org.apache.calcite.sql.type.SqlTypeFamily.INTERVAL_DAY_TIME;
 import static org.apache.calcite.sql.type.SqlTypeName.DAY_INTERVAL_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.INTERVAL_DAY_SECOND;
@@ -139,7 +140,7 @@ public final class HazelcastTypeUtils {
     }
 
     public static boolean isObjectIdentifier(SqlIdentifier identifier) {
-        return identifier.isSimple() && SqlColumnType.OBJECT.name().equalsIgnoreCase(identifier.getSimple());
+        return identifier.isSimple() && equalsIgnoreCase(SqlColumnType.OBJECT.name(), identifier.getSimple());
     }
 
     /**

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.sql;
 
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
@@ -236,7 +237,7 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
     }
 
     public static String hadoopNonExistingPath() {
-        return System.getProperty("os.name").toLowerCase().contains("windows")
+        return StringUtil.lowerCaseInternal(System.getProperty("os.name")).contains("windows")
                 ? "c:\\non\\existing\\path"
                 : "/non/existing/path";
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.fail;
 
@@ -468,12 +469,12 @@ public class NestingAndCasingExpressionTest extends ExpressionTestSupport {
 
     private void check(String sql, Object... params) {
         checkValue0(sql, SqlColumnType.VARCHAR, SKIP_VALUE_CHECK, params);
-        checkValue0(sql.toLowerCase(), SqlColumnType.VARCHAR, SKIP_VALUE_CHECK, params);
+        checkValue0(lowerCaseInternal(sql), SqlColumnType.VARCHAR, SKIP_VALUE_CHECK, params);
     }
 
     private void check(String sql, SqlColumnType type, Object... params) {
         checkValue0(sql, type, SKIP_VALUE_CHECK, params);
-        checkValue0(sql.toLowerCase(), type, SKIP_VALUE_CHECK, params);
+        checkValue0(lowerCaseInternal(sql), type, SKIP_VALUE_CHECK, params);
     }
 
     private String sql(String expression) {

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -68,6 +68,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static java.lang.String.format;
 import static java.lang.Thread.currentThread;
@@ -318,7 +319,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             handleSetRemoveMany(args);
         } else if (first.equals("m.replace")) {
             handleMapReplace(args);
-        } else if (first.equalsIgnoreCase("m.putIfAbsent")) {
+        } else if (equalsIgnoreCase(first, "m.putIfAbsent")) {
             handleMapPutIfAbsent(args);
         } else if (first.equals("m.putAsync")) {
             handleMapPutAsync(args);
@@ -328,7 +329,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             handleMapPut(args);
         } else if (first.equals("m.get")) {
             handleMapGet(args);
-        } else if (first.equalsIgnoreCase("m.getMapEntry")) {
+        } else if (equalsIgnoreCase(first, "m.getMapEntry")) {
             handleMapGetMapEntry(args);
         } else if (first.equals("m.remove")) {
             handleMapRemove(args);
@@ -336,15 +337,15 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             handleMapDelete(args);
         } else if (first.equals("m.evict")) {
             handleMapEvict(args);
-        } else if (first.equals("m.putmany") || first.equalsIgnoreCase("m.putAll")) {
+        } else if (first.equals("m.putmany") || equalsIgnoreCase(first, "m.putAll")) {
             handleMapPutMany(args);
         } else if (first.equals("m.getmany")) {
             handleMapGetMany(args);
         } else if (first.equals("m.removemany")) {
             handleMapRemoveMany(args);
-        } else if (command.equalsIgnoreCase("m.localKeys")) {
+        } else if (equalsIgnoreCase(command, "m.localKeys")) {
             handleMapLocalKeys();
-        } else if (command.equalsIgnoreCase("m.localSize")) {
+        } else if (equalsIgnoreCase(command, "m.localSize")) {
             handleMapLocalSize();
         } else if (command.equals("m.keys")) {
             handleMapKeys();
@@ -354,7 +355,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             handleMapEntries();
         } else if (first.equals("m.lock")) {
             handleMapLock(args);
-        } else if (first.equalsIgnoreCase("m.tryLock")) {
+        } else if (equalsIgnoreCase(first, "m.tryLock")) {
             handleMapTryLock(args);
         } else if (first.equals("m.unlock")) {
             handleMapUnlock(args);
@@ -376,7 +377,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             handleMultiMapEntries();
         } else if (first.equals("mm.lock")) {
             handleMultiMapLock(args);
-        } else if (first.equalsIgnoreCase("mm.tryLock")) {
+        } else if (equalsIgnoreCase(first, "mm.tryLock")) {
             handleMultiMapTryLock(args);
         } else if (first.equals("mm.unlock")) {
             handleMultiMapUnlock(args);
@@ -402,25 +403,15 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             execute(args);
         } else if (first.equals("partitions")) {
             handlePartitions(args);
-//        } else if (first.equals("txn")) {
-//            hazelcast.getTransaction().begin();
-//        } else if (first.equals("commit")) {
-//            hazelcast.getTransaction().commit();
-//        } else if (first.equals("rollback")) {
-//            hazelcast.getTransaction().rollback();
-        } else if (first.equalsIgnoreCase("executeOnKey")) {
+        } else if (equalsIgnoreCase(first, "executeOnKey")) {
             executeOnKey(args);
-        } else if (first.equalsIgnoreCase("executeOnMember")) {
+        } else if (equalsIgnoreCase(first, "executeOnMember")) {
             executeOnMember(args);
-        } else if (first.equalsIgnoreCase("executeOnMembers")) {
+        } else if (equalsIgnoreCase(first, "executeOnMembers")) {
             executeOnMembers(args);
-            // } else if (first.equalsIgnoreCase("longOther") || first.equalsIgnoreCase("executeLongOther")) {
-            //     executeLongTaskOnOtherMember(args);
-            //} else if (first.equalsIgnoreCase("long") || first.equalsIgnoreCase("executeLong")) {
-            //    executeLong(args);
-        } else if (first.equalsIgnoreCase("instances")) {
+        } else if (equalsIgnoreCase(first, "instances")) {
             handleInstances(args);
-        } else if (first.equalsIgnoreCase("quit") || first.equalsIgnoreCase("exit")) {
+        } else if (equalsIgnoreCase(first, "quit") || equalsIgnoreCase(first, "exit")) {
             System.exit(0);
         } else if (first.startsWith("e") && first.endsWith(".simulateLoad")) {
             handleExecutorSimulate(args);
@@ -952,13 +943,13 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         String lockStr = args[0];
         String key = args[1];
         Lock lock = hazelcast.getCPSubsystem().getLock(key);
-        if (lockStr.equalsIgnoreCase("lock")) {
+        if (equalsIgnoreCase(lockStr, "lock")) {
             lock.lock();
             println("true");
-        } else if (lockStr.equalsIgnoreCase("unlock")) {
+        } else if (equalsIgnoreCase(lockStr, "unlock")) {
             lock.unlock();
             println("true");
-        } else if (lockStr.equalsIgnoreCase("trylock")) {
+        } else if (equalsIgnoreCase(lockStr, "trylock")) {
             String timeout = args.length > 2 ? args[2] : null;
             if (timeout == null) {
                 println(lock.tryLock());

--- a/hazelcast/src/main/java/com/hazelcast/config/BitmapIndexOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/BitmapIndexOptions.java
@@ -94,7 +94,7 @@ public class BitmapIndexOptions implements IdentifiedDataSerializable {
                 throw new IllegalArgumentException("empty unique key transformation");
             }
 
-            String upperCasedText = name.toUpperCase();
+            String upperCasedText = StringUtil.upperCaseInternal(name);
             if (upperCasedText.equals(OBJECT.name)) {
                 return OBJECT;
             }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -83,6 +83,7 @@ import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkState;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableCollection;
@@ -479,7 +480,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     }
 
     public CPGroupSummary createRaftGroup(String groupName, Collection<RaftEndpoint> groupEndpoints, long groupId) {
-        checkFalse(METADATA_CP_GROUP_NAME.equalsIgnoreCase(groupName), groupName + " is reserved for internal usage!");
+        checkFalse(equalsIgnoreCase(METADATA_CP_GROUP_NAME, groupName), groupName + " is reserved for internal usage!");
         checkMetadataGroupInitSuccessful();
 
         // keep configuration on every metadata node
@@ -640,7 +641,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
     public void forceDestroyRaftGroup(String groupName) {
         checkNotNull(groupName);
-        checkFalse(METADATA_CP_GROUP_NAME.equalsIgnoreCase(groupName), "Cannot force-destroy the METADATA CP group!");
+        checkFalse(equalsIgnoreCase(METADATA_CP_GROUP_NAME, groupName), "Cannot force-destroy the METADATA CP group!");
         checkMetadataGroupInitSuccessful();
 
         boolean found = false;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -143,6 +143,7 @@ import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkState;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.UuidUtil.newUnsecureUUID;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
 import static com.hazelcast.spi.impl.executionservice.ExecutionService.SYSTEM_EXECUTOR;
@@ -1050,7 +1051,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
 
         checkTrue(name.indexOf("@", i + 1) == -1, "Custom group name must be specified at most once");
         String groupName = name.substring(i + 1).trim();
-        if (groupName.equalsIgnoreCase(DEFAULT_GROUP_NAME)) {
+        if (equalsIgnoreCase(groupName, DEFAULT_GROUP_NAME)) {
             return name.substring(0, i);
         }
 
@@ -1068,8 +1069,9 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
         checkTrue(name.indexOf("@", i + 1) == -1, "Custom group name must be specified at most once");
         String groupName = name.substring(i + 1).trim();
         checkTrue(groupName.length() > 0, "Custom CP group name cannot be empty string");
-        checkFalse(groupName.equalsIgnoreCase(METADATA_CP_GROUP_NAME), "CP data structures cannot run on the METADATA CP group!");
-        return groupName.equalsIgnoreCase(DEFAULT_GROUP_NAME) ? DEFAULT_GROUP_NAME : groupName;
+        checkFalse(equalsIgnoreCase(groupName, METADATA_CP_GROUP_NAME),
+                "CP data structures cannot run on the METADATA CP group!");
+        return equalsIgnoreCase(groupName, DEFAULT_GROUP_NAME) ? DEFAULT_GROUP_NAME : groupName;
     }
 
     public static String getObjectNameForProxy(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -45,6 +45,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 
 @SuppressWarnings({"checkstyle:methodcount"})
 public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand> {
@@ -370,7 +371,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         String queueName = uri.substring(URI_QUEUES.length(), indexEnd);
         String secondStr = (uri.length() > (indexEnd + 1)) ? uri.substring(indexEnd + 1) : null;
 
-        if (QUEUE_SIZE_COMMAND.equalsIgnoreCase(secondStr)) {
+        if (equalsIgnoreCase(QUEUE_SIZE_COMMAND, secondStr)) {
             int size = textCommandService.size(queueName);
             prepareResponse(command, Integer.toString(size));
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
@@ -28,6 +28,7 @@ import org.xml.sax.helpers.DefaultHandler;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -98,7 +99,7 @@ public class AbstractXmlConfigRootTagRecognizer implements ConfigRecognizer {
 
         @Override
         public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-            if (expectedRootNode.equalsIgnoreCase(qName)) {
+            if (equalsIgnoreCase(expectedRootNode, qName)) {
                 isMemberXml = true;
             }
             throw new TerminateParseException();

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DeclarativeConfigUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DeclarativeConfigUtil.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.config;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -140,7 +141,7 @@ public final class DeclarativeConfigUtil {
      * the accepted list, {@code false} otherwise
      */
     public static boolean isAcceptedSuffixConfigured(String configFile, Collection<String> acceptedSuffixes) {
-        String configFileLower = configFile.toLowerCase();
+        String configFileLower = StringUtil.lowerCaseInternal(configFile);
         int lastDotIndex = configFileLower.lastIndexOf('.');
         if (lastDotIndex == -1) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -219,6 +219,7 @@ import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getDoubleValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getLongValue;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
@@ -1221,7 +1222,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     private static Method getMethod(Object target, String methodName, boolean requiresArg) {
         Method[] methods = target.getClass().getMethods();
         for (Method method : methods) {
-            if (method.getName().equalsIgnoreCase(methodName)) {
+            if (equalsIgnoreCase(method.getName(), methodName)) {
                 if (!requiresArg) {
                     return method;
                 }
@@ -1252,6 +1253,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             if (c == '_' || c == '-' || c == '.') {
                 upper = true;
             } else if (upper) {
+                // Character.toUpperCase is not Locale dependant, so we're safe here.
                 sb.append(Character.toUpperCase(c));
                 upper = false;
             } else {
@@ -1360,7 +1362,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         NamedNodeMap attributes = node.getAttributes();
         for (int a = 0; a < attributes.getLength(); a++) {
             Node att = attributes.item(a);
-            if (matches("enabled", att.getNodeName().toLowerCase())) {
+            if (matches("enabled", lowerCaseInternal(att.getNodeName()))) {
                 config.setEnabled(getBooleanValue(getTextContent(att)));
             } else if (matches(att.getNodeName(), "connection-timeout-seconds")) {
                 config.setProperty("connection-timeout-seconds", getTextContent(att));

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/EnvVariablesConfigParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/EnvVariablesConfigParser.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.hazelcast.internal.util.StringUtil;
+
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -53,10 +55,9 @@ class EnvVariablesConfigParser {
     }
 
     private String processKey(Map.Entry<String, String> e) {
-        return e.getKey()
+        return StringUtil.lowerCaseInternal(e.getKey()
           .replaceFirst(prefix, rootNode + ".")
           .replace("_", ".")
-          .replace(" ", "")
-          .toLowerCase();
+          .replace(" ", ""));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/PropertiesToNodeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/PropertiesToNodeConverter.java
@@ -18,6 +18,8 @@ package com.hazelcast.internal.config.override;
 
 import com.hazelcast.config.InvalidConfigurationException;
 
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,7 +59,7 @@ final class PropertiesToNodeConverter {
 
     private static void parseEntry(String key, String value, ConfigNode root) {
         ConfigNode last = root;
-        for (String s : key.toLowerCase().split("\\.")) {
+        for (String s : lowerCaseInternal(key).split("\\.")) {
             ConfigNode node = last.getChildren().get(s);
             if (node == null) {
                 node = new ConfigNode(s, last);

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/SystemPropertiesConfigParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/SystemPropertiesConfigParser.java
@@ -19,6 +19,8 @@ import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Properties;
 
+import com.hazelcast.internal.util.StringUtil;
+
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -50,9 +52,8 @@ class SystemPropertiesConfigParser {
     }
 
     private String processKey(AbstractMap.SimpleEntry<String, String> e) {
-        return e.getKey()
+        return StringUtil.lowerCaseInternal(e.getKey()
           .replace(" ", "")
-          .replaceFirst(prefix, rootNode + ".")
-          .toLowerCase();
+          .replaceFirst(prefix, rootNode + "."));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricDescriptorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricDescriptorImpl.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -223,7 +224,7 @@ public final class MetricDescriptorImpl implements MetricDescriptor {
         }
 
         if (unit != null) {
-            sb.append("unit=").append(unit.name().toLowerCase()).append(',');
+            sb.append("unit=").append(lowerCaseInternal(unit.name())).append(',');
         }
 
         if (metric != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -46,10 +46,9 @@ public final class StringUtil {
 
     /**
      * LOCALE_INTERNAL is the default locale for string operations and number formatting. Initialized to
-     * {@code java.util.Locale.US} (US English).
+     * {@code java.util.Locale.ROOT} (language neutral).
      */
-    //TODO Use java.util.Locale#ROOT value (language neutral) in Hazelcast 4
-    public static final Locale LOCALE_INTERNAL = Locale.US;
+    public static final Locale LOCALE_INTERNAL = Locale.ROOT;
 
     /**
      * Pattern used to tokenize version strings.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadAffinityHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadAffinityHelper.java
@@ -28,6 +28,7 @@ import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.internal.nio.IOUtil.copy;
 import static com.hazelcast.internal.nio.IOUtil.getFileFromResourcesAsStream;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 
 /**
  * Affinity helper class that uses a Hazelcast developed affinity
@@ -117,7 +118,7 @@ public final class ThreadAffinityHelper {
 
     static {
         boolean hzAffinityLibLoaded = false;
-        boolean libDisabled = "true".equalsIgnoreCase(System.getProperty(AFFINITY_LIB_DISABLED));
+        boolean libDisabled = equalsIgnoreCase("true", System.getProperty(AFFINITY_LIB_DISABLED));
         if (!libDisabled && OsHelper.isLinux() && !JVMUtil.is32bitJVM()) {
             try {
                 System.load(extractBundledLib());

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/DAG.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/DAG.java
@@ -428,7 +428,7 @@ public class DAG implements IdentifiedDataSerializable, Iterable<Vertex> {
             edge.add("toOrdinal", e.getDestOrdinal());
             edge.add("priority", e.getPriority());
             edge.add("distributedTo", String.valueOf(e.getDistributedTo()));
-            edge.add("type", e.getRoutingPolicy().toString().toLowerCase());
+            edge.add("type", StringUtil.lowerCaseInternal(e.getRoutingPolicy().toString()));
             edges.add(edge);
         }
         dag.add("edges", edges);
@@ -531,7 +531,7 @@ public class DAG implements IdentifiedDataSerializable, Iterable<Vertex> {
             labels.add("distributed to " + e.getDistributedTo());
         }
         if (e.getRoutingPolicy() != RoutingPolicy.UNICAST) {
-            labels.add(e.getRoutingPolicy().toString().toLowerCase());
+            labels.add(StringUtil.lowerCaseInternal(e.getRoutingPolicy().toString()));
         }
         return String.join("-", labels);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -150,7 +150,7 @@ import static java.util.stream.Collectors.toMap;
  * <h3>Example usage</h3>
  * This will test one of the jet-provided processors:
  * <pre>{@code
- * TestSupport.verifyProcessor(Processors.map((String s) -> s.toUpperCase()))
+ * TestSupport.verifyProcessor(Processors.map((String s) -> s.toUpperCase(Locale.ROOT)))
  *            .disableCompleteCall()             // enabled by default
  *            .disableLogging()                  // enabled by default
  *            .disableProgressAssertion()        // enabled by default

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -77,6 +77,7 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.jet.Util.idFromString;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.IOUtil.fileNameFromUrl;
@@ -284,7 +285,7 @@ public class JobRepository {
                 if (zipEntry.isDirectory()) {
                     continue;
                 }
-                if (zipEntry.getName().toLowerCase().endsWith(".jar")) {
+                if (lowerCaseInternal(zipEntry.getName()).endsWith(".jar")) {
                     loadJarFromInputStream(map, zis);
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -73,7 +73,7 @@ public interface GeneralStage<T> extends Stage {
      * <p>
      * This sample takes a stream of names and outputs the names in lowercase:
      * <pre>{@code
-     * stage.map(name -> name.toLowerCase())
+     * stage.map(name -> name.toLowerCase(Locale.ROOT))
      * }</pre>
      *
      * @param mapFn a mapping function. It must be stateless and {@linkplain

--- a/hazelcast/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
@@ -105,6 +105,7 @@ import java.util.logging.LogManager;
 
 import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.internal.util.StringUtil.trim;
 import static com.hazelcast.jet.Util.idToString;
@@ -247,16 +248,16 @@ public class JetCommandLine implements Runnable {
                 if ("".equals(command)) {
                     continue;
                 }
-                if ("clear".equalsIgnoreCase(command)) {
+                if (equalsIgnoreCase("clear", command)) {
                     reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
                     continue;
                 }
-                if ("help".equalsIgnoreCase(command)) {
+                if (equalsIgnoreCase("help", command)) {
                     writer.println(helpPrompt(jet));
                     writer.flush();
                     continue;
                 }
-                if ("history".equalsIgnoreCase(command)) {
+                if (equalsIgnoreCase("history", command)) {
                     History hist = reader.getHistory();
                     ListIterator<History.Entry> iterator = hist.iterator();
                     while (iterator.hasNext()) {
@@ -278,7 +279,7 @@ public class JetCommandLine implements Runnable {
                     }
                     continue;
                 }
-                if ("exit".equalsIgnoreCase(command)) {
+                if (equalsIgnoreCase("exit", command)) {
                     writer.println(SQLCliConstants.EXIT_PROMPT);
                     writer.flush();
                     break;

--- a/hazelcast/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
@@ -94,7 +94,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -106,6 +105,8 @@ import java.util.logging.LogManager;
 
 import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
+import static com.hazelcast.internal.util.StringUtil.trim;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
@@ -1194,7 +1195,7 @@ public class JetCommandLine implements Runnable {
                 }
             }
 
-            if (SQLCliConstants.COMMAND_SET.contains(line.trim().toLowerCase(Locale.US))) {
+            if (SQLCliConstants.COMMAND_SET.contains(lowerCaseInternal(trim(line)))) {
                 return;
             }
             // These EOFError exceptions are captured in LineReader's

--- a/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
@@ -42,6 +42,7 @@ import java.util.logging.LogRecord;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
 
 public class LoggingServiceImpl implements LoggingService {
 
@@ -125,7 +126,7 @@ public class LoggingServiceImpl implements LoggingService {
     public void setLevel(@Nonnull String level) {
         Level parsedLevel;
         try {
-            parsedLevel = Level.parse(level.toUpperCase());
+            parsedLevel = Level.parse(upperCaseInternal(level));
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     "Invalid level '" + level + "', known levels are: " + String.join(", ", Level.OFF.getName(),

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
@@ -34,6 +34,7 @@ import static com.hazelcast.internal.config.DomConfigHelper.childElements;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
 import static com.hazelcast.internal.config.DomConfigHelper.getTextContent;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
 /**
@@ -338,17 +339,15 @@ public final class IndexUtils {
     }
 
     public static IndexType getIndexTypeFromXmlName(String typeStr) {
-        if (typeStr == null || typeStr.isEmpty()) {
+        if (isNullOrEmpty(typeStr)) {
             typeStr = IndexConfig.DEFAULT_TYPE.name();
         }
 
-        typeStr = typeStr.toLowerCase();
-
-        if (typeStr.equals(IndexType.SORTED.name().toLowerCase())) {
+        if (equalsIgnoreCase(typeStr, IndexType.SORTED.name())) {
             return IndexType.SORTED;
-        } else if (typeStr.equals(IndexType.HASH.name().toLowerCase())) {
+        } else if (equalsIgnoreCase(typeStr, IndexType.HASH.name())) {
             return IndexType.HASH;
-        } else if (typeStr.equals(IndexType.BITMAP.name().toLowerCase())) {
+        } else if (equalsIgnoreCase(typeStr, IndexType.BITMAP.name())) {
             return IndexType.BITMAP;
         } else {
             throw new IllegalArgumentException("Unsupported index type: " + typeStr);
@@ -370,19 +369,7 @@ public final class IndexUtils {
             typeStr = IndexConfig.DEFAULT_TYPE.name();
         }
 
-        typeStr = typeStr.toLowerCase();
-
-        IndexType type;
-
-        if (typeStr.equals(IndexType.SORTED.name().toLowerCase())) {
-            type = IndexType.SORTED;
-        } else if (typeStr.equals(IndexType.HASH.name().toLowerCase())) {
-            type = IndexType.HASH;
-        } else if (typeStr.equals(IndexType.BITMAP.name().toLowerCase())) {
-            type = IndexType.BITMAP;
-        } else {
-            throw new IllegalArgumentException("Unsupported index type: " + typeStr);
-        }
+        IndexType type = getIndexTypeFromXmlName(typeStr);
 
         IndexConfig res = new IndexConfig().setName(name).setType(type);
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlParser.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 
 class SqlParser {
@@ -121,7 +122,7 @@ class SqlParser {
             betweens:
             while (found) {
                 for (int i = 0; i < tokens.size(); i++) {
-                    if ("between".equalsIgnoreCase(tokens.get(i))) {
+                    if (equalsIgnoreCase("between", tokens.get(i))) {
                         tokens.set(i, "betweenAnd");
                         tokens.remove(i + 2);
                         dirty = true;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
 import static com.hazelcast.query.Predicates.ilike;
@@ -189,25 +190,25 @@ public class SqlPredicate
                         createComparison(mapPhrases, tokens, i, LESS_EQUAL_FACTORY);
                     } else if ("<".equals(token)) {
                         createComparison(mapPhrases, tokens, i, LESS_THAN_FACTORY);
-                    } else if ("LIKE".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("LIKE", token)) {
                         int position = (i - 2);
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, like((String) first, (String) second));
-                    } else if ("ILIKE".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("ILIKE", token)) {
                         int position = (i - 2);
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, ilike((String) first, (String) second));
-                    } else if ("REGEX".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("REGEX", token)) {
                         int position = (i - 2);
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, regex((String) first, (String) second));
-                    } else if ("IN".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("IN", token)) {
                         int position = i - 2;
                         validateOperandPosition(position);
                         String exp = (String) toValue(tokens.remove(position), mapPhrases);
@@ -219,25 +220,25 @@ public class SqlPredicate
                         } else {
                             setOrAdd(tokens, position, Predicates.in(exp, values));
                         }
-                    } else if ("NOT".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("NOT", token)) {
                         int position = i - 1;
                         validateOperandPosition(position);
                         Object exp = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, Predicates.not(eval(exp)));
-                    } else if ("BETWEEN".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("BETWEEN", token)) {
                         int position = i - 3;
                         validateOperandPosition(position);
                         Object expression = tokens.remove(position);
                         Object from = toValue(tokens.remove(position), mapPhrases);
                         Object to = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, between((String) expression, (Comparable) from, (Comparable) to));
-                    } else if ("AND".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("AND", token)) {
                         int position = i - 2;
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, flattenCompound(eval(first), eval(second), AndPredicate.class));
-                    } else if ("OR".equalsIgnoreCase(token)) {
+                    } else if (equalsIgnoreCase("OR", token)) {
                         int position = i - 2;
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
@@ -287,7 +288,7 @@ public class SqlPredicate
         final String value = phrases.get(key);
         if (value != null) {
             return value;
-        } else if (key instanceof String && ("null".equalsIgnoreCase((String) key))) {
+        } else if (key instanceof String && (equalsIgnoreCase("null", (String) key))) {
             return null;
         } else {
             return key;

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSet;
 
@@ -302,7 +303,7 @@ public class HazelcastProperties {
         String value = getString(property);
 
         for (E enumConstant : enumClazz.getEnumConstants()) {
-            if (enumConstant.name().equalsIgnoreCase(value)) {
+            if (equalsIgnoreCase(enumConstant.name(), value)) {
                 return enumConstant;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.sql.impl.expression.math.ExpressionMath.DECIMAL_MATH_CONTEXT;
 
 /**
@@ -46,9 +47,9 @@ public abstract class AbstractStringConverter extends Converter {
     public final boolean asBoolean(Object val) {
         String val0 = cast(val);
 
-        if (val0.equalsIgnoreCase(BooleanConverter.TRUE)) {
+        if (equalsIgnoreCase(val0, BooleanConverter.TRUE)) {
             return true;
-        } else if (val0.equalsIgnoreCase(BooleanConverter.FALSE)) {
+        } else if (equalsIgnoreCase(val0, BooleanConverter.FALSE)) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigRecognizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigRecognizerTest.java
@@ -29,6 +29,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.util.Scanner;
 
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -317,7 +318,7 @@ public class ConfigRecognizerTest {
                 firstLine = scanner.nextLine();
             }
 
-            return "test-hazelcast-config".equalsIgnoreCase(firstLine);
+            return equalsIgnoreCase("test-hazelcast-config", firstLine);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -66,6 +66,7 @@ import static com.hazelcast.config.PersistentMemoryMode.MOUNTED;
 import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
 import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2473,7 +2474,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertFalse(wanReplicationRef.isRepublishingEnabled());
         assertEquals("PassThroughMergePolicy", wanReplicationRef.getMergePolicyClassName());
         assertEquals(1, wanReplicationRef.getFilters().size());
-        assertEquals("com.example.SampleFilter".toLowerCase(), wanReplicationRef.getFilters().get(0).toLowerCase());
+        assertEquals(lowerCaseInternal("com.example.SampleFilter"), lowerCaseInternal(wanReplicationRef.getFilters().get(0)));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -65,6 +65,7 @@ import static com.hazelcast.config.PersistentMemoryMode.MOUNTED;
 import static com.hazelcast.config.PersistentMemoryMode.SYSTEM_MEMORY;
 import static com.hazelcast.config.WanQueueFullBehavior.DISCARD_AFTER_MUTATION;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static java.io.File.createTempFile;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -2501,7 +2502,7 @@ public class YamlConfigBuilderTest
         assertFalse(wanReplicationRef.isRepublishingEnabled());
         assertEquals("PassThroughMergePolicy", wanReplicationRef.getMergePolicyClassName());
         assertEquals(1, wanReplicationRef.getFilters().size());
-        assertEquals("com.example.SampleFilter".toLowerCase(), wanReplicationRef.getFilters().get(0).toLowerCase());
+        assertEquals(lowerCaseInternal("com.example.SampleFilter"), lowerCaseInternal(wanReplicationRef.getFilters().get(0)));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
@@ -47,6 +47,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.StringTokenizer;
@@ -258,7 +259,7 @@ public class WordCountTest extends HazelcastTestSupport implements Serializable 
 
         @Override
         public void accumulate(Entry<Integer, String> input) {
-            String text = input.getValue().toLowerCase();
+            String text = input.getValue().toLowerCase(Locale.ROOT);
             Matcher m = PATTERN.matcher(text);
             while (m.find()) {
                 accumulate(m.group(), 1L);
@@ -291,7 +292,7 @@ public class WordCountTest extends HazelcastTestSupport implements Serializable 
 
         @Override
         public boolean tryProcess(int ordinal, @Nonnull Object item) {
-            String text = ((Entry<Integer, String>) item).getValue().toLowerCase();
+            String text = ((Entry<Integer, String>) item).getValue().toLowerCase(Locale.ROOT);
             Matcher m = PATTERN.matcher(text);
             while (m.find()) {
                 accumulate(m.group());

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 
 import static com.hazelcast.function.Functions.wholeItem;
 import static com.hazelcast.jet.Traversers.traverseArray;
@@ -147,7 +148,7 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
     private Pipeline createPipeline(String text) {
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items(text))
-         .flatMap(line -> traverseArray(line.toLowerCase().split("\\W+")))
+         .flatMap(line -> traverseArray(line.toLowerCase(Locale.ROOT).split("\\W+")))
          .filter(word -> !word.isEmpty())
          .groupingKey(wholeItem())
          .aggregate(counting())

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/AssertionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/AssertionsTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -358,7 +359,7 @@ public class AssertionsTest extends PipelineTestSupport {
 
         p.readFrom(TestSources.items("some text here and here and some here"))
                 .apply(Assertions.assertOrdered(Arrays.asList("some text here and here and some here")))
-                .flatMap(line -> traverseArray(line.toLowerCase().split("\\W+")))
+                .flatMap(line -> traverseArray(line.toLowerCase(Locale.ROOT).split("\\W+")))
                 .apply(Assertions.assertAnyOrder(
                         Arrays.asList("some", "text", "here", "and", "here", "and", "some", "here")))
                 .filter(word -> !word.equals("and"))

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -88,6 +88,7 @@ import java.util.function.BiConsumer;
 import static com.hazelcast.internal.partition.TestPartitionUtils.getPartitionServiceState;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.OsHelper.isLinux;
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
 import static java.lang.Integer.getInteger;
 import static java.lang.String.format;
@@ -1632,7 +1633,7 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void assumeThatNoWindowsOS() {
-        assumeFalse(System.getProperty("os.name").toLowerCase().contains("windows"));
+        assumeFalse(lowerCaseInternal(System.getProperty("os.name")).contains("windows"));
     }
 
     public static void assumeThatLinuxOS() {

--- a/hazelcast/src/test/java/usercodedeployment/CapitalizingFirstNameExtractor.java
+++ b/hazelcast/src/test/java/usercodedeployment/CapitalizingFirstNameExtractor.java
@@ -16,12 +16,14 @@
 
 package usercodedeployment;
 
+import java.util.Locale;
+
 import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
 
 public class CapitalizingFirstNameExtractor implements ValueExtractor<Person, Object> {
     @Override
     public void extract(Person target, Object argument, ValueCollector collector) {
-        collector.addObject(target.getName().toUpperCase());
+        collector.addObject(target.getName().toUpperCase(Locale.ROOT));
     }
 }


### PR DESCRIPTION
Use the `Locale.ROOT` instead of the `Locale.US` as the internal locale in Hazelcast.