### PR TITLE
Fix job restart before StartExecutionOp

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -582,6 +582,12 @@ public class MasterJobContext {
                     // have to use Async version, the future is completed inside a synchronized block
                     .whenCompleteAsync(withTryCatch(logger, (r, e) -> finalizeJob(finalError)));
         } else {
+            if (error instanceof ExecutionNotFoundException) {
+                // If the StartExecutionOperation didn't find the execution, it means that we must have cancelled it.
+                // Let's pretend that the StartExecutionOperation returned JobTerminateRequestedException
+                assert requestedTerminationMode != null && !requestedTerminationMode.isWithTerminalSnapshot();
+                error = new JobTerminateRequestedException(requestedTerminationMode);
+            }
             finalizeJob(error);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -659,7 +659,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
     @Test
     public void test_jobStatusCompleting() {
-        assumeFalse(useLightJob); // test not applicable to light jobs
+        assumeFalse(useLightJob); // light jobs cannot be restarted
 
         DAG dag = new DAG();
         dag.newVertex("v", () -> new TestProcessors.MockP().streaming());


### PR DESCRIPTION
Fixes this scenario:
- master assigns jobStatus=RUNNING and sends the StartExecutionOp
- job restart is requested. Master sends the TerminateExecutionOp to
  members.
- the TerminateExecutionOp on member is handled before the
  StartExecutionOp. The execution is removed from the member
- now the StartExecutionOp is handled and (correctly) throws
  ExecutionNotFoundException
- the master receives the ExecutionNotFoundException and handled it as
  an unspecific exception and fails the job

The fix is to handle this exception as if JobTerminateRequestedException
was received.

The issue can be easily reproduced by inserting a 100ms sleep at the
beginning of `StartExecutionOperation.doRun()`.

Fixes #18860