### PR TITLE
Fix test failing due to `shutdown` replaced by `terminate`

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastInstanceFactoryTest.java
@@ -183,7 +183,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
                         }
                         return null;
                     }
-                }).when(nodeExtension).beforeShutdown(false);
+                }).when(nodeExtension).beforeShutdown(true);
                 return nodeExtension;
             }
         };
@@ -207,12 +207,9 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
             public NodeExtension createNodeExtension(final Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);
 
-                doAnswer(new Answer() {
-                    @Override
-                    public Object answer(InvocationOnMock invocation) throws Throwable {
-                        node.hazelcastInstance.shutdown();
-                        return null;
-                    }
+                doAnswer(invocation -> {
+                    node.hazelcastInstance.shutdown();
+                    return null;
                 }).when(nodeExtension).afterStart();
 
                 return nodeExtension;


### PR DESCRIPTION
Some test was not properly adapted to replacing `shutdown()` with `terminate()` in tests.

Fixes #18720

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible