### PR TITLE
Fix size based eviction when cluster scaled down

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/BackupListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/BackupListenerLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -22,11 +22,12 @@ import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.internal.eviction.impl.comparator.LRUEvictionPolicyComparator;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.util.MemoryInfoAccessor;
+import com.hazelcast.internal.util.MutableLong;
 import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
@@ -38,6 +39,8 @@ import com.hazelcast.map.impl.eviction.EvictorImpl;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
@@ -52,7 +55,10 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.config.MaxSizePolicy.FREE_HEAP_PERCENTAGE;
 import static com.hazelcast.config.MaxSizePolicy.FREE_HEAP_SIZE;
@@ -85,8 +91,9 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
 
     @Test
     public void testPerNodePolicy_afterGracefulShutdown() {
-        int nodeCount = 2;
+        int nodeCount = 3;
         int perNodeMaxSize = 1000;
+        int numberOfPuts = 3000;
 
         // eviction takes place if a partitions size exceeds this number
         // see EvictionChecker#toPerPartitionMaxSize
@@ -94,29 +101,40 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
 
         String mapName = "testPerNodePolicy_afterGracefulShutdown";
         Config config = createConfig(PER_NODE, perNodeMaxSize, mapName);
-
+        ConcurrentHashMap<EntryEventType, MutableLong> eventsPerType = new ConcurrentHashMap<>();
+        Set<Object> evictedKeySet = Collections.newSetFromMap(new ConcurrentHashMap<>());
         // populate map from one of the nodes
-        Collection<HazelcastInstance> nodes = createNodes(nodeCount, config);
-        for (HazelcastInstance node : nodes) {
-            IMap map = node.getMap(mapName);
-            for (int i = 0; i < 5000; i++) {
-                map.put(i, i);
-            }
+        List<HazelcastInstance> nodes = createNodes(nodeCount, config);
 
-            node.shutdown();
-            break;
+        IMap map = nodes.get(0).getMap(mapName);
+        for (int i = 0; i < numberOfPuts; i++) {
+            map.put(i, i);
         }
 
-        for (HazelcastInstance node : nodes) {
-            if (node.getLifecycleService().isRunning()) {
-                int mapSize = node.getMap(mapName).size();
-                String message = format("map size is %d and it should be smaller "
-                                + "than maxPartitionSize * PARTITION_COUNT which is %.0f",
-                        mapSize, maxPartitionSize * PARTITION_COUNT);
+        int initialMapSize = map.size();
 
-                assertTrue(message, mapSize <= maxPartitionSize * PARTITION_COUNT);
+        nodes.get(1).getMap(mapName).addEntryListener((EntryEvictedListener) event -> {
+            evictedKeySet.add(event.getKey());
+        }, true);
+
+        nodes.get(0).shutdown();
+
+        assertTrueEventually(() -> {
+            for (HazelcastInstance node : nodes) {
+                if (node.getLifecycleService().isRunning()) {
+                    int currentMapSize = node.getMap(mapName).size();
+                    int evictedKeyCount = evictedKeySet.size();
+                    String message = format("initialMapSize=%d, evictedKeyCount=%d, map size is %d and it should be smaller "
+                                    + "than maxPartitionSize * PARTITION_COUNT which is %.0f",
+                            initialMapSize, evictedKeyCount, currentMapSize, maxPartitionSize * PARTITION_COUNT);
+
+                    assertEquals(message, initialMapSize, evictedKeyCount + currentMapSize);
+                    // current map size should approximately be around (nodeCount - 1) * perNodeMaxSize.
+                    assertTrue(message, ((nodeCount - 1) * perNodeMaxSize)
+                            + (PARTITION_COUNT / nodeCount) >= currentMapSize);
+                }
             }
-        }
+        });
     }
 
     /**
@@ -403,6 +421,7 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
 
     Config createConfig(MaxSizePolicy maxSizePolicy, int maxSize, String mapName) {
         Config config = getConfig();
+        config.getMetricsConfig().setEnabled(false);
         config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT));
 
         MapConfig mapConfig = config.getMapConfig(mapName);
@@ -414,10 +433,10 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
         return config;
     }
 
-    Collection<HazelcastInstance> createNodes(int nodeCount, Config config) {
+    List<HazelcastInstance> createNodes(int nodeCount, Config config) {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
         factory.newInstances(config);
-        return factory.getAllHazelcastInstances();
+        return new ArrayList<>(factory.getAllHazelcastInstances());
     }
 
     int getSize(Collection<IMap> maps) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/AbstractReplicatedMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/AbstractReplicatedMapListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/14046

__Modification:__
Main changes are in replication operation. In this operation, before putting entries into record-store, we first calculate `ownedEntryCountOnThisNode`. If this value is below the per-node max-size, we put entries till we reach the max-size. After reaching it, we quit putting entries.

This is an approximation approach. Base on my tests it is working and keeps per-node map-size around set value.

Forward-port: https://github.com/hazelcast/hazelcast/pull/18873