### PR TITLE
[HZ-393] Standardize TIME and TIMESTAMP temporal formats

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/CastFunctionIntegrationTest.java
@@ -155,16 +155,19 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         // LocalTime
         putAndCheckValue(new ExpressionValue.StringVal(), sql("field1", TIME), TIME, null);
         putAndCheckValue(LOCAL_TIME_VAL.toString(), sql("this", TIME), TIME, LOCAL_TIME_VAL);
+        putAndCheckValue(STANDARD_LOCAL_TIME_VAL, sql("this", TIME), TIME, LOCAL_TIME_VAL);
         putAndCheckFailure("bad", sql("this", TIME), DATA_EXCEPTION, "Cannot parse VARCHAR value to TIME");
 
         // LocalDateTime
         putAndCheckValue(new ExpressionValue.StringVal(), sql("field1", TIMESTAMP), TIMESTAMP, null);
         putAndCheckValue(LOCAL_DATE_TIME_VAL.toString(), sql("this", TIMESTAMP), TIMESTAMP, LOCAL_DATE_TIME_VAL);
+        putAndCheckValue(STANDARD_LOCAL_DATE_TIME_VAL, sql("this", TIMESTAMP), TIMESTAMP, LOCAL_DATE_TIME_VAL);
         putAndCheckFailure("bad", sql("this", TIMESTAMP), DATA_EXCEPTION, "Cannot parse VARCHAR value to TIMESTAMP");
 
         // OffsetDateTime
         putAndCheckValue(new ExpressionValue.StringVal(), sql("field1", TIMESTAMP_WITH_TIME_ZONE), TIMESTAMP_WITH_TIME_ZONE, null);
         putAndCheckValue(OFFSET_DATE_TIME_VAL.toString(), sql("this", TIMESTAMP_WITH_TIME_ZONE), TIMESTAMP_WITH_TIME_ZONE, OFFSET_DATE_TIME_VAL);
+        putAndCheckValue(STANDARD_LOCAL_OFFSET_TIME_VAL, sql("this", TIMESTAMP_WITH_TIME_ZONE), TIMESTAMP_WITH_TIME_ZONE, OFFSET_DATE_TIME_VAL);
         putAndCheckFailure("bad", sql("this", TIMESTAMP_WITH_TIME_ZONE), DATA_EXCEPTION, "Cannot parse VARCHAR value to TIMESTAMP WITH TIME ZONE");
 
         // Object
@@ -261,18 +264,24 @@ public class CastFunctionIntegrationTest extends ExpressionTestSupport {
         checkFailure0(sql(stringLiteral("false"), DOUBLE), PARSING, "CAST function cannot convert literal 'false' to type DOUBLE: Cannot parse VARCHAR value to DOUBLE");
 
         // VARCHAR -> DATE
+        checkValue0(sql(stringLiteral("2020-1-01"), DATE), DATE, LocalDate.parse("2020-01-01"));
+        checkValue0(sql(stringLiteral("2020-9-1"), DATE), DATE, LocalDate.parse("2020-09-01"));
         checkValue0(sql(stringLiteral("2020-01-01"), DATE), DATE, LocalDate.parse("2020-01-01"));
         checkFailure0(sql(stringLiteral("foo"), DATE), PARSING, "CAST function cannot convert literal 'foo' to type DATE: Cannot parse VARCHAR value to DATE");
 
         // VARCHAR -> TIME
         checkValue0(sql(stringLiteral("00:00"), TIME), TIME, LocalTime.parse("00:00"));
+        checkValue0(sql(stringLiteral("0:0"), TIME), TIME, LocalTime.parse("00:00"));
+        checkValue0(sql(stringLiteral("9:0"), TIME), TIME, LocalTime.parse("09:00"));
         checkValue0(sql(stringLiteral("00:01"), TIME), TIME, LocalTime.parse("00:01"));
+        checkValue0(sql(stringLiteral("00:1"), TIME), TIME, LocalTime.parse("00:01"));
         checkValue0(sql(stringLiteral("02:01"), TIME), TIME, LocalTime.parse("02:01"));
         checkValue0(sql(stringLiteral("00:00:00"), TIME), TIME, LocalTime.parse("00:00:00"));
         checkValue0(sql(stringLiteral("00:00:01"), TIME), TIME, LocalTime.parse("00:00:01"));
         checkValue0(sql(stringLiteral("00:02:01"), TIME), TIME, LocalTime.parse("00:02:01"));
         checkValue0(sql(stringLiteral("03:02:01"), TIME), TIME, LocalTime.parse("03:02:01"));
 
+        checkFailure0(sql(stringLiteral("9"), TIME), PARSING, "CAST function cannot convert literal '9' to type TIME: Cannot parse VARCHAR value to TIME");
         checkFailure0(sql(stringLiteral("00:60"), TIME), PARSING, "CAST function cannot convert literal '00:60' to type TIME: Cannot parse VARCHAR value to TIME");
         checkFailure0(sql(stringLiteral("00:00:60"), TIME), PARSING, "CAST function cannot convert literal '00:00:60' to type TIME: Cannot parse VARCHAR value to TIME");
         checkFailure0(sql(stringLiteral("25:00"), TIME), PARSING, "CAST function cannot convert literal '25:00' to type TIME: Cannot parse VARCHAR value to TIME");

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/ExpressionTestSupport.java
@@ -79,6 +79,9 @@ public abstract class ExpressionTestSupport extends SqlTestSupport {
 
     protected static final Object SKIP_VALUE_CHECK = new Object();
     protected static final String STANDARD_LOCAL_DATE_VAL = "2020-1-1";
+    protected static final String STANDARD_LOCAL_TIME_VAL = "0:0:0";
+    protected static final String STANDARD_LOCAL_OFFSET_TIME_VAL = "2020-1-1 0:0:0+00:00";
+    protected static final String STANDARD_LOCAL_DATE_TIME_VAL = "2020-1-1 0:0:0";
 
     protected static HazelcastInstance member;
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -77,9 +77,7 @@ public abstract class AbstractStringConverter extends Converter {
 
     static final DateTimeFormatter STANDARD_OFFSET_DATE_TIME_FORMAT = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .append(STANDARD_DATE_FORMAT)
-            .appendPattern("['T'][' ']")
-            .append(STANDARD_TIME_FORMAT)
+            .append(STANDARD_DATE_TIME_FORMAT)
             .appendOffsetId()
             .toFormatter();
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/converter/AbstractStringConverter.java
@@ -33,7 +33,11 @@ import java.time.format.SignStyle;
 import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.sql.impl.expression.math.ExpressionMath.DECIMAL_MATH_CONTEXT;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 
 /**
@@ -43,6 +47,7 @@ public abstract class AbstractStringConverter extends Converter {
     private static final int MIN_YEAR_SYMBOLS = 4;
     private static final int MAX_YEAR_SYMBOLS = 10;
 
+    // region date-time formatters
     static final DateTimeFormatter STANDARD_DATE_FORMAT = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
             .appendValue(YEAR, MIN_YEAR_SYMBOLS, MAX_YEAR_SYMBOLS, SignStyle.EXCEEDS_PAD)
@@ -51,6 +56,34 @@ public abstract class AbstractStringConverter extends Converter {
             .appendLiteral('-')
             .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NEVER)
             .toFormatter();
+
+    @SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:DeclarationOrder"})
+    static final DateTimeFormatter STANDARD_TIME_FORMAT = new DateTimeFormatterBuilder()
+            .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NEVER)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NEVER)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NEVER)
+            .optionalStart()
+            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .toFormatter();
+
+    static final DateTimeFormatter STANDARD_DATE_TIME_FORMAT = new DateTimeFormatterBuilder()
+            .append(STANDARD_DATE_FORMAT)
+            .appendPattern("['T'][' ']")
+            .append(STANDARD_TIME_FORMAT)
+            .toFormatter();
+
+    static final DateTimeFormatter STANDARD_OFFSET_DATE_TIME_FORMAT = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(STANDARD_DATE_FORMAT)
+            .appendPattern("['T'][' ']")
+            .append(STANDARD_TIME_FORMAT)
+            .appendOffsetId()
+            .toFormatter();
+
+    //endregion
 
     protected AbstractStringConverter(int id) {
         super(id, QueryDataTypeFamily.VARCHAR);
@@ -154,7 +187,7 @@ public abstract class AbstractStringConverter extends Converter {
     @Override
     public final LocalTime asTime(Object val) {
         try {
-            return LocalTime.parse(cast(val));
+            return LocalTime.parse(cast(val), STANDARD_TIME_FORMAT);
         } catch (DateTimeParseException e) {
             throw cannotParseError(QueryDataTypeFamily.TIME);
         }
@@ -163,7 +196,7 @@ public abstract class AbstractStringConverter extends Converter {
     @Override
     public final LocalDateTime asTimestamp(Object val) {
         try {
-            return LocalDateTime.parse(cast(val));
+            return LocalDateTime.parse(cast(val), STANDARD_DATE_TIME_FORMAT);
         } catch (DateTimeParseException e) {
             throw cannotParseError(QueryDataTypeFamily.TIMESTAMP);
         }
@@ -172,7 +205,7 @@ public abstract class AbstractStringConverter extends Converter {
     @Override
     public final OffsetDateTime asTimestampWithTimezone(Object val) {
         try {
-            return OffsetDateTime.parse(cast(val));
+            return OffsetDateTime.parse(cast(val), STANDARD_OFFSET_DATE_TIME_FORMAT);
         } catch (DateTimeParseException e) {
             throw cannotParseError(QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE);
         }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/converter/ConvertersTest.java
@@ -590,6 +590,9 @@ public class ConvertersTest {
         checkDataException(() -> c.asDouble(invalid));
 
         // Temporal
+        assertEquals(LocalTime.parse("01:02"), c.asTime("1:2"));
+        assertEquals(LocalTime.parse("01:22"), c.asTime("1:22"));
+        assertEquals(LocalTime.parse("11:02"), c.asTime("11:2"));
         assertEquals(LocalTime.parse("11:22"), c.asTime("11:22"));
         assertEquals(LocalTime.parse("11:22:33"), c.asTime("11:22:33"));
         assertEquals(LocalTime.parse("11:22:33.444"), c.asTime("11:22:33.444"));
@@ -625,6 +628,22 @@ public class ConvertersTest {
         checkDataException(() -> c.asTimestamp("2020-01-01T11:22:66"));
         checkDataException(() -> c.asTimestamp("2020-01-01T11:22:33.4444444444"));
         checkDataException(() -> c.asTimestamp(invalid));
+
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22"), c.asTimestamp("2020-01-01 11:22"));
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22:33"), c.asTimestamp("2020-01-01 11:22:33"));
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22:33.444"), c.asTimestamp("2020-01-01 11:22:33.444"));
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22:33.444444444"), c.asTimestamp("2020-01-01 11:22:33.444444444"));
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22"), c.asTimestamp("2020-01-01 11:22"));
+        assertEquals(LocalDateTime.parse("2020-01-01T01:22:33"), c.asTimestamp("2020-01-01 1:22:33"));
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22:33.444"), c.asTimestamp("2020-01-01 11:22:33.444"));
+        assertEquals(LocalDateTime.parse("2020-01-01T11:22:33.444444444"), c.asTimestamp("2020-01-01 11:22:33.444444444"));
+        checkDataException(() -> c.asTimestamp("2020-13-01 11:22"));
+        checkDataException(() -> c.asTimestamp("2020-13-01 11:22"));
+        checkDataException(() -> c.asTimestamp("2020-01-35 11:22"));
+        checkDataException(() -> c.asTimestamp("2020-01-1 33:22"));
+        checkDataException(() -> c.asTimestamp("2020-01-1 11:66"));
+        checkDataException(() -> c.asTimestamp("2020-01-1 T11:22:66"));
+        checkDataException(() -> c.asTimestamp("2020-01-01 11:22:33.4444444444"));
 
         assertEquals(OffsetDateTime.parse("2020-01-01T11:22:33.444444444Z"),
             c.asTimestampWithTimezone("2020-01-01T11:22:33.444444444Z"));


### PR DESCRIPTION
Add support of TIME without leading zeroes and TIMESTAMP with space instead of 'T' symbol.

Supported formats examples : 
- **TIME** : `0:0`, `00:0`, `0:00`, `00:00`, `0:0:0`, `00:0:0`, `0:00:00`, `00:00:00`, 
- **TIMESTAMP** : both `2021-1-1T00:00:00` and `2021-1-1 0:0:0` formats


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible

Fixes #18840
