### PR TITLE
[HZ-393] Add support for DATE without leading zeroes

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -148,8 +148,8 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         // LocalDate
         putAndCheckValue(new ExpressionValue.StringVal(), sql("field1", DATE), DATE, null);
         putAndCheckValue(LOCAL_DATE_VAL.toString(), sql("this", DATE), DATE, LOCAL_DATE_VAL);
-        /// Hazelcast also allows to cast VARCHAR as date without leading zeroes to DATE.
-        putAndCheckValue(NON_STANDARD_LOCAL_DATE_VAL, sql("this", DATE), DATE, LOCAL_DATE_VAL);
+        // SQL standard also accepts DATE without leading zeroes to DATE.
+        putAndCheckValue(STANDARD_LOCAL_DATE_VAL, sql("this", DATE), DATE, LOCAL_DATE_VAL);
         putAndCheckFailure("bad", sql("this", DATE), DATA_EXCEPTION, "Cannot parse VARCHAR value to DATE");
 
         // LocalTime

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -148,6 +148,8 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         // LocalDate
         putAndCheckValue(new ExpressionValue.StringVal(), sql("field1", DATE), DATE, null);
         putAndCheckValue(LOCAL_DATE_VAL.toString(), sql("this", DATE), DATE, LOCAL_DATE_VAL);
+        /// Hazelcast also allows to cast VARCHAR as date without leading zeroes to DATE.
+        putAndCheckValue(NON_STANDARD_LOCAL_DATE_VAL, sql("this", DATE), DATE, LOCAL_DATE_VAL);
         putAndCheckFailure("bad", sql("this", DATE), DATA_EXCEPTION, "Cannot parse VARCHAR value to DATE");
 
         // LocalTime

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -78,6 +78,8 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
     public static final ExpressionValue OBJECT_VAL = new ExpressionValue.ObjectVal();
 
     protected static final Object SKIP_VALUE_CHECK = new Object();
+    protected static final String NON_STANDARD_LOCAL_DATE_VAL = "2020-1-1";
+
     protected static HazelcastInstance member;
 
     private static final TestHazelcastFactory factory = new TestHazelcastFactory();

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -78,7 +78,7 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
     public static final ExpressionValue OBJECT_VAL = new ExpressionValue.ObjectVal();
 
     protected static final Object SKIP_VALUE_CHECK = new Object();
-    protected static final String NON_STANDARD_LOCAL_DATE_VAL = "2020-1-1";
+    protected static final String STANDARD_LOCAL_DATE_VAL = "2020-1-1";
 
     protected static HazelcastInstance member;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -24,18 +24,34 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.MonthDay;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
-import java.util.regex.Pattern;
+import java.time.format.SignStyle;
 
 import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.sql.impl.expression.math.ExpressionMath.DECIMAL_MATH_CONTEXT;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
 
 /**
  * Common converter for string-based classes.
  */
 public abstract class AbstractStringConverter extends Converter {
+    private static final int MIN_YEAR_SYMBOLS = 4;
+    private static final int MAX_YEAR_SYMBOLS = 10;
+
+    static final DateTimeFormatter STANDARD_DATE_FORMAT = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(YEAR, MIN_YEAR_SYMBOLS, MAX_YEAR_SYMBOLS, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('-')
+            .appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NEVER)
+            .appendLiteral('-')
+            .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NEVER)
+            .toFormatter();
+
     protected AbstractStringConverter(int id) {
         super(id, QueryDataTypeFamily.VARCHAR);
     }
@@ -129,9 +145,9 @@ public abstract class AbstractStringConverter extends Converter {
     @Override
     public final LocalDate asDate(Object val) {
         try {
-            return LocalDate.parse(cast(val));
+            return LocalDate.parse(cast(val), STANDARD_DATE_FORMAT);
         } catch (DateTimeParseException e) {
-            return parseDateWithPossibleLeadingZeroes(val);
+            throw cannotParseError(QueryDataTypeFamily.DATE);
         }
     }
 
@@ -173,40 +189,6 @@ public abstract class AbstractStringConverter extends Converter {
     }
 
     protected abstract String cast(Object val);
-
-    /**
-     * Parse non-standard dates with possible leading zeroes.
-     * Before method tried to parse such a date, potential date candidate
-     */
-    private LocalDate parseDateWithPossibleLeadingZeroes(Object val) {
-        if (!(val instanceof String)) {
-            throw new DateTimeParseException("Can't parse date from non-String source", "", 0);
-        }
-
-        // This pattern checks both cases with and without leading zeroes in date.
-        Pattern pattern = Pattern.compile("\\d{4}-([1-9]|[0-1][0-2])-([1-9]|[0-2][0-9]|3[01])$");
-        String possibleDate = (String) val;
-
-        if (!pattern.matcher(possibleDate).matches()) {
-            throw cannotParseError(QueryDataTypeFamily.DATE);
-        }
-
-        final String[] dateParts = possibleDate.split("-");
-        if (dateParts.length != 3) {
-            throw new DateTimeParseException("Date can contain only 3 parts : year, month and day", possibleDate, 0);
-        }
-        String monthChars = dateParts[1];
-        String dayChars = dateParts[2];
-
-        int year = Integer.parseInt(dateParts[0]);
-        int monthNumerical = Integer.parseInt(monthChars);
-        int dayNumerical = Integer.parseInt(dayChars);
-
-        // It will throw an exception if query want to cast e.g., 31st of February.
-        MonthDay monthDay = MonthDay.of(monthNumerical, dayNumerical);
-
-        return LocalDate.of(year, monthDay.getMonth(), monthDay.getDayOfMonth());
-    }
 
     private static QueryException cannotParseError(QueryDataTypeFamily target) {
         String message = "Cannot parse " + QueryDataTypeFamily.VARCHAR + " value to " + target;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
@@ -606,6 +606,8 @@ public class ConvertersTest {
         assertEquals(LocalDate.parse("2020-01-01"), c.asDate("2020-1-1"));
         assertEquals(LocalDate.parse("2020-12-01"), c.asDate("2020-12-1"));
         assertEquals(LocalDate.parse("2020-01-12"), c.asDate("2020-1-12"));
+        assertEquals(LocalDate.parse("2020-09-12"), c.asDate("2020-09-12"));
+        assertEquals(LocalDate.parse("2020-09-12"), c.asDate("2020-9-12"));
         checkDataException(() -> c.asDate("2020-13-01"));
         checkDataException(() -> c.asDate("2020-01-35"));
         checkDataException(() -> c.asDate("2020-13-1"));

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
@@ -601,8 +601,15 @@ public class ConvertersTest {
         checkDataException(() -> c.asTime(invalid));
 
         assertEquals(LocalDate.parse("2020-01-01"), c.asDate("2020-01-01"));
+        assertEquals(LocalDate.parse("2020-01-01"), c.asDate("2020-1-01"));
+        assertEquals(LocalDate.parse("2020-01-01"), c.asDate("2020-01-1"));
+        assertEquals(LocalDate.parse("2020-01-01"), c.asDate("2020-1-1"));
+        assertEquals(LocalDate.parse("2020-12-01"), c.asDate("2020-12-1"));
+        assertEquals(LocalDate.parse("2020-01-12"), c.asDate("2020-1-12"));
         checkDataException(() -> c.asDate("2020-13-01"));
         checkDataException(() -> c.asDate("2020-01-35"));
+        checkDataException(() -> c.asDate("2020-13-1"));
+        checkDataException(() -> c.asDate("2020-1-35"));
         checkDataException(() -> c.asDate(invalid));
 
         assertEquals(LocalDateTime.parse("2020-01-01T11:22"), c.asTimestamp("2020-01-01T11:22"));


### PR DESCRIPTION
**Summary**

This PR introduces support of leading non-zeroes characters in VARCHAR -> DATE conversion.  Examples : 

- `2000-1-1`
- `1970-01-1`
- `2020-1-01` 

A special regular expression was used to decect the date pattern:  `\\d{4}-([1-9]|[0-1][0-2])-([1-9]|[0-2][0-9]|3[01])$` 
If you want to play with it, check it out [here](https://regex101.com/r/ILYyMh/1).

This PR is a part of #18840, but it doesn't cover it completely.