### PR TITLE
[HZ-317] Add ClientConsole entrypoint into HazelcastCommandLine

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -1548,11 +1548,10 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         println("  executeOnKey <echo-input> <key>         executes an echo task on the member that");
         println("                                            owns the given key");
         println("  executeOnMembers <echo-input>           executes an echo task on all of the members");
-        println("  executeOnMembers <echo-input>");
-        println("                      <memberIndex>       executes an echo task on the member with given index");
-        println("  e<threadcount>.simulateLoad");
-        println("           <task-count> <delaySeconds>    simulates load on executor with given number of");
-        println("                                            thread (e1..e16)");
+        println("  executeOnMembers <echo-input>           executes an echo task on the member with");
+        println("                     <memberIndex>          given index");
+        println("  e<threadcount>.simulateLoad             simulates load on executor with given number");
+        println("          <task-count> <delaySeconds>       of thread (e1..e16)");
         println("");
     }
 
@@ -1560,23 +1559,28 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         printlnBold("IAtomicLong commands:");
         println("  a.get                                   gets the current value of atomic long");
         println("  a.set <long>                            atomically sets the given value");
-        println("  a.incrementAndGet                       atomically increment the current value by one and");
-        println("                                            then gets the resulting value");
-        println("  a.decrementAndGet                       atomically decrement the current value by one and");
-        println("                                            then gets the resulting value");
+        println("  a.incrementAndGet                       atomically increment the current value by");
+        println("                                            one and then gets the resulting value");
+        println("  a.decrementAndGet                       atomically decrement the current value by");
+        println("                                            one and then gets the resulting value");
         println("");
     }
 
     private void printListCommands() {
         printlnBold("List commands:");
-        println("  l.add <string>                          adds the given string object to the end of the list");
-        println("  l.add <index> <string>                  adds the given string object to the specified position");
+        println("  l.add <string>                          adds the given string object to the end of the");
+        println("                                            list");
+        println("  l.add <index> <string>                  adds the given string object to the specified");
+        println("                                             position in the list");
+        println("  l.contains <string>                     checks whether if the given string presents");
         println("                                            in the list");
-        println("  l.contains <string>                     checks whether if the given string presents in the list");
         println("  l.remove <string>                       removes the first occurrence of the given string");
-        println("  l.remove <index>                        removes the string from the specified position of the list");
-        println("  l.set <index> <string>                  replaces the element at the specified pos. with given string");
-        println("  l.iterator [remove]                     iterates over the items of the list, remove if specified");
+        println("  l.remove <index>                        removes the string element from the specified");
+        println("                                             position of the list");
+        println("  l.set <index> <string>                  replaces the element at the specified position");
+        println("                                            with given string");
+        println("  l.iterator [remove]                     iterates over the items of the list, remove");
+        println("                                            if specified");
         println("  l.size                                  returns the number of element in the list");
         println("  l.clear                                 removes all items from the list");
         println("");

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -137,7 +137,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
                         .style(AttributedStyle.BOLD.foreground(COLOR)).append("%M%P > ").toAnsi())
                 .variable(LineReader.INDENTATION, 2)
                 .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
-                .appName("hazelcast-client-console-app")
+                .appName("hazelcast-console-app")
                 .build();
         if (writer == null) {
             this.writer = lineReader.getTerminal().writer();
@@ -209,7 +209,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
                 writer.flush();
                 break;
             } catch (UserInterruptException e) {
-                // Ctrl+C cancels the not-yet-submitted query
+                // Ctrl+C cancels the not-yet-submitted command
                 continue;
             }
             running = running && client.getLifecycleService().isRunning();
@@ -307,12 +307,11 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             while (iterator.hasNext()) {
                 History.Entry entry = iterator.next();
                 if (iterator.hasNext()) {
-                    String entryLine = new AttributedStringBuilder()
-                            .style(AttributedStyle.BOLD)
-                            .append(String.valueOf(entry.index() + 1))
+                    String entryLine = new StringBuilder()
+                            .append(entry.index() + 1)
                             .append(" - ")
                             .append(entry.line())
-                            .toAnsi();
+                            .toString();
                     writer.println(entryLine);
                     writer.flush();
                 } else {
@@ -443,9 +442,9 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             handleAtomicNumberGet(args);
         } else if ("a.set".equals(first)) {
             handleAtomicNumberSet(args);
-        } else if ("a.inc".equals(first)) {
+        } else if ("a.incrementAndGet".equals(first)) {
             handleAtomicNumberInc(args);
-        } else if ("a.dec".equals(first)) {
+        } else if ("a.decrementAndGet".equals(first)) {
             handleAtomicNumberDec(args);
         } else if (first.equals("execute")) {
             execute(args);
@@ -1416,13 +1415,13 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     protected void handleHelp(String command) {
         boolean silentBefore = silent;
         silent = false;
-        println("Commands:");
+        printlnBold("Commands:");
 
         printGeneralCommands();
+        printMapCommands();
         printQueueCommands();
         printSetCommands();
         printLockCommands();
-        printMapCommands();
         printMulitiMapCommands();
         printListCommands();
         printAtomicLongCommands();
@@ -1432,34 +1431,35 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
     private void printGeneralCommands() {
-        println("General commands:");
+        printlnBold("General commands:");
         println("  echo true|false                         turns on/off echo of commands (default false)");
         println("  clear                                   clears the terminal screen");
         println("  exit                                    exits from the client console app.");
         println("  silent true|false                       turns on/off silent of command output (default false)");
-        println("  #<number> <command>                     repeats <number> time <command>, replace $i in\n"
-                + "<command> with current iteration (0..<number-1>)");
-        println("  &<number> <command>                     forks <number> threads to execute <command>,");
-        println("replace $t in <command> with current thread number (0..<number-1>");
-        println("When using #x or &x, is is advised to use silent true as well.");
-        println("When using &x with m.putmany and m.removemany, each thread will get a different");
-        println("share of keys unless a start key index is specified\n");
+        println("  #<number> <command>                     repeats <number> time <command>, replace $i in");
+        println("                                            <command> with current iteration (0..<number-1>)");
+        println("  &<number> <command>                     forks <number> threads to execute <command>, replace");
+        println("                                            $t in <command> with current thread number (0..<number-1>).");
+        println("                                            When using #x or &x, is is advised to use silent true");
+        println("                                            as well. When using &x with m.putmany and m.removemany,");
+        println("                                            each thread will get a different share of keys unless");
+        println("                                            a start key index is specified.");
         println("  history                                 shows the command history of the current session");
         println("  jvm                                     displays info about the runtime");
         println("  who                                     displays info about the cluster");
-        println("  ns <string>                             switch the namespace for using the distributed\n"
-                + " queue/map/set/list <string> (defaults to \"default\"");
-        println("  @<file>                                 executes the given <file> script. Use '//' for\n"
-                + " comments in the script");
+        println("  ns <string>                             switch the namespace for using the distributed");
+        println("                                            queue/map/set/list <string> (defaults to \"default\")");
+        println("  @<file>                                 executes the given <file> script. Use '//' for");
+        println("                                            comments in the script");
         println("");
     }
 
     private void printQueueCommands() {
-        println("Queue commands:");
+        printlnBold("Queue commands:");
         println("  q.offer <string>                        adds a string object to the queue");
         println("  q.poll                                  takes an object from the queue");
-        println("  q.offermany <number> [<size>]           adds indicated number of string objects to the queue ('obj<i>' or "
-                + "byte[<size>]) ");
+        println("  q.offermany <number> [<size>]           adds indicated number of string objects to the");
+        println("                                            queue ('obj<i>' or  byte[<size>]) ");
         println("  q.pollmany <number>                     takes indicated number of objects from the queue");
         println("  q.iterator [remove]                     iterates the queue, remove if specified");
         println("  q.size                                  size of the queue");
@@ -1468,10 +1468,11 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
     private void printSetCommands() {
-        println("Set commands:");
+        printlnBold("Set commands:");
         println("  s.add <string>                          adds a string object to the set");
         println("  s.remove <string>                       removes the string object from the set");
-        println("  s.addmany <number>                      adds indicated number of string objects to the set ('obj<i>')");
+        println("  s.addmany <number>                      adds indicated number of string objects");
+        println("                                            to the set ('obj<i>')");
         println("  s.removemany <number>                   takes indicated number of objects from the set");
         println("  s.iterator [remove]                     iterates the set, removes if specified");
         println("  s.size                                  size of the set");
@@ -1480,31 +1481,31 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
     private void printLockCommands() {
-        println("Lock commands:");
-        println("These lock commands demonstrate the usage of Hazelcast's linearizable, distributed, and reentrant");
-        println("implementation of Lock.");
-        println("For more information, see `com.hazelcast.cp.lock.FencedLock`");
-        println(" lock <name>                               acquires the lock with the given name");
-        println(" tryLock <name>                            acquires the lock only if it is free at the time\n"
-                + "of invocation");
-        println(" tryLock <name> <time>                     acquires the lock if it is free within the given\n"
-                + "waiting time");
-        println(" unlock <name>                             releases the lock if the lock is currently held\n"
-                + "by the current thread");
+        printlnBold("Lock commands:");
+        println("  These lock commands demonstrate the usage of Hazelcast's linearizable, distributed, and reentrant");
+        println("  implementation of Lock. For more information, see `com.hazelcast.cp.lock.FencedLock`.");
+        println("  lock <name>                             acquires the lock with the given name");
+        println("  tryLock <name>                          acquires the lock only if it is free at the time");
+        println("                                            of invocation");
+        println("  tryLock <name> <time>                   acquires the lock if it is free within the given");
+        println("                                            waiting time");
+        println("  unlock <name>                           releases the lock if the lock is currently held");
+        println("                                            by the current thread");
         println("");
     }
 
     private void printMapCommands() {
-        println("Map commands:");
+        printlnBold("Map commands:");
         println("  m.put <key> <value>                     puts an entry to the map");
         println("  m.remove <key>                          removes the entry of given key from the map");
         println("  m.get <key>                             returns the value of given key from the map");
         println("  m.putmany <number> [<size>] [<index>]   puts indicated number of entries to the map:");
-        println("('key<i>':byte[<size>], <index>+(0..<number>)");
+        println("                                            ('key<i>':byte[<size>], <index>+(0..<number>)");
         println("  m.removemany <number> [<index>]         removes indicated number of entries from the map");
-        println("('key<i>', <index>+(0..<number>)");
-        println("When using &x with m.putmany and m.removemany, each thread will get a different share of keys unless a "
-                + "start key <index> is specified");
+        println("                                            ('key<i>', <index>+(0..<number>)");
+        println("                                            When using &x with m.putmany and m.removemany, each");
+        println("                                            thread will get a different share of keys unless a");
+        println("                                            start key <index> is specified");
         println("  m.keys                                  iterates the keys of the map");
         println("  m.values                                iterates the values of the map");
         println("  m.entries                               iterates the entries of the map");
@@ -1522,7 +1523,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
     private void printMulitiMapCommands() {
-        println("MultiMap commands:");
+        printlnBold("MultiMap commands:");
         println("  mm.put <key> <value>                    puts an entry to the multimap");
         println("  mm.get <key>                            returns the value of given key from the multimap");
         println("  mm.remove <key>                         removes the entry of given key from the multimap");
@@ -1542,51 +1543,60 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
     private void printExecutorServiceCommands() {
-        println("Executor Service commands:");
-        println("  execute <echo-input>                           executes an echo task on random member");
-        println("  executeOnKey <echo-input> <key>                executes an echo task on the member that owns the given key");
-        println("  executeOnMembers <echo-input>                  executes an echo task on all of the members");
-        println("  executeOnMembers <echo-input> <memberIndex>    executes an echo task on the member with given index");
-        println("  e<threadcount>.simulateLoad <task-count> <delaySeconds>     simulates load on executor with given");
-        println("number of thread (e1..e16)");
+        printlnBold("Executor Service commands:");
+        println("  execute <echo-input>                    executes an echo task on random member");
+        println("  executeOnKey <echo-input> <key>         executes an echo task on the member that");
+        println("                                            owns the given key");
+        println("  executeOnMembers <echo-input>           executes an echo task on all of the members");
+        println("  executeOnMembers <echo-input>");
+        println("                      <memberIndex>       executes an echo task on the member with given index");
+        println("  e<threadcount>.simulateLoad");
+        println("           <task-count> <delaySeconds>    simulates load on executor with given number of");
+        println("                                            thread (e1..e16)");
         println("");
     }
 
     private void printAtomicLongCommands() {
-        println("IAtomicLong commands:");
-        println("  a.get");
-        println("  a.set <long>");
-        println("  a.inc");
-        println("  a.dec");
-        print("");
+        printlnBold("IAtomicLong commands:");
+        println("  a.get                                   gets the current value of atomic long");
+        println("  a.set <long>                            atomically sets the given value");
+        println("  a.incrementAndGet                       atomically increment the current value by one and");
+        println("                                            then gets the resulting value");
+        println("  a.decrementAndGet                       atomically decrement the current value by one and");
+        println("                                            then gets the resulting value");
+        println("");
     }
 
     private void printListCommands() {
-        println("List commands:");
-        println("  l.add <string>");
-        println("  l.add <index> <string>");
-        println("  l.contains <string>");
-        println("  l.remove <string>");
-        println("  l.remove <index>");
-        println("  l.set <index> <string>");
-        println("  l.iterator [remove]");
-        println("  l.size");
-        println("  l.clear");
-        print("");
+        printlnBold("List commands:");
+        println("  l.add <string>                          adds the given string object to the end of the list");
+        println("  l.add <index> <string>                  adds the given string object to the specified position");
+        println("                                            in the list");
+        println("  l.contains <string>                     checks whether if the given string presents in the list");
+        println("  l.remove <string>                       removes the first occurrence of the given string");
+        println("  l.remove <index>                        removes the string from the specified position of the list");
+        println("  l.set <index> <string>                  replaces the element at the specified pos. with given string");
+        println("  l.iterator [remove]                     iterates over the items of the list, remove if specified");
+        println("  l.size                                  returns the number of element in the list");
+        println("  l.clear                                 removes all items from the list");
+        println("");
     }
 
     public void println(Object obj) {
         if (!silent) {
-            writer.println(new AttributedStringBuilder()
-                    .style(AttributedStyle.BOLD)
-                    .append(String.valueOf(obj))
-                    .toAnsi());
+            writer.println(obj);
         }
     }
 
     public void print(Object obj) {
         if (!silent) {
-            writer.print(new AttributedStringBuilder()
+            writer.print(obj);
+        }
+    }
+
+    public void printlnBold(Object obj) {
+        if (!silent) {
+            writer.println(new AttributedStringBuilder()
                     .style(AttributedStyle.BOLD)
                     .append(String.valueOf(obj))
                     .toAnsi());
@@ -1601,18 +1611,16 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         Cluster cluster = hazelcastClientImpl.getCluster();
         Set<Member> members = cluster.getMembers();
         String versionString = "Hazelcast " + clusterMetadata.getMemberVersion();
-        return new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD)
+        return new StringBuilder()
                 .append("Hazelcast Console Application has started.\n")
                 .append("Connected to ")
                 .append(versionString)
                 .append(" at ")
                 .append(members.iterator().next().getAddress().toString())
                 .append(" (+")
-                .append(String.valueOf(members.size() - 1))
+                .append(members.size() - 1)
                 .append(" more)\n")
-                .append("Type 'help' for instructions")
-                .toAnsi();
+                .append("Type 'help' for instructions").toString();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -1537,7 +1537,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
      * Starts the test application. It loads the client configuration using the resolution logic as described in
      * {@link HazelcastClient#newHazelcastClient()}.
      */
-    public static void main(String[] args) {
+    public static void run(String[] args) {
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
         ClientConsoleApp clientConsoleApp = new ClientConsoleApp(client, System.out);
         clientConsoleApp.start(args);

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -1423,7 +1423,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         println("                                            <command> with current iteration (0..<number-1>)");
         println("  &<number> <command>                     forks <number> threads to execute <command>, replace");
         println("                                            $t in <command> with current thread number (0..<number-1>).");
-        println("                                            When using #x or &x, is is advised to use silent true");
+        println("                                            When using #x or &x, it is advised to use silent true");
         println("                                            as well. When using &x with m.putmany and m.removemany,");
         println("                                            each thread will get a different share of keys unless");
         println("                                            a start key index is specified.");

--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -1583,8 +1583,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
      * Starts the test application. It loads the client configuration using the resolution logic as described in
      * {@link HazelcastClient#newHazelcastClient()}.
      */
-    public static void run(String[] args) {
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+    public static void run(HazelcastInstance client, String[] args) {
         ClientConsoleApp clientConsoleApp = new ClientConsoleApp(client);
         clientConsoleApp.start(args);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -202,7 +202,7 @@ public class HazelcastCommandLine implements Runnable {
     @Command(
             name = "console-app",
             description = "Starts the console application for trying out in-memory data structures of Hazelcast."
-                    + "It is not recommended for use in production.")
+                    + " It is not recommended for use in production.")
     public void consoleApp(
             @Mixin(name = "verbosity") Verbosity verbosity,
             @Mixin(name = "targets") TargetsMixin targets

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -200,7 +200,7 @@ public class HazelcastCommandLine implements Runnable {
     }
 
     @Command(
-            name = "console-app",
+            name = "console",
             description = "Starts the console application for trying out in-memory data structures of Hazelcast."
                     + " It is not recommended for use in production.")
     public void consoleApp(

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -199,11 +199,18 @@ public class HazelcastCommandLine implements Runnable {
                 file.getAbsolutePath(), snapshotName, name, mainClass, params);
     }
 
-    @Command(description = "Starts the demo console application to demonstrate a Hazelcast data structures.")
-    public void consoleapp(@Mixin(name = "verbosity") Verbosity verbosity,
-                           @Mixin(name = "targets") TargetsMixin targets
+    @Command(
+            name = "console-app",
+            description = "Starts the console application for trying out in-memory data structures of Hazelcast."
+                    + "It is not recommended for use in production.")
+    public void consoleApp(@Mixin(name = "verbosity") Verbosity verbosity,
+                           @Mixin(name = "targets") TargetsMixin targets,
+                           @Parameters(index = "0..*",
+                                   paramLabel = "<arguments>",
+                                   description = "Arguments to pass to the client console application"
+                           ) List<String> params
     ) {
-        runWithHazelcast(targets, verbosity, true, client -> ClientConsoleApp.run(client, new String[]{""}));
+        runWithHazelcast(targets, verbosity, true, client -> ClientConsoleApp.run(client, params));
     }
 
     @Command(description = "Suspends a running job")

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -203,14 +203,11 @@ public class HazelcastCommandLine implements Runnable {
             name = "console-app",
             description = "Starts the console application for trying out in-memory data structures of Hazelcast."
                     + "It is not recommended for use in production.")
-    public void consoleApp(@Mixin(name = "verbosity") Verbosity verbosity,
-                           @Mixin(name = "targets") TargetsMixin targets,
-                           @Parameters(index = "0..*",
-                                   paramLabel = "<arguments>",
-                                   description = "Arguments to pass to the client console application"
-                           ) List<String> params
+    public void consoleApp(
+            @Mixin(name = "verbosity") Verbosity verbosity,
+            @Mixin(name = "targets") TargetsMixin targets
     ) {
-        runWithHazelcast(targets, verbosity, true, client -> ClientConsoleApp.run(client, params));
+        runWithHazelcast(targets, verbosity, true, ClientConsoleApp::run);
     }
 
     @Command(description = "Suspends a running job")

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -44,28 +44,7 @@ import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JobSummary;
-import com.hazelcast.sql.HazelcastSqlException;
-import com.hazelcast.sql.SqlColumnMetadata;
-import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.SqlResult;
-import com.hazelcast.sql.SqlRow;
-import com.hazelcast.sql.SqlRowMetadata;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.jline.reader.EOFError;
-import org.jline.reader.EndOfFileException;
-import org.jline.reader.History;
-import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
-import org.jline.reader.ParsedLine;
-import org.jline.reader.Parser;
-import org.jline.reader.SyntaxError;
-import org.jline.reader.UserInterruptException;
-import org.jline.reader.impl.DefaultParser;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.AttributedStringBuilder;
-import org.jline.utils.AttributedStyle;
-import org.jline.utils.InfoCmp;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.DefaultExceptionHandler;
@@ -81,23 +60,17 @@ import picocli.CommandLine.ParseResult;
 import picocli.CommandLine.RunAll;
 
 import java.io.File;
-import java.io.IOError;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -105,9 +78,6 @@ import java.util.logging.LogManager;
 
 import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
-import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
-import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
-import static com.hazelcast.internal.util.StringUtil.trim;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
@@ -119,10 +89,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
         "MismatchedQueryAndUpdateOfCollection",
         "checkstyle:ClassFanOutComplexity",
         "checkstyle:MethodCount",
-        "checkstyle:CyclomaticComplexity",
-        "checkstyle:MethodLength",
-        "checkstyle:NPathComplexity",
-        "checkstyle:TrailingComment"
 })
 @Command(
         name = "hazelcast",
@@ -139,8 +105,6 @@ public class HazelcastCommandLine implements Runnable {
 
     private static final int MAX_STR_LENGTH = 24;
     private static final int WAIT_INTERVAL_MILLIS = 100;
-    private static final int PRIMARY_COLOR = AttributedStyle.YELLOW;
-    private static final int SECONDARY_COLOR = 12;
 
     private final Function<ClientConfig, HazelcastInstance> hzClientFn;
     private final PrintStream out;
@@ -184,99 +148,7 @@ public class HazelcastCommandLine implements Runnable {
     public void sql(@Mixin(name = "verbosity") Verbosity verbosity,
                     @Mixin(name = "targets") TargetsMixin targets
     ) {
-        runWithHazelcast(targets, verbosity, true, hz -> {
-            LineReader reader = LineReaderBuilder.builder().parser(new MultilineParser())
-                    .variable(LineReader.SECONDARY_PROMPT_PATTERN, new AttributedStringBuilder()
-                            .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR)).append("%M%P > ").toAnsi())
-                    .variable(LineReader.INDENTATION, 2)
-                    .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
-                    .appName("hazelcast-sql")
-                    .build();
-
-            AtomicReference<SqlResult> activeSqlResult = new AtomicReference<>();
-            reader.getTerminal().handle(Signal.INT, signal -> {
-                SqlResult r = activeSqlResult.get();
-                if (r != null) {
-                    r.close();
-                }
-            });
-
-            PrintWriter writer = reader.getTerminal().writer();
-            writer.println(sqlStartingPrompt(hz));
-            writer.flush();
-
-            for (; ; ) {
-                String command;
-                try {
-                    command = reader.readLine(new AttributedStringBuilder()
-                            .style(AttributedStyle.DEFAULT.foreground(SECONDARY_COLOR))
-                            .append("sql> ").toAnsi()).trim();
-                } catch (EndOfFileException | IOError e) {
-                    // Ctrl+D, and kill signals result in exit
-                    writer.println(SQLCliConstants.EXIT_PROMPT);
-                    writer.flush();
-                    break;
-                } catch (UserInterruptException e) {
-                    // Ctrl+C cancels the not-yet-submitted query
-                    continue;
-                }
-
-                command = command.trim();
-                if (command.length() > 0 && command.charAt(command.length() - 1) == ';') {
-                    command = command.substring(0, command.length() - 1).trim();
-                } else if (command.lastIndexOf(";") >= 0) {
-                    String errorPrompt = new AttributedStringBuilder()
-                            .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                            .append("There are non-whitespace characters after the semicolon")
-                            .toAnsi();
-                    writer.println(errorPrompt);
-                    writer.flush();
-                    continue;
-                }
-
-                if ("".equals(command)) {
-                    continue;
-                }
-                if (equalsIgnoreCase("clear", command)) {
-                    reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
-                    continue;
-                }
-                if (equalsIgnoreCase("help", command)) {
-                    writer.println(helpPrompt(hz));
-                    writer.flush();
-                    continue;
-                }
-                if (equalsIgnoreCase("history", command)) {
-                    History hist = reader.getHistory();
-                    ListIterator<History.Entry> iterator = hist.iterator();
-                    while (iterator.hasNext()) {
-                        History.Entry entry = iterator.next();
-                        if (iterator.hasNext()) {
-                            String entryLine = new AttributedStringBuilder()
-                                    .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                                    .append(String.valueOf(entry.index() + 1))
-                                    .append(" - ")
-                                    .append(entry.line())
-                                    .toAnsi();
-                            writer.println(entryLine);
-                            writer.flush();
-                        } else {
-                            // remove the "history" command from the history
-                            iterator.remove();
-                            hist.resetIndex();
-                        }
-                    }
-                    continue;
-                }
-                if (equalsIgnoreCase("exit", command)) {
-                    writer.println(SQLCliConstants.EXIT_PROMPT);
-                    writer.flush();
-                    break;
-                }
-
-                executeSqlCmd(hz, command, reader.getTerminal(), activeSqlResult);
-            }
-        });
+        runWithHazelcast(targets, verbosity, true, SqlConsole::run);
     }
 
     @Command(description = "Submits a job to the cluster")
@@ -548,7 +420,7 @@ public class HazelcastCommandLine implements Runnable {
         });
     }
 
-    private CompletableFuture<MCClusterMetadata> getClusterMetadata(HazelcastClientInstanceImpl client, Member member) {
+    protected static CompletableFuture<MCClusterMetadata> getClusterMetadata(HazelcastClientInstanceImpl client, Member member) {
         checkNotNull(member);
 
         ClientInvocation invocation = new ClientInvocation(
@@ -647,98 +519,7 @@ public class HazelcastCommandLine implements Runnable {
         out.println(msg);
     }
 
-    private void executeSqlCmd(
-            HazelcastInstance hz,
-            String command,
-            Terminal terminal,
-            AtomicReference<SqlResult> activeSqlResult
-    ) {
-        PrintWriter out = terminal.writer();
-        try (SqlResult sqlResult = hz.getSql().execute(command)) {
-            activeSqlResult.set(sqlResult);
 
-            // if it's a result with an update count, just print it
-            if (sqlResult.updateCount() != -1) {
-                String message = new AttributedStringBuilder()
-                        .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                        .append("OK")
-                        .toAnsi();
-                out.println(message);
-                return;
-            }
-            SqlRowMetadata rowMetadata = sqlResult.getRowMetadata();
-            int[] colWidths = determineColumnWidths(rowMetadata);
-            Alignment[] alignments = determineAlignments(rowMetadata);
-
-            // this is a result with rows. Print the header and rows, watch for concurrent cancellation
-            printMetadataInfo(rowMetadata, colWidths, alignments, out);
-
-            int rowCount = 0;
-            for (SqlRow row : sqlResult) {
-                rowCount++;
-                printRow(row, colWidths, alignments, out);
-            }
-
-            // bottom line after all the rows
-            printSeparatorLine(sqlResult.getRowMetadata().getColumnCount(), colWidths, out);
-
-            String message = new AttributedStringBuilder()
-                    .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                    .append(String.valueOf(rowCount))
-                    .append(" row(s) selected")
-                    .toAnsi();
-            out.println(message);
-        } catch (HazelcastSqlException e) {
-            // the query failed to execute
-            String errorPrompt = new AttributedStringBuilder()
-                    .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                    .append(e.getMessage())
-                    .toAnsi();
-            out.println(errorPrompt);
-        }
-    }
-
-    private String sqlStartingPrompt(HazelcastInstance hz) {
-        HazelcastClientInstanceImpl hazelcastClientImpl = getHazelcastClientInstanceImpl(hz);
-        ClientClusterService clientClusterService = hazelcastClientImpl.getClientClusterService();
-        MCClusterMetadata clusterMetadata =
-                FutureUtil.getValue(getClusterMetadata(hazelcastClientImpl, clientClusterService.getMasterMember()));
-        Cluster cluster = hazelcastClientImpl.getCluster();
-        Set<Member> members = cluster.getMembers();
-        String versionString = "Hazelcast Platform " + clusterMetadata.getMemberVersion();
-        return new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                .append("Connected to ")
-                .append(versionString)
-                .append(" at ")
-                .append(members.iterator().next().getAddress().toString())
-                .append(" (+")
-                .append(String.valueOf(members.size() - 1))
-                .append(" more)\n")
-                .append("Type 'help' for instructions")
-                .toAnsi();
-    }
-
-    private String helpPrompt(HazelcastInstance hz) {
-        HazelcastClientInstanceImpl hazelcastClientImpl = getHazelcastClientInstanceImpl(hz);
-        ClientClusterService clientClusterService = hazelcastClientImpl.getClientClusterService();
-        AttributedStringBuilder builder = new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                .append("Available Commands:\n")
-                .append("  clear    Clears the terminal screen\n")
-                .append("  exit     Exits from the SQL console\n")
-                .append("  help     Provides information about available commands\n")
-                .append("  history  Shows the command history of the current session\n")
-                .append("Hints:\n")
-                .append("  Semicolon completes a query\n")
-                .append("  Ctrl+C cancels a streaming query\n")
-                .append("  https://docs.hazelcast.com/");
-        return builder.toAnsi();
-    }
-
-    private enum Alignment {
-        LEFT, RIGHT
-    }
 
     static void runCommandLine(
             Function<ClientConfig, HazelcastInstance> hzClientFn,
@@ -818,7 +599,7 @@ public class HazelcastCommandLine implements Runnable {
         return status != JobStatus.FAILED && status != JobStatus.COMPLETED;
     }
 
-    private static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
+    protected static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
         if (client instanceof HazelcastClientProxy) {
             return ((HazelcastClientProxy) client).client;
         } else if (client instanceof HazelcastClientInstanceImpl) {
@@ -827,172 +608,6 @@ public class HazelcastCommandLine implements Runnable {
             throw new IllegalArgumentException("This method can be called only with client"
                     + " instances such as HazelcastClientProxy and HazelcastClientInstanceImpl.");
         }
-    }
-
-    private static int[] determineColumnWidths(SqlRowMetadata metadata) {
-        int colCount = metadata.getColumnCount();
-        int[] colWidths = new int[colCount];
-        for (int i = 0; i < colCount; i++) {
-            SqlColumnMetadata colMetadata = metadata.getColumn(i);
-            SqlColumnType type = colMetadata.getType();
-            String colName = colMetadata.getName();
-            switch (type) {
-                case BOOLEAN:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.BOOLEAN_FORMAT_LENGTH);
-                    break;
-                case DATE:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.DATE_FORMAT_LENGTH);
-                    break;
-                case TIMESTAMP_WITH_TIME_ZONE:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.TIMESTAMP_WITH_TIME_ZONE_FORMAT_LENGTH);
-                    break;
-                case DECIMAL:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.DECIMAL_FORMAT_LENGTH);
-                    break;
-                case REAL:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.REAL_FORMAT_LENGTH);
-                    break;
-                case DOUBLE:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.DOUBLE_FORMAT_LENGTH);
-                    break;
-                case INTEGER:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.INTEGER_FORMAT_LENGTH);
-                    break;
-                case NULL:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.NULL_FORMAT_LENGTH);
-                    break;
-                case TINYINT:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.TINYINT_FORMAT_LENGTH);
-                    break;
-                case SMALLINT:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.SMALLINT_FORMAT_LENGTH);
-                    break;
-                case TIMESTAMP:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.TIMESTAMP_FORMAT_LENGTH);
-                    break;
-                case BIGINT:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.BIGINT_FORMAT_LENGTH);
-                    break;
-                case VARCHAR:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.VARCHAR_FORMAT_LENGTH);
-                    break;
-                case OBJECT:
-                    colWidths[i] = determineColumnWidth(colName, SQLCliConstants.OBJECT_FORMAT_LENGTH);
-                    break;
-                default:
-                    throw new UnsupportedOperationException(type.toString());
-            }
-        }
-        return colWidths;
-    }
-
-    private static int determineColumnWidth(String header, int typeLength) {
-        return Math.max(Math.min(header.length(), SQLCliConstants.VARCHAR_FORMAT_LENGTH), typeLength);
-    }
-
-    private static Alignment[] determineAlignments(SqlRowMetadata metadata) {
-        int colCount = metadata.getColumnCount();
-        Alignment[] alignments = new Alignment[colCount];
-        for (int i = 0; i < colCount; i++) {
-            SqlColumnMetadata colMetadata = metadata.getColumn(i);
-            SqlColumnType type = colMetadata.getType();
-            String colName = colMetadata.getName();
-            switch (type) {
-                case BIGINT:
-                case DECIMAL:
-                case DOUBLE:
-                case INTEGER:
-                case REAL:
-                case SMALLINT:
-                case TINYINT:
-                    alignments[i] = Alignment.RIGHT;
-                    break;
-                case BOOLEAN:
-                case DATE:
-                case NULL:
-                case OBJECT:
-                case TIMESTAMP:
-                case VARCHAR:
-                case TIMESTAMP_WITH_TIME_ZONE:
-                default:
-                    alignments[i] = Alignment.LEFT;
-            }
-        }
-        return alignments;
-    }
-
-    private static void printMetadataInfo(SqlRowMetadata metadata, int[] colWidths,
-                                          Alignment[] alignments, PrintWriter out) {
-        int colCount = metadata.getColumnCount();
-        printSeparatorLine(colCount, colWidths, out);
-        AttributedStringBuilder builder = new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
-        builder.append("|");
-        for (int i = 0; i < colCount; i++) {
-            String colName = metadata.getColumn(i).getName();
-            colName = sanitize(colName, colWidths[i]);
-            builder.style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR));
-            appendAligned(colWidths[i], colName, alignments[i], builder);
-            builder.style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
-            builder.append('|');
-        }
-        out.println(builder.toAnsi());
-        printSeparatorLine(colCount, colWidths, out);
-        out.flush();
-    }
-
-    private static void printRow(SqlRow row, int[] colWidths, Alignment[] alignments, PrintWriter out) {
-        AttributedStringBuilder builder = new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
-        builder.append("|");
-        int columnCount = row.getMetadata().getColumnCount();
-        for (int i = 0; i < columnCount; i++) {
-            String colString = row.getObject(i) != null ? sanitize(row.getObject(i).toString(), colWidths[i]) : "NULL";
-            builder.style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR));
-            appendAligned(colWidths[i], colString, alignments[i], builder);
-            builder.style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
-            builder.append('|');
-        }
-        out.println(builder.toAnsi());
-        out.flush();
-    }
-
-    private static String sanitize(String s, int width) {
-        s = s.replace("\n", "\\n");
-        if (s.length() > width) {
-            s = s.substring(0, width - 1) + "\u2026";
-        }
-        return s;
-    }
-
-    private static void appendAligned(int width, String s, Alignment alignment, AttributedStringBuilder builder) {
-        int padding = width - s.length();
-        assert padding >= 0;
-
-        if (alignment == Alignment.RIGHT) {
-            appendPadding(builder, padding, ' ');
-        }
-        builder.append(s);
-        if (alignment == Alignment.LEFT) {
-            appendPadding(builder, padding, ' ');
-        }
-    }
-
-    private static void appendPadding(AttributedStringBuilder builder, int length, char paddingChar) {
-        for (int i = 0; i < length; i++) {
-            builder.append(paddingChar);
-        }
-    }
-
-    private static void printSeparatorLine(int colSize, int[] colWidths, PrintWriter out) {
-        AttributedStringBuilder builder = new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
-        builder.append('+');
-        for (int i = 0; i < colSize; i++) {
-            appendPadding(builder, colWidths[i], '-');
-            builder.append('+');
-        }
-        out.println(builder.toAnsi());
     }
 
     public static class HazelcastVersionProvider implements IVersionProvider {
@@ -1104,139 +719,5 @@ public class HazelcastCommandLine implements Runnable {
             }
             return e;
         }
-    }
-
-    /**
-     * A parser for SQL-like inputs. Commands are terminated with a semicolon.
-     * It is adapted from
-     * <a href="https://github.com/julianhyde/sqlline/blob/master/src/main/java/sqlline/SqlLineParser.java">
-     * SqlLineParser</a>
-     * which is licensed under the BSD-3-Clause License.
-     */
-    private static final class MultilineParser extends DefaultParser {
-
-        private MultilineParser() {
-        }
-
-        @Override
-        public ParsedLine parse(String line, int cursor, Parser.ParseContext context) throws SyntaxError {
-            super.setQuoteChars(new char[]{'\'', '"'});
-            super.setEofOnUnclosedQuote(true);
-            stateCheck(line, cursor);
-            return new ArgumentList(line, Collections.emptyList(), -1, -1,
-                    cursor, "'", -1, -1);
-        }
-
-        private void stateCheck(String line, int cursor) {
-            boolean containsNonWhitespaceData = false;
-            int quoteStart = -1;
-            int oneLineCommentStart = -1;
-            int multiLineCommentStart = -1;
-            int lastSemicolonIdx = -1;
-            for (int i = 0; i < line.length(); i++) {
-                // If a one line comment, a multiline comment or a quote is not started before,
-                // check if the character we're on is a quote character
-                if (oneLineCommentStart == -1
-                        && multiLineCommentStart == -1
-                        && quoteStart < 0
-                        && (isQuoteChar(line, i))) {
-                    // Start a quote block
-                    quoteStart = i;
-                    containsNonWhitespaceData = true;
-                } else {
-                    char currentChar = line.charAt(i);
-                    if (quoteStart >= 0) {
-                        // In a quote block
-                        if ((line.charAt(quoteStart) == currentChar) && !isEscaped(line, i)) {
-                            // End the block; arg could be empty, but that's fine
-                            quoteStart = -1;
-                        }
-                    } else if (oneLineCommentStart == -1
-                            && line.regionMatches(i, "/*", 0, "/*".length())) {
-                        // Enter the multiline comment block
-                        multiLineCommentStart = i;
-                        containsNonWhitespaceData = true;
-                    } else if (multiLineCommentStart >= 0) {
-                        // In a multiline comment block
-                        if (i - multiLineCommentStart > 2
-                                && line.regionMatches(i - 1, "*/", 0, "*/".length())) {
-                            // End the multiline block
-                            multiLineCommentStart = -1;
-                        }
-                    } else if (oneLineCommentStart == -1
-                            && line.regionMatches(i, "--", 0, "--".length())) {
-                        // Enter the one line comment block
-                        oneLineCommentStart = i;
-                        containsNonWhitespaceData = true;
-                    } else if (oneLineCommentStart >= 0) {
-                        // In a one line comment
-                        if (currentChar == '\n') {
-                            // End the one line comment block
-                            oneLineCommentStart = -1;
-                        }
-                    } else {
-                        // Not in a quote or comment block
-                        if (currentChar == ';') {
-                            lastSemicolonIdx = i;
-                        } else if (!Character.isWhitespace(currentChar)) {
-                            containsNonWhitespaceData = true;
-                        }
-                    }
-                }
-            }
-
-            if (SQLCliConstants.COMMAND_SET.contains(lowerCaseInternal(trim(line)))) {
-                return;
-            }
-            // These EOFError exceptions are captured in LineReader's
-            // readLine() method and it points out that the command
-            // being written to console is not finalized and command
-            // won't be read
-            if (isEofOnEscapedNewLine() && isEscapeChar(line, line.length() - 1)) {
-                throw new EOFError(-1, cursor, "Escaped new line");
-            }
-
-            if (isEofOnUnclosedQuote() && quoteStart >= 0) {
-                throw new EOFError(-1, quoteStart, "Missing closing quote",
-                        line.charAt(quoteStart) == '\'' ? "quote" : "dquote");
-            }
-
-            if (oneLineCommentStart != -1) {
-                throw new EOFError(-1, cursor, "One line comment");
-            }
-
-            if (multiLineCommentStart != -1) {
-                throw new EOFError(-1, cursor, "Missing end of comment", "**");
-            }
-
-            if (containsNonWhitespaceData
-                    && (lastSemicolonIdx == -1 || lastSemicolonIdx >= cursor)) {
-                throw new EOFError(-1, cursor, "Missing semicolon (;)");
-            }
-        }
-
-    }
-
-    private static class SQLCliConstants {
-
-        static final Set<String> COMMAND_SET = new HashSet<>(Arrays.asList("clear", "exit", "help", "history"));
-        static final String EXIT_PROMPT = new AttributedStringBuilder()
-                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
-                .append("Exiting from SQL console")
-                .toAnsi();
-        static final Integer BOOLEAN_FORMAT_LENGTH = 5;
-        static final Integer BIGINT_FORMAT_LENGTH = 20;
-        static final Integer DATE_FORMAT_LENGTH = 10;
-        static final Integer DECIMAL_FORMAT_LENGTH = 25; // it has normally unlimited precision
-        static final Integer DOUBLE_FORMAT_LENGTH = 25; // it has normally unlimited precision
-        static final Integer INTEGER_FORMAT_LENGTH = 12;
-        static final Integer NULL_FORMAT_LENGTH = 4;
-        static final Integer REAL_FORMAT_LENGTH = 25; // it has normally unlimited precision
-        static final Integer OBJECT_FORMAT_LENGTH = 20; // it has normally unlimited precision
-        static final Integer TINYINT_FORMAT_LENGTH = 4;
-        static final Integer SMALLINT_FORMAT_LENGTH = 6;
-        static final Integer TIMESTAMP_FORMAT_LENGTH = 19;
-        static final Integer TIMESTAMP_WITH_TIME_ZONE_FORMAT_LENGTH = 25;
-        static final Integer VARCHAR_FORMAT_LENGTH = 20; // it has normally unlimited precision
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -199,6 +199,13 @@ public class HazelcastCommandLine implements Runnable {
                 file.getAbsolutePath(), snapshotName, name, mainClass, params);
     }
 
+    @Command(description = "Starts the demo console application to demonstrate a Hazelcast data structures.")
+    public void consoleapp(@Mixin(name = "verbosity") Verbosity verbosity,
+                           @Mixin(name = "targets") TargetsMixin targets
+    ) {
+        runWithHazelcast(targets, verbosity, true, client -> ClientConsoleApp.run(client, new String[]{""}));
+    }
+
     @Command(description = "Suspends a running job")
     public void suspend(
             @Mixin(name = "verbosity") Verbosity verbosity,
@@ -518,7 +525,6 @@ public class HazelcastCommandLine implements Runnable {
     private void println(String msg) {
         out.println(msg);
     }
-
 
 
     static void runCommandLine(

--- a/hazelcast/src/main/java/com/hazelcast/client/console/SqlConsole.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/SqlConsole.java
@@ -1,0 +1,558 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.console;
+
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.management.MCClusterMetadata;
+import com.hazelcast.client.impl.spi.ClientClusterService;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.FutureUtil;
+import com.hazelcast.sql.HazelcastSqlException;
+import com.hazelcast.sql.SqlColumnMetadata;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.SqlRowMetadata;
+import org.jline.reader.EOFError;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser;
+import org.jline.reader.SyntaxError;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+import org.jline.utils.InfoCmp;
+
+import java.io.IOError;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.client.console.HazelcastCommandLine.getClusterMetadata;
+import static com.hazelcast.client.console.HazelcastCommandLine.getHazelcastClientInstanceImpl;
+import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
+import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
+import static com.hazelcast.internal.util.StringUtil.trim;
+
+@SuppressWarnings({
+        "checkstyle:CyclomaticComplexity",
+        "checkstyle:MethodLength",
+        "checkstyle:NPathComplexity",
+        "checkstyle:TrailingComment"
+})
+public final class SqlConsole {
+    private static final int PRIMARY_COLOR = AttributedStyle.YELLOW;
+    private static final int SECONDARY_COLOR = 12;
+
+    private SqlConsole() { };
+
+    public static void run(HazelcastInstance hzClient) {
+        LineReader reader = LineReaderBuilder.builder().parser(new MultilineParser())
+                .variable(LineReader.SECONDARY_PROMPT_PATTERN, new AttributedStringBuilder()
+                        .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR)).append("%M%P > ").toAnsi())
+                .variable(LineReader.INDENTATION, 2)
+                .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                .appName("hazelcast-sql")
+                .build();
+
+        AtomicReference<SqlResult> activeSqlResult = new AtomicReference<>();
+        reader.getTerminal().handle(Terminal.Signal.INT, signal -> {
+            SqlResult r = activeSqlResult.get();
+            if (r != null) {
+                r.close();
+            }
+        });
+
+        PrintWriter writer = reader.getTerminal().writer();
+        writer.println(sqlStartingPrompt(hzClient));
+        writer.flush();
+
+        for (; ; ) {
+            String command;
+            try {
+                command = reader.readLine(new AttributedStringBuilder()
+                        .style(AttributedStyle.DEFAULT.foreground(SECONDARY_COLOR))
+                        .append("sql> ").toAnsi()).trim();
+            } catch (EndOfFileException | IOError e) {
+                // Ctrl+D, and kill signals result in exit
+                writer.println(Constants.EXIT_PROMPT);
+                writer.flush();
+                break;
+            } catch (UserInterruptException e) {
+                // Ctrl+C cancels the not-yet-submitted query
+                continue;
+            }
+
+            command = command.trim();
+            if (command.length() > 0 && command.charAt(command.length() - 1) == ';') {
+                command = command.substring(0, command.length() - 1).trim();
+            } else if (command.lastIndexOf(";") >= 0) {
+                String errorPrompt = new AttributedStringBuilder()
+                        .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                        .append("There are non-whitespace characters after the semicolon")
+                        .toAnsi();
+                writer.println(errorPrompt);
+                writer.flush();
+                continue;
+            }
+
+            if ("".equals(command)) {
+                continue;
+            }
+            if (equalsIgnoreCase("clear", command)) {
+                reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
+                continue;
+            }
+            if (equalsIgnoreCase("help", command)) {
+                writer.println(helpPrompt());
+                writer.flush();
+                continue;
+            }
+            if (equalsIgnoreCase("history", command)) {
+                History hist = reader.getHistory();
+                ListIterator<History.Entry> iterator = hist.iterator();
+                while (iterator.hasNext()) {
+                    History.Entry entry = iterator.next();
+                    if (iterator.hasNext()) {
+                        String entryLine = new AttributedStringBuilder()
+                                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                                .append(String.valueOf(entry.index() + 1))
+                                .append(" - ")
+                                .append(entry.line())
+                                .toAnsi();
+                        writer.println(entryLine);
+                        writer.flush();
+                    } else {
+                        // remove the "history" command from the history
+                        iterator.remove();
+                        hist.resetIndex();
+                    }
+                }
+                continue;
+            }
+            if (equalsIgnoreCase("exit", command)) {
+                writer.println(Constants.EXIT_PROMPT);
+                writer.flush();
+                break;
+            }
+            executeSqlCmd(hzClient, command, reader.getTerminal(), activeSqlResult);
+        }
+    }
+
+    private static void executeSqlCmd(
+            HazelcastInstance hz,
+            String command,
+            Terminal terminal,
+            AtomicReference<SqlResult> activeSqlResult
+    ) {
+        PrintWriter out = terminal.writer();
+        try (SqlResult sqlResult = hz.getSql().execute(command)) {
+            activeSqlResult.set(sqlResult);
+
+            // if it's a result with an update count, just print it
+            if (sqlResult.updateCount() != -1) {
+                String message = new AttributedStringBuilder()
+                        .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                        .append("OK")
+                        .toAnsi();
+                out.println(message);
+                return;
+            }
+            SqlRowMetadata rowMetadata = sqlResult.getRowMetadata();
+            int[] colWidths = determineColumnWidths(rowMetadata);
+            Alignment[] alignments = determineAlignments(rowMetadata);
+
+            // this is a result with rows. Print the header and rows, watch for concurrent cancellation
+            printMetadataInfo(rowMetadata, colWidths, alignments, out);
+
+            int rowCount = 0;
+            for (SqlRow row : sqlResult) {
+                rowCount++;
+                printRow(row, colWidths, alignments, out);
+            }
+
+            // bottom line after all the rows
+            printSeparatorLine(sqlResult.getRowMetadata().getColumnCount(), colWidths, out);
+
+            String message = new AttributedStringBuilder()
+                    .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                    .append(String.valueOf(rowCount))
+                    .append(" row(s) selected")
+                    .toAnsi();
+            out.println(message);
+        } catch (HazelcastSqlException e) {
+            // the query failed to execute
+            String errorPrompt = new AttributedStringBuilder()
+                    .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                    .append(e.getMessage())
+                    .toAnsi();
+            out.println(errorPrompt);
+        }
+    }
+
+    private static String sqlStartingPrompt(HazelcastInstance hz) {
+        HazelcastClientInstanceImpl hazelcastClientImpl = getHazelcastClientInstanceImpl(hz);
+        ClientClusterService clientClusterService = hazelcastClientImpl.getClientClusterService();
+        MCClusterMetadata clusterMetadata =
+                FutureUtil.getValue(getClusterMetadata(hazelcastClientImpl, clientClusterService.getMasterMember()));
+        Cluster cluster = hazelcastClientImpl.getCluster();
+        Set<Member> members = cluster.getMembers();
+        String versionString = "Hazelcast " + clusterMetadata.getMemberVersion();
+        return new AttributedStringBuilder()
+                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                .append("Connected to ")
+                .append(versionString)
+                .append(" at ")
+                .append(members.iterator().next().getAddress().toString())
+                .append(" (+")
+                .append(String.valueOf(members.size() - 1))
+                .append(" more)\n")
+                .append("Type 'help' for instructions")
+                .toAnsi();
+    }
+
+    private static String helpPrompt() {
+        AttributedStringBuilder builder = new AttributedStringBuilder()
+                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                .append("Available Commands:\n")
+                .append("  clear    Clears the terminal screen\n")
+                .append("  exit     Exits from the SQL console\n")
+                .append("  help     Provides information about available commands\n")
+                .append("  history  Shows the command history of the current session\n")
+                .append("Hints:\n")
+                .append("  Semicolon completes a query\n")
+                .append("  Ctrl+C cancels a streaming query\n")
+                .append("  https://docs.hazelcast.com/");
+        return builder.toAnsi();
+    }
+
+
+    private enum Alignment {
+        LEFT, RIGHT
+    }
+
+    private static int[] determineColumnWidths(SqlRowMetadata metadata) {
+        int colCount = metadata.getColumnCount();
+        int[] colWidths = new int[colCount];
+        for (int i = 0; i < colCount; i++) {
+            SqlColumnMetadata colMetadata = metadata.getColumn(i);
+            SqlColumnType type = colMetadata.getType();
+            String colName = colMetadata.getName();
+            switch (type) {
+                case BOOLEAN:
+                    colWidths[i] = determineColumnWidth(colName, Constants.BOOLEAN_FORMAT_LENGTH);
+                    break;
+                case DATE:
+                    colWidths[i] = determineColumnWidth(colName, Constants.DATE_FORMAT_LENGTH);
+                    break;
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    colWidths[i] = determineColumnWidth(colName, Constants.TIMESTAMP_WITH_TIME_ZONE_FORMAT_LENGTH);
+                    break;
+                case DECIMAL:
+                    colWidths[i] = determineColumnWidth(colName, Constants.DECIMAL_FORMAT_LENGTH);
+                    break;
+                case REAL:
+                    colWidths[i] = determineColumnWidth(colName, Constants.REAL_FORMAT_LENGTH);
+                    break;
+                case DOUBLE:
+                    colWidths[i] = determineColumnWidth(colName, Constants.DOUBLE_FORMAT_LENGTH);
+                    break;
+                case INTEGER:
+                    colWidths[i] = determineColumnWidth(colName, Constants.INTEGER_FORMAT_LENGTH);
+                    break;
+                case NULL:
+                    colWidths[i] = determineColumnWidth(colName, Constants.NULL_FORMAT_LENGTH);
+                    break;
+                case TINYINT:
+                    colWidths[i] = determineColumnWidth(colName, Constants.TINYINT_FORMAT_LENGTH);
+                    break;
+                case SMALLINT:
+                    colWidths[i] = determineColumnWidth(colName, Constants.SMALLINT_FORMAT_LENGTH);
+                    break;
+                case TIMESTAMP:
+                    colWidths[i] = determineColumnWidth(colName, Constants.TIMESTAMP_FORMAT_LENGTH);
+                    break;
+                case BIGINT:
+                    colWidths[i] = determineColumnWidth(colName, Constants.BIGINT_FORMAT_LENGTH);
+                    break;
+                case VARCHAR:
+                    colWidths[i] = determineColumnWidth(colName, Constants.VARCHAR_FORMAT_LENGTH);
+                    break;
+                case OBJECT:
+                    colWidths[i] = determineColumnWidth(colName, Constants.OBJECT_FORMAT_LENGTH);
+                    break;
+                default:
+                    throw new UnsupportedOperationException(type.toString());
+            }
+        }
+        return colWidths;
+    }
+
+    private static int determineColumnWidth(String header, int typeLength) {
+        return Math.max(Math.min(header.length(), Constants.VARCHAR_FORMAT_LENGTH), typeLength);
+    }
+
+    private static Alignment[] determineAlignments(SqlRowMetadata metadata) {
+        int colCount = metadata.getColumnCount();
+        Alignment[] alignments = new Alignment[colCount];
+        for (int i = 0; i < colCount; i++) {
+            SqlColumnMetadata colMetadata = metadata.getColumn(i);
+            SqlColumnType type = colMetadata.getType();
+            switch (type) {
+                case BIGINT:
+                case DECIMAL:
+                case DOUBLE:
+                case INTEGER:
+                case REAL:
+                case SMALLINT:
+                case TINYINT:
+                    alignments[i] = Alignment.RIGHT;
+                    break;
+                case BOOLEAN:
+                case DATE:
+                case NULL:
+                case OBJECT:
+                case TIMESTAMP:
+                case VARCHAR:
+                case TIMESTAMP_WITH_TIME_ZONE:
+                default:
+                    alignments[i] = Alignment.LEFT;
+            }
+        }
+        return alignments;
+    }
+
+    private static void printMetadataInfo(SqlRowMetadata metadata, int[] colWidths,
+                                          Alignment[] alignments, PrintWriter out) {
+        int colCount = metadata.getColumnCount();
+        printSeparatorLine(colCount, colWidths, out);
+        AttributedStringBuilder builder = new AttributedStringBuilder()
+                .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
+        builder.append("|");
+        for (int i = 0; i < colCount; i++) {
+            String colName = metadata.getColumn(i).getName();
+            colName = sanitize(colName, colWidths[i]);
+            builder.style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR));
+            appendAligned(colWidths[i], colName, alignments[i], builder);
+            builder.style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
+            builder.append('|');
+        }
+        out.println(builder.toAnsi());
+        printSeparatorLine(colCount, colWidths, out);
+        out.flush();
+    }
+
+    private static void printRow(SqlRow row, int[] colWidths, Alignment[] alignments, PrintWriter out) {
+        AttributedStringBuilder builder = new AttributedStringBuilder()
+                .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
+        builder.append("|");
+        int columnCount = row.getMetadata().getColumnCount();
+        for (int i = 0; i < columnCount; i++) {
+            String colString = row.getObject(i) != null ? sanitize(row.getObject(i).toString(), colWidths[i]) : "NULL";
+            builder.style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR));
+            appendAligned(colWidths[i], colString, alignments[i], builder);
+            builder.style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
+            builder.append('|');
+        }
+        out.println(builder.toAnsi());
+        out.flush();
+    }
+
+    private static String sanitize(String s, int width) {
+        s = s.replace("\n", "\\n");
+        if (s.length() > width) {
+            s = s.substring(0, width - 1) + "\u2026";
+        }
+        return s;
+    }
+
+    private static void appendAligned(int width, String s, Alignment alignment, AttributedStringBuilder builder) {
+        int padding = width - s.length();
+        assert padding >= 0;
+
+        if (alignment == Alignment.RIGHT) {
+            appendPadding(builder, padding, ' ');
+        }
+        builder.append(s);
+        if (alignment == Alignment.LEFT) {
+            appendPadding(builder, padding, ' ');
+        }
+    }
+
+    private static void appendPadding(AttributedStringBuilder builder, int length, char paddingChar) {
+        for (int i = 0; i < length; i++) {
+            builder.append(paddingChar);
+        }
+    }
+
+    private static void printSeparatorLine(int colSize, int[] colWidths, PrintWriter out) {
+        AttributedStringBuilder builder = new AttributedStringBuilder()
+                .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
+        builder.append('+');
+        for (int i = 0; i < colSize; i++) {
+            appendPadding(builder, colWidths[i], '-');
+            builder.append('+');
+        }
+        out.println(builder.toAnsi());
+    }
+
+
+    /**
+     * A parser for SQL-like inputs. Commands are terminated with a semicolon.
+     * It is adapted from
+     * <a href="https://github.com/julianhyde/sqlline/blob/master/src/main/java/sqlline/SqlLineParser.java">
+     * SqlLineParser</a>
+     * which is licensed under the BSD-3-Clause License.
+     */
+    private static final class MultilineParser extends DefaultParser {
+
+        private MultilineParser() {
+        }
+
+        @Override
+        public ParsedLine parse(String line, int cursor, Parser.ParseContext context) throws SyntaxError {
+            super.setQuoteChars(new char[]{'\'', '"'});
+            super.setEofOnUnclosedQuote(true);
+            stateCheck(line, cursor);
+            return new ArgumentList(line, Collections.emptyList(), -1, -1,
+                    cursor, "'", -1, -1);
+        }
+
+        private void stateCheck(String line, int cursor) {
+            boolean containsNonWhitespaceData = false;
+            int quoteStart = -1;
+            int oneLineCommentStart = -1;
+            int multiLineCommentStart = -1;
+            int lastSemicolonIdx = -1;
+            for (int i = 0; i < line.length(); i++) {
+                // If a one line comment, a multiline comment or a quote is not started before,
+                // check if the character we're on is a quote character
+                if (oneLineCommentStart == -1
+                        && multiLineCommentStart == -1
+                        && quoteStart < 0
+                        && (isQuoteChar(line, i))) {
+                    // Start a quote block
+                    quoteStart = i;
+                    containsNonWhitespaceData = true;
+                } else {
+                    char currentChar = line.charAt(i);
+                    if (quoteStart >= 0) {
+                        // In a quote block
+                        if ((line.charAt(quoteStart) == currentChar) && !isEscaped(line, i)) {
+                            // End the block; arg could be empty, but that's fine
+                            quoteStart = -1;
+                        }
+                    } else if (oneLineCommentStart == -1
+                            && line.regionMatches(i, "/*", 0, "/*".length())) {
+                        // Enter the multiline comment block
+                        multiLineCommentStart = i;
+                        containsNonWhitespaceData = true;
+                    } else if (multiLineCommentStart >= 0) {
+                        // In a multiline comment block
+                        if (i - multiLineCommentStart > 2
+                                && line.regionMatches(i - 1, "*/", 0, "*/".length())) {
+                            // End the multiline block
+                            multiLineCommentStart = -1;
+                        }
+                    } else if (oneLineCommentStart == -1
+                            && line.regionMatches(i, "--", 0, "--".length())) {
+                        // Enter the one line comment block
+                        oneLineCommentStart = i;
+                        containsNonWhitespaceData = true;
+                    } else if (oneLineCommentStart >= 0) {
+                        // In a one line comment
+                        if (currentChar == '\n') {
+                            // End the one line comment block
+                            oneLineCommentStart = -1;
+                        }
+                    } else {
+                        // Not in a quote or comment block
+                        if (currentChar == ';') {
+                            lastSemicolonIdx = i;
+                        } else if (!Character.isWhitespace(currentChar)) {
+                            containsNonWhitespaceData = true;
+                        }
+                    }
+                }
+            }
+
+            if (Constants.COMMAND_SET.contains(lowerCaseInternal(trim(line)))) {
+                return;
+            }
+            // These EOFError exceptions are captured in LineReader's
+            // readLine() method and it points out that the command
+            // being written to console is not finalized and command
+            // won't be read
+            if (isEofOnEscapedNewLine() && isEscapeChar(line, line.length() - 1)) {
+                throw new EOFError(-1, cursor, "Escaped new line");
+            }
+
+            if (isEofOnUnclosedQuote() && quoteStart >= 0) {
+                throw new EOFError(-1, quoteStart, "Missing closing quote",
+                        line.charAt(quoteStart) == '\'' ? "quote" : "dquote");
+            }
+
+            if (oneLineCommentStart != -1) {
+                throw new EOFError(-1, cursor, "One line comment");
+            }
+
+            if (multiLineCommentStart != -1) {
+                throw new EOFError(-1, cursor, "Missing end of comment", "**");
+            }
+
+            if (containsNonWhitespaceData
+                    && (lastSemicolonIdx == -1 || lastSemicolonIdx >= cursor)) {
+                throw new EOFError(-1, cursor, "Missing semicolon (;)");
+            }
+        }
+    }
+
+    private static class Constants {
+
+        static final Set<String> COMMAND_SET = new HashSet<>(Arrays.asList("clear", "exit", "help", "history"));
+        static final String EXIT_PROMPT = new AttributedStringBuilder()
+                .style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR))
+                .append("Exiting from SQL console")
+                .toAnsi();
+        static final Integer BOOLEAN_FORMAT_LENGTH = 5;
+        static final Integer BIGINT_FORMAT_LENGTH = 20;
+        static final Integer DATE_FORMAT_LENGTH = 10;
+        static final Integer DECIMAL_FORMAT_LENGTH = 25; // it has normally unlimited precision
+        static final Integer DOUBLE_FORMAT_LENGTH = 25; // it has normally unlimited precision
+        static final Integer INTEGER_FORMAT_LENGTH = 12;
+        static final Integer NULL_FORMAT_LENGTH = 4;
+        static final Integer REAL_FORMAT_LENGTH = 25; // it has normally unlimited precision
+        static final Integer OBJECT_FORMAT_LENGTH = 20; // it has normally unlimited precision
+        static final Integer TINYINT_FORMAT_LENGTH = 4;
+        static final Integer SMALLINT_FORMAT_LENGTH = 6;
+        static final Integer TIMESTAMP_FORMAT_LENGTH = 19;
+        static final Integer TIMESTAMP_WITH_TIME_ZONE_FORMAT_LENGTH = 25;
+        static final Integer VARCHAR_FORMAT_LENGTH = 20; // it has normally unlimited precision
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleAppTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleAppTest.java
@@ -33,8 +33,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
@@ -50,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 public class ClientConsoleAppTest extends HazelcastTestSupport {
 
     private static ByteArrayOutputStream baos;
-    private static PrintStream printStream;
+    private static PrintWriter printWriter;
 
     private HazelcastInstance hazelcastInstance;
     private TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
@@ -58,11 +57,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
     @BeforeClass
     public static void beforeClass() {
         baos = new ByteArrayOutputStream();
-        try {
-            printStream = new PrintStream(baos, true, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // Should never happen for the UTF-8
-        }
+        printWriter = new PrintWriter(baos, true);
     }
 
     @Before
@@ -79,7 +74,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
 
     @Test
     public void executeOnKey() {
-        ClientConsoleApp consoleApp = new ClientConsoleApp(hazelcastFactory.newHazelcastClient(new ClientConfig()), printStream);
+        ClientConsoleApp consoleApp = new ClientConsoleApp(hazelcastFactory.newHazelcastClient(new ClientConfig()), printWriter);
         for (int i = 0; i < 100; i++) {
             consoleApp.handleCommand(String.format("executeOnKey message%d key%d", i, i));
             assertTextInSystemOut("message" + i);
@@ -92,7 +87,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
     @Test
     public void mapPut() {
         HazelcastInstance hz = hazelcastFactory.newHazelcastClient(new ClientConfig());
-        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printStream);
+        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printWriter);
 
         IMap<String, String> map = hz.getMap("default");
 
@@ -116,7 +111,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
     @Test
     public void mapRemove() {
         HazelcastInstance hz = hazelcastFactory.newHazelcastClient(new ClientConfig());
-        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printStream);
+        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printWriter);
         IMap<String, String> map = hz.getMap("default");
         map.put("a", "valueOfA");
         map.put("b", "valueOfB");
@@ -133,7 +128,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
     @Test
     public void mapDelete() {
         HazelcastInstance hz = hazelcastFactory.newHazelcastClient(new ClientConfig());
-        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printStream);
+        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printWriter);
         IMap<String, String> map = hz.getMap("default");
         map.put("a", "valueOfA");
         map.put("b", "valueOfB");
@@ -150,7 +145,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
     @Test
     public void mapGet() {
         HazelcastInstance hz = hazelcastFactory.newHazelcastClient(new ClientConfig());
-        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printStream);
+        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printWriter);
         hz.<String, String>getMap("default").put("testGetKey", "testGetValue");
         consoleApp.handleCommand("m.get testGetKey");
         assertTextInSystemOut("testGetValue");
@@ -162,7 +157,7 @@ public class ClientConsoleAppTest extends HazelcastTestSupport {
     @Test
     public void mapPutMany() {
         HazelcastInstance hz = hazelcastFactory.newHazelcastClient(new ClientConfig());
-        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printStream);
+        ClientConsoleApp consoleApp = new ClientConsoleApp(hz, printWriter);
         IMap<String, ?> map = hz.getMap("default");
         consoleApp.handleCommand("m.putmany 100 8 1000");
         assertEquals("Unexpected map size", 100, map.size());

--- a/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
@@ -95,7 +95,7 @@ public class ClientConsoleTest {
         try {
             LineEndingsInputStream bqIn = new LineEndingsInputStream();
             System.setIn(bqIn);
-            tp.execute(() -> ClientConsoleApp.run(null));
+            tp.execute(() -> ClientConsoleApp.run(HazelcastClient.newHazelcastClient(), null));
             assertTrueEventually(() -> assertFalse(hz.getClientService().getConnectedClients().isEmpty()));
             HazelcastInstance client = HazelcastClient.getHazelcastClientByName("clientConsoleApp");
             assertNotNull(client);

--- a/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
@@ -95,7 +95,7 @@ public class ClientConsoleTest {
         try {
             LineEndingsInputStream bqIn = new LineEndingsInputStream();
             System.setIn(bqIn);
-            tp.execute(() -> ClientConsoleApp.run(HazelcastClient.newHazelcastClient(), null));
+            tp.execute(() -> ClientConsoleApp.run(HazelcastClient.newHazelcastClient()));
             assertTrueEventually(() -> assertFalse(hz.getClientService().getConnectedClients().isEmpty()));
             HazelcastInstance client = HazelcastClient.getHazelcastClientByName("clientConsoleApp");
             assertNotNull(client);

--- a/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
@@ -95,7 +95,7 @@ public class ClientConsoleTest {
         try {
             LineEndingsInputStream bqIn = new LineEndingsInputStream();
             System.setIn(bqIn);
-            tp.execute(() -> ClientConsoleApp.main(null));
+            tp.execute(() -> ClientConsoleApp.run(null));
             assertTrueEventually(() -> assertFalse(hz.getClientService().getConnectedClients().isEmpty()));
             HazelcastInstance client = HazelcastClient.getHazelcastClientByName("clientConsoleApp");
             assertNotNull(client);


### PR DESCRIPTION
This PR adds a new `hazelcast console` command to
`HazelcastCommandLine` to start the `ClientConsoleApp`.

Also, I replaced the line reader of client console app with jline reader
to add clear terminal, history like functionalities to this application
and made some cleanup on commands which was not working.

Additionally, I extracted `SqlConsole` to a separate class from `HazelcastCommandLine`.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
