### PR TITLE
Fix misprinted log at node startup 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
@@ -129,6 +129,8 @@ public class JetExtension {
 
     public void onClusterVersionChange(Version newVersion) {
         if (!activated && isAfterStartCalled && newVersion.isGreaterOrEqual(Versions.V5_0)) {
+            // Activate Jet after rolling upgrade in which the cluster
+            // version is upgraded from 4.x to 5.0
             activated = true;
             jetServiceBackend.getJobCoordinationService().startScanningForJobs();
             logger.info("Jet is enabled after the cluster version upgrade.");

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
@@ -49,12 +49,14 @@ public class JetExtension {
     private final ILogger logger;
     private final JetServiceBackend jetServiceBackend;
     private volatile boolean activated;
+    private volatile boolean isAfterStartCalled;
 
     public JetExtension(Node node, JetServiceBackend jetServiceBackend) {
         this.node = node;
         this.logger = node.getLogger(getClass().getName());
         this.jetServiceBackend = jetServiceBackend;
         this.activated = false;
+        this.isAfterStartCalled = false;
     }
 
     private void checkLosslessRestartAllowed() {
@@ -97,10 +99,11 @@ public class JetExtension {
         if (node.isRunning() && node.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V5_0)) {
             activated = true;
             jetServiceBackend.getJobCoordinationService().startScanningForJobs();
-            logger.info("Jet extension is enabled");
+            logger.info("Jet is enabled");
         } else {
-            logger.info("Jet extension is disabled due to current cluster version being less than 5.0.");
+            logger.info("Jet is disabled due to current cluster version being less than 5.0.");
         }
+        isAfterStartCalled = true;
     }
 
     public void beforeClusterStateChange(ClusterState requestedState) {
@@ -125,10 +128,10 @@ public class JetExtension {
     }
 
     public void onClusterVersionChange(Version newVersion) {
-        if (!activated && newVersion.isGreaterOrEqual(Versions.V5_0)) {
+        if (!activated && isAfterStartCalled && newVersion.isGreaterOrEqual(Versions.V5_0)) {
             activated = true;
             jetServiceBackend.getJobCoordinationService().startScanningForJobs();
-            logger.info("Jet extension is enabled after the cluster version upgrade.");
+            logger.info("Jet is enabled after the cluster version upgrade.");
         }
     }
 


### PR DESCRIPTION
This PR aims to disable `JetExtension#onClusterVersionChange`
callbacks made before `JetExtension#afterStart()` is being performed.

Since `JetExtension#onClusterVersionChange`'s intended use (while it
is introduced by me), is to be called after the cluster version upgrade
scenarios, not at the initial version setting. Although running this after
the initial version setting did not cause execution errors, it was producing
meaningless logs. 

Due to this issue, the log that should normally be printed in rolling upgrade
scenarios, was being printed at startup time:

```
2021-06-07 13:28:57,706 [ INFO] [main] [c.h.i.i.JetExtension]: [172.17.0.2]:5701 [dev] [5.0-SNAPSHOT] Jet extension is enabled after the cluster version upgrade.
```

Also, this pr removes extension terms from logs.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
