### PR TITLE
Fix problematic reflection usage

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.replicatedmap;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.memory.impl.UnsafeUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -40,7 +41,6 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 import java.util.Random;
@@ -190,15 +190,9 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
         }
     }
 
-    private void updateFactoryField(DataSerializableFactory factory) throws Exception {
-        // Get Unsafe object
-        final Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
-        unsafeField.setAccessible(true);
-        final Unsafe unsafe = (Unsafe) unsafeField.get(null);
-
-        // Update the field
-        final Object staticFieldBase = unsafe.staticFieldBase(field);
-        final long staticFieldOffset = unsafe.staticFieldOffset(field);
-        unsafe.putObject(staticFieldBase, staticFieldOffset, factory);
+    private void updateFactoryField(DataSerializableFactory factory) {
+        final Object staticFieldBase = UnsafeUtil.UNSAFE.staticFieldBase(field);
+        final long staticFieldOffset = UnsafeUtil.UNSAFE.staticFieldOffset(field);
+        UnsafeUtil.UNSAFE.putObject(staticFieldBase, staticFieldOffset, factory);
     }
 }


### PR DESCRIPTION
There is a nightly tests failing in Zulu JDK 16 #18782. This is because after JDK 12 one can't access fields of `Field` class. We want to do this in order to change access modifiers of `ReplicatedMapDataSerializerHook#FACTORY`. This PR modifies the code so that `Unsafe` is used in order to change modifiers of `ReplicatedMapDataSerializerHook#FACTORY`

Fixes #18782

This could be backported

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
