### PR TITLE
Portable with OBJECT format on SQL when factory is missing

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/PortableQueryTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/PortableQueryTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql;
 
+import com.google.common.collect.Iterators;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -41,12 +42,10 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -101,10 +100,8 @@ public class PortableQueryTest extends HazelcastTestSupport {
         fillMap(map, 50, ChildPortable::new);
 
         SqlResult rows = client.getSql().execute("SELECT * FROM test WHERE i >= 45");
-        AtomicInteger integer = new AtomicInteger(0);
-        rows.iterator().forEachRemaining(sqlRow -> integer.incrementAndGet());
 
-        assertEquals(5, integer.get());
+        assertEquals(5, Iterators.size(rows.iterator()));
     }
 
     @Test
@@ -122,9 +119,7 @@ public class PortableQueryTest extends HazelcastTestSupport {
         SqlResult rows = clientSql.execute("SELECT sa FROM test WHERE c = ?", expected);
 
         Iterator<SqlRow> iterator = rows.iterator();
-        SqlRow row = iterator.next();
-        assertFalse(iterator.hasNext());
-
+        SqlRow row = Iterators.getOnlyElement(iterator);
         String[] rowObject = row.getObject("sa");
         assertEquals(String.valueOf(10), rowObject[0]);
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/PortableQueryTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/PortableQueryTest.java
@@ -50,9 +50,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeTrue;
 
 /**
- * Verifies that the member can handle queries on
- * PortableGenericRecords when it does not have the necessary
- * PortableFactory in its config.
+ * Verifies that the member can extract fields from PortableGenericRecords
+ * when it does not have the necessary PortableFactory in its config.
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
@@ -62,11 +61,11 @@ public class PortableQueryTest extends HazelcastTestSupport {
     public InMemoryFormat inMemoryFormat;
 
     @Parameterized.Parameter(1)
-    public boolean clusterHavePortableConfig;
+    public boolean clusterHasPortableConfig;
 
     public TestHazelcastFactory factory = new TestHazelcastFactory();
 
-    @Parameterized.Parameters(name = "inMemoryFormat:{0}, clusterHavePortableConfig:{1}")
+    @Parameterized.Parameters(name = "inMemoryFormat:{0}, clusterHasPortableConfig:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
                 {InMemoryFormat.BINARY, true},
@@ -82,7 +81,7 @@ public class PortableQueryTest extends HazelcastTestSupport {
         mapConfig.setInMemoryFormat(inMemoryFormat);
         Config config = smallInstanceConfig();
         config.addMapConfig(mapConfig);
-        if (clusterHavePortableConfig) {
+        if (clusterHasPortableConfig) {
             config.getSerializationConfig().addPortableFactory(1, new TestPortableFactory());
         }
         factory.newHazelcastInstance(config);
@@ -111,7 +110,7 @@ public class PortableQueryTest extends HazelcastTestSupport {
     @Test
     public void testQueryOnObject() {
         //To be able to run comparison methods on objects on the server we need the classes
-        assumeTrue(clusterHavePortableConfig);
+        assumeTrue(clusterHasPortableConfig);
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getSerializationConfig().addPortableFactory(1, new TestPortableFactory());
         HazelcastInstance client = factory.newHazelcastClient(clientConfig);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -188,6 +188,10 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> implements Iden
                 if (valueObject instanceof Portable) {
                     targetObject = getValueData();
                 } else {
+                    // Note that targetObject could be PortableGenericRecord
+                    // And it will be handled on PortableGetter for query.
+                    // We get PortableGenericRecord here when in memory format is Object and
+                    // the cluster does not have PortableFactory configuration for Portable
                     targetObject = getValue();
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -188,10 +188,10 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> implements Iden
                 if (valueObject instanceof Portable) {
                     targetObject = getValueData();
                 } else {
-                    // Note that targetObject could be PortableGenericRecord
-                    // And it will be handled on PortableGetter for query.
-                    // We get PortableGenericRecord here when in memory format is Object and
-                    // the cluster does not have PortableFactory configuration for Portable
+                    // Note that targetObject can be PortableGenericRecord
+                    // and it will be handled with PortableGetter for query.
+                    // We get PortableGenericRecord here when in-memory format is OBJECT and
+                    // the cluster does not have PortableFactory configuration for the object's factory ID
                     targetObject = getValue();
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
@@ -18,6 +18,7 @@ package com.hazelcast.sql.impl.schema.map.sample;
 
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.portable.PortableGenericRecord;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.sql.impl.FieldsUtil;
@@ -75,6 +76,11 @@ public final class MapSampleMetadataResolver {
                 } else {
                     return resolveClass(ss.toObject(data).getClass(), key, jetMapMetadataResolver);
                 }
+            } else if (target instanceof PortableGenericRecord) {
+                // We get PortableGenericRecord here when in memory format is Object and
+                // the cluster does not have PortableFactory configuration for Portable
+                // PortableGetter can handle PortableGenericRecord to extract fields.
+                return resolvePortable(((PortableGenericRecord) target).getClassDefinition(), key, jetMapMetadataResolver);
             } else {
                 return resolveClass(target.getClass(), key, jetMapMetadataResolver);
             }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
@@ -77,9 +77,9 @@ public final class MapSampleMetadataResolver {
                     return resolveClass(ss.toObject(data).getClass(), key, jetMapMetadataResolver);
                 }
             } else if (target instanceof PortableGenericRecord) {
-                // We get PortableGenericRecord here when in memory format is Object and
-                // the cluster does not have PortableFactory configuration for Portable
-                // PortableGetter can handle PortableGenericRecord to extract fields.
+                // We get PortableGenericRecord here when in-memory format is OBJECT and
+                // the cluster does not have PortableFactory configuration for this Portable.
+                // PortableGetter can extract fields PortableGenericRecord.
                 return resolvePortable(((PortableGenericRecord) target).getClassDefinition(), key, jetMapMetadataResolver);
             } else {
                 return resolveClass(target.getClass(), key, jetMapMetadataResolver);

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/PortableGenericRecordQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/PortableGenericRecordQueryTest.java
@@ -59,11 +59,11 @@ public class PortableGenericRecordQueryTest extends HazelcastTestSupport {
     public InMemoryFormat inMemoryFormat;
 
     @Parameterized.Parameter(1)
-    public boolean clusterHavePortableConfig;
+    public boolean clusterHasPortableConfig;
 
     public TestHazelcastFactory factory = new TestHazelcastFactory();
 
-    @Parameterized.Parameters(name = "inMemoryFormat:{0}, clusterHavePortableConfig:{1}")
+    @Parameterized.Parameters(name = "inMemoryFormat:{0}, clusterHasPortableConfig:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
                 {InMemoryFormat.BINARY, true},
@@ -79,7 +79,7 @@ public class PortableGenericRecordQueryTest extends HazelcastTestSupport {
         mapConfig.setInMemoryFormat(inMemoryFormat);
         Config config = smallInstanceConfig();
         config.addMapConfig(mapConfig);
-        if (clusterHavePortableConfig) {
+        if (clusterHasPortableConfig) {
             config.getSerializationConfig().addPortableFactory(1, new TestPortableFactory());
         }
         factory.newHazelcastInstance(config);


### PR DESCRIPTION
When the factory config is missing on the server but
the map is configured with in-memory format Object, we can store
Portables as PortableGenericRecord and still query them
without needing to convert them to Object/Data.

This PR adds related test to old query engine.
Also updates new query system to allow that usage and adds
a related test.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
