### PR TITLE
Add jcache jar to the distributions

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -144,6 +144,13 @@
             <version>${prometheus.version}</version>
         </dependency>
 
+        <!-- JCache API - needed server-side as we use and extend some classes -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>${jsr107.api.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-aws</artifactId>

--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -37,6 +37,7 @@
                 <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>com.hazelcast:hazelcast-wm</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>
+                <include>javax.cache:cache-api</include>
                 <include>org.apache.logging.log4j:*</include>
                 <include>org.slf4j:*</include>
                 <include>info.picocli:picocli</include>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -36,6 +36,7 @@
                 <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>com.hazelcast:hazelcast-wm</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>
+                <include>javax.cache:cache-api</include>
                 <include>org.apache.logging.log4j:*</include>
                 <include>org.slf4j:*</include>
                 <include>info.picocli:picocli</include>


### PR DESCRIPTION
The jar is needed serverside for jcache service to run (it uses and extends some of the classes).
The jar is small - 51k, so it can go to the slim distribution as well.