### PR TITLE
Re-add accidentally removed network metric update

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -120,6 +120,7 @@ public final class NioInboundPipeline extends NioPipeline implements InboundPipe
         if (readBytes > 0) {
             processCount.inc();
             lastReadTime = currentTimeMillis();
+            bytesRead.inc(readBytes);
         }
 
         // currently the whole pipeline is retried when one of the handlers is dirty; but only the dirty handler


### PR DESCRIPTION
This PR fixes the advanced network stats tests by re-adding `bytesRead` update
which is previously removed in https://github.com/hazelcast/hazelcast/commit/6e412293ac8c8ae0b1bb2ef4919ede434934dda4#diff-4ad594ba905e8fffaaf3e2705da852ff5ef68d65899c70aff4051c2ef3be8dcdL125 

Fixes #18849


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
