### PR TITLE
[HZ-333] Add support for server side IMap.putIfAbsentAsync

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -44,8 +44,8 @@ import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.map.impl.iterator.MapIterable;
 import com.hazelcast.map.impl.iterator.MapIterator;
 import com.hazelcast.map.impl.iterator.MapPartitionIterable;
-import com.hazelcast.map.impl.iterator.MapQueryIterable;
 import com.hazelcast.map.impl.iterator.MapPartitionIterator;
+import com.hazelcast.map.impl.iterator.MapQueryIterable;
 import com.hazelcast.map.impl.iterator.MapQueryPartitionIterable;
 import com.hazelcast.map.impl.iterator.MapQueryPartitionIterator;
 import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
@@ -391,6 +391,28 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         return newDelegatingFuture(
                 serializationService,
                 putAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit));
+    }
+
+    public InternalCompletableFuture<V> putIfAbsentAsync(@Nonnull K key, @Nonnull V value) {
+        return putIfAbsentAsync(key, value, UNSET, TimeUnit.MILLISECONDS);
+    }
+
+    public InternalCompletableFuture<V> putIfAbsentAsync(@Nonnull K key, @Nonnull V value,
+                                                    long ttl, @Nonnull TimeUnit timeunit) {
+        return putIfAbsentAsync(key, value, ttl, timeunit, UNSET, TimeUnit.MILLISECONDS);
+    }
+
+    public InternalCompletableFuture<V> putIfAbsentAsync(@Nonnull K key, @Nonnull V value,
+                                                         long ttl, @Nonnull TimeUnit timeunit,
+                                                         long maxIdle, @Nonnull TimeUnit maxIdleUnit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
+        checkNotNull(timeunit, NULL_TIMEUNIT_IS_NOT_ALLOWED);
+
+        Data valueData = toData(value);
+        return newDelegatingFuture(
+                serializationService,
+                putIfAbsentAsyncInternal(key, valueData, ttl, timeunit, maxIdle, maxIdleUnit));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -408,6 +408,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
         checkNotNull(timeunit, NULL_TIMEUNIT_IS_NOT_ALLOWED);
+        checkNotNull(maxIdleUnit, NULL_MAX_IDLE_UNIT_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
         return newDelegatingFuture(

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -215,6 +215,18 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
+    protected InternalCompletableFuture<Data> putIfAbsentAsyncInternal(Object key, Data valueData,
+                                                                       long ttl, TimeUnit ttlUnit,
+                                                                       long maxIdle, TimeUnit maxIdleUnit) {
+        key = toNearCacheKeyWithStrategy(key);
+        try {
+            return super.putIfAbsentAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
+        } finally {
+            invalidateNearCache(key);
+        }
+    }
+
+    @Override
     protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data valueData, long ttl, TimeUnit ttlUnit,
                                                                long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -222,6 +222,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         try {
             return super.putIfAbsentAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
+            // If the operation is retried, the return value can be wrong.
+            // Consider: key k isn't present. We do putIfAbsent(k, v). The operation puts the value, updates
+            // the backup, but before the response is sent, the member crashes. The caller doesn't receive the response,
+            // so retries with the new key owner. This time, the operation does nothing because the key isn't absent,
+            // and returns the old value.
+            //The unnecessary invalidation doesn't hurt as much as non-invalidated near cache would.
             invalidateNearCache(key);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/core/standalone/AllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/standalone/AllTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.Message;
@@ -454,6 +455,15 @@ public class AllTest {
                 IMap map = hazelcast.getMap("myMap");
                 map.putIfAbsent(random.nextInt(SIZE), new Customer(random.nextInt(100), String.valueOf(random.nextInt(10000))));
             }
+        }, 5);
+        addOperation(operations, () -> {
+            MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) hazelcast.getMap("myMap");
+            map.putIfAbsentAsync(random.nextInt(SIZE), new Customer(random.nextInt(100), String.valueOf(random.nextInt(10000))),
+                    10, TimeUnit.MILLISECONDS);
+        }, 5);
+        addOperation(operations, () -> {
+            MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) hazelcast.getMap("myMap");
+            map.putIfAbsentAsync(random.nextInt(SIZE), new Customer(random.nextInt(100), String.valueOf(random.nextInt(10000))));
         }, 5);
         addOperation(operations, new Runnable() {
             public void run() {

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapLoader;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.JsonMetadataStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
@@ -182,6 +183,16 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
     public void testPutIfAbsentCreatesMetadataForJson() {
         for (int i = 0; i < ENTRY_COUNT; i++) {
             map.putIfAbsent(createJsonValue("key", i), createJsonValue("value", i));
+        }
+        assertMetadataCreated(map.getName());
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testPutIfAbsentAsyncCreatesMetadataForJson() throws ExecutionException, InterruptedException {
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            ((MapProxyImpl) map)
+                    .putIfAbsentAsync(createJsonValue("key", i), createJsonValue("value", i)).toCompletableFuture().get();
         }
         assertMetadataCreated(map.getName());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.map;
 import com.hazelcast.aggregation.impl.CountAggregator;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.projection.Projections;
@@ -179,7 +180,7 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
         assertThrowsNPE(m -> m.setTtl("", -1, null));
     }
 
-    private void assertThrowsNPE(ConsumerEx<IMap<Object, Object>> method) {
+    protected void assertThrowsNPE(ConsumerEx<IMap<Object, Object>> method) {
         assertThrows(NullPointerException.class, method);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
@@ -19,14 +19,13 @@ package com.hazelcast.map;
 import com.hazelcast.aggregation.impl.CountAggregator;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.internal.util.ExceptionUtil;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -81,6 +82,28 @@ public class AsyncTest extends HazelcastTestSupport {
         Future<String> f1 = map.putAsync(key, value1, 3, TimeUnit.SECONDS).toCompletableFuture();
         String f1Val = f1.get();
         assertNull(f1Val);
+        assertEquals(value1, map.get(key));
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull(map.get(key));
+    }
+
+    @Test
+    public void testPutIfAbsentAsync() throws Exception {
+        MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) instance.getMap(randomString());
+        assertNull(map.putIfAbsentAsync(key, value1).toCompletableFuture().get());
+        assertEquals(value1, map.putIfAbsentAsync(key, value2).toCompletableFuture().get());
+        assertEquals(value1, map.putIfAbsentAsync(key, value2).toCompletableFuture().get());
+    }
+
+    @Test
+    public void testPutIfAbsentAsyncWithTtl() throws Exception {
+        MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) instance.getMap(randomString());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        map.addEntryListener((EntryExpiredListener<String, String>) event -> latch.countDown(), true);
+
+        assertNull(map.putIfAbsentAsync(key, value1, 3, TimeUnit.SECONDS).toCompletableFuture().get());
         assertEquals(value1, map.get(key));
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.query.PagingPredicate;
@@ -951,6 +952,19 @@ public class BasicMapTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testPutIfAbsentAsync() {
+        MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) getInstance().getMap("testPutIfAbsentAsync");
+        try {
+            assertNull(map.putIfAbsentAsync(1, 1).toCompletableFuture().get());
+            assertEquals(1, map.putIfAbsentAsync(1, 2).toCompletableFuture().get());
+            assertEquals(1, map.putIfAbsentAsync(1, 3).toCompletableFuture().get());
+            assertEquals(1, map.size());
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     public void testAsyncMethodChaining() {
         IMap<Integer, Integer> map = getInstance().getMap("testGetPutRemoveAsync");
         CompletionStage<Integer> setThenGet = map.setAsync(1, 1)
@@ -1688,6 +1702,18 @@ public class BasicMapTest extends HazelcastTestSupport {
             }
         };
         assertRunnableThrowsNullPointerException(runnable, "putAsync(\"key\", null, 1, TimeUnit.SECONDS)");
+
+        runnable = () -> ((MapProxyImpl<String, String>) map).putIfAbsentAsync(null, "value");
+        assertRunnableThrowsNullPointerException(runnable, "putIfAbsentAsync(null, \"value\")");
+
+        runnable = () -> ((MapProxyImpl<String, String>) map).putIfAbsentAsync("key", null);
+        assertRunnableThrowsNullPointerException(runnable, "putIfAbsentAsync(\"key\", null)");
+
+        runnable = () -> ((MapProxyImpl<String, String>) map).putIfAbsentAsync(null, "value", 1, SECONDS);
+        assertRunnableThrowsNullPointerException(runnable, "putIfAbsentAsync(null, \"value\", 1, TimeUnit.SECONDS)");
+
+        runnable = () -> ((MapProxyImpl<String, String>) map).putIfAbsentAsync("key", null, 1, SECONDS);
+        assertRunnableThrowsNullPointerException(runnable, "putIfAbsentAsync(\"key\", null, 1, TimeUnit.SECONDS)");
 
         runnable = new Runnable() {
             public void run() {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -125,6 +126,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
 
     @Test
     public void testPutIfAbsentAsync() {
+        assumeTrue(getMap() instanceof MapProxyImpl);
+
         MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) getMap();
         for (int i = 0; i < 100; i++) {
             map.putIfAbsentAsync(i, i);

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -17,12 +17,13 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.Clock;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.Clock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -119,6 +120,16 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.putAsync(i, i);
         }
         final LocalMapStats localMapStats = getMapStats();
+        assertTrueEventually(() -> assertEquals(100, localMapStats.getPutOperationCount()));
+    }
+
+    @Test
+    public void testPutIfAbsentAsync() {
+        MapProxyImpl<Object, Object> map = (MapProxyImpl<Object, Object>) getMap();
+        for (int i = 0; i < 100; i++) {
+            map.putIfAbsentAsync(i, i);
+        }
+        LocalMapStats localMapStats = getMapStats();
         assertTrueEventually(() -> assertEquals(100, localMapStats.getPutOperationCount()));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MemberMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MemberMapNullTest.java
@@ -57,6 +57,8 @@ public class MemberMapNullTest extends AbstractMapNullTest {
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void testNullability() {
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync(null, ""));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", null));
         assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync(null, "", -1, TimeUnit.SECONDS));
         assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", null, -1, TimeUnit.SECONDS));
         assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", "", -1, null));

--- a/hazelcast/src/test/java/com/hazelcast/map/MemberMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MemberMapNullTest.java
@@ -17,13 +17,17 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Member implementation for basic map methods nullability tests
@@ -48,5 +52,17 @@ public class MemberMapNullTest extends AbstractMapNullTest {
     @Override
     protected HazelcastInstance getDriver() {
         return instance;
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testNullability() {
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync(null, "", -1, TimeUnit.SECONDS));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", null, -1, TimeUnit.SECONDS));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", "", -1, null));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync(null, "", -1, TimeUnit.SECONDS, -1, TimeUnit.SECONDS));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", null, -1, TimeUnit.SECONDS, -1, TimeUnit.SECONDS));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", "", -1, null, -1, TimeUnit.SECONDS));
+        assertThrowsNPE(m -> ((MapProxyImpl) m).putIfAbsentAsync("", "", -1, TimeUnit.SECONDS, -1, null));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapKeyLoader;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
@@ -232,6 +233,12 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
     public void testPutIfAbsent_returnValue() {
         testEntryLoader.putExternally("key", "val", 5 , TimeUnit.DAYS);
         assertEquals("val", map.putIfAbsent("key", "val2"));
+    }
+
+    @Test
+    public void testPutIfAbsentAsync_returnValue() throws ExecutionException, InterruptedException {
+        testEntryLoader.putExternally("key", "val", 5, TimeUnit.DAYS);
+        assertEquals("val", ((MapProxyImpl<String, String>) map).putIfAbsentAsync("key", "val2").toCompletableFuture().get());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -65,6 +65,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -237,6 +238,8 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
 
     @Test
     public void testPutIfAbsentAsync_returnValue() throws ExecutionException, InterruptedException {
+        assumeTrue(map instanceof MapProxyImpl);
+
         testEntryLoader.putExternally("key", "val", 5, TimeUnit.DAYS);
         assertEquals("val", ((MapProxyImpl<String, String>) map).putIfAbsentAsync("key", "val2").toCompletableFuture().get());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
@@ -48,6 +48,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
@@ -220,6 +221,8 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
 
     @Test
     public void testPutIfAbsentAsync() throws ExecutionException, InterruptedException {
+        assumeTrue(map instanceof MapProxyImpl);
+
         ((MapProxyImpl<String, String>) map)
                 .putIfAbsentAsync("key", "value").toCompletableFuture().get();
         assertEntryStore("key", "value");
@@ -227,6 +230,8 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
 
     @Test
     public void testPutIfAbsentAsync_withTtl() throws ExecutionException, InterruptedException {
+        assumeTrue(map instanceof MapProxyImpl);
+
         ((MapProxyImpl<String, String>) map)
                 .putIfAbsentAsync("key", "value", 10, TimeUnit.DAYS).toCompletableFuture().get();
         assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
@@ -234,6 +239,8 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
 
     @Test
     public void testPutIfAbsentAsync_withMaxIdle() throws ExecutionException, InterruptedException {
+        assumeTrue(map instanceof MapProxyImpl);
+
         ((MapProxyImpl<String, String>) map)
                 .putIfAbsentAsync("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS).toCompletableFuture().get();
         assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
@@ -214,6 +215,27 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
     @Test
     public void testPutIfAbsent_withMaxIdle() {
         map.putIfAbsent("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS);
+        assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
+    }
+
+    @Test
+    public void testPutIfAbsentAsync() throws ExecutionException, InterruptedException {
+        ((MapProxyImpl<String, String>) map)
+                .putIfAbsentAsync("key", "value").toCompletableFuture().get();
+        assertEntryStore("key", "value");
+    }
+
+    @Test
+    public void testPutIfAbsentAsync_withTtl() throws ExecutionException, InterruptedException {
+        ((MapProxyImpl<String, String>) map)
+                .putIfAbsentAsync("key", "value", 10, TimeUnit.DAYS).toCompletableFuture().get();
+        assertEntryStore("key", "value", 10, TimeUnit.DAYS, 10000);
+    }
+
+    @Test
+    public void testPutIfAbsentAsync_withMaxIdle() throws ExecutionException, InterruptedException {
+        ((MapProxyImpl<String, String>) map)
+                .putIfAbsentAsync("key", "value", 10, TimeUnit.DAYS, 5, TimeUnit.DAYS).toCompletableFuture().get();
         assertEntryStore("key", "value", 5, TimeUnit.DAYS, 10000);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/AbstractMapNearCacheLocalInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/AbstractMapNearCacheLocalInvalidationTest.java
@@ -275,7 +275,7 @@ public abstract class AbstractMapNearCacheLocalInvalidationTest extends Hazelcas
 
             // this brings the CACHED_AS_NULL into the Near Cache
             String value1 = map.get(key);
-            Future<String> future = ((MapProxyImpl<String, String>)map).putIfAbsentAsync(key, value).toCompletableFuture();
+            Future<String> future = ((MapProxyImpl<String, String>) map).putIfAbsentAsync(key, value).toCompletableFuture();
             String oldValue = null;
             try {
                 oldValue = future.get();

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/map/MapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/map/MapSplitBrainProtectionWriteTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.splitbrainprotection.map;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.TestLoggingEntryProcessor;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.splitbrainprotection.AbstractSplitBrainProtectionTest;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionException;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
@@ -42,7 +43,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
-import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
@@ -116,6 +116,18 @@ public class MapSplitBrainProtectionWriteTest extends AbstractSplitBrainProtecti
     @Test(expected = ExecutionException.class)
     public void putAsync_failing_whenSplitBrainProtectionSize_met() throws Exception {
         map(3).putAsync("foo", "bar").toCompletableFuture().get();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void putIfAbsentAsync_successful_whenSplitBrainProtectionSize_met() throws Exception {
+        ((MapProxyImpl<Object, Object>) map(0)).putIfAbsentAsync("foo", "bar").toCompletableFuture().get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    @SuppressWarnings("unchecked")
+    public void putIfAbsentAsync_failing_whenSplitBrainProtectionSize_met() throws Exception {
+        ((MapProxyImpl<Object, Object>) map(3)).putIfAbsentAsync("foo", "bar").toCompletableFuture().get();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/map/MapSplitBrainProtectionWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/map/MapSplitBrainProtectionWriteTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
 import static java.util.Arrays.asList;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
@@ -121,12 +122,16 @@ public class MapSplitBrainProtectionWriteTest extends AbstractSplitBrainProtecti
     @Test
     @SuppressWarnings("unchecked")
     public void putIfAbsentAsync_successful_whenSplitBrainProtectionSize_met() throws Exception {
+        assumeTrue(map(0) instanceof MapProxyImpl);
+
         ((MapProxyImpl<Object, Object>) map(0)).putIfAbsentAsync("foo", "bar").toCompletableFuture().get();
     }
 
     @Test(expected = ExecutionException.class)
     @SuppressWarnings("unchecked")
     public void putIfAbsentAsync_failing_whenSplitBrainProtectionSize_met() throws Exception {
+        assumeTrue(map(3) instanceof MapProxyImpl);
+
         ((MapProxyImpl<Object, Object>) map(3)).putIfAbsentAsync("foo", "bar").toCompletableFuture().get();
     }
 


### PR DESCRIPTION
Added server side, async version of `IMap.putIfAbsent()` in form of `MapProxyImpl.putIfAbsentAsync()`.

This is prerequisite for SQL `IMap` INSERTs.