### PR TITLE
Fix getJob(long) after new master takes over

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -104,6 +104,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
+import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -459,7 +460,8 @@ public class JobCoordinationService {
                 if (lightMasterContexts.get(onlyJobId) != null) {
                     return new GetJobIdsResult(onlyJobId, true);
                 }
-                if (isMaster() && (masterContexts.get(onlyJobId) != null || jobRepository.getJobResult(onlyJobId) != null)) {
+                if (isMaster()
+                        && callWithJob(onlyJobId, mc -> true, jobResult -> true, jobRecord -> true, null).get() == TRUE) {
                     return new GetJobIdsResult(onlyJobId, false);
                 }
                 return GetJobIdsResult.EMPTY;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -469,7 +469,7 @@ public class JobCoordinationService {
                         if (e.getCause() instanceof JobNotFoundException) {
                             return GetJobIdsResult.EMPTY;
                         }
-                        else throw e;
+                        throw e;
                     }
                     return new GetJobIdsResult(onlyJobId, false);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -79,6 +79,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -104,7 +105,6 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
-import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -460,8 +460,17 @@ public class JobCoordinationService {
                 if (lightMasterContexts.get(onlyJobId) != null) {
                     return new GetJobIdsResult(onlyJobId, true);
                 }
-                if (isMaster()
-                        && callWithJob(onlyJobId, mc -> true, jobResult -> true, jobRecord -> true, null).get() == TRUE) {
+
+                if (isMaster()) {
+                    try {
+                        callWithJob(onlyJobId, mc -> null, jobResult -> null, jobRecord -> null, null)
+                                .get();
+                    } catch (ExecutionException e) {
+                        if (e.getCause() instanceof JobNotFoundException) {
+                            return GetJobIdsResult.EMPTY;
+                        }
+                        else throw e;
+                    }
                     return new GetJobIdsResult(onlyJobId, false);
                 }
                 return GetJobIdsResult.EMPTY;


### PR DESCRIPTION
The `GetJobIdsOperation` with `onlyJobId` parameter, on a master, looked
only at `JobCoordinatorService.masterContexts` and at `JobResults` map,
but not at `JobRecords`. After a new master takes over, it takes a short
time until the new master loads `JobRecords`. During this time,
`getJob(long)` returned null for an existing job.

The fix is to look at all `JobRecords` too.

Credits to @ufukyilmaz for figuring out the root cause.

Fixes #18864