### PR TITLE
wip: Support for JSON in Rest interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/HttpContentTypeParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/HttpContentTypeParser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.ascii;
 
 import java.nio.charset.Charset;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/HttpContentTypeParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/HttpContentTypeParser.java
@@ -1,0 +1,127 @@
+package com.hazelcast.internal.ascii;
+
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Locale;
+
+/**
+ * Utility for parsing Content-Type HTTP header
+ *
+ * TODO: This started as very simplistic thing and evolved into a relatively complex and inefficient thing.
+ * Moreover very very far from being bullet proof. Consider using a proper parser, for example we could use
+ * one from the Apache HTTP client project.
+ *
+ */
+public final class HttpContentTypeParser {
+    private static final String CHARSET_PARAMETER_KEY_NAME = "charset=";
+    private static final int    CHARSET_PARAMETER_KEY_NAME_LENGTH = CHARSET_PARAMETER_KEY_NAME.length();
+    private static final char   PARAMETER_DELIMITER = ';';
+    private static final char   SUBTYPE_DELIMITER = '/';
+    // use US locale to prevent oddities in some other locales
+    private static final Locale LOCALE = Locale.US;
+
+    private HttpContentTypeParser() {
+
+    }
+
+    /**
+     * Parse charset from HTTP content-type header.
+     * When charset is not present or is unknown the method returns null.
+     * It also returns null when charset parameter is malformed.
+     *
+     * @param contentTypeValue content type value
+     * @return charset if found and is a valid charset otherwise null
+     */
+    public static Charset parseCharset(String contentTypeValue) {
+        if (contentTypeValue == null) {
+            return null;
+        }
+        // parameter name tokens are case insensitive
+        contentTypeValue = contentTypeValue.toLowerCase(LOCALE);
+
+        // find the charset parameter token and remove it
+        int i = contentTypeValue.indexOf(CHARSET_PARAMETER_KEY_NAME);
+        if (i == -1 || i == 0) {
+            // content type cannot start with charset. there must be media type first
+            return null;
+        }
+        char charBeforeParamKey = contentTypeValue.charAt(i - 1);
+        if (charBeforeParamKey != PARAMETER_DELIMITER && charBeforeParamKey != ' ') {
+            return null;
+        }
+        String charset = contentTypeValue.substring(i + CHARSET_PARAMETER_KEY_NAME_LENGTH);
+
+        // remove possible trailing space or semicolons
+        i = charset.indexOf(' ');
+        if (i != -1) {
+            charset = charset.substring(0, i);
+        }
+        i = charset.indexOf(PARAMETER_DELIMITER);
+        if (i != -1) {
+            charset = charset.substring(0, i);
+        }
+
+        // parameters are allowed to be in double-quotes. let's remove them.
+        i = charset.indexOf('"');
+        if (i != -1) {
+            if (i != 0) {
+                return null;
+            }
+            if (charset.length() == 1) {
+                return null;
+            }
+            int i2 = charset.indexOf('"', 1);
+            if (i2 != charset.length() - 1) {
+                return null;
+            }
+            charset = charset.substring(i + 1, i2);
+        }
+
+        if (charset.isEmpty()) {
+            return null;
+        }
+        try {
+            return Charset.forName(charset);
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+            return null;
+        }
+    }
+
+    /**
+     * TODO
+     *
+     * @param contentTypeValue
+     * @return
+     */
+    public static String parseMediaType(String contentTypeValue) {
+        if (contentTypeValue == null) {
+            return null;
+        }
+        contentTypeValue = contentTypeValue.trim().toLowerCase(LOCALE);
+
+        int i = contentTypeValue.indexOf(SUBTYPE_DELIMITER);
+        if (i == -1) {
+            return null;
+        }
+
+        // remove trailing semicolon
+        i = contentTypeValue.indexOf(PARAMETER_DELIMITER);
+        if (i != -1) {
+            contentTypeValue = contentTypeValue.substring(0, i);
+        }
+
+        // remove trailing space
+        i = contentTypeValue.indexOf(' ');
+        if (i != -1) {
+            contentTypeValue = contentTypeValue.substring(0, i);
+        }
+
+        i = contentTypeValue.indexOf(SUBTYPE_DELIMITER);
+        if (i == -1 || i == 0 || i == contentTypeValue.length() - 1) {
+            return null;
+        }
+
+        return contentTypeValue;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -22,14 +22,10 @@ import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.util.StringUtil;
-import org.jetbrains.annotations.Nullable;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.UnsupportedCharsetException;
-import java.util.Locale;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -16,14 +16,20 @@
 
 package com.hazelcast.internal.ascii.rest;
 
+import com.hazelcast.internal.ascii.HttpContentTypeParser;
 import com.hazelcast.internal.ascii.NoOpCommand;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.util.StringUtil;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Locale;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
@@ -134,12 +140,20 @@ public class HttpPostCommand extends HttpCommand {
         }
     }
 
-    byte[] getContentType() {
+    byte[] getContentTypeBytes() {
         if (contentType == null) {
             return null;
         } else {
             return stringToBytes(contentType);
         }
+    }
+
+    Charset getCharset() {
+        return HttpContentTypeParser.parseCharset(contentType);
+    }
+
+    String getMediaType() {
+        return HttpContentTypeParser.parseMediaType(contentType);
     }
 
     private void readCRLFOrPositionChunkSize(ByteBuffer cb) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -497,7 +497,7 @@ public class HTTPCommunicator {
             data = URLEncodedUtils.format(nameValuePairs, charset);
         } else if (params.length == 1) {
             data = params[0];
-        } else if (params.length == 0){
+        } else if (params.length == 0) {
             data = "";
         } else {
             throw new AssertionError("Media Type is set to " + mediaType + ", but there are multiple"

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HttpContentTypeParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HttpContentTypeParserTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.ascii;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HttpContentTypeParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HttpContentTypeParserTest.java
@@ -1,0 +1,165 @@
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HttpContentTypeParserTest extends HazelcastTestSupport {
+    //reference: https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1
+    @Test
+    public void parseCharset_NullContentType() {
+        assertNull(HttpContentTypeParser.parseCharset(null));
+    }
+
+    @Test
+    public void parseCharset_MissingCharsetField() {
+        assertNull(HttpContentTypeParser.parseCharset("application/json"));
+    }
+
+    @Test
+    public void parseCharset_MissingCharsetValue() {
+        assertNull(HttpContentTypeParser.parseCharset("application/json charset="));
+    }
+
+    @Test
+    public void parseCharset_InvalidCharsetField() {
+        assertNull(HttpContentTypeParser.parseCharset("foocharset=UTF"));
+    }
+
+    @Test
+    public void parseCharset_HappyCharset() {
+        Charset charset = HttpContentTypeParser.parseCharset("text/html; charset=UTF-8");
+        assertEquals(StandardCharsets.UTF_8, charset);
+    }
+
+    @Test
+    public void parseCharset_CharsetFieldAfterSemicolon() {
+        Charset charset = HttpContentTypeParser.parseCharset("text/html;charset=utf-8");
+        assertEquals(StandardCharsets.UTF_8, charset);
+    }
+
+    @Test
+    public void parseCharset_SpaceAfterEncoding() {
+        Charset charset = HttpContentTypeParser.parseCharset("text/html;charset=utf-8 ");
+        assertEquals(StandardCharsets.UTF_8, charset);
+    }
+
+    @Test
+    public void parseCharset_SemicolonAfterEncoding() {
+        Charset charset = HttpContentTypeParser.parseCharset("text/html;charset=utf-8;");
+        assertEquals(StandardCharsets.UTF_8, charset);
+    }
+
+    @Test
+    public void parseCharset_UnknownEncoding() {
+        assertNull(HttpContentTypeParser.parseCharset("text/html;charset=8-ftu;"));
+    }
+
+    @Test
+    public void parseCharset_CharsetFieldInUpperCare() {
+        Charset charset = HttpContentTypeParser.parseCharset("text/html;CHARSET=utf-8;");
+        assertEquals(StandardCharsets.UTF_8, charset);
+    }
+
+    @Test
+    public void parseCharset_CharsetNameInDoubleQuotes() {
+        Charset charset = HttpContentTypeParser.parseCharset("text/html;charset=\"utf-8\"");
+        assertEquals(StandardCharsets.UTF_8, charset);
+    }
+
+    @Test
+    public void parseCharset_FirstDoubleQuoteInsideCharset() {
+        assertNull(HttpContentTypeParser.parseCharset("text/html;charset=u\"tf-8\";"));
+    }
+
+    @Test
+    public void parseCharset_SecondDoubleQuoteInsideCharset() {
+        assertNull(HttpContentTypeParser.parseCharset("text/html;charset=\"utf-\"8;"));
+    }
+
+    @Test
+    public void parseCharset_NoMatchingDoubleQuote() {
+        assertNull(HttpContentTypeParser.parseCharset("text/html;charset=\"utf-8;"));
+    }
+
+    @Test
+    public void parseCharset_MissingCharsetValueInDoubleQuotes() {
+        assertNull(HttpContentTypeParser.parseCharset("text/html;charset=\"\""));
+    }
+
+    @Test
+    public void parseCharset_MissingCharsetValueInDoubleQuotesAndNoMatching() {
+        assertNull(HttpContentTypeParser.parseCharset("text/html;charset=\""));
+    }
+
+    @Test
+    public void parseCharset_MissingMediaType() {
+        assertNull(HttpContentTypeParser.parseCharset("charset=utf-8"));
+    }
+
+    @Test
+    public void parseMediaType_NullContentType() {
+        assertNull(HttpContentTypeParser.parseMediaType(null));
+    }
+
+    @Test
+    public void parseMediaType_HappyCase() {
+        String s = HttpContentTypeParser.parseMediaType("text/html; charset=UTF-8");
+        assertEquals("text/html", s);
+    }
+
+    @Test
+    public void parseMediaType_PlainMediaType() {
+        String s = HttpContentTypeParser.parseMediaType("text/html");
+        assertEquals("text/html", s);
+    }
+
+    @Test
+    public void parseMediaType_SpaceActAsASeparator() {
+        String s = HttpContentTypeParser.parseMediaType("text/html bar");
+        assertEquals("text/html", s);
+    }
+
+    @Test
+    public void parseMediaType_MediaTypeInUpperCase() {
+        String s = HttpContentTypeParser.parseMediaType("TEXT/HTML");
+        assertEquals("text/html", s);
+    }
+
+    @Test
+    public void parseMediaType_NoSubtype() {
+        assertNull(HttpContentTypeParser.parseMediaType("TEXT"));
+    }
+
+    @Test
+    public void parseMediaType_NotStartingWithMediaType() {
+        assertNull(HttpContentTypeParser.parseMediaType("texthtml fds/bar"));
+    }
+
+    @Test
+    public void parseMediaType_MissingType() {
+        assertNull(HttpContentTypeParser.parseMediaType("/html"));
+    }
+
+    @Test
+    public void parseMediaType_MissingSubType() {
+        assertNull(HttpContentTypeParser.parseMediaType("text/"));
+    }
+
+    @Test
+    public void parseMediaType_MissingSubTypeAndType() {
+        assertNull(HttpContentTypeParser.parseMediaType("/"));
+    }
+}


### PR DESCRIPTION
It's an experiment to allow inserting JSON values into Queue/Map over the Rest interface in a way that Hazelcast understand it's JSON, you can query it, process in Pipelines, etc. 

It's still WIP, I am not happy with the content-type parser. It started as something simple, but evolved into a big piece of crap. 
