### PR TITLE
SQL DML cleanups + tests

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.sql.impl.schema.MappingField;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.schema.Table;
-import org.apache.calcite.sql.SqlNodeList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -310,7 +309,7 @@ public interface SqlConnector {
      * returned by {@link #getPrimaryKey(Table)}.
      */
     @Nonnull
-    default Vertex deleteProcessor(@Nonnull DAG dag, @Nonnull Table table) {
+    default Vertex delete(@Nonnull DAG dag, @Nonnull Table table) {
         throw new UnsupportedOperationException("DELETE not supported for " + typeName());
     }
 
@@ -318,14 +317,14 @@ public interface SqlConnector {
      * Return the indexes of fields that are primary key. These fields will be
      * fed to the delete processor.
      * <p>
-     * Every connector that supports a {@link #deleteProcessor} should have a
-     * primary key on each table, otherwise deleting cannot work. If some table
+     * Every connector that supports a {@link #delete} should have a primary
+     * key on each table, otherwise deleting cannot work. If some table
      * doesn't have a primary key and an empty node list is returned from this
      * method, an error will be thrown.
      */
     @Nonnull
-    default SqlNodeList getPrimaryKey(Table table) {
-        throw new UnsupportedOperationException("DELETE not supported by connector: " + typeName());
+    default List<String> getPrimaryKey(Table table) {
+        throw new UnsupportedOperationException("PRIMARY KEY not supported by connector: " + typeName());
     }
 
     /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -286,7 +286,7 @@ public interface SqlConnector {
      * Returns {@code true}, if {@code SINK INTO} is required instead of {@code
      * INSERT INTO} statements.
      * <p>
-     * Unused for connectors that don't override {@link #sink}.
+     * Unused for connectors that don't override {@link #sinkProcessor}.
      */
     default boolean requiresSink() {
         return false;
@@ -296,7 +296,7 @@ public interface SqlConnector {
      * Returns the supplier for the sink processor.
      */
     @Nonnull
-    default Vertex sink(
+    default Vertex sinkProcessor(
             @Nonnull DAG dag,
             @Nonnull Table table
     ) {
@@ -309,7 +309,7 @@ public interface SqlConnector {
      * returned by {@link #getPrimaryKey(Table)}.
      */
     @Nonnull
-    default Vertex delete(@Nonnull DAG dag, @Nonnull Table table) {
+    default Vertex deleteProcessor(@Nonnull DAG dag, @Nonnull Table table) {
         throw new UnsupportedOperationException("DELETE not supported for " + typeName());
     }
 
@@ -317,7 +317,7 @@ public interface SqlConnector {
      * Return the indexes of fields that are primary key. These fields will be
      * fed to the delete processor.
      * <p>
-     * Every connector that supports a {@link #delete} should have a primary
+     * Every connector that supports a {@link #deleteProcessor} should have a primary
      * key on each table, otherwise deleting cannot work. If some table
      * doesn't have a primary key and an empty node list is returned from this
      * method, an error will be thrown.

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -143,7 +143,7 @@ public class KafkaSqlConnector implements SqlConnector {
     }
 
     @Nonnull @Override
-    public Vertex sink(
+    public Vertex sinkProcessor(
             @Nonnull DAG dag,
             @Nonnull Table table0
     ) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -44,9 +44,6 @@ import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.MapTableField;
 import com.hazelcast.sql.impl.schema.map.PartitionedMapTable;
 import com.hazelcast.sql.impl.type.QueryDataType;
-import org.apache.calcite.sql.SqlIdentifier;
-import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -74,8 +71,7 @@ public class IMapSqlConnector implements SqlConnector {
             MetadataJsonResolver.INSTANCE
     );
 
-    private static final SqlNodeList KEY_NODE_LIST = new SqlNodeList(singletonList(
-            new SqlIdentifier(QueryPath.KEY, SqlParserPos.ZERO)), SqlParserPos.ZERO);
+    private static final List<String> PRIMARY_KEY_LIST = singletonList(QueryPath.KEY);
 
     @Override
     public String typeName() {
@@ -220,13 +216,7 @@ public class IMapSqlConnector implements SqlConnector {
 
     @Nonnull
     @Override
-    public SqlNodeList getPrimaryKey(Table table0) {
-        return KEY_NODE_LIST;
-    }
-
-    @Nonnull
-    @Override
-    public Vertex deleteProcessor(@Nonnull DAG dag, @Nonnull Table table0) {
+    public Vertex delete(@Nonnull DAG dag, @Nonnull Table table0) {
         PartitionedMapTable table = (PartitionedMapTable) table0;
 
         return dag.newUniqueVertex(
@@ -236,6 +226,12 @@ public class IMapSqlConnector implements SqlConnector {
                     assert row.length == 1;
                     return row[0];
                 }, (v, t) -> null));
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getPrimaryKey(Table table0) {
+        return PRIMARY_KEY_LIST;
     }
 
     private static String toString(PartitionedMapTable table) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -185,7 +185,7 @@ public class IMapSqlConnector implements SqlConnector {
 
     @Nonnull
     @Override
-    public Vertex sink(
+    public Vertex sinkProcessor(
             @Nonnull DAG dag,
             @Nonnull Table table0
     ) {
@@ -216,7 +216,7 @@ public class IMapSqlConnector implements SqlConnector {
 
     @Nonnull
     @Override
-    public Vertex delete(@Nonnull DAG dag, @Nonnull Table table0) {
+    public Vertex deleteProcessor(@Nonnull DAG dag, @Nonnull Table table0) {
         PartitionedMapTable table = (PartitionedMapTable) table0;
 
         return dag.newUniqueVertex(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DeleteLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DeleteLogicalRule.java
@@ -39,18 +39,18 @@ public final class DeleteLogicalRule extends ConverterRule {
 
     @Override
     public RelNode convert(RelNode rel) {
-        TableModify tableModify = (TableModify) rel;
+        TableModify delete = (TableModify) rel;
 
         return new DeleteLogicalRel(
-                tableModify.getCluster(),
-                OptUtils.toLogicalConvention(tableModify.getTraitSet()),
-                tableModify.getTable(),
-                tableModify.getCatalogReader(),
-                OptUtils.toLogicalInput(tableModify.getInput()),
-                tableModify.getOperation(),
-                tableModify.getUpdateColumnList(),
-                tableModify.getSourceExpressionList(),
-                tableModify.isFlattened()
+                delete.getCluster(),
+                OptUtils.toLogicalConvention(delete.getTraitSet()),
+                delete.getTable(),
+                delete.getCatalogReader(),
+                OptUtils.toLogicalInput(delete.getInput()),
+                delete.getOperation(),
+                delete.getUpdateColumnList(),
+                delete.getSourceExpressionList(),
+                delete.isFlattened()
         );
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/InsertLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/InsertLogicalRule.java
@@ -39,18 +39,18 @@ final class InsertLogicalRule extends ConverterRule {
 
     @Override
     public RelNode convert(RelNode rel) {
-        TableModify tableModify = (TableModify) rel;
+        TableModify insert = (TableModify) rel;
 
         return new InsertLogicalRel(
-                tableModify.getCluster(),
-                OptUtils.toLogicalConvention(tableModify.getTraitSet()),
-                tableModify.getTable(),
-                tableModify.getCatalogReader(),
-                OptUtils.toLogicalInput(tableModify.getInput()),
-                tableModify.getOperation(),
-                tableModify.getUpdateColumnList(),
-                tableModify.getSourceExpressionList(),
-                tableModify.isFlattened()
+                insert.getCluster(),
+                OptUtils.toLogicalConvention(insert.getTraitSet()),
+                insert.getTable(),
+                insert.getCatalogReader(),
+                OptUtils.toLogicalInput(insert.getInput()),
+                insert.getOperation(),
+                insert.getUpdateColumnList(),
+                insert.getSourceExpressionList(),
+                insert.isFlattened()
         );
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalRules.java
@@ -62,6 +62,9 @@ public final class LogicalRules {
                 // Aggregate rules
                 AggregateLogicalRule.INSTANCE,
 
+                // Sort
+                SortLogicalRule.INSTANCE,
+
                 // Join
                 JoinLogicalRule.INSTANCE,
                 JoinProjectTransposeRule.RIGHT_PROJECT_INCLUDE_OUTER,
@@ -77,16 +80,13 @@ public final class LogicalRules {
                 ValuesLogicalRules.PROJECT_FILTER_INSTANCE,
                 ValuesLogicalRules.UNION_INSTANCE,
 
-                // Insert rules
+                // DML rules
                 InsertLogicalRule.INSTANCE,
-
-                // Delete rules
                 DeleteLogicalRule.INSTANCE,
 
                 // Miscellaneous
                 PruneEmptyRules.PROJECT_INSTANCE,
-                PruneEmptyRules.FILTER_INSTANCE,
-                SortLogicalRule.INSTANCE
+                PruneEmptyRules.FILTER_INSTANCE
         );
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
@@ -100,7 +100,7 @@ public class CreateDagVisitor {
         Table table = rel.getTable().unwrap(HazelcastTable.class).getTarget();
         collectObjectKeys(table);
 
-        Vertex vertex = getJetSqlConnector(table).sink(dag, table);
+        Vertex vertex = getJetSqlConnector(table).sinkProcessor(dag, table);
         connectInput(rel.getInput(), vertex, null);
         return vertex;
     }
@@ -108,7 +108,7 @@ public class CreateDagVisitor {
     public Vertex onDelete(DeletePhysicalRel rel) {
         Table table = rel.getTable().unwrap(HazelcastTable.class).getTarget();
 
-        Vertex vertex = getJetSqlConnector(table).delete(dag, table);
+        Vertex vertex = getJetSqlConnector(table).deleteProcessor(dag, table);
         connectInput(rel.getInput(), vertex, null);
         return vertex;
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
@@ -78,14 +78,6 @@ public class CreateDagVisitor {
         this.parameterMetadata = parameterMetadata;
     }
 
-    public Vertex onDelete(DeletePhysicalRel rel) {
-        Table table = rel.getTable().unwrap(HazelcastTable.class).getTarget();
-
-        Vertex vertex = getJetSqlConnector(table).deleteProcessor(dag, table);
-        connectInput(rel.getInput(), vertex, null);
-        return vertex;
-    }
-
     public Vertex onValues(ValuesPhysicalRel rel) {
         List<ExpressionValues> values = rel.values();
 
@@ -109,6 +101,14 @@ public class CreateDagVisitor {
         collectObjectKeys(table);
 
         Vertex vertex = getJetSqlConnector(table).sink(dag, table);
+        connectInput(rel.getInput(), vertex, null);
+        return vertex;
+    }
+
+    public Vertex onDelete(DeletePhysicalRel rel) {
+        Table table = rel.getTable().unwrap(HazelcastTable.class).getTarget();
+
+        Vertex vertex = getJetSqlConnector(table).delete(dag, table);
         connectInput(rel.getInput(), vertex, null);
         return vertex;
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRel.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rex.RexNode;
 import java.util.List;
 
 public class DeletePhysicalRel extends TableModify implements PhysicalRel {
+
     DeletePhysicalRel(
             RelOptCluster cluster,
             RelTraitSet traitSet,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRule.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.sql.impl.opt.logical.DeleteLogicalRel;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
-import org.apache.calcite.rel.core.TableModify;
 
 import static com.hazelcast.jet.sql.impl.opt.JetConventions.LOGICAL;
 import static com.hazelcast.jet.sql.impl.opt.JetConventions.PHYSICAL;
@@ -32,7 +31,7 @@ public final class DeletePhysicalRule extends ConverterRule {
 
     private DeletePhysicalRule() {
         super(
-                DeleteLogicalRel.class, TableModify::isDelete, LOGICAL, PHYSICAL,
+                DeleteLogicalRel.class, LOGICAL, PHYSICAL,
                 DeletePhysicalRule.class.getSimpleName()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRule.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.sql.impl.opt.logical.InsertLogicalRel;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
-import org.apache.calcite.rel.core.TableModify;
 
 import static com.hazelcast.jet.sql.impl.opt.JetConventions.LOGICAL;
 import static com.hazelcast.jet.sql.impl.opt.JetConventions.PHYSICAL;
@@ -32,7 +31,7 @@ final class InsertPhysicalRule extends ConverterRule {
 
     private InsertPhysicalRule() {
         super(
-                InsertLogicalRel.class, TableModify::isInsert, LOGICAL, PHYSICAL,
+                InsertLogicalRel.class, LOGICAL, PHYSICAL,
                 InsertPhysicalRule.class.getSimpleName()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/PhysicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/PhysicalRules.java
@@ -32,10 +32,10 @@ public final class PhysicalRules {
                 ProjectPhysicalRule.INSTANCE,
                 FullScanPhysicalRule.INSTANCE,
                 AggregatePhysicalRule.INSTANCE,
+                SortPhysicalRule.INSTANCE,
                 JoinPhysicalRule.INSTANCE,
                 ValuesPhysicalRule.INSTANCE,
                 InsertPhysicalRule.INSTANCE,
-                SortPhysicalRule.INSTANCE,
                 DeletePhysicalRule.INSTANCE,
                 new AbstractConverter.ExpandConversionRule(RelFactories.LOGICAL_BUILDER)
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlValidator.java
@@ -224,24 +224,25 @@ public class JetSqlValidator extends HazelcastSqlValidator {
     @Override
     protected SqlSelect createSourceSelectForDelete(SqlDelete call) {
         SqlNode sourceTable = call.getTargetTable();
-        Table table = getCatalogReader().getTable(((SqlIdentifier) sourceTable).names).unwrap(HazelcastTable.class).getTarget();
-        SqlConnector connector = getJetSqlConnector(table);
+        SqlValidatorTable validatorTable = getCatalogReader().getTable(((SqlIdentifier) sourceTable).names);
 
-        // The Calcite default implementation selects all fields (using SELECT *). I'm not sure about how's this supposed
-        // to work. We need to feed primary keys to the delete processor so that it can directly delete the records.
-        // Therefore we use the primary key for the select list.
-        SqlNodeList selectList = connector.getPrimaryKey(table);
-        if (selectList.size() == 0) {
-            throw QueryException.error("Cannot DELETE from " + call.getTargetTable() + ": it doesn't have a primary key");
+        SqlNodeList selectList = new SqlNodeList(SqlParserPos.ZERO);
+        if (validatorTable != null) {
+            Table table = validatorTable.unwrap(HazelcastTable.class).getTarget();
+            SqlConnector connector = getJetSqlConnector(table);
+
+            // We need to feed primary keys to the delete processor so that it can directly delete the records.
+            // Therefore we use the primary key for the select list.
+            connector.getPrimaryKey(table).forEach(name -> selectList.add(new SqlIdentifier(name, SqlParserPos.ZERO)));
+            if (selectList.size() == 0) {
+                throw QueryException.error("Cannot DELETE from " + call.getTargetTable() + ": it doesn't have a primary key");
+            }
         }
 
         if (call.getAlias() != null) {
-          sourceTable =
-              SqlValidatorUtil.addAlias(
-                  sourceTable,
-                  call.getAlias().getSimple());
+            sourceTable = SqlValidatorUtil.addAlias(sourceTable, call.getAlias().getSimple());
         }
         return new SqlSelect(SqlParserPos.ZERO, null, selectList, sourceTable,
-            call.getCondition(), null, null, null, null, null, null, null);
+                call.getCondition(), null, null, null, null, null, null, null);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
@@ -338,6 +338,9 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
                 processSelect((SqlSelect) call);
                 break;
 
+            case DELETE:
+                break;
+
             case JOIN:
                 processJoin((SqlJoin) call);
                 break;
@@ -349,9 +352,6 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
 
             case OTHER_DDL:
                 processOtherDdl(call);
-                break;
-
-            case DELETE:
                 break;
 
             default:

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlDeleteTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlDeleteTest.java
@@ -24,8 +24,10 @@ import org.junit.Test;
 import java.io.Serializable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class SqlDeleteQueriesTest extends SqlTestSupport {
+public class SqlDeleteTest extends SqlTestSupport {
+
     @BeforeClass
     public static void setUpClass() {
         initialize(2, null);
@@ -121,8 +123,27 @@ public class SqlDeleteQueriesTest extends SqlTestSupport {
         assertMapDoesNotContainKey(name, 1);
     }
 
-    private SqlResult execute(String sql) {
-        return instance().getSql().execute(sql);
+    @Test
+    public void deleteByDynamicParam() {
+        IMap<Object, Object> map = instance().getMap("test_map");
+        map.put(1, 1);
+        map.put(2, 2);
+        map.put(3, 3);
+
+        execute("delete from test_map where __key = ?", 2);
+        assertMapContainsKey(1);
+        assertMapDoesNotContainKey(2);
+        assertMapContainsKey(3);
+    }
+
+    @Test
+    public void when_deleteFromUnknownMapping_then_throws() {
+        assertThatThrownBy(() -> execute("delete from test_map where __key = 1"))
+                .hasMessageContaining("Object 'test_map' not found");
+    }
+
+    private SqlResult execute(String sql, Object... arguments) {
+        return instance().getSql().execute(sql, arguments);
     }
 
     private void checkUpdateCount(String sql, int expected) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
@@ -16,15 +16,12 @@
 
 package com.hazelcast.jet.sql;
 
-import com.hazelcast.jet.sql.impl.connector.kafka.KafkaSqlConnector;
 import com.hazelcast.jet.sql.impl.connector.test.TestBatchSqlConnector;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.impl.QueryException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
-import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SqlUnsupportedFeaturesTest extends SqlTestSupport {
@@ -108,26 +105,10 @@ public class SqlUnsupportedFeaturesTest extends SqlTestSupport {
     }
 
     @Test
-    public void test_delete_noDeleteProcessor() {
-        sqlService.execute("CREATE MAPPING b ("
-                + "__key INT"
-                + ", this INT"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='int'"
-                + ", '" + OPTION_VALUE_FORMAT + "'='int'"
-                + ")"
-        );
-
-        assertThatThrownBy(() -> sqlService.execute("DELETE FROM b WHERE v=1"))
-                .hasMessageContaining("DELETE not supported by connector: Kafka");
-    }
-
-    @Test
     public void test_delete_noPrimaryKey() {
         TestBatchSqlConnector.create(sqlService, "b", 1);
 
         assertThatThrownBy(() -> sqlService.execute("DELETE FROM b WHERE v=1"))
-                .hasMessageContaining("DELETE not supported by connector: TestBatch");
+                .hasMessageContaining("PRIMARY KEY not supported by connector: TestBatch");
     }
 }


### PR DESCRIPTION
Removed `Calcite` usage from `SqlConnector` - `getPrimaryKeys()` returns `List<String>` instead of `SqlNodeList`.
Handled `DELETE` from unknown table case and added tests.
Simplified couple of rules.