### PR TITLE
Use test instance factory in MemberReconnectionStressTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.jet.core.TestProcessors.MockP;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -47,7 +47,6 @@ public class MemberReconnectionStressTest extends JetTestSupport {
     @After
     public void after() {
         terminated.set(true);
-        Hazelcast.shutdownAll();
     }
 
     @Test
@@ -69,9 +68,8 @@ public class MemberReconnectionStressTest extends JetTestSupport {
         config.setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "2000");
         config.setClusterName(randomName());
 
-        HazelcastInstance inst1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance inst2 = Hazelcast.newHazelcastInstance(config);
-
+        HazelcastInstance inst1 = createHazelcastInstance(config);
+        HazelcastInstance inst2 = createHazelcastInstance(config);
         logger.info("Instances started");
 
         new Thread(() -> {


### PR DESCRIPTION
`MemberReconnectionStressTest` was failing due to the interference
with other tests. So, I used the test instance factory while creating instances
to avoid the interference between tests.
See this kind of `AuthenticationMessageTask` warning logs in the test failure, which are not related to the test:
```
03:35:41,504  WARN |test| - [AuthenticationMessageTask] hz.mystifying_wilbur.priority-generic-operation.thread-0 - [127.0.0.1]:5701 [ac344c52-7334-4378-8825-e95a4d5d6156] [5.0-SNAPSHOT] Received auth from Connection[id=586, /127.0.0.1:5701->/127.0.0.1:33575, qualifier=null, endpoint=null, alive=true, connectionType=NONE, planeIndex=-1] with clientUuid 0bb37a43-e6ee-4222-b09c-118852d53bf1, authentication failed
```
Here, it was interfering with `c.h.jet.MulticastDiscoveryTest`.
Note: `c.h.jet.MulticastDiscoveryTest` was marked as serial but
 `MemberReconnectionStressTest` is not. Marking `MemberReconnectionStressTest`
 as serial would probably solve this problem, but I chose a different way.

Fixes #18863

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
