### PR TITLE
HZ-397 - TO_TIMESTAMP_TZ SQL function

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
@@ -193,6 +193,7 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
 
         // Datetime
         SUPPORTED_OPERATORS.add(HazelcastSqlOperatorTable.EXTRACT);
+        SUPPORTED_OPERATORS.add(HazelcastSqlOperatorTable.TO_TIMESTAMP_TZ);
 
         // Extensions
         SUPPORTED_OPERATORS.add(SqlOption.OPERATOR);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/RexToExpression.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/RexToExpression.java
@@ -416,7 +416,7 @@ public final class RexToExpression {
                     Expression<?> start = operands.length > 2 ? operands[2] : null;
                     return PositionFunction.create(operands[0], operands[1], start);
                 } else if (function == HazelcastSqlOperatorTable.TO_TIMESTAMP_TZ) {
-                    return ToTimestampTzFunction.create(operands[0], QueryDataType.TIMESTAMP_WITH_TZ_DATE);
+                    return ToTimestampTzFunction.create(operands[0]);
                 }
 
                 break;
@@ -450,7 +450,7 @@ public final class RexToExpression {
                 break;
 
             case BIGINT:
-                // Calcite incorrectly convers the DECIMAL literal to BIGINT using the "BigDecimal.unscaledValue" method.
+                // Calcite incorrectly converts the DECIMAL literal to BIGINT using the "BigDecimal.unscaledValue" method.
                 // We fix it here.
                 if (literal.getTypeName() == SqlTypeName.DECIMAL) {
                     value = literal.getValueAs(BigDecimal.class).longValue();

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/RexToExpression.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/opt/physical/visitor/RexToExpression.java
@@ -28,6 +28,7 @@ import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.SymbolExpression;
 import com.hazelcast.sql.impl.expression.datetime.ExtractField;
 import com.hazelcast.sql.impl.expression.datetime.ExtractFunction;
+import com.hazelcast.sql.impl.expression.datetime.ToTimestampTzFunction;
 import com.hazelcast.sql.impl.expression.math.AbsFunction;
 import com.hazelcast.sql.impl.expression.math.DivideFunction;
 import com.hazelcast.sql.impl.expression.math.DoubleBiFunction;
@@ -414,10 +415,11 @@ public final class RexToExpression {
                 } else if (function == HazelcastSqlOperatorTable.POSITION) {
                     Expression<?> start = operands.length > 2 ? operands[2] : null;
                     return PositionFunction.create(operands[0], operands[1], start);
+                } else if (function == HazelcastSqlOperatorTable.TO_TIMESTAMP_TZ) {
+                    return ToTimestampTzFunction.create(operands[0], QueryDataType.TIMESTAMP_WITH_TZ_DATE);
                 }
 
                 break;
-
             default:
                 break;
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/parse/UnsupportedOperationVisitor.java
@@ -162,6 +162,7 @@ public final class UnsupportedOperationVisitor implements SqlVisitor<Void> {
 
         // Datetime
         SUPPORTED_OPERATORS.add(HazelcastSqlOperatorTable.EXTRACT);
+        SUPPORTED_OPERATORS.add(HazelcastSqlOperatorTable.TO_TIMESTAMP_TZ);
 
         // Sorting
         SUPPORTED_OPERATORS.add(HazelcastSqlOperatorTable.DESC);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql.impl.calcite.validate;
 
 import com.hazelcast.sql.impl.calcite.validate.operators.datetime.HazelcastExtractFunction;
 import com.hazelcast.sql.impl.calcite.validate.operators.HazelcastSqlCase;
+import com.hazelcast.sql.impl.calcite.validate.operators.datetime.HazelcastToTimestampTzFunction;
 import com.hazelcast.sql.impl.calcite.validate.operators.misc.HazelcastCoalesceFunction;
 import com.hazelcast.sql.impl.calcite.validate.operators.misc.HazelcastNullIfFunction;
 import com.hazelcast.sql.impl.calcite.validate.operators.math.HazelcastAbsFunction;
@@ -197,6 +198,7 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
     public static final SqlFunction POSITION = HazelcastPositionFunction.INSTANCE;
 
     public static final SqlFunction EXTRACT = HazelcastExtractFunction.INSTANCE;
+    public static final SqlFunction TO_TIMESTAMP_TZ = HazelcastToTimestampTzFunction.INSTANCE;
 
     public static final SqlPostfixOperator DESC = HazelcastDescOperator.DESC;
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/datetime/HazelcastToTimestampTzFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/datetime/HazelcastToTimestampTzFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.calcite.validate.operators.datetime;
+
+import com.hazelcast.sql.impl.calcite.validate.HazelcastCallBinding;
+import com.hazelcast.sql.impl.calcite.validate.operand.TypedOperandChecker;
+import com.hazelcast.sql.impl.calcite.validate.operators.ReplaceUnknownOperandTypeInference;
+import com.hazelcast.sql.impl.calcite.validate.operators.common.HazelcastFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+public final class HazelcastToTimestampTzFunction extends HazelcastFunction {
+    public static final HazelcastToTimestampTzFunction INSTANCE = new HazelcastToTimestampTzFunction();
+
+    private HazelcastToTimestampTzFunction() {
+        super(
+                "TO_TIMESTAMP_TZ",
+                SqlKind.OTHER_FUNCTION,
+                ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                new ReplaceUnknownOperandTypeInference(SqlTypeName.BIGINT),
+                SqlFunctionCategory.SYSTEM
+        );
+    }
+
+    @Override
+    public SqlOperandCountRange getOperandCountRange() {
+        return SqlOperandCountRanges.of(1);
+    }
+
+    @Override
+    public boolean checkOperandTypes(HazelcastCallBinding binding, boolean throwOnFailure) {
+        return TypedOperandChecker.BIGINT.check(binding, throwOnFailure, 0);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
@@ -469,7 +469,7 @@ public class NestingAndCasingExpressionTest extends ExpressionTestSupport {
 
     @Test
     public void test_TO_TIMESTAMP_TZ() {
-        check(sql("TO_TIMESTAMP_TZ(?) || TO_TIMESTAMP_TZ(1)"), 1L);
+        check(sql("TO_TIMESTAMP_TZ(?) || TO_TIMESTAMP_TZ(?)"), 1L, 1L);
     }
 
     private void check(String sql, Object... params) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/NestingAndCasingExpressionTest.java
@@ -467,6 +467,11 @@ public class NestingAndCasingExpressionTest extends ExpressionTestSupport {
         check(sql("COALESCE('1', ?) || COALESCE('2', ?)"), "1", "2");
     }
 
+    @Test
+    public void test_TO_TIMESTAMP_TZ() {
+        check(sql("TO_TIMESTAMP_TZ(?) || TO_TIMESTAMP_TZ(1)"), 1L);
+    }
+
     private void check(String sql, Object... params) {
         checkValue0(sql, SqlColumnType.VARCHAR, SKIP_VALUE_CHECK, params);
         checkValue0(lowerCaseInternal(sql), SqlColumnType.VARCHAR, SKIP_VALUE_CHECK, params);

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
@@ -62,7 +62,6 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
         checkColumn(MICROSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MICROSECONDS, ChronoUnit.MICROS));
         checkColumn(NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
         checkColumn(Long.MAX_VALUE, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(Long.MAX_VALUE, ChronoUnit.NANOS));
-        checkColumn(Long.MIN_VALUE, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(Long.MIN_VALUE, ChronoUnit.NANOS));
 
         checkColumnFailure("'1'", SqlErrorCode.PARSING, signatureError(SqlColumnType.VARCHAR));
         checkColumnFailure(BigDecimal.valueOf(1.0), SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
@@ -94,7 +93,6 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
         checkLiteral(NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
         checkLiteral("-10000", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-10000L, ChronoUnit.SECONDS));
         checkLiteral("0", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(0L, ChronoUnit.SECONDS));
-        checkLiteral("-9223372036854775808", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-9223372036854775808L, ChronoUnit.NANOS));
         checkLiteral("9223372036854775807", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(9223372036854775807L, ChronoUnit.NANOS));
         checkLiteral("null", TIMESTAMP_WITH_TIME_ZONE, null);
 
@@ -113,7 +111,6 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
         checkParameter(MICROSECONDS, fromEpoch(MICROSECONDS, ChronoUnit.MICROS));
         checkParameter(NANOSECONDS, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
         checkParameter(Long.MAX_VALUE, fromEpoch(Long.MAX_VALUE, ChronoUnit.NANOS));
-        checkParameter(Long.MIN_VALUE, fromEpoch(Long.MIN_VALUE, ChronoUnit.NANOS));
         checkParameter(null, null);
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, VARCHAR), "foo");

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
@@ -56,6 +56,9 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
 
     @Test
     public void testColumn() {
+        checkColumn((byte) 1, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(1L, ChronoUnit.SECONDS));
+        checkColumn((short) 1, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(1L, ChronoUnit.SECONDS));
+        checkColumn(1, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(1L, ChronoUnit.SECONDS));
         checkColumn(1L, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(1L, ChronoUnit.SECONDS));
         checkColumn(SECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(SECONDS, ChronoUnit.SECONDS));
         checkColumn(MILLISECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MILLISECONDS, ChronoUnit.MILLIS));

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.datetime;
+
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.impl.SqlErrorCode;
+import com.hazelcast.sql.impl.expression.ExpressionTestSupport;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+import static com.hazelcast.sql.SqlColumnType.BIGINT;
+import static com.hazelcast.sql.SqlColumnType.BOOLEAN;
+import static com.hazelcast.sql.SqlColumnType.DATE;
+import static com.hazelcast.sql.SqlColumnType.DECIMAL;
+import static com.hazelcast.sql.SqlColumnType.DOUBLE;
+import static com.hazelcast.sql.SqlColumnType.OBJECT;
+import static com.hazelcast.sql.SqlColumnType.REAL;
+import static com.hazelcast.sql.SqlColumnType.TIME;
+import static com.hazelcast.sql.SqlColumnType.TIMESTAMP;
+import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.hazelcast.sql.SqlColumnType.VARCHAR;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
+    private static final Long SECONDS = 31536001L;
+    private static final Long MILLISECONDS = SECONDS * 1000L;
+    private static final Long MICROSECONDS = MILLISECONDS * 1000L;
+    private static final Long NANOSECONDS = MICROSECONDS * 1000L;
+
+    @Test
+    public void testColumn() {
+        checkColumn(1L, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(1L, ChronoUnit.SECONDS));
+        checkColumn(SECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(SECONDS, ChronoUnit.SECONDS));
+        checkColumn(MILLISECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MILLISECONDS, ChronoUnit.MILLIS));
+        checkColumn(MICROSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MICROSECONDS, ChronoUnit.MICROS));
+        checkColumn(NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
+        checkColumn(Long.MAX_VALUE, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(Long.MAX_VALUE, ChronoUnit.NANOS));
+        checkColumn(Long.MIN_VALUE, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(Long.MIN_VALUE, ChronoUnit.NANOS));
+
+        checkColumnFailure("'1'", SqlErrorCode.PARSING, signatureError(SqlColumnType.VARCHAR));
+        checkColumnFailure(BigDecimal.valueOf(1.0), SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
+        checkColumnFailure(BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE), SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
+        checkColumnFailure(BigDecimal.valueOf(Long.MIN_VALUE).subtract(BigDecimal.ONE), SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
+        checkColumnFailure(1.0d, SqlErrorCode.PARSING, signatureError(SqlColumnType.DOUBLE));
+        checkColumnFailure(1.0f, SqlErrorCode.PARSING, signatureError(SqlColumnType.REAL));
+        checkColumnFailure(true, SqlErrorCode.PARSING, signatureError(SqlColumnType.BOOLEAN));
+        checkColumnFailure(LOCAL_DATE_TIME_VAL, SqlErrorCode.PARSING, signatureError(TIMESTAMP));
+        checkColumnFailure(OFFSET_DATE_TIME_VAL, SqlErrorCode.PARSING, signatureError(TIMESTAMP_WITH_TIME_ZONE));
+        checkColumnFailure(LOCAL_DATE_VAL, SqlErrorCode.PARSING, signatureError(DATE));
+        checkColumnFailure(LOCAL_TIME_VAL, SqlErrorCode.PARSING, signatureError(TIME));
+        checkColumnFailure(OBJECT_VAL, SqlErrorCode.PARSING, signatureError(OBJECT));
+    }
+
+    @Test
+    public void testNull() {
+        put(0);
+        check("null", TIMESTAMP_WITH_TIME_ZONE, null);
+    }
+
+    @Test
+    public void testLiteral() {
+        put(0);
+        checkLiteral(1L, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(1L, ChronoUnit.SECONDS));
+        checkLiteral(SECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(SECONDS, ChronoUnit.SECONDS));
+        checkLiteral(MILLISECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MILLISECONDS, ChronoUnit.MILLIS));
+        checkLiteral(MICROSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MICROSECONDS, ChronoUnit.MICROS));
+        checkLiteral(NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
+        checkLiteral("-10000", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-10000L, ChronoUnit.SECONDS));
+        checkLiteral("0", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(0L, ChronoUnit.SECONDS));
+        checkLiteral("-9223372036854775808", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-9223372036854775808L, ChronoUnit.NANOS));
+        checkLiteral("9223372036854775807", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(9223372036854775807L, ChronoUnit.NANOS));
+        checkLiteral("null", TIMESTAMP_WITH_TIME_ZONE, null);
+
+        checkFailure("'1'", SqlErrorCode.PARSING, signatureError(SqlColumnType.VARCHAR));
+        checkFailure("1.0", SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
+        checkFailure("9223372036854775808", SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
+        checkFailure("-9223372036854775809", SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
+    }
+
+    @Test
+    public void testParameter() {
+        put(0);
+        checkParameter(1L, fromEpoch(1L, ChronoUnit.SECONDS));
+        checkParameter(SECONDS, fromEpoch(SECONDS, ChronoUnit.SECONDS));
+        checkParameter(MILLISECONDS, fromEpoch(MILLISECONDS, ChronoUnit.MILLIS));
+        checkParameter(MICROSECONDS, fromEpoch(MICROSECONDS, ChronoUnit.MICROS));
+        checkParameter(NANOSECONDS, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
+        checkParameter(Long.MAX_VALUE, fromEpoch(Long.MAX_VALUE, ChronoUnit.NANOS));
+        checkParameter(Long.MIN_VALUE, fromEpoch(Long.MIN_VALUE, ChronoUnit.NANOS));
+        checkParameter(null, null);
+
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, VARCHAR), "foo");
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, BOOLEAN), true);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, DECIMAL), BigInteger.ZERO);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, DECIMAL), BigDecimal.ZERO);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, REAL), 0.0f);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, DOUBLE), 0.0d);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, DATE), LOCAL_DATE_VAL);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, TIME), LOCAL_TIME_VAL);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, TIMESTAMP), LOCAL_DATE_TIME_VAL);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, TIMESTAMP_WITH_TIME_ZONE), OFFSET_DATE_TIME_VAL);
+        checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, OBJECT), OBJECT_VAL);
+    }
+
+    private OffsetDateTime fromEpoch(final Long timestamp, final TemporalUnit unit) {
+        final Instant instant = Instant.EPOCH.plus(timestamp, unit);
+        return OffsetDateTime.from(instant.atZone(ZoneOffset.systemDefault()));
+    }
+
+    private void checkColumn(Object value, SqlColumnType expectedType, Object expectedResult) {
+        put(value);
+        check("this", expectedType, expectedResult);
+    }
+
+    private void checkParameter(Object parameterValue, Object expectedValue) {
+        check("?", TIMESTAMP_WITH_TIME_ZONE, expectedValue, parameterValue);
+    }
+
+    private void checkLiteral(Object literal, SqlColumnType expectedType, Object expectedValue) {
+        check(literal.toString(), expectedType, expectedValue);
+    }
+
+    private void checkFailure(Object operand, int expectedErrorCode, String expectedErrorMessage, Object... params) {
+        String sql = "SELECT TO_TIMESTAMP_TZ(" + operand + ") FROM map";
+
+        checkFailure0(sql, expectedErrorCode, expectedErrorMessage, params);
+    }
+
+    private void checkColumnFailure(Object value, int expectedErrorCode, String expectedErrorMessage) {
+        put(value);
+        checkFailure("this", expectedErrorCode, expectedErrorMessage);
+    }
+
+    private void check(Object operand, SqlColumnType expectedType, Object expectedValue, Object... params) {
+        final String sql = "SELECT TO_TIMESTAMP_TZ(" + operand + ") FROM map";
+        checkValue0(sql, expectedType, expectedValue, params);
+    }
+
+    private static String signatureError(SqlColumnType type) {
+        return signatureErrorFunction("TO_TIMESTAMP_TZ", type);
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzIntegrationTest.java
@@ -53,6 +53,7 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
     private static final Long MILLISECONDS = SECONDS * 1000L;
     private static final Long MICROSECONDS = MILLISECONDS * 1000L;
     private static final Long NANOSECONDS = MICROSECONDS * 1000L;
+    private static final Long MIN_NEGATIVE_SECONDS = -31557014135596800L;
 
     @Test
     public void testColumn() {
@@ -65,6 +66,10 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
         checkColumn(MICROSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MICROSECONDS, ChronoUnit.MICROS));
         checkColumn(NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
         checkColumn(Long.MAX_VALUE, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(Long.MAX_VALUE, ChronoUnit.NANOS));
+        checkColumn(-MILLISECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-MILLISECONDS, ChronoUnit.SECONDS));
+        checkColumn(-MICROSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-MICROSECONDS, ChronoUnit.SECONDS));
+        checkColumn(-NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-NANOSECONDS, ChronoUnit.SECONDS));
+        checkColumn(MIN_NEGATIVE_SECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MIN_NEGATIVE_SECONDS, ChronoUnit.SECONDS));
 
         checkColumnFailure("'1'", SqlErrorCode.PARSING, signatureError(SqlColumnType.VARCHAR));
         checkColumnFailure(BigDecimal.valueOf(1.0), SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
@@ -98,6 +103,10 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
         checkLiteral("0", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(0L, ChronoUnit.SECONDS));
         checkLiteral("9223372036854775807", TIMESTAMP_WITH_TIME_ZONE, fromEpoch(9223372036854775807L, ChronoUnit.NANOS));
         checkLiteral("null", TIMESTAMP_WITH_TIME_ZONE, null);
+        checkLiteral(-MILLISECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-MILLISECONDS, ChronoUnit.SECONDS));
+        checkLiteral(-MICROSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-MICROSECONDS, ChronoUnit.SECONDS));
+        checkLiteral(-NANOSECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(-NANOSECONDS, ChronoUnit.SECONDS));
+        checkLiteral(MIN_NEGATIVE_SECONDS, TIMESTAMP_WITH_TIME_ZONE, fromEpoch(MIN_NEGATIVE_SECONDS, ChronoUnit.SECONDS));
 
         checkFailure("'1'", SqlErrorCode.PARSING, signatureError(SqlColumnType.VARCHAR));
         checkFailure("1.0", SqlErrorCode.PARSING, signatureError(SqlColumnType.DECIMAL));
@@ -115,6 +124,10 @@ public class ToTimestampTzIntegrationTest extends ExpressionTestSupport {
         checkParameter(NANOSECONDS, fromEpoch(NANOSECONDS, ChronoUnit.NANOS));
         checkParameter(Long.MAX_VALUE, fromEpoch(Long.MAX_VALUE, ChronoUnit.NANOS));
         checkParameter(null, null);
+        checkParameter(-MILLISECONDS, fromEpoch(-MILLISECONDS, ChronoUnit.SECONDS));
+        checkParameter(-MICROSECONDS, fromEpoch(-MICROSECONDS, ChronoUnit.SECONDS));
+        checkParameter(-NANOSECONDS, fromEpoch(-NANOSECONDS, ChronoUnit.SECONDS));
+        checkParameter(MIN_NEGATIVE_SECONDS, fromEpoch(MIN_NEGATIVE_SECONDS, ChronoUnit.SECONDS));
 
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, VARCHAR), "foo");
         checkFailure("?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, BIGINT, BOOLEAN), true);

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
@@ -32,6 +32,7 @@ import com.hazelcast.sql.impl.expression.ColumnExpression;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.ParameterExpression;
 import com.hazelcast.sql.impl.expression.datetime.ExtractFunction;
+import com.hazelcast.sql.impl.expression.datetime.ToTimestampTzFunction;
 import com.hazelcast.sql.impl.expression.math.AbsFunction;
 import com.hazelcast.sql.impl.expression.math.DivideFunction;
 import com.hazelcast.sql.impl.expression.math.DoubleBiFunction;
@@ -199,9 +200,9 @@ public class SqlDataSerializerHook implements DataSerializerHook {
 
     public static final int EXPRESSION_EXTRACT = 72;
 
-//    Reserved
+    public static final int EXPRESSION_TO_TIMESTAMP_TZ = 73;
 
-    public static final int LEN = EXPRESSION_EXTRACT + 1;
+    public static final int LEN = EXPRESSION_TO_TIMESTAMP_TZ + 1;
 
     @Override
     public int getFactoryId() {
@@ -305,6 +306,8 @@ public class SqlDataSerializerHook implements DataSerializerHook {
         constructors[INTERVAL_DAY_SECOND] = arg -> new SqlDaySecondInterval();
 
         constructors[EXPRESSION_CASE] = arg -> new CaseExpression<>();
+
+        constructors[EXPRESSION_TO_TIMESTAMP_TZ] = arg -> new ToTimestampTzFunction();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -77,17 +77,16 @@ public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> i
      * Returns TemporalUnit of the given unixTimestamp, using the magnitude of
      * the value to determine most likely unit.
      * <ol>
-     * <li>unixTimestamp < MILLISECONDS_IN_YEAR (365 * 86400 *
-     * 1000) - timestamp is in seconds
-     * <li>unixTimestamp >= MILLISECONDS_IN_YEAR (365 * 86400 * 1000)
-     * - timestamp is in milliseconds
-     * <li>unixTimestamp >= MICROSECONDS_IN_YEAR
-     * (365 * 86400 * 1000_000) - timestamp is in microseconds
-     * <li>unixTimestamp >= NANOSECONDS_IN_YEAR (365 * 86400
-     * * 1000_000_000) - timestamp is in nanoseconds
-     * <li>unixTimestamp < 0 - timestamp is in seconds
+     *      <li>unixTimestamp < MILLISECONDS_IN_YEAR (365 * 86400 * 1000)
+     *          - timestamp is in seconds
+     *      <li>unixTimestamp >= MILLISECONDS_IN_YEAR (365 * 86400 * 1000)
+     *          - timestamp is in milliseconds
+     *      <li>unixTimestamp >= MICROSECONDS_IN_YEAR (365 * 86400 * 1000_000)
+     *          - timestamp is in microseconds
+     *      <li>unixTimestamp >= NANOSECONDS_IN_YEAR (365 * 86400 * 1000_000_000)
+     *          - timestamp is in nanoseconds
+     *      <li>unixTimestamp < 0 - timestamp is in seconds
      * </ol>
-     *
      * <p>
      * Note that this also imposes limits on the possible max correctly
      * interpreted timestamp value, that would be otherwise correctly
@@ -99,7 +98,6 @@ public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> i
      * also imposes the min date possible to be interpreted in milliseconds,
      * microseconds and nanoseconds. Additionally any value less than 0 is
      * treated as seconds regardless of the magnitude.
-     *
      * <p>
      * Summary of Date limits (under which the
      * interpretation of the timestamp's unit is correct):

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -31,9 +31,9 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 
 public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> implements IdentifiedDataSerializable {
-    private static final long YEAR_MILLISECONDS = 31536000000L;
-    private static final long YEAR_MICROSECONDS = YEAR_MILLISECONDS * 1000L;
-    private static final long YEAR_NANOSECONDS = YEAR_MICROSECONDS * 1000L;
+    private static final long MILLISECONDS_IN_YEAR = 31536000000L;
+    private static final long MICROSECONDS_IN_YEAR = MILLISECONDS_IN_YEAR * 1000L;
+    private static final long NANOSECONDS_IN_YEAR = MICROSECONDS_IN_YEAR * 1000L;
 
     public ToTimestampTzFunction() { }
 
@@ -73,12 +73,37 @@ public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> i
         return QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME;
     }
 
+    /**
+     * Returns TemporalUnit of the given unixTimestamp, using the magnitude of the value to determine most likely unit.
+     * - unixTimestamp < MILLISECONDS_IN_YEAR (365 * 86400 * 1000) - timestamp is in Seconds
+     * - unixTimestamp >= MILLISECONDS_IN_YEAR (365 * 86400 * 1000) - timestamp in in Milliseconds
+     * - unixTimestamp >= MICROSECONDS_IN_YEAR (365 * 86400 * 1000_000) - timestamp is in Microseconds
+     * - unixTimestamp >= NANOSECONDS_IN_YEAR (365 * 86400 * 1000_000_000) - timestamp is in Nanoseconds
+     * - unixTimestamp < 0 - timestamp is in Seconds
+     *
+     * Note that this also imposes limits on the possible max correctly interpreted timestamp value,
+     * that would be otherwise correctly interpreted as in Seconds/Milliseconds/Microseconds.
+     * For example if this function is called on a unixTimestamp of 31_536_000_001 which in seconds
+     * corresponds to datetime of 2969-05-03 00:00:01, this function would instead interpret it
+     * as 1971-01-01 00:00:00.001. This is also true for maximum date expressed in milliseconds and microseconds.
+     * Additionally this of course also imposes the min date possible to be interpreted in Milliseconds, Microseconds and
+     * Nanoseconds.
+     *
+     * Summary of Date limits (under which the interpretation of the timestamp's unit is correct):
+     * 1. Seconds:      1970-01-01 00:00:00Z   (0)                    - 2969-05-02 23:59:59Z (MILLISECONDS_IN_YEAR - 1)
+     * 2. Milliseconds: 1971-01-01 00:00:00.0Z (MILLISECONDS_IN_YEAR) - 2969-05-02 23:59:59.999Z (MICROSECONDS_IN_YEAR - 1)
+     * 3. Microseconds: 1971-01-01 00:00:00.0Z (MICROSECONDS_IN_YEAR) - 2969-05-02 23:59:59.999999Z (NANOSECONDS_IN_YEAR - 1)
+     * 4. Nanoseconds:  1971-01-01 00:00:00.0Z (NANOSECONDS_IN_YEAR)  - 2262-04-11 23:47:16.854775807Z (Long.MAX_VALUE of nanoseconds).
+     *
+     * @param unixTimestamp - input timestamp
+     * @return - determined {@link TemporalUnit} of the value, inferred based on the magnitude of the input unixTimestamp
+     */
     private TemporalUnit getChronoUnit(final long unixTimestamp) {
-        if (unixTimestamp < YEAR_MILLISECONDS) {
+        if (unixTimestamp < MILLISECONDS_IN_YEAR) {
             return ChronoUnit.SECONDS;
-        } else if (unixTimestamp < YEAR_MICROSECONDS) {
+        } else if (unixTimestamp < MICROSECONDS_IN_YEAR) {
             return ChronoUnit.MILLIS;
-        } else if (unixTimestamp < YEAR_NANOSECONDS) {
+        } else if (unixTimestamp < NANOSECONDS_IN_YEAR) {
             return ChronoUnit.MICROS;
         } else {
             return ChronoUnit.NANOS;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression.datetime;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UniExpressionWithType;
+import com.hazelcast.sql.impl.row.Row;
+import com.hazelcast.sql.impl.type.QueryDataType;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+public final class ToTimestampTzFunction extends UniExpressionWithType<OffsetDateTime> implements IdentifiedDataSerializable {
+    private static final long YEAR_MILLISECONDS = 31536000000L;
+    private static final long YEAR_MICROSECONDS = YEAR_MILLISECONDS * 1000L;
+    private static final long YEAR_NANOSECONDS = YEAR_MICROSECONDS * 1000L;
+
+    public ToTimestampTzFunction() { }
+
+    private ToTimestampTzFunction(Expression<?> operand, QueryDataType resultType) {
+        super(operand, resultType);
+    }
+
+    public static ToTimestampTzFunction create(Expression<?> operand, QueryDataType resultType) {
+        return new ToTimestampTzFunction(operand, resultType);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SqlDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SqlDataSerializerHook.EXPRESSION_TO_TIMESTAMP_TZ;
+    }
+
+    @Override
+    public OffsetDateTime eval(final Row row, final ExpressionEvalContext context) {
+        final Number value = (Number) this.operand.eval(row, context);
+        if (value == null) {
+            return null;
+        }
+
+        final long unixTimestamp = value.longValue();
+        final TemporalUnit unit = getChronoUnit(unixTimestamp);
+        final Instant instant = Instant.EPOCH.plus(unixTimestamp, unit);
+
+        return OffsetDateTime.from(instant.atZone(ZoneOffset.systemDefault()));
+    }
+
+    @Override
+    public QueryDataType getType() {
+        return QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME;
+    }
+
+    private TemporalUnit getChronoUnit(final long unixTimestamp) {
+        // -Long.MIN_VALUE returns Long.MIN_VALUE, probably because an absolute value of that is Long.MAX_VALUE + 1.
+        final long absTimestamp = unixTimestamp == Long.MIN_VALUE
+                ? Long.MAX_VALUE
+                : Math.abs(unixTimestamp);
+        if (absTimestamp < YEAR_MILLISECONDS) {
+            return ChronoUnit.SECONDS;
+        } else if (absTimestamp < YEAR_MICROSECONDS) {
+            return ChronoUnit.MILLIS;
+        } else if (absTimestamp < YEAR_NANOSECONDS) {
+            return ChronoUnit.MICROS;
+        } else {
+            return ChronoUnit.NANOS;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -86,17 +86,22 @@ public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> i
      * For example if this function is called on a unixTimestamp of 31_536_000_001 which in seconds
      * corresponds to datetime of 2969-05-03 00:00:01, this function would instead interpret it
      * as 1971-01-01 00:00:00.001. This is also true for maximum date expressed in milliseconds and microseconds.
-     * Additionally this of course also imposes the min date possible to be interpreted in Milliseconds, Microseconds and
-     * Nanoseconds.
+     * Additionally this of course also imposes the min date possible to be interpreted in Milliseconds,
+     * Microseconds and Nanoseconds.
      *
      * Summary of Date limits (under which the interpretation of the timestamp's unit is correct):
-     * 1. Seconds:      1970-01-01 00:00:00Z   (0)                    - 2969-05-02 23:59:59Z (MILLISECONDS_IN_YEAR - 1)
-     * 2. Milliseconds: 1971-01-01 00:00:00.0Z (MILLISECONDS_IN_YEAR) - 2969-05-02 23:59:59.999Z (MICROSECONDS_IN_YEAR - 1)
-     * 3. Microseconds: 1971-01-01 00:00:00.0Z (MICROSECONDS_IN_YEAR) - 2969-05-02 23:59:59.999999Z (NANOSECONDS_IN_YEAR - 1)
-     * 4. Nanoseconds:  1971-01-01 00:00:00.0Z (NANOSECONDS_IN_YEAR)  - 2262-04-11 23:47:16.854775807Z (Long.MAX_VALUE of nanoseconds).
+     * 1. Seconds:      from 1970-01-01 00:00:00Z (0)
+     *                  to   2969-05-02 23:59:59Z (MILLISECONDS_IN_YEAR - 1)
+     * 2. Milliseconds: from 1971-01-01 00:00:00.0Z (MILLISECONDS_IN_YEAR)
+     *                  to   2969-05-02 23:59:59.999Z (MICROSECONDS_IN_YEAR - 1)
+     * 3. Microseconds: from 1971-01-01 00:00:00.0Z (MICROSECONDS_IN_YEAR)
+     *                  to   2969-05-02 23:59:59.999999Z (NANOSECONDS_IN_YEAR - 1)
+     * 4. Nanoseconds:  from 1971-01-01 00:00:00.0Z (NANOSECONDS_IN_YEAR)
+     *                  to   2262-04-11 23:47:16.854775807Z (Long.MAX_VALUE of nanoseconds).
      *
      * @param unixTimestamp - input timestamp
-     * @return - determined {@link TemporalUnit} of the value, inferred based on the magnitude of the input unixTimestamp
+     * @return - determined {@link TemporalUnit} of the value, inferred based on the magnitude
+     * of the input unixTimestamp
      */
     private TemporalUnit getChronoUnit(final long unixTimestamp) {
         if (unixTimestamp < MILLISECONDS_IN_YEAR) {

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
-import com.hazelcast.sql.impl.expression.UniExpressionWithType;
+import com.hazelcast.sql.impl.expression.UniExpression;
 import com.hazelcast.sql.impl.row.Row;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
@@ -30,19 +30,19 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 
-public final class ToTimestampTzFunction extends UniExpressionWithType<OffsetDateTime> implements IdentifiedDataSerializable {
+public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> implements IdentifiedDataSerializable {
     private static final long YEAR_MILLISECONDS = 31536000000L;
     private static final long YEAR_MICROSECONDS = YEAR_MILLISECONDS * 1000L;
     private static final long YEAR_NANOSECONDS = YEAR_MICROSECONDS * 1000L;
 
     public ToTimestampTzFunction() { }
 
-    private ToTimestampTzFunction(Expression<?> operand, QueryDataType resultType) {
-        super(operand, resultType);
+    private ToTimestampTzFunction(Expression<?> operand) {
+        super(operand);
     }
 
-    public static ToTimestampTzFunction create(Expression<?> operand, QueryDataType resultType) {
-        return new ToTimestampTzFunction(operand, resultType);
+    public static ToTimestampTzFunction create(Expression<?> operand) {
+        return new ToTimestampTzFunction(operand);
     }
 
     @Override
@@ -57,12 +57,11 @@ public final class ToTimestampTzFunction extends UniExpressionWithType<OffsetDat
 
     @Override
     public OffsetDateTime eval(final Row row, final ExpressionEvalContext context) {
-        final Number value = (Number) this.operand.eval(row, context);
-        if (value == null) {
+        final Long unixTimestamp = (Long) this.operand.eval(row, context);
+        if (unixTimestamp == null) {
             return null;
         }
 
-        final long unixTimestamp = value.longValue();
         final TemporalUnit unit = getChronoUnit(unixTimestamp);
         final Instant instant = Instant.EPOCH.plus(unixTimestamp, unit);
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -74,34 +74,35 @@ public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> i
     }
 
     /**
-     * Returns TemporalUnit of the given unixTimestamp, using the
-     * magnitude of the value to determine most likely unit.
+     * Returns TemporalUnit of the given unixTimestamp, using the magnitude of
+     * the value to determine most likely unit.
      * <ol>
      * <li>unixTimestamp < MILLISECONDS_IN_YEAR (365 * 86400 *
-     * 1000) - timestamp is in seconds</li>
+     * 1000) - timestamp is in seconds
      * <li>unixTimestamp >= MILLISECONDS_IN_YEAR (365 * 86400 * 1000)
-     * - timestamp is in milliseconds</li>
+     * - timestamp is in milliseconds
      * <li>unixTimestamp >= MICROSECONDS_IN_YEAR
-     * (365 * 86400 * 1000_000) - timestamp is in microseconds</li>
+     * (365 * 86400 * 1000_000) - timestamp is in microseconds
      * <li>unixTimestamp >= NANOSECONDS_IN_YEAR (365 * 86400
-     * * 1000_000_000) - timestamp is in nanoseconds</li>
-     * <li>unixTimestamp < 0 - timestamp is in seconds</li>
+     * * 1000_000_000) - timestamp is in nanoseconds
+     * <li>unixTimestamp < 0 - timestamp is in seconds
      * </ol>
      *
-     * <p>Note that this also imposes limits on the possible max
-     * correctly interpreted timestamp value, that would be otherwise
-     * correctly interpreted as in seconds/milliseconds/microseconds.
-     * For example if this function is called on a unixTimestamp of
-     * 31_536_000_001 which in seconds corresponds to datetime of
-     * 2969-05-03 00:00:01, this function would instead interpret it
-     * as 1971-01-01 00:00:00.001. This is also true for maximum date
-     * expressed in milliseconds and microseconds. This of course also
-     * imposes the min date possible to be interpreted in milliseconds,
-     * microseconds and nanoseconds. Additionally any value less
-     * than 0 is treated as seconds regardless of the magnitude.</p>
+     * <p>
+     * Note that this also imposes limits on the possible max correctly
+     * interpreted timestamp value, that would be otherwise correctly
+     * interpreted as in seconds/milliseconds/microseconds. For example if this
+     * function is called on a unixTimestamp of 31_536_000_001 which in seconds
+     * corresponds to datetime of 2969-05-03 00:00:01, this function would
+     * instead interpret it as 1971-01-01 00:00:00.001. This is also true for
+     * maximum date expressed in milliseconds and microseconds. This of course
+     * also imposes the min date possible to be interpreted in milliseconds,
+     * microseconds and nanoseconds. Additionally any value less than 0 is
+     * treated as seconds regardless of the magnitude.
      *
-     * <p>Summary of Date limits (under which the
-     * interpretation of the timestamp's unit is correct):</p>
+     * <p>
+     * Summary of Date limits (under which the
+     * interpretation of the timestamp's unit is correct):
      * <pre>
      * 1. negative
      *    seconds:      from -999999999-01-01T00:00Z (-31557014135596800)

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -75,15 +75,11 @@ public final class ToTimestampTzFunction extends UniExpressionWithType<OffsetDat
     }
 
     private TemporalUnit getChronoUnit(final long unixTimestamp) {
-        // -Long.MIN_VALUE returns Long.MIN_VALUE, probably because an absolute value of that is Long.MAX_VALUE + 1.
-        final long absTimestamp = unixTimestamp == Long.MIN_VALUE
-                ? Long.MAX_VALUE
-                : Math.abs(unixTimestamp);
-        if (absTimestamp < YEAR_MILLISECONDS) {
+        if (unixTimestamp < YEAR_MILLISECONDS) {
             return ChronoUnit.SECONDS;
-        } else if (absTimestamp < YEAR_MICROSECONDS) {
+        } else if (unixTimestamp < YEAR_MICROSECONDS) {
             return ChronoUnit.MILLIS;
-        } else if (absTimestamp < YEAR_NANOSECONDS) {
+        } else if (unixTimestamp < YEAR_NANOSECONDS) {
             return ChronoUnit.MICROS;
         } else {
             return ChronoUnit.NANOS;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/datetime/ToTimestampTzFunction.java
@@ -74,30 +74,47 @@ public final class ToTimestampTzFunction extends UniExpression<OffsetDateTime> i
     }
 
     /**
-     * Returns TemporalUnit of the given unixTimestamp, using the magnitude of the value to determine most likely unit.
-     * - unixTimestamp < MILLISECONDS_IN_YEAR (365 * 86400 * 1000) - timestamp is in Seconds
-     * - unixTimestamp >= MILLISECONDS_IN_YEAR (365 * 86400 * 1000) - timestamp in in Milliseconds
-     * - unixTimestamp >= MICROSECONDS_IN_YEAR (365 * 86400 * 1000_000) - timestamp is in Microseconds
-     * - unixTimestamp >= NANOSECONDS_IN_YEAR (365 * 86400 * 1000_000_000) - timestamp is in Nanoseconds
-     * - unixTimestamp < 0 - timestamp is in Seconds
+     * Returns TemporalUnit of the given unixTimestamp, using the
+     * magnitude of the value to determine most likely unit.
+     * <ol>
+     * <li>unixTimestamp < MILLISECONDS_IN_YEAR (365 * 86400 *
+     * 1000) - timestamp is in seconds</li>
+     * <li>unixTimestamp >= MILLISECONDS_IN_YEAR (365 * 86400 * 1000)
+     * - timestamp is in milliseconds</li>
+     * <li>unixTimestamp >= MICROSECONDS_IN_YEAR
+     * (365 * 86400 * 1000_000) - timestamp is in microseconds</li>
+     * <li>unixTimestamp >= NANOSECONDS_IN_YEAR (365 * 86400
+     * * 1000_000_000) - timestamp is in nanoseconds</li>
+     * <li>unixTimestamp < 0 - timestamp is in seconds</li>
+     * </ol>
      *
-     * Note that this also imposes limits on the possible max correctly interpreted timestamp value,
-     * that would be otherwise correctly interpreted as in Seconds/Milliseconds/Microseconds.
-     * For example if this function is called on a unixTimestamp of 31_536_000_001 which in seconds
-     * corresponds to datetime of 2969-05-03 00:00:01, this function would instead interpret it
-     * as 1971-01-01 00:00:00.001. This is also true for maximum date expressed in milliseconds and microseconds.
-     * Additionally this of course also imposes the min date possible to be interpreted in Milliseconds,
-     * Microseconds and Nanoseconds.
+     * <p>Note that this also imposes limits on the possible max
+     * correctly interpreted timestamp value, that would be otherwise
+     * correctly interpreted as in seconds/milliseconds/microseconds.
+     * For example if this function is called on a unixTimestamp of
+     * 31_536_000_001 which in seconds corresponds to datetime of
+     * 2969-05-03 00:00:01, this function would instead interpret it
+     * as 1971-01-01 00:00:00.001. This is also true for maximum date
+     * expressed in milliseconds and microseconds. This of course also
+     * imposes the min date possible to be interpreted in milliseconds,
+     * microseconds and nanoseconds. Additionally any value less
+     * than 0 is treated as seconds regardless of the magnitude.</p>
      *
-     * Summary of Date limits (under which the interpretation of the timestamp's unit is correct):
-     * 1. Seconds:      from 1970-01-01 00:00:00Z (0)
+     * <p>Summary of Date limits (under which the
+     * interpretation of the timestamp's unit is correct):</p>
+     * <pre>
+     * 1. negative
+     *    seconds:      from -999999999-01-01T00:00Z (-31557014135596800)
+     *                  to   1969-12-31 23:59:59Z (-1)
+     * 2. seconds:      from 1970-01-01 00:00:00Z (0)
      *                  to   2969-05-02 23:59:59Z (MILLISECONDS_IN_YEAR - 1)
-     * 2. Milliseconds: from 1971-01-01 00:00:00.0Z (MILLISECONDS_IN_YEAR)
+     * 3. milliseconds: from 1971-01-01 00:00:00.0Z (MILLISECONDS_IN_YEAR)
      *                  to   2969-05-02 23:59:59.999Z (MICROSECONDS_IN_YEAR - 1)
-     * 3. Microseconds: from 1971-01-01 00:00:00.0Z (MICROSECONDS_IN_YEAR)
+     * 4. microseconds: from 1971-01-01 00:00:00.0Z (MICROSECONDS_IN_YEAR)
      *                  to   2969-05-02 23:59:59.999999Z (NANOSECONDS_IN_YEAR - 1)
-     * 4. Nanoseconds:  from 1971-01-01 00:00:00.0Z (NANOSECONDS_IN_YEAR)
+     * 5. nanoseconds:  from 1971-01-01 00:00:00.0Z (NANOSECONDS_IN_YEAR)
      *                  to   2262-04-11 23:47:16.854775807Z (Long.MAX_VALUE of nanoseconds).
+     * </pre>
      *
      * @param unixTimestamp - input timestamp
      * @return - determined {@link TemporalUnit} of the value, inferred based on the magnitude


### PR DESCRIPTION
Adds support for `TO_TIMESTAMP_TZ`  SQL function which converts arbitrary `BIGINT` values to `TIMESTAMP_WITH_TIMEZONE`. 

Example query: 
```
SELECT TO_TIMESTAMP_TZ(v) FROM TABLE (generate_series(1,3))
```

Example result: 
```
1970-01-01T03:00:00.001+03:00
1970-01-01T03:00:00.002+03:00
1970-01-01T03:00:00.003+03:00
```