### PR TITLE
Fix Kinesis tests

### DIFF
--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({SlowTest.class, ParallelJVMTest.class})
-class AbstractKinesisTest extends JetTestSupport {
+public abstract class AbstractKinesisTest extends JetTestSupport {
 
     protected static final int KEYS = 250;
     protected static final int MEMBER_COUNT = 2;


### PR DESCRIPTION
Kinesis integration tests are set to nightly and they don't run properly as such.

Fixes #18717

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
