### PR TITLE
Use light jobs for SQL statements

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetPlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetPlanExecutor.java
@@ -190,12 +190,12 @@ class JetPlanExecutor {
         JobConfig jobConfig = new JobConfig().setArgument(SQL_ARGUMENTS_KEY_NAME, args);
 
         JetQueryResultProducer queryResultProducer = new JetQueryResultProducer();
-        AbstractJetInstance jet = (AbstractJetInstance) hazelcastInstance.getJet();
+        AbstractJetInstance<?> jet = (AbstractJetInstance<?>) hazelcastInstance.getJet();
         Long jobId = jet.newJobId();
         Object oldValue = resultConsumerRegistry.put(jobId, queryResultProducer);
         assert oldValue == null : oldValue;
         try {
-            Job job = jet.newJob(jobId, plan.getDag(), jobConfig);
+            Job job = jet.newLightJob(jobId, plan.getDag(), jobConfig);
             job.getFuture().whenComplete((r, t) -> {
                 if (t != null) {
                     int errorCode = findQueryExceptionCode(t);
@@ -215,7 +215,7 @@ class JetPlanExecutor {
         List<Object> args = prepareArguments(plan.getParameterMetadata(), arguments);
         JobConfig jobConfig = new JobConfig().setArgument(SQL_ARGUMENTS_KEY_NAME, args);
 
-        Job job = hazelcastInstance.getJet().newJob(plan.getDag(), jobConfig);
+        Job job = hazelcastInstance.getJet().newLightJob(plan.getDag(), jobConfig);
         job.join();
 
         return SqlResultImpl.createUpdateCountResult(0);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/JetPlanExecutorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/JetPlanExecutorTest.java
@@ -135,7 +135,7 @@ public class JetPlanExecutorTest {
         );
 
         given(hazelcastInstance.getJet()).willReturn(jet);
-        given(jet.newJob(eq(dag), isA(JobConfig.class))).willReturn(job);
+        given(jet.newLightJob(eq(dag), isA(JobConfig.class))).willReturn(job);
 
         // when
         SqlResult result = planExecutor.execute(plan, queryId, emptyList());

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastBootstrap.java
@@ -684,7 +684,7 @@ public final class HazelcastBootstrap {
         }
 
         @Override
-        public Job newJobProxy(long jobId, boolean isLightJob, Object jobDefinition, JobConfig config) {
+        public Job newJobProxy(long jobId, boolean isLightJob, @Nonnull Object jobDefinition, @Nonnull JobConfig config) {
             return jet.newJobProxy(jobId, isLightJob, jobDefinition, config);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/JetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/JetService.java
@@ -150,14 +150,24 @@ public interface JetService {
     Job newJobIfAbsent(@Nonnull Pipeline pipeline, @Nonnull JobConfig config);
 
     /**
+     * Submits a new light job with a default config. See {@link
+     * #newLightJob(Pipeline, JobConfig)}.
+     */
+    @Nonnull
+    default Job newLightJob(@Nonnull Pipeline p) {
+        return newLightJob(p, new JobConfig());
+    }
+
+    /**
      * Submits a light job for execution. This kind of job is focused on
      * reducing the job startup and teardown time: only a single operation is
      * used to deploy the job instead of 2 for normal jobs.
      *
      * Limitation of light jobs:
      * <ul>
-     *     <li>no job configuration, that means no processing guarantee, no custom
+     *     <li>very limited job configuration: no processing guarantee, no custom
      *         classes or job resources - all job code must be available in the cluster.
+     *         Refer to {@link JobConfig} for details.
      *
      *     <li>metrics not available through {@link Job#getMetrics()}. However,
      *         light jobs are included in member metrics accessed through other means.
@@ -176,16 +186,24 @@ public interface JetService {
      * A light job will not be cancelled if the client disconnects. It's
      * potential failure will be only logged in member logs.
      */
+    Job newLightJob(@Nonnull Pipeline p, @Nonnull JobConfig config);
+
+    /**
+     * Submits a job defined in the Core API with a default config.
+     * <p>
+     * See {@link #newLightJob(Pipeline, JobConfig)} for more information.
+     */
     @Nonnull
-    Job newLightJob(Pipeline p);
+    default Job newLightJob(@Nonnull DAG dag) {
+        return newLightJob(dag, new JobConfig());
+    }
 
     /**
      * Submits a job defined in the Core API.
      * <p>
-     * See {@link #newLightJob(Pipeline)} for more information.
+     * See {@link #newLightJob(Pipeline, JobConfig)} for more information.
      */
-    @Nonnull
-    Job newLightJob(DAG dag);
+    Job newLightJob(@Nonnull DAG dag, @Nonnull JobConfig config);
 
     /**
      * Returns all submitted jobs. The result includes completed normal jobs,

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.jet.impl.util.ReflectionUtils.Resources;
+import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
@@ -96,7 +97,8 @@ public class JobConfig implements IdentifiedDataSerializable {
      * <p>
      * The job name is printed in logs and is visible in Management Center.
      * <p>
-     * The default value is {@code null}.
+     * The default value is {@code null}. Must be set to {@code null} for
+     * {@linkplain JetService#newLightJob(Pipeline) light jobs}.
      *
      * @return {@code this} instance for fluent API
      * @since Jet 3.0
@@ -139,6 +141,8 @@ public class JobConfig implements IdentifiedDataSerializable {
      * If {@linkplain #setAutoScaling(boolean) auto scaling} is disabled and you
      * manually {@link Job#resume} the job, the job won't start executing until the
      * quorum is met, but will remain in the resumed state.
+     * <p>
+     * Ignored for {@linkplain JetService#newLightJob(Pipeline) light jobs}.
      *
      * @return {@code this} instance for fluent API
      */
@@ -150,7 +154,8 @@ public class JobConfig implements IdentifiedDataSerializable {
 
     /**
      * Sets whether Jet will scale the job up or down when a member is added or
-     * removed from the cluster. Enabled by default.
+     * removed from the cluster. Enabled by default. Ignored for {@linkplain
+     * JetService#newLightJob(Pipeline) light jobs}.
      *
      * <pre>
      * +--------------------------+-----------------------+----------------+
@@ -189,7 +194,8 @@ public class JobConfig implements IdentifiedDataSerializable {
      *     deleted.
      * </ul>
      * <p>
-     * By default it's disabled.
+     * By default it's disabled. Ignored for {@linkplain
+     * JetService#newLightJob(Pipeline) light jobs}.
      *
      * @return {@code this} instance for fluent API
      *
@@ -226,7 +232,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@link #setSnapshotIntervalMillis(long)}, otherwise it will default to 10
      * seconds.
      * <p>
-     * The default value is {@link ProcessingGuarantee#NONE}.
+     * The default value is {@link ProcessingGuarantee#NONE}. Must be set to
+     * {@code NONE} for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @return {@code this} instance for fluent API
      */
@@ -269,6 +277,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * the classes from the Jet instance's classpath.)
      * <p>
      * See also {@link #addJar} and {@link #addClasspathResource}.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -292,6 +303,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * the Jet instance's classpath.)
      * <p>
      * See also {@link #addJar} and {@link #addClasspathResource}.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -319,6 +333,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * This variant identifies the JAR with a URL, which must contain at least one
      * path segment. The last path segment ("filename") will be used as the resource
      * ID, so two JARs with the same filename will be in conflict.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -341,6 +358,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * This variant identifies the JAR with a {@code File}. The filename part of the
      * path will be used as the resource ID, so two JARs with the same filename will
      * be in conflict.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -364,6 +384,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * This variant identifies the JAR with a path string. The filename part will be
      * used as the resource ID, so two JARs with the same filename will be in
      * conflict.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -388,6 +411,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * resource ID, so two ZIPs with the same filename will be in conflict.
      * <p>
      * The ZIP file should contain only JARs. Any other files will be ignored.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -413,6 +439,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * in conflict.
      * <p>
      * The ZIP file should contain only JARs. Any other files will be ignored.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -439,6 +468,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * in conflict.
      * <p>
      * The ZIP file should contain only JARs. Any other files will be ignored.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -460,6 +492,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * This variant identifies the resource with a URL, which must contain at least
      * one path segment. The last path segment ("filename") will be used as the
      * resource ID, so two resources with the same filename will be in conflict.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -478,6 +513,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * code attached to the underlying pipeline or DAG will have access to it. The
      * supplied {@code id} becomes the path under which the resource is available
      * from the class loader.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -497,6 +535,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * it. The file will reside in the root of the classpath, under its own
      * filename. This means that two files with the same filename will be in
      * conflict.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -516,6 +557,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * All the code attached to the underlying pipeline or DAG will have access to
      * it. The supplied {@code id} becomes the path under which the resource is
      * available from the class loader.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -535,6 +579,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * All the code attached to the underlying pipeline or DAG will have access to
      * it. It will reside in the root of the classpath, under its own filename. This
      * means that two files with the same filename will be in conflict.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -553,6 +600,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * All the code attached to the underlying pipeline or DAG will have access to
      * it. The supplied {@code id} becomes the path under which the resource is
      * available from the class loader.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -578,6 +628,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * example, to {@link ServiceFactory#createContextFn()}. The file will have the
      * same name as the one supplied here, but it will be in a temporary directory
      * on the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -603,6 +656,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * example, to {@link ServiceFactory#createContextFn()}. The file will have the
      * same name as the one supplied here, but it will be in a temporary directory
      * on the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -629,6 +685,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * example, to {@link ServiceFactory#createContextFn()}. The file will have the
      * same name as the one supplied here, but it will be in a temporary directory
      * on the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -654,6 +713,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * example, to {@link ServiceFactory#createContextFn()}. The file will have the
      * same name as the one supplied here, but it will be in a temporary directory
      * on the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -681,6 +743,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * example, to {@link ServiceFactory#createContextFn()}. The file will have the
      * same name as the one supplied here, but it will be in a temporary directory
      * on the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -706,6 +771,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * example, to {@link ServiceFactory#createContextFn()}. The file will have the
      * same name as the one supplied here, but it will be in a temporary directory
      * on the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -733,6 +801,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@code ProcessorSupplier} context available, for example, to
      * {@link ServiceFactory#createContextFn()}. It will be a temporary directory on
      * the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -759,6 +830,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@code ProcessorSupplier} context available, for example, to
      * {@link ServiceFactory#createContextFn()}. It will be a temporary directory on
      * the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -788,6 +862,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@code ProcessorSupplier} context available, for example, to
      * {@link ServiceFactory#createContextFn()}. It will be a temporary directory on
      * the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -814,6 +891,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@code ProcessorSupplier} context available, for example, to
      * {@link ServiceFactory#createContextFn()}. It will be a temporary directory on
      * the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -840,6 +920,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@code ProcessorSupplier} context available, for example, to
      * {@link ServiceFactory#createContextFn()}. It will be a temporary directory on
      * the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -866,6 +949,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@code ProcessorSupplier} context available, for example, to
      * {@link ServiceFactory#createContextFn()}. It will be a temporary directory on
      * the Jet server.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -885,6 +971,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@link #attachDirectory(File, String) attachDirectory(dir, id)} for every
      * entry that resolves to a directory and {@link #attachFile(File, String)
      * attachFile(file, id)} for every entry that resolves to a regular file.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @implNote Backing storage for this method is an {@link IMap} with a default
      *           backup count of 1. When adding big files as a resource, size the
@@ -973,6 +1062,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * serializer registered on the cluster level.
      * <p>
      * The serializer must have no-arg constructor.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @param clazz           class to register serializer for
      * @param serializerClass class of the serializer to be registered
@@ -1045,8 +1137,9 @@ public class JobConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Sets a custom {@link JobClassLoaderFactory} that will be used to load job
-     * classes and resources on Jet members.
+     * Sets a custom {@link JobClassLoaderFactory} that will be used to load
+     * job classes and resources on Jet members. Not supported for {@linkplain
+     * JetService#newLightJob(Pipeline) light jobs}
      *
      * @return {@code this} instance for fluent API
      */
@@ -1082,6 +1175,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * The job will use the state even if
      * {@linkplain #setProcessingGuarantee(ProcessingGuarantee) processing
      * guarantee} is set to {@link ProcessingGuarantee#NONE}.
+     * <p>
+     * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
+     * jobs}.
      *
      * @param initialSnapshotName the snapshot name given to
      *                            {@link Job#exportSnapshot(String)}
@@ -1098,8 +1194,9 @@ public class JobConfig implements IdentifiedDataSerializable {
      * Sets whether metrics collection should be enabled for the job. Needs
      * {@link MetricsConfig#isEnabled()} to be on in order to function.
      * <p>
-     * Metrics for running jobs can be queried using {@link Job#getMetrics()} It's
-     * enabled by default.
+     * Metrics for running jobs can be queried using {@link Job#getMetrics()}
+     * It's enabled by default. Ignored for {@linkplain
+     * JetService#newLightJob(Pipeline) light jobs}.
      *
      * @since Jet 3.2
      */
@@ -1144,7 +1241,8 @@ public class JobConfig implements IdentifiedDataSerializable {
      * {@link MetricsConfig#setEnabled global metrics collection} or
      * {@link JobConfig#isMetricsEnabled() per job metrics collection}.
      * <p>
-     * It's disabled by default.
+     * It's disabled by default. Ignored for {@linkplain
+     * JetService#newLightJob(Pipeline) light jobs}.
      *
      * @since Jet 3.2
      */

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
@@ -94,7 +94,7 @@ public abstract class AbstractJobProxy<C, M> implements Job {
         submittingInstance = false;
     }
 
-    AbstractJobProxy(C container, long jobId, boolean isLightJob, Object jobDefinition, JobConfig config) {
+    AbstractJobProxy(C container, long jobId, boolean isLightJob, @Nonnull Object jobDefinition, @Nonnull JobConfig config) {
         this.jobId = jobId;
         this.container = container;
         this.lightJobCoordinator = isLightJob ? findLightJobCoordinator() : null;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -65,7 +65,13 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl, UUID
         super(client, jobId, coordinator);
     }
 
-    ClientJobProxy(JetClientInstanceImpl client, long jobId, boolean isLightJob, Object jobDefinition, JobConfig config) {
+    ClientJobProxy(
+            JetClientInstanceImpl client,
+            long jobId,
+            boolean isLightJob,
+            @Nonnull Object jobDefinition,
+            @Nonnull JobConfig config
+    ) {
         super(client, jobId, isLightJob, jobDefinition, config);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
@@ -112,7 +112,7 @@ public class JetClientInstanceImpl extends AbstractJetInstance<UUID> {
         return new ClientJobProxy(this, jobId, lightJobCoordinator);
     }
 
-    public Job newJobProxy(long jobId, boolean isLightJob, Object jobDefinition, JobConfig config) {
+    public Job newJobProxy(long jobId, boolean isLightJob, @Nonnull Object jobDefinition, @Nonnull JobConfig config) {
         return new ClientJobProxy(this, jobId, isLightJob, jobDefinition, config);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -152,7 +152,7 @@ public class JetInstanceImpl extends AbstractJetInstance<Address> {
     }
 
     @Override
-    public Job newJobProxy(long jobId, boolean isLightJob, Object jobDefinition, JobConfig config) {
+    public Job newJobProxy(long jobId, boolean isLightJob, @Nonnull Object jobDefinition, @Nonnull JobConfig config) {
         return new JobProxy(nodeEngine, jobId, isLightJob, jobDefinition, config);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -196,12 +196,11 @@ public class JobCoordinationService {
         executionService.schedule(COORDINATOR_EXECUTOR_NAME, this::scanJobs, 0, MILLISECONDS);
     }
 
-    public CompletableFuture<Void> submitJob(long jobId, Data serializedJobDefinition, Data serializedConfig) {
+    public CompletableFuture<Void> submitJob(long jobId, Data serializedJobDefinition, JobConfig jobConfig) {
         CompletableFuture<Void> res = new CompletableFuture<>();
         submitToCoordinatorThread(() -> {
             MasterContext masterContext;
             try {
-                JobConfig jobConfig = nodeEngine.getSerializationService().toObject(serializedConfig);
                 assertIsMaster("Cannot submit job " + idToString(jobId) + " to non-master node");
                 checkOperationalState();
 
@@ -283,7 +282,7 @@ public class JobCoordinationService {
         return res;
     }
 
-    public CompletableFuture<Void> submitLightJob(long jobId, Data serializedJobDefinition) {
+    public CompletableFuture<Void> submitLightJob(long jobId, Data serializedJobDefinition, JobConfig jobConfig) {
         Object jobDefinition = nodeEngine().getSerializationService().toObject(serializedJobDefinition);
         DAG dag;
         if (jobDefinition instanceof DAG) {
@@ -306,7 +305,7 @@ public class JobCoordinationService {
 
         // Initialize and start the job (happens in the constructor). We do this before adding the actual
         // LightMasterContext to the map to avoid possible races of the the job initialization and cancellation.
-        LightMasterContext mc = new LightMasterContext(nodeEngine, dag, jobId);
+        LightMasterContext mc = new LightMasterContext(nodeEngine, dag, jobId, jobConfig);
         oldContext = lightMasterContexts.put(jobId, mc);
         assert oldContext == UNINITIALIZED_LIGHT_JOB_MARKER;
 
@@ -399,6 +398,14 @@ public class JobCoordinationService {
 
         return future
                 .thenCompose(identity()); // unwrap the inner future
+    }
+
+    public CompletableFuture<Void> joinLightJob(long jobId) {
+        Object mc = lightMasterContexts.get(jobId);
+        if (mc == null || mc == UNINITIALIZED_LIGHT_JOB_MARKER) {
+            throw new JobNotFoundException(jobId);
+        }
+        return ((LightMasterContext) mc).getCompletionFuture();
     }
 
     public CompletableFuture<Void> terminateJob(long jobId, TerminationMode terminationMode) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobProxy.java
@@ -58,7 +58,13 @@ public class JobProxy extends AbstractJobProxy<NodeEngineImpl, Address> {
         super(nodeEngine, jobId, coordinator);
     }
 
-    public JobProxy(NodeEngineImpl engine, long jobId, boolean isLightJob, Object jobDefinition, JobConfig config) {
+    public JobProxy(
+            NodeEngineImpl engine,
+            long jobId,
+            boolean isLightJob,
+            @Nonnull Object jobDefinition,
+            @Nonnull JobConfig config
+    ) {
         super(engine, jobId, isLightJob, jobDefinition, config);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/LightMasterContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/LightMasterContext.java
@@ -59,10 +59,6 @@ import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
 
 public class LightMasterContext {
 
-    public static final JobConfig LIGHT_JOB_CONFIG = new JobConfig()
-            .setMetricsEnabled(false)
-            .setAutoScaling(false);
-
     private static final Object NULL_OBJECT = new Object() {
         @Override
         public String toString() {
@@ -83,7 +79,7 @@ public class LightMasterContext {
     private final Set<Vertex> vertices;
 
     @SuppressWarnings("checkstyle:ExecutableStatementCount")
-    public LightMasterContext(NodeEngine nodeEngine, DAG dag, long jobId) {
+    public LightMasterContext(NodeEngine nodeEngine, DAG dag, long jobId, JobConfig config) {
         this.nodeEngine = nodeEngine;
         this.jobId = jobId;
 
@@ -103,7 +99,7 @@ public class LightMasterContext {
         dag.iterator().forEachRemaining(vertices::add);
         Map<MemberInfo, ExecutionPlan> executionPlanMapTmp;
         try {
-            executionPlanMapTmp = createExecutionPlans(nodeEngine, membersView, dag, jobId, jobId, LIGHT_JOB_CONFIG, 0, true);
+            executionPlanMapTmp = createExecutionPlans(nodeEngine, membersView, dag, jobId, jobId, config, 0, true);
         } catch (Throwable e) {
             executionPlanMap = null;
             finalizeJob(e);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
-import static com.hazelcast.jet.impl.LightMasterContext.LIGHT_JOB_CONFIG;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.PrefixedLogger.prefix;
 import static com.hazelcast.jet.impl.util.PrefixedLogger.prefixedLogger;
@@ -65,7 +64,6 @@ public final class ExecutionPlanBuilder {
             NodeEngine nodeEngine, MembersView membersView, DAG dag, long jobId, long executionId,
             JobConfig jobConfig, long lastSnapshotId, boolean isLightJob
     ) {
-        assert !isLightJob || jobConfig == LIGHT_JOB_CONFIG;
         final HazelcastInstance hazelcastInstance = nodeEngine.getHazelcastInstance();
         final int defaultParallelism = hazelcastInstance.getConfig().getJetConfig()
                 .getInstanceConfig().getCooperativeThreadCount();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
@@ -37,7 +37,11 @@ public class JoinSubmittedJobOperation extends AsyncJobOperation {
 
     @Override
     protected CompletableFuture<?> doRun() {
-        return getJobCoordinationService().joinSubmittedJob(jobId());
+        if (isLightJob) {
+            return getJobCoordinationService().joinLightJob(jobId());
+        } else {
+            return getJobCoordinationService().joinSubmittedJob(jobId());
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -17,10 +17,11 @@
 package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -29,7 +30,7 @@ public class SubmitJobOperation extends AsyncJobOperation {
 
     // force serialization of fields to avoid sharing of the mutable instances if submitted to the master member
     private Data jobDefinition;
-    private Data config;
+    private Data serializedConfig;
     private boolean isLightJob;
 
     public SubmitJobOperation() {
@@ -38,17 +39,18 @@ public class SubmitJobOperation extends AsyncJobOperation {
     public SubmitJobOperation(long jobId, Data jobDefinition, Data config, boolean isLightJob) {
         super(jobId);
         this.jobDefinition = jobDefinition;
-        this.config = config;
+        this.serializedConfig = config;
         this.isLightJob = isLightJob;
     }
 
     @Override
     public CompletableFuture<Void> doRun() {
+        JobConfig jobConfig = getNodeEngine().getSerializationService().toObject(serializedConfig);
         if (isLightJob) {
             assert !getNodeEngine().getLocalMember().isLiteMember() : "light job submitted to a lite member";
-            return getJobCoordinationService().submitLightJob(jobId(), jobDefinition);
+            return getJobCoordinationService().submitLightJob(jobId(), jobDefinition, jobConfig);
         } else {
-            return getJobCoordinationService().submitJob(jobId(), jobDefinition, config);
+            return getJobCoordinationService().submitJob(jobId(), jobDefinition, jobConfig);
         }
     }
 
@@ -61,7 +63,7 @@ public class SubmitJobOperation extends AsyncJobOperation {
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         IOUtil.writeData(out, jobDefinition);
-        IOUtil.writeData(out, config);
+        IOUtil.writeData(out, serializedConfig);
         out.writeBoolean(isLightJob);
     }
 
@@ -69,7 +71,7 @@ public class SubmitJobOperation extends AsyncJobOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         jobDefinition = IOUtil.readData(in);
-        config = IOUtil.readData(in);
+        serializedConfig = IOUtil.readData(in);
         isLightJob = in.readBoolean();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -30,11 +32,13 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -159,6 +163,47 @@ public class JobConfigTest extends JetTestSupport {
 
         // Then
         assertThat(config.isSuspendOnFailure(), equalTo(TRUE));
+    }
+
+    @Test
+    public void test_jobConfigForLightJob() {
+        HazelcastInstance inst = createHazelcastInstance();
+        DAG dag = new DAG();
+
+        JobConfig configWithName = new JobConfig();
+        configWithName.setName("foo");
+        assertThatThrownBy(() -> inst.getJet().newLightJob(dag, configWithName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported for light jobs");
+
+        JobConfig configWithResource = new JobConfig();
+        configWithResource.addClass(JobConfigTest.class);
+        assertThatThrownBy(() -> inst.getJet().newLightJob(dag, configWithResource))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported for light jobs");
+
+        JobConfig configWithGuarantee = new JobConfig();
+        configWithGuarantee.setProcessingGuarantee(EXACTLY_ONCE);
+        assertThatThrownBy(() -> inst.getJet().newLightJob(dag, configWithGuarantee))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported for light jobs");
+
+        JobConfig configWithClassLoaderFactory = new JobConfig();
+        configWithClassLoaderFactory.setClassLoaderFactory(new JobClassLoaderFactory() {
+            @Nonnull @Override
+            public ClassLoader getJobClassLoader() {
+                throw new UnsupportedOperationException();
+            }
+        });
+        assertThatThrownBy(() -> inst.getJet().newLightJob(dag, configWithClassLoaderFactory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported for light jobs");
+
+        JobConfig configWithInitialSnapshot = new JobConfig();
+        configWithInitialSnapshot.setInitialSnapshotName("foo");
+        assertThatThrownBy(() -> inst.getJet().newLightJob(dag, configWithInitialSnapshot))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported for light jobs");
     }
 
     private static class ObjectSerializer implements StreamSerializer<Object> {


### PR DESCRIPTION
Use the new light job feature for running SQL statements. Also enables `JobConfig` for light jobs, but documents and verifies, which settings are not applicable to light jobs (most aren't). We needed this to pass dynamic parameters to queries, but it's a better design in general: also `maxProcessorAccumulatedRecords` can be used by light jobs.

Also fix joining of a light job which wasn't implemented at all by mistake :)