### PR TITLE
Fix failures related to not cleaning HazelcastBootstrap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastBootstrap.java
@@ -245,6 +245,17 @@ public final class HazelcastBootstrap {
     }
 
     /**
+     * Sets the static instance supplier field to null. We have
+     * introduced this method to use only in test cleanup. We needed
+     * this because the lifetime of static fields spans many test
+     * classes run on the same JVM and we didn't want multiple
+     * test classes to interfere with each other.
+     */
+    protected static synchronized void cleanUpSupplier() {
+        supplier = null;
+    }
+
+    /**
      * Returns the bootstrapped {@code HazelcastInstance}. The instance will be
      * automatically shut down once the {@code main()} method of the JAR returns.
      */

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastBootstrap.java
@@ -245,17 +245,6 @@ public final class HazelcastBootstrap {
     }
 
     /**
-     * Sets the static instance supplier field to null. We have
-     * introduced this method to use only in test cleanup. We needed
-     * this because the lifetime of static fields spans many test
-     * classes run on the same JVM and we didn't want multiple
-     * test classes to interfere with each other.
-     */
-    protected static synchronized void cleanUpSupplier() {
-        supplier = null;
-    }
-
-    /**
      * Returns the bootstrapped {@code HazelcastInstance}. The instance will be
      * automatically shut down once the {@code main()} method of the JAR returns.
      */

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastBootstrapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastBootstrapTest.java
@@ -55,13 +55,7 @@ public class HazelcastBootstrapTest {
         // HazelcastCommandLineTest to fail with "IllegalStateException:
         // Supplier of HazelcastInstance was already set.".
         // See: https://github.com/hazelcast/hazelcast/issues/18725
-
-        // Set HazelcastBootstrap.supplier to null
-        Field field = HazelcastBootstrap.class.getDeclaredField("supplier");
-        field.setAccessible(true);
-        final Object staticFieldBase = UnsafeUtil.UNSAFE.staticFieldBase(field);
-        final long staticFieldOffset = UnsafeUtil.UNSAFE.staticFieldOffset(field);
-        UnsafeUtil.UNSAFE.putObject(staticFieldBase, staticFieldOffset, null);
+        HazelcastBootstrap.cleanUpSupplier();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastBootstrapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastBootstrapTest.java
@@ -18,10 +18,9 @@ package com.hazelcast.instance.impl;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.memory.impl.UnsafeUtil;
-import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
@@ -33,7 +32,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
This PR fixes the HazelcastCommandLine test failures caused by not clearing
the static field, `HazelcastBootstrap.supplier`, used by two separate tests.
 
Because static field cleanup is not performed after `HazelcastBootstrapTest`,
`HazelcastCommandLineTest` tests were failing with
 `IllegalStateException: Supplier of HazelcastInstance was already set...`. 
This was happening when these two tests run on the same JVM (share same static field)
and `HazelcastBootstrapTest` runs before`HazelcastCommandLineTest`. Now,
we cleanup this static field after running this `HazelcastBootstrapTest`.

Fixes #18830

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes

