### PR TITLE
Fail fast at startup for invalid WAN merge policy

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -319,7 +319,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         WanReplicationRef wanRef = cacheConfig.getWanReplicationRef();
         assertEquals("testWan", wanRef.getName());
-        assertEquals("PUT_IF_ABSENT", wanRef.getMergePolicyClassName());
+        assertEquals("PutIfAbsentMergePolicy", wanRef.getMergePolicyClassName());
         assertEquals(1, wanRef.getFilters().size());
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
     }
@@ -404,7 +404,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         // test testMapConfig2's WanReplicationConfig
         WanReplicationRef wanReplicationRef = testMapConfig2.getWanReplicationRef();
         assertEquals("testWan", wanReplicationRef.getName());
-        assertEquals("PUT_IF_ABSENT", wanReplicationRef.getMergePolicyClassName());
+        assertEquals("PutIfAbsentMergePolicy", wanReplicationRef.getMergePolicyClassName());
         assertTrue(wanReplicationRef.isRepublishingEnabled());
 
         assertEquals(1000, testMapConfig2.getEvictionConfig().getSize());
@@ -471,7 +471,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         // test testMapConfig2's WanReplicationConfig
         WanReplicationRef wanReplicationRef = testMapConfig2.getWanReplicationRef();
         assertEquals("testWan", wanReplicationRef.getName());
-        assertEquals("PUT_IF_ABSENT", wanReplicationRef.getMergePolicyClassName());
+        assertEquals("PutIfAbsentMergePolicy", wanReplicationRef.getMergePolicyClassName());
     }
 
     @Test

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -374,7 +374,7 @@
                               implementation="dummyMapStore"
                               write-delay-seconds="0"
                               initial-mode="LAZY"/>
-                <hz:wan-replication-ref name="testWan" merge-policy-class-name="PUT_IF_ABSENT"/>
+                <hz:wan-replication-ref name="testWan" merge-policy-class-name="PutIfAbsentMergePolicy"/>
 
                 <hz:entry-listeners>
                     <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener" include-value="true"/>
@@ -508,7 +508,7 @@
             </hz:map>
 
             <hz:cache name="testCache" disable-per-entry-invalidation-events="true">
-                <hz:wan-replication-ref name="testWan" merge-policy-class-name="PUT_IF_ABSENT"
+                <hz:wan-replication-ref name="testWan" merge-policy-class-name="PutIfAbsentMergePolicy"
                                         republishing-enabled="false">
                     <hz:filters>
                         <hz:filter-impl>com.example.SampleFilter</hz:filter-impl>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -64,6 +64,7 @@ import com.hazelcast.wan.impl.WanReplicationService;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -106,6 +107,7 @@ public class MapContainer {
      * Holds number of registered {@link InvalidationListener} from clients.
      */
     protected final AtomicInteger invalidationListenerCount = new AtomicInteger();
+    protected final AtomicLong lastInvalidMergePolicyCheckTime = new AtomicLong();
 
     protected SplitBrainMergePolicy wanMergePolicy;
     protected DelegatingWanScheme wanReplicationDelegate;
@@ -167,6 +169,10 @@ public class MapContainer {
                 .partitionCount(partitionCount)
                 .resultFilterFactory(new IndexResultFilterFactory())
                 .build();
+    }
+
+    public AtomicLong getLastInvalidMergePolicyCheckTime() {
+        return lastInvalidMergePolicyCheckTime;
     }
 
     private class IndexResultFilterFactory implements Supplier<Predicate<QueryableEntry>> {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
@@ -31,6 +33,9 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
 
 import static com.hazelcast.core.EntryEventType.MERGED;
 import static com.hazelcast.internal.config.MergePolicyValidator.checkMapMergePolicy;
@@ -43,6 +48,8 @@ import static com.hazelcast.internal.config.MergePolicyValidator.checkMapMergePo
  */
 public class MergeOperation extends MapOperation
         implements PartitionAwareOperation, BackupAwareOperation {
+
+    private static final long MERGE_POLICY_CHECK_PERIOD = TimeUnit.MINUTES.toMillis(1);
 
     private boolean disableWanReplicationEvent;
     private List<MapMergeTypes<Object, Object>> mergingEntries;
@@ -78,8 +85,15 @@ public class MergeOperation extends MapOperation
 
     @Override
     protected void runInternal() {
-        checkMapMergePolicy(mapContainer.getMapConfig(), mergePolicy.getClass().getName(),
-                getNodeEngine().getSplitBrainMergePolicyProvider());
+        // Check once in a minute as earliest to avoid log bursts.
+        if (shouldCheckNow(mapContainer.getLastInvalidMergePolicyCheckTime())) {
+            try {
+                checkMapMergePolicy(mapContainer.getMapConfig(), mergePolicy.getClass().getName(),
+                        getNodeEngine().getSplitBrainMergePolicyProvider());
+            } catch (InvalidConfigurationException e) {
+                logger().log(Level.WARNING, e.getMessage(), e);
+            }
+        }
 
         hasMapListener = mapEventPublisher.hasEventListener(name);
         hasWanReplication = mapContainer.isWanReplicationEnabled()
@@ -102,6 +116,16 @@ public class MergeOperation extends MapOperation
             merge(mergingEntries.get(currentIndex));
             currentIndex++;
         }
+    }
+
+    private static boolean shouldCheckNow(AtomicLong lastLogTime) {
+        long now = Clock.currentTimeMillis();
+        long lastLogged = lastLogTime.get();
+        if (now - lastLogged >= MERGE_POLICY_CHECK_PERIOD) {
+            return lastLogTime.compareAndSet(lastLogged, now);
+        }
+
+        return false;
     }
 
     private void merge(MapMergeTypes<Object, Object> mergingEntry) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.hazelcast.core.EntryEventType.MERGED;
+import static com.hazelcast.internal.config.MergePolicyValidator.checkMapMergePolicy;
 
 /**
  * Contains multiple merge entries for split-brain
@@ -77,6 +78,9 @@ public class MergeOperation extends MapOperation
 
     @Override
     protected void runInternal() {
+        checkMapMergePolicy(mapContainer.getMapConfig(), mergePolicy.getClass().getName(),
+                getNodeEngine().getSplitBrainMergePolicyProvider());
+
         hasMapListener = mapEventPublisher.hasEventListener(name);
         hasWanReplication = mapContainer.isWanReplicationEnabled()
                 && !disableWanReplicationEvent;

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
@@ -17,8 +17,8 @@
 package com.hazelcast.spi.merge;
 
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.internal.util.ConstructorFunction;
+import com.hazelcast.spi.impl.NodeEngine;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +51,7 @@ public final class SplitBrainMergePolicyProvider {
         addPolicy(PutIfAbsentMergePolicy.class, new PutIfAbsentMergePolicy());
     }
 
-    private final NodeEngine nodeEngine;
+    private final ClassLoader configClassLoader;
 
     private final ConcurrentMap<String, SplitBrainMergePolicy> mergePolicyMap
             = new ConcurrentHashMap<String, SplitBrainMergePolicy>();
@@ -61,7 +61,7 @@ public final class SplitBrainMergePolicyProvider {
         @Override
         public SplitBrainMergePolicy createNew(String className) {
             try {
-                return newInstance(nodeEngine.getConfigClassLoader(), className);
+                return newInstance(configClassLoader, className);
             } catch (Exception e) {
                 throw new InvalidConfigurationException("Invalid SplitBrainMergePolicy: " + className, e);
             }
@@ -73,8 +73,8 @@ public final class SplitBrainMergePolicyProvider {
      *
      * @param nodeEngine the {@link NodeEngine} to retrieve the classloader from
      */
-    public SplitBrainMergePolicyProvider(NodeEngine nodeEngine) {
-        this.nodeEngine = nodeEngine;
+    public SplitBrainMergePolicyProvider(ClassLoader configClassLoader) {
+        this.configClassLoader = configClassLoader;
         this.mergePolicyMap.putAll(OUT_OF_THE_BOX_MERGE_POLICIES);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
@@ -1376,13 +1377,17 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    " + mapName + ":\n"
                 + "      wan-replication-ref:\n"
                 + "        test:\n"
-                + "          merge-policy-class-name: TestMergePolicy\n"
+                + "          merge-policy-class-name: LatestUpdateMergePolicy\n"
                 + "          filters:\n"
                 + "            - com.example.SampleFilter\n";
 
         Config config = buildConfig(yaml);
         MapConfig mapConfig = config.getMapConfig(mapName);
         WanReplicationRef wanRef = mapConfig.getWanReplicationRef();
+        mapConfig.setPerEntryStatsEnabled(false);
+
+
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
 
         assertEquals(refName, wanRef.getName());
         assertEquals(mergePolicy, wanRef.getMergePolicyClassName());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
@@ -1377,17 +1376,13 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    " + mapName + ":\n"
                 + "      wan-replication-ref:\n"
                 + "        test:\n"
-                + "          merge-policy-class-name: LatestUpdateMergePolicy\n"
+                + "          merge-policy-class-name: TestMergePolicy\n"
                 + "          filters:\n"
                 + "            - com.example.SampleFilter\n";
 
         Config config = buildConfig(yaml);
         MapConfig mapConfig = config.getMapConfig(mapName);
         WanReplicationRef wanRef = mapConfig.getWanReplicationRef();
-        mapConfig.setPerEntryStatsEnabled(false);
-
-
-        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
 
         assertEquals(refName, wanRef.getName());
         assertEquals(mergePolicy, wanRef.getMergePolicyClassName());

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -65,7 +65,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
         NodeEngine nodeEngine = Mockito.mock(NodeEngine.class);
         when(nodeEngine.getConfigClassLoader()).thenReturn(config.getClassLoader());
 
-        splitBrainMergePolicyProvider = new SplitBrainMergePolicyProvider(nodeEngine);
+        splitBrainMergePolicyProvider = new SplitBrainMergePolicyProvider(config.getClassLoader());
         when(nodeEngine.getSplitBrainMergePolicyProvider()).thenReturn(splitBrainMergePolicyProvider);
 
         properties = nodeEngine.getProperties();

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorMapIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorMapIntegrationTest.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyValidatorIntegrationTest {
 
-    private boolean perEntryStatsEnabled = false;
+    private boolean perEntryStatsEnabled = true;
 
     @Override
     void addConfig(Config config, String name, MergePolicyConfig mergePolicyConfig) {
@@ -60,9 +60,9 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withHyperLogLogMergePolicy() {
+        expectCardinalityEstimatorException();
         HazelcastInstance hz = getHazelcastInstance("cardinalityEstimator", hyperLogLogMergePolicy);
 
-        expectCardinalityEstimatorException();
         hz.getMap("cardinalityEstimator");
     }
 
@@ -76,9 +76,9 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
 
     @Test
     public void testMap_withInvalidMergePolicy() {
+        expectedInvalidMergePolicyException();
         HazelcastInstance hz = getHazelcastInstance("invalid", invalidMergePolicyConfig);
 
-        expectedInvalidMergePolicyException();
         hz.getMap("invalid");
     }
 
@@ -105,9 +105,11 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
      */
     @Test
     public void testMap_withLastStoredTimeMergePolicy() {
+        perEntryStatsEnabled = false;
+        expectedMapStatisticsDisabledException(lastStoredTimeMergePolicy);
+
         HazelcastInstance hz = getHazelcastInstance("lastStoredTime", lastStoredTimeMergePolicy);
 
-        expectedMapStatisticsDisabledException(lastStoredTimeMergePolicy);
         hz.getMap("lastStoredTime");
     }
 
@@ -124,9 +126,11 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
      */
     @Test
     public void testMap_withLastStoredTimeMergePolicyNoTypeVariable() {
+        perEntryStatsEnabled = false;
+        expectedMapStatisticsDisabledException(lastStoredTimeMergePolicyNoTypeVariable);
+
         HazelcastInstance hz = getHazelcastInstance("lastStoredTimeNoTypeVariable", lastStoredTimeMergePolicyNoTypeVariable);
 
-        expectedMapStatisticsDisabledException(lastStoredTimeMergePolicyNoTypeVariable);
         hz.getMap("lastStoredTimeNoTypeVariable");
     }
 
@@ -163,9 +167,10 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
      */
     @Test
     public void testMap_withCustomMapMergePolicy() {
+        perEntryStatsEnabled = false;
+        expectedMapStatisticsDisabledException(customMapMergePolicy);
         HazelcastInstance hz = getHazelcastInstance("customMap", customMapMergePolicy);
 
-        expectedMapStatisticsDisabledException(customMapMergePolicy);
         hz.getMap("customMap");
     }
 
@@ -183,9 +188,11 @@ public class MergePolicyValidatorMapIntegrationTest extends AbstractMergePolicyV
      */
     @Test
     public void testMap_withCustomMapMergePolicyNoTypeVariable() {
+        perEntryStatsEnabled = false;
+        expectedMapStatisticsDisabledException(customMapMergePolicyNoTypeVariable);
+
         HazelcastInstance hz = getHazelcastInstance("customMapNoTypeVariable", customMapMergePolicyNoTypeVariable);
 
-        expectedMapStatisticsDisabledException(customMapMergePolicyNoTypeVariable);
         hz.getMap("customMapNoTypeVariable");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/MergePolicyValidatorTest.java
@@ -43,7 +43,7 @@ public class MergePolicyValidatorTest extends HazelcastTestSupport {
         NodeEngine nodeEngine = Mockito.mock(NodeEngine.class);
         when(nodeEngine.getConfigClassLoader()).thenReturn(config.getClassLoader());
 
-        mapMergePolicyProvider = new SplitBrainMergePolicyProvider(nodeEngine);
+        mapMergePolicyProvider = new SplitBrainMergePolicyProvider(config.getClassLoader());
         when(nodeEngine.getSplitBrainMergePolicyProvider()).thenReturn(mapMergePolicyProvider);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProviderTest.java
@@ -48,7 +48,7 @@ public class SplitBrainMergePolicyProviderTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        mergePolicyProvider = new SplitBrainMergePolicyProvider(getNode(createHazelcastInstance()).getNodeEngine());
+        mergePolicyProvider = new SplitBrainMergePolicyProvider(getNode(createHazelcastInstance()).getConfigClassLoader());
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/18804

__Modifications:__
- Validate wan and split-brain merge policies at node-engine creation time to fail-fast at node start time.
- Also adds a logging to MergeOperation to catch unreasonable merge-policy configs that cannot be catch at start-up. Example to this is, you have WAN replication between 2 clusters, even though source cluster has per-entry-stats enabled, target cluster doesn't have it enabled. In this case MergeOperation catches this anomaly and prints it as a warning.