### PR TITLE
Remove resourceUploadEnabled check for server-side

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.cluster.Endpoint;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.function.FunctionEx;
@@ -196,7 +197,9 @@ public class JobCoordinationService {
         executionService.schedule(COORDINATOR_EXECUTOR_NAME, this::scanJobs, 0, MILLISECONDS);
     }
 
-    public CompletableFuture<Void> submitJob(long jobId, Data serializedJobDefinition, Data serializedConfig) {
+    public CompletableFuture<Void> submitJob(
+            long jobId, Data serializedJobDefinition, Data serializedConfig, Endpoint endpoint
+    ) {
         CompletableFuture<Void> res = new CompletableFuture<>();
         submitToCoordinatorThread(() -> {
             MasterContext masterContext;
@@ -214,7 +217,8 @@ public class JobCoordinationService {
                             + jobResult);
                     return;
                 }
-                if (!config.isResourceUploadEnabled() && !jobConfig.getResourceConfigs().isEmpty()) {
+                if (endpoint != null &&
+                        !config.isResourceUploadEnabled() && !jobConfig.getResourceConfigs().isEmpty()) {
                     throw new JetException("The JobConfig contains resources to upload, but the resource upload " +
                             "is disabled. Either remove the resources from the job config or enabled resource " +
                             "uploading, see JetConfig#setResourceUploadEnabled.");

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetSubmitJobMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetSubmitJobMessageTask.java
@@ -31,7 +31,7 @@ public class JetSubmitJobMessageTask extends AbstractJetMessageTask<JetSubmitJob
 
     @Override
     protected Operation prepareOperation() {
-        return new SubmitJobOperation(parameters.jobId, parameters.dag, parameters.jobConfig, parameters.isLightJob);
+        return new SubmitJobOperation(parameters.jobId, parameters.dag, parameters.jobConfig, parameters.isLightJob, endpoint);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.jet.impl.operation;
 
+import com.hazelcast.client.impl.ClientEndpoint;
+import com.hazelcast.cluster.Endpoint;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -32,14 +34,22 @@ public class SubmitJobOperation extends AsyncJobOperation {
     private Data config;
     private boolean isLightJob;
 
+    private transient Endpoint endpoint;
+
     public SubmitJobOperation() {
     }
 
     public SubmitJobOperation(long jobId, Data jobDefinition, Data config, boolean isLightJob) {
+        this(jobId, jobDefinition, config, isLightJob, null);
+    }
+
+    public SubmitJobOperation(
+            long jobId, Data jobDefinition, Data config, boolean isLightJob, ClientEndpoint endpoint) {
         super(jobId);
         this.jobDefinition = jobDefinition;
         this.config = config;
         this.isLightJob = isLightJob;
+        this.endpoint = endpoint;
     }
 
     @Override
@@ -48,7 +58,7 @@ public class SubmitJobOperation extends AsyncJobOperation {
             assert !getNodeEngine().getLocalMember().isLiteMember() : "light job submitted to a lite member";
             return getJobCoordinationService().submitLightJob(jobId(), jobDefinition);
         } else {
-            return getJobCoordinationService().submitJob(jobId(), jobDefinition, config);
+            return getJobCoordinationService().submitJob(jobId(), jobDefinition, config, endpoint);
         }
     }
 


### PR DESCRIPTION
Added `ClientEndpoint` parameter to `submitJob` method to check if the operation is originated from client or server.
It will also be used to check for permissions in this [PR](https://github.com/hazelcast/hazelcast/pull/18688)

Fixes https://github.com/hazelcast/hazelcast/issues/18801

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
