### PR TITLE
[HZ-463] SimpleAuthentication configuration added

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -117,6 +117,7 @@ import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.config.security.SimpleAuthenticationConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
@@ -629,6 +630,18 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(kerbIdentity);
         assertEquals("HAZELCAST.COM", kerbIdentity.getRealm());
         assertEquals(TRUE, kerbIdentity.getUseCanonicalHostname());
+
+        RealmConfig simpleRealm = securityConfig.getRealmConfig("simpleRealm");
+        assertNotNull(simpleRealm);
+        SimpleAuthenticationConfig simpleAuthnCfg = simpleRealm.getSimpleAuthenticationConfig();
+        assertNotNull(simpleAuthnCfg);
+        assertEquals(2, simpleAuthnCfg.getUsernames().size());
+        assertTrue(simpleAuthnCfg.getUsernames().contains("test"));
+        assertEquals("a1234", simpleAuthnCfg.getPassword("test"));
+        Set<String> expectedRoles = new HashSet<>();
+        expectedRoles.add("monitor");
+        expectedRoles.add("hazelcast");
+        assertEquals(expectedRoles, simpleAuthnCfg.getRoles("test"));
     }
 
     @Test

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -673,6 +673,19 @@
                             <hz:token encoding="base64">aGF6ZWxjYXN0</hz:token>
                         </hz:identity>
                     </hz:realm>
+                    <hz:realm name="simpleRealm">
+                        <hz:authentication>
+                            <hz:simple>
+                                <hz:user username="test" password="a1234">
+                                    <hz:role>monitor</hz:role>
+                                    <hz:role>hazelcast</hz:role>
+                                </hz:user>
+                                <hz:user username="root" password="secret">
+                                    <hz:role>root</hz:role>
+                                </hz:user>
+                            </hz:simple>
+                        </hz:authentication>
+                    </hz:realm>
                     <hz:realm name="kerberosRealm">
                         <hz:authentication>
                             <hz:kerberos>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1745,14 +1745,14 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private BeanDefinition handleSimpleUser(Node node) {
             BeanDefinitionBuilder simpleUserBuilder = createBeanBuilder(SimpleAuthenticationConfig.UserDto.class);
             simpleUserBuilder.addConstructorArgValue(getAttribute(node, "password"));
-            ManagedSet<String> roles = new ManagedSet<>();
+            List<String> roles = new ArrayList<String>();
             for (Node child : childElements(node)) {
                 String nodeName = cleanNodeName(child);
                 if ("role".equals(nodeName)) {
                     roles.add(getTextContent(child));
                 }
             }
-            simpleUserBuilder.addPropertyValue("roles", roles);
+            simpleUserBuilder.addConstructorArgValue(roles.toArray(new String[roles.size()]));
             return simpleUserBuilder.getBeanDefinition();
         }
 

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.0.xsd
@@ -5452,6 +5452,7 @@
             <xs:element name="tls" type="tls-authentication"/>
             <xs:element name="ldap" type="ldap-authentication"/>
             <xs:element name="kerberos" type="kerberos-authentication"/>
+            <xs:element name="simple" type="simple-authentication"/>
         </xs:choice>
     </xs:complexType>
 
@@ -5511,6 +5512,22 @@
             <xs:element name="keytab-file" type="xs:string" minOccurs="0"/>
             <xs:element name="ldap" type="ldap-authentication" minOccurs="0"/>
         </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="simple-authentication">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="user" type="simple-user" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="role-separator" type="xs:string" minOccurs="0" default=","/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="simple-user">
+        <xs:complexContent>
+            <xs:extension base="username-password">
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element name="role" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="identity">

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -29,6 +29,7 @@ import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.config.security.SimpleAuthenticationConfig;
 import com.hazelcast.config.security.TlsAuthenticationConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.config.security.UsernamePasswordIdentityConfig;
@@ -300,6 +301,7 @@ public class ConfigXmlGenerator {
             tlsAuthenticationGenerator(gen, c.getTlsAuthenticationConfig());
             ldapAuthenticationGenerator(gen, c.getLdapAuthenticationConfig());
             kerberosAuthenticationGenerator(gen, c.getKerberosAuthenticationConfig());
+            simpleAuthenticationGenerator(gen, c.getSimpleAuthenticationConfig());
             gen.close();
         }
         if (c.isIdentityConfigured()) {
@@ -372,6 +374,23 @@ public class ConfigXmlGenerator {
                 .nodeIfContents("principal", c.getPrincipal());
         ldapAuthenticationGenerator(kerberosGen, c.getLdapAuthenticationConfig());
         kerberosGen.close();
+    }
+
+    private static void simpleAuthenticationGenerator(XmlGenerator gen, SimpleAuthenticationConfig c) {
+        if (c == null) {
+            return;
+        }
+        XmlGenerator simpleGen = gen.open("simple");
+        addClusterLoginElements(simpleGen, c).nodeIfContents("role-separator", c.getRoleSeparator());
+        for (String username : c.getUsernames()) {
+            simpleGen.open("user", "username", username, "password", c.getPassword(username));
+            for (String role : c.getRoles(username)) {
+                simpleGen.node("role", role);
+            }
+            // close <user> node
+            simpleGen.close();
+        }
+        simpleGen.close();
     }
 
     private static void kerberosIdentityGenerator(XmlGenerator gen, KerberosIdentityConfig c) {

--- a/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
@@ -74,6 +74,15 @@ public class RealmConfig {
         return this;
     }
 
+    public SimpleAuthenticationConfig getSimpleAuthenticationConfig() {
+        return getIfType(authenticationConfig, SimpleAuthenticationConfig.class);
+    }
+
+    public RealmConfig setSimpleAuthenticationConfig(SimpleAuthenticationConfig authenticationConfig) {
+        this.authenticationConfig = requireNonNull(authenticationConfig, "Authentication config can't be null");
+        return this;
+    }
+
     public UsernamePasswordIdentityConfig getUsernamePasswordIdentityConfig() {
         return getIfType(identityConfig, UsernamePasswordIdentityConfig.class);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/security/SimpleAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/SimpleAuthenticationConfig.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.security;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+
+/**
+ * Typed authentication configuration for {@code SimplePropertiesLoginModule}. The user configuration (username, password, and
+ * assigned roles) is directly part of the configuration object.
+ */
+public class SimpleAuthenticationConfig extends AbstractClusterLoginConfig<SimpleAuthenticationConfig> {
+
+    private final Map<String, UserDto> userMap = new ConcurrentHashMap<>();
+    private volatile String roleSeparator;
+
+    /**
+     * Adds one user to the configuration.
+     *
+     * @param username username
+     * @param password user's password
+     * @param roles roles assigned to the user
+     * @return this object
+     */
+    public SimpleAuthenticationConfig addUser(@Nonnull String username, @Nonnull String password, String... roles) {
+        userMap.computeIfAbsent(requireNonNull(username), u -> new UserDto(password)).setRoles(roles);
+        return self();
+    }
+
+    /**
+     * Adds one user to the configuration.
+     *
+     * @param username username
+     * @param userDto user's attributes
+     * @return this object
+     */
+    public SimpleAuthenticationConfig addUser(@Nonnull String username, @Nonnull UserDto userDto) {
+        userMap.put(requireNonNull(username, "Username has to be provided"),
+                requireNonNull(userDto, "UserDto object has to be provided"));
+        return self();
+    }
+
+    /**
+     * Allows to use a custom role separator in the configuration. It's important in case when a role name contains the default
+     * separator "," (comma).
+     *
+     * @param roleSeparator new separator
+     * @return this object
+     */
+    public SimpleAuthenticationConfig setRoleSeparator(@Nullable String roleSeparator) {
+        this.roleSeparator = roleSeparator;
+        return self();
+    }
+
+    /**
+     * Returns the custom role separator (when set). If no custom one is used, {@code null} is returned and default separator is
+     * used ("," - comma).
+     *
+     * @return the separator
+     */
+    public String getRoleSeparator() {
+        return roleSeparator;
+    }
+
+    /**
+     * Returns names of users registered in the configuration.
+     *
+     * @return set of usernames
+     */
+    public @Nonnull Set<String> getUsernames() {
+        return new HashSet<>(userMap.keySet());
+    }
+
+    /**
+     * Return the configured password for given username.
+     *
+     * @param username username
+     * @return user's password or null if such user doesn't exist
+     */
+    public String getPassword(@Nonnull String username) {
+        UserDto user = userMap.get(requireNonNull(username, "Username has to be provided"));
+        return user == null ? null : user.password;
+    }
+
+    /**
+     * Returns role names assigned to the given user.
+     *
+     * @param username username
+     * @return configured roles or null if the user doesn't exist
+     */
+    public Set<String> getRoles(@Nonnull String username) {
+        UserDto user = userMap.get(requireNonNull(username, "Username has to be provided"));
+        return user == null ? null : new HashSet<>(user.roles);
+    }
+
+    /**
+     * Replaces the users with ones from the given map.
+     *
+     * @param map map of new users
+     * @return this object
+     */
+    public SimpleAuthenticationConfig setUserMap(@Nullable Map<String, UserDto> map) {
+        userMap.clear();
+        if (map != null) {
+            userMap.putAll(map);
+        }
+        return self();
+    }
+
+    @Override
+    protected Properties initLoginModuleProperties() {
+        Properties props = super.initLoginModuleProperties();
+        setIfConfigured(props, "roleSeparator", roleSeparator);
+        String rs = roleSeparator != null ? roleSeparator : ",";
+        for (Map.Entry<String, UserDto> entry : userMap.entrySet()) {
+            String name = entry.getKey();
+            UserDto user = entry.getValue();
+            setIfConfigured(props, "password." + name, user.password);
+            setIfConfigured(props, "roles." + name, user.roles.stream().collect(joining(rs)));
+        }
+        return props;
+    }
+
+    @Override
+    public LoginModuleConfig[] asLoginModuleConfigs() {
+        LoginModuleConfig loginModuleConfig = new LoginModuleConfig(
+                "com.hazelcast.security.loginimpl.SimplePropertiesLoginModule", LoginModuleUsage.REQUIRED);
+
+        loginModuleConfig.setProperties(initLoginModuleProperties());
+
+        return new LoginModuleConfig[] { loginModuleConfig };
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleAuthenticationConfig [userMap=" + userMap + ", roleSeparator=" + roleSeparator + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(roleSeparator, userMap);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SimpleAuthenticationConfig other = (SimpleAuthenticationConfig) obj;
+        return Objects.equals(roleSeparator, other.roleSeparator) && Objects.equals(userMap, other.userMap);
+    }
+
+    @Override
+    protected SimpleAuthenticationConfig self() {
+        return this;
+    }
+
+    /**
+     * Helper object representing user attributes (i.e. password and roles) in the {@link SimpleAuthenticationConfig}.
+     */
+    public static class UserDto {
+        volatile String password;
+        final Set<String> roles = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+        /**
+         * Constructor taking the user's password as a mandatory attribute.
+         */
+        public UserDto(@Nonnull String password) {
+            this.password = requireNonNull(password, "Password can't be null");
+        }
+
+        /**
+         * Changes user's password.
+         */
+        public UserDto setPassword(@Nonnull String password) {
+            this.password = requireNonNull(password, "Password can't be null");
+            return this;
+        }
+
+        /**
+         * Replaces current set of roles with the ones provided as arguments.
+         */
+        public UserDto setRoles(String... roles) {
+            this.roles.clear();
+            addRoles(roles);
+            return this;
+        }
+
+        /**
+         * Replaces current set of roles with the ones provided in the argument.
+         */
+        public UserDto setRoles(Set<String> roles) {
+            this.roles.clear();
+            if (roles != null) {
+                this.roles.addAll(roles);
+            }
+            return this;
+        }
+
+        /**
+         * Adds provided roles to the current set of roles.
+         */
+        public UserDto addRoles(String... roles) {
+            if (roles != null) {
+                for (String role : roles) {
+                    this.roles.add(role);
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "{password=***, roles=" + roles + "}";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(password, roles);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            UserDto other = (UserDto) obj;
+            return Objects.equals(password, other.password) && Objects.equals(roles, other.roles);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -126,6 +126,7 @@ import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.config.security.SimpleAuthenticationConfig;
 import com.hazelcast.config.security.TlsAuthenticationConfig;
 import com.hazelcast.config.security.TokenEncoding;
 import com.hazelcast.config.security.TokenIdentityConfig;
@@ -3001,6 +3002,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 realmConfig.setLdapAuthenticationConfig(createLdapAuthentication(child));
             } else if (matches("kerberos", nodeName)) {
                 handleKerberosAuthentication(realmConfig, child);
+            } else if (matches("simple", nodeName)) {
+                handleSimpleAuthentication(realmConfig, child);
             }
         }
     }
@@ -3132,6 +3135,33 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         realmConfig.setKerberosAuthenticationConfig(krbCfg);
     }
 
+    protected void handleSimpleAuthentication(RealmConfig realmConfig, Node node) {
+        SimpleAuthenticationConfig simpleCfg = new SimpleAuthenticationConfig();
+        fillClusterLoginConfig(simpleCfg, node);
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            if (matches("user", nodeName)) {
+                addSimpleUser(simpleCfg, child);
+            } else if (matches("role-separator", nodeName)) {
+                simpleCfg.setRoleSeparator(getTextContent(child));
+            }
+        }
+        realmConfig.setSimpleAuthenticationConfig(simpleCfg);
+    }
+
+    private void addSimpleUser(SimpleAuthenticationConfig simpleCfg, Node node) {
+        String username = getAttribute(node, "username");
+        SimpleAuthenticationConfig.UserDto userDto = new SimpleAuthenticationConfig.UserDto(getAttribute(node, "password"));
+
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            if (matches("role", nodeName)) {
+                userDto.addRoles(getTextContent(child));
+            }
+        }
+        simpleCfg.addUser(username, userDto);
+    }
+
     private void handleCredentialsFactory(RealmConfig realmConfig, Node node) {
         String className = getAttribute(node, "class-name");
         CredentialsFactoryConfig credentialsFactoryConfig = new CredentialsFactoryConfig(className);
@@ -3144,7 +3174,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         }
     }
 
-    private void fillClusterLoginConfig(AbstractClusterLoginConfig<?> config, Node node) {
+    protected void fillClusterLoginConfig(AbstractClusterLoginConfig<?> config, Node node) {
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             if (matches("skip-identity", nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -149,9 +149,11 @@ import org.w3c.dom.Node;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -3151,14 +3153,15 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     private void addSimpleUser(SimpleAuthenticationConfig simpleCfg, Node node) {
         String username = getAttribute(node, "username");
-        SimpleAuthenticationConfig.UserDto userDto = new SimpleAuthenticationConfig.UserDto(getAttribute(node, "password"));
-
+        List<String> roles = new ArrayList<>();
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             if (matches("role", nodeName)) {
-                userDto.addRoles(getTextContent(child));
+                roles.add(getTextContent(child));
             }
         }
+        SimpleAuthenticationConfig.UserDto userDto = new SimpleAuthenticationConfig.UserDto(getAttribute(node, "password"),
+                roles.toArray(new String[roles.size()]));
         simpleCfg.addUser(username, userDto);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -90,6 +90,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -882,23 +884,24 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
 
     protected void addSimpleUsers(SimpleAuthenticationConfig simpleCfg, Node node) {
         for (Node child : childElements(node)) {
-            String username = getAttribute(child, "username");
-            SimpleAuthenticationConfig.UserDto userDto = new SimpleAuthenticationConfig.UserDto(
-                    getAttribute(child, "password"));
-            fillSimpleUserRoles(child, userDto);
-            simpleCfg.addUser(username, userDto);
+            simpleCfg.addUser(
+                    getAttribute(child, "username"),
+                    getAttribute(child, "password"),
+                    getSimpleUserRoles(child));
         }
     }
 
-    private void fillSimpleUserRoles(Node node, SimpleAuthenticationConfig.UserDto userDto) {
+    private String[] getSimpleUserRoles(Node node) {
+        List<String> roles = new ArrayList<>();
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             if (matches("roles", nodeName)) {
                 for (Node roleNode : childElements(child)) {
-                    userDto.addRoles(getTextContent(roleNode));
+                    roles.add(getTextContent(roleNode));
                 }
             }
         }
+        return roles.toArray(new String[roles.size()]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -75,6 +75,7 @@ import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.config.security.SimpleAuthenticationConfig;
 import com.hazelcast.config.security.TokenEncoding;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.instance.ProtocolType;
@@ -105,12 +106,9 @@ import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
 import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
 import static java.lang.Integer.parseInt;
 
-@SuppressWarnings({"checkstyle:methodcount",
-                   "checkstyle:cyclomaticcomplexity",
-                   "checkstyle:classfanoutcomplexity",
-                   "checkstyle:classdataabstractioncoupling"})
+@SuppressWarnings({ "checkstyle:methodcount", "checkstyle:cyclomaticcomplexity", "checkstyle:classfanoutcomplexity",
+        "checkstyle:classdataabstractioncoupling" })
 public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
-
 
     public YamlMemberDomConfigProcessor(boolean domLevel3, Config config) {
         super(domLevel3, config);
@@ -126,7 +124,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
         cfg.addSecurityInterceptorConfig(new SecurityInterceptorConfig(className));
     }
 
-    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:methodlength"})
+    @SuppressWarnings({ "checkstyle:npathcomplexity", "checkstyle:methodlength" })
     protected void handleSecurityPermissions(Node node) {
         String onJoinOp = getAttribute(node, "on-join-operation");
         if (onJoinOp != null) {
@@ -146,8 +144,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
                 throw new InvalidConfigurationException("Security permission type is not valid " + nodeName);
             }
 
-            if (PermissionConfig.PermissionType.CONFIG == type
-                    || PermissionConfig.PermissionType.ALL == type
+            if (PermissionConfig.PermissionType.CONFIG == type || PermissionConfig.PermissionType.ALL == type
                     || PermissionConfig.PermissionType.TRANSACTION == type) {
                 handleSecurityPermission(child, type);
             } else {
@@ -245,10 +242,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleQueue(Node node) {
         for (Node queueNode : childElements(node)) {
-            QueueConfig queueConfig = ConfigUtils.getByNameOrNew(
-                                config.getQueueConfigs(),
-                                queueNode.getNodeName(),
-                                QueueConfig.class);
+            QueueConfig queueConfig = ConfigUtils.getByNameOrNew(config.getQueueConfigs(), queueNode.getNodeName(),
+                    QueueConfig.class);
             handleQueueNode(queueNode, queueConfig);
         }
     }
@@ -256,10 +251,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleList(Node node) {
         for (Node listNode : childElements(node)) {
-            ListConfig listConfig = ConfigUtils.getByNameOrNew(
-                                config.getListConfigs(),
-                                listNode.getNodeName(),
-                                ListConfig.class);
+            ListConfig listConfig = ConfigUtils.getByNameOrNew(config.getListConfigs(), listNode.getNodeName(),
+                    ListConfig.class);
             handleListNode(listNode, listConfig);
         }
     }
@@ -267,10 +260,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleSet(Node node) {
         for (Node setNode : childElements(node)) {
-            SetConfig setConfig = ConfigUtils.getByNameOrNew(
-                                config.getSetConfigs(),
-                                setNode.getNodeName(),
-                                SetConfig.class);
+            SetConfig setConfig = ConfigUtils.getByNameOrNew(config.getSetConfigs(), setNode.getNodeName(), SetConfig.class);
             handleSetNode(setNode, setConfig);
         }
     }
@@ -297,10 +287,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     protected void handleRingbuffer(Node node) {
         for (Node rbNode : childElements(node)) {
             handleRingBufferNode(rbNode,
-                    ConfigUtils.getByNameOrNew(
-                            config.getRingbufferConfigs(),
-                            rbNode.getNodeName(),
-                            RingbufferConfig.class));
+                    ConfigUtils.getByNameOrNew(config.getRingbufferConfigs(), rbNode.getNodeName(), RingbufferConfig.class));
         }
     }
 
@@ -308,10 +295,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     protected void handleMap(Node parentNode) throws Exception {
         for (Node mapNode : childElements(parentNode)) {
             String name = mapNode.getNodeName();
-            MapConfig mapConfig = ConfigUtils.getByNameOrNew(
-                                config.getMapConfigs(),
-                                name,
-                                MapConfig.class);
+            MapConfig mapConfig = ConfigUtils.getByNameOrNew(config.getMapConfigs(), name, MapConfig.class);
             handleMapNode(mapNode, mapConfig);
         }
     }
@@ -320,10 +304,7 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     protected void handleCache(Node parentNode) throws Exception {
         for (Node cacheNode : childElements(parentNode)) {
             handleCacheNode(cacheNode,
-                            ConfigUtils.getByNameOrNew(
-                                config.getCacheConfigs(),
-                                cacheNode.getNodeName(),
-                                CacheSimpleConfig.class));
+                    ConfigUtils.getByNameOrNew(config.getCacheConfigs(), cacheNode.getNodeName(), CacheSimpleConfig.class));
         }
     }
 
@@ -331,10 +312,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     protected void handleSplitBrainProtection(Node node) {
         for (Node splitBrainProtectionNode : childElements(node)) {
             String name = splitBrainProtectionNode.getNodeName();
-            SplitBrainProtectionConfig splitBrainProtectionConfig = ConfigUtils.getByNameOrNew(
-                                config.getSplitBrainProtectionConfigs(),
-                                name,
-                                SplitBrainProtectionConfig.class);
+            SplitBrainProtectionConfig splitBrainProtectionConfig = ConfigUtils
+                    .getByNameOrNew(config.getSplitBrainProtectionConfigs(), name, SplitBrainProtectionConfig.class);
             handleSplitBrainProtectionNode(splitBrainProtectionNode, splitBrainProtectionConfig, name);
         }
     }
@@ -342,10 +321,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleFlakeIdGenerator(Node node) {
         for (Node genNode : childElements(node)) {
-            FlakeIdGeneratorConfig genConfig = ConfigUtils.getByNameOrNew(
-                                config.getFlakeIdGeneratorConfigs(),
-                                genNode.getNodeName(),
-                                FlakeIdGeneratorConfig.class);
+            FlakeIdGeneratorConfig genConfig = ConfigUtils.getByNameOrNew(config.getFlakeIdGeneratorConfigs(),
+                    genNode.getNodeName(), FlakeIdGeneratorConfig.class);
 
             handleFlakeIdGeneratorNode(genNode, genConfig);
         }
@@ -354,10 +331,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleExecutor(Node node) throws Exception {
         for (Node executorNode : childElements(node)) {
-            ExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(
-                                config.getExecutorConfigs(),
-                                executorNode.getNodeName(),
-                                ExecutorConfig.class);
+            ExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(config.getExecutorConfigs(), executorNode.getNodeName(),
+                    ExecutorConfig.class);
             handleViaReflection(executorNode, config, executorConfig);
         }
     }
@@ -365,10 +340,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleDurableExecutor(Node node) throws Exception {
         for (Node executorNode : childElements(node)) {
-            DurableExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(
-                    config.getDurableExecutorConfigs(),
-                    executorNode.getNodeName(),
-                    DurableExecutorConfig.class);
+            DurableExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(config.getDurableExecutorConfigs(),
+                    executorNode.getNodeName(), DurableExecutorConfig.class);
             handleViaReflection(executorNode, config, executorConfig);
         }
     }
@@ -376,10 +349,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleScheduledExecutor(Node node) {
         for (Node executorNode : childElements(node)) {
-            ScheduledExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(
-                                config.getScheduledExecutorConfigs(),
-                                executorNode.getNodeName(),
-                                ScheduledExecutorConfig.class);
+            ScheduledExecutorConfig executorConfig = ConfigUtils.getByNameOrNew(config.getScheduledExecutorConfigs(),
+                    executorNode.getNodeName(), ScheduledExecutorConfig.class);
             handleScheduledExecutorNode(executorNode, executorConfig);
         }
     }
@@ -387,10 +358,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleCardinalityEstimator(Node node) {
         for (Node estimatorNode : childElements(node)) {
-            CardinalityEstimatorConfig estimatorConfig = ConfigUtils.getByNameOrNew(
-                    config.getCardinalityEstimatorConfigs(),
-                    estimatorNode.getNodeName(),
-                    CardinalityEstimatorConfig.class);
+            CardinalityEstimatorConfig estimatorConfig = ConfigUtils.getByNameOrNew(config.getCardinalityEstimatorConfigs(),
+                    estimatorNode.getNodeName(), CardinalityEstimatorConfig.class);
 
             handleCardinalityEstimatorNode(estimatorNode, estimatorConfig);
         }
@@ -399,10 +368,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handlePNCounter(Node node) throws Exception {
         for (Node counterNode : childElements(node)) {
-            PNCounterConfig counterConfig = ConfigUtils.getByNameOrNew(
-                                config.getPNCounterConfigs(),
-                                counterNode.getNodeName(),
-                                PNCounterConfig.class);
+            PNCounterConfig counterConfig = ConfigUtils.getByNameOrNew(config.getPNCounterConfigs(), counterNode.getNodeName(),
+                    PNCounterConfig.class);
 
             handleViaReflection(counterNode, config, counterConfig);
         }
@@ -411,10 +378,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleMultiMap(Node node) {
         for (Node multiMapNode : childElements(node)) {
-            MultiMapConfig multiMapConfig = ConfigUtils.getByNameOrNew(
-                                config.getMultiMapConfigs(),
-                                multiMapNode.getNodeName(),
-                                MultiMapConfig.class);
+            MultiMapConfig multiMapConfig = ConfigUtils.getByNameOrNew(config.getMultiMapConfigs(), multiMapNode.getNodeName(),
+                    MultiMapConfig.class);
             handleMultiMapNode(multiMapNode, multiMapConfig);
         }
     }
@@ -422,10 +387,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleReplicatedMap(Node node) {
         for (Node replicatedMapNode : childElements(node)) {
-            ReplicatedMapConfig replicatedMapConfig = ConfigUtils.getByNameOrNew(
-                                config.getReplicatedMapConfigs(),
-                                replicatedMapNode.getNodeName(),
-                                ReplicatedMapConfig.class);
+            ReplicatedMapConfig replicatedMapConfig = ConfigUtils.getByNameOrNew(config.getReplicatedMapConfigs(),
+                    replicatedMapNode.getNodeName(), ReplicatedMapConfig.class);
             handleReplicatedMapNode(replicatedMapNode, replicatedMapConfig);
         }
     }
@@ -556,10 +519,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleItemListeners(Node n, Consumer<ItemListenerConfig> configAddFunction) {
         for (Node listenerNode : childElements(n)) {
-            boolean incValue = getBooleanValue(getTextContent(
-              getNamedItemNode(listenerNode, "include-value")));
-            String listenerClass = getTextContent(
-              getNamedItemNode(listenerNode, "class-name"));
+            boolean incValue = getBooleanValue(getTextContent(getNamedItemNode(listenerNode, "include-value")));
+            String listenerClass = getTextContent(getNamedItemNode(listenerNode, "class-name"));
             configAddFunction.accept(new ItemListenerConfig(listenerClass, incValue));
         }
     }
@@ -567,12 +528,9 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     @Override
     protected void handleEntryListeners(Node n, Consumer<EntryListenerConfig> configAddFunction) {
         for (Node listenerNode : childElements(n)) {
-            boolean incValue = getBooleanValue(getTextContent(
-              getNamedItemNode(listenerNode, "include-value")));
-            boolean local = getBooleanValue(getTextContent(
-              getNamedItemNode(listenerNode, "local")));
-            String listenerClass = getTextContent(
-              getNamedItemNode(listenerNode, "class-name"));
+            boolean incValue = getBooleanValue(getTextContent(getNamedItemNode(listenerNode, "include-value")));
+            boolean local = getBooleanValue(getTextContent(getNamedItemNode(listenerNode, "local")));
+            String listenerClass = getTextContent(getNamedItemNode(listenerNode, "class-name"));
             configAddFunction.accept(new EntryListenerConfig(listenerClass, local, incValue));
         }
     }
@@ -675,8 +633,8 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
         GlobalSerializerConfig globalSerializerConfig = new GlobalSerializerConfig();
         String attrClassName = getAttribute(child, "class-name");
         String attrOverrideJavaSerialization = getAttribute(child, "override-java-serialization");
-        boolean overrideJavaSerialization =
-                attrOverrideJavaSerialization != null && getBooleanValue(attrOverrideJavaSerialization.trim());
+        boolean overrideJavaSerialization = attrOverrideJavaSerialization != null
+                && getBooleanValue(attrOverrideJavaSerialization.trim());
         globalSerializerConfig.setClassName(attrClassName);
         globalSerializerConfig.setOverrideJavaSerialization(overrideJavaSerialization);
         serializationConfig.setGlobalSerializerConfig(globalSerializerConfig);
@@ -700,12 +658,10 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
             final Node factoryIdNode = getNamedItemNode(child, "factory-id");
             final Node classNameNode = getNamedItemNode(child, "class-name");
             if (factoryIdNode == null) {
-                throw new IllegalArgumentException(
-                        "'factory-id' attribute of 'data-serializable-factory' is required!");
+                throw new IllegalArgumentException("'factory-id' attribute of 'data-serializable-factory' is required!");
             }
             if (classNameNode == null) {
-                throw new IllegalArgumentException(
-                        "'class-name' attribute of 'data-serializable-factory' is required!");
+                throw new IllegalArgumentException("'class-name' attribute of 'data-serializable-factory' is required!");
             }
             int factoryId = Integer.parseInt(getTextContent(factoryIdNode));
             String className = getTextContent(classNameNode);
@@ -907,6 +863,42 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
         TokenEncoding encoding = TokenEncoding.getTokenEncoding(getAttribute(node, "encoding"));
         TokenIdentityConfig tic = new TokenIdentityConfig(encoding, getAttribute(node, "value"));
         realmConfig.setTokenIdentityConfig(tic);
+    }
+
+    @Override
+    protected void handleSimpleAuthentication(RealmConfig realmConfig, Node node) {
+        SimpleAuthenticationConfig simpleCfg = new SimpleAuthenticationConfig();
+        fillClusterLoginConfig(simpleCfg, node);
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            if (matches("users", nodeName)) {
+                addSimpleUsers(simpleCfg, child);
+            } else if (matches("role-separator", nodeName)) {
+                simpleCfg.setRoleSeparator(getTextContent(child));
+            }
+        }
+        realmConfig.setSimpleAuthenticationConfig(simpleCfg);
+    }
+
+    protected void addSimpleUsers(SimpleAuthenticationConfig simpleCfg, Node node) {
+        for (Node child : childElements(node)) {
+            String username = getAttribute(child, "username");
+            SimpleAuthenticationConfig.UserDto userDto = new SimpleAuthenticationConfig.UserDto(
+                    getAttribute(child, "password"));
+            fillSimpleUserRoles(child, userDto);
+            simpleCfg.addUser(username, userDto);
+        }
+    }
+
+    private void fillSimpleUserRoles(Node node, SimpleAuthenticationConfig.UserDto userDto) {
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            if (matches("roles", nodeName)) {
+                for (Node roleNode : childElements(child)) {
+                    userDto.addRoles(getTextContent(roleNode));
+                }
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.json
@@ -2475,7 +2475,8 @@
                     "jaas",
                     "tls",
                     "ldap",
-                    "kerberos"
+                    "kerberos",
+                    "simple"
                   ]
                 },
                 "maxProperties": 1,
@@ -2585,6 +2586,38 @@
                       },
                       "security-realm": {
                         "type": "string"
+                      }
+                    }
+                  },
+                  "simple": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                      "role-separator": {
+                        "type": "string"
+                      },
+                      "users": {
+                        "type": "array",
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "username": {
+                              "type": "string"
+                            },
+                            "password": {
+                              "type": "string"
+                            },
+                            "roles": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": [
+                            "username", "password"
+                          ]
+                        }
                       }
                     }
                   }

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
@@ -5259,6 +5259,7 @@
             <xs:element name="jaas" type="login-modules"/>
             <xs:element name="tls" type="tls-authentication"/>
             <xs:element name="ldap" type="ldap-authentication"/>
+            <xs:element name="simple" type="simple-authentication"/>
             <xs:element name="kerberos" type="kerberos-authentication"/>
         </xs:choice>
     </xs:complexType>
@@ -5330,6 +5331,25 @@
                     <xs:element name="principal" type="xs:string" minOccurs="0"/>
                     <xs:element name="keytab-file" type="xs:string" minOccurs="0"/>
                     <xs:element name="ldap" type="ldap-authentication" minOccurs="0"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="simple-authentication">
+        <xs:complexContent>
+            <xs:extension base="basic-authentication">
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element name="user" type="simple-user" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="role-separator" type="xs:string" minOccurs="0" default=","/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="simple-user">
+        <xs:complexContent>
+            <xs:extension base="username-password">
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element name="role" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:choice>
             </xs:extension>
         </xs:complexContent>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2200,6 +2200,8 @@
                 Currently, the realms support configuring <authentication> and/or <identity>. Only one type of authentication
                 configuration and one type of identity configuration is allowed per the realm.
                 Authentication types:
+                * <simple>
+                    Simple authentication where users with their username, password and roles are directly listed in the configuration
                 * <jaas>
                     Defines JAAS authentication - i.e. list of <login-modules> and its optional <properties>
                 * <tls>
@@ -2227,7 +2229,20 @@
                 * <kerberos>
                     Uses Kerberos ticket (wrapped as GSS-API init token) as the identity.
             -->
-            <realm name="mr">
+            <realm name="simpleRealm">
+                <authentication>
+                    <simple>
+                        <user username="test" password="a1234">
+                            <role>monitor</role>
+                            <role>hazelcast</role>
+                        </user>
+                        <user username="dev" password="secret">
+                            <role>root</role>
+                        </user>
+                    </simple>
+                </authentication>
+            </realm>
+            <realm name="jaasRealm">
                 <authentication>
                     <jaas>
                         <login-module class-name="com.hazelcast.examples.MyRequiredLoginModule" usage="REQUIRED">
@@ -2244,22 +2259,6 @@
                         </properties>
                     </credentials-factory>
                 </identity>
-            </realm>
-            <realm name="cr">
-                <authentication>
-                    <jaas>
-                        <login-module class-name="com.hazelcast.examples.MyOptionalLoginModule" usage="OPTIONAL">
-                            <properties>
-                                <property name="property">value</property>
-                            </properties>
-                        </login-module>
-                        <login-module class-name="com.hazelcast.examples.MyRequiredLoginModule" usage="REQUIRED">
-                            <properties>
-                                <property name="property">value</property>
-                            </properties>
-                        </login-module>
-                    </jaas>
-                </authentication>
             </realm>
             <realm name="ldapRealm">
                 <authentication>
@@ -2378,8 +2377,8 @@
                 </authentication>
             </realm>
         </realms>
-        <member-authentication realm="mr"/>
-        <client-authentication realm="cr"/>
+        <member-authentication realm="jaasRealm"/>
+        <client-authentication realm="simpleRealm"/>
         <client-permission-policy class-name="com.hazelcast.examples.MyPermissionPolicy">
             <properties>
                 <property name="property">value</property>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2207,7 +2207,20 @@ hazelcast:
   security:
     enabled: false
     realms:
-      - name: mr
+      - name: simpleRealm
+        authentication:
+          simple:
+            users:
+              - username: test
+                password: 'a1234'
+                roles:
+                  - monitor
+                  - hazelcast
+              - username: dev
+                password: 'secret'
+                roles:
+                  - root
+      - name: jaasRealm
         authentication:
           jaas:
             - class-name: com.hazelcast.examples.MyRequiredLoginModule
@@ -2219,17 +2232,6 @@ hazelcast:
             class-name: com.hazelcast.examples.MyCredentialsFactory
             properties:
               property: value
-      - name: cr
-        authentication:
-          jaas:
-            - class-name: com.hazelcast.examples.MyOptionalLoginModule
-              usage: OPTIONAL
-              properties:
-                property: value
-            - class-name: com.hazelcast.examples.MyRequiredLoginModule
-              usage: REQUIRED
-              properties:
-                property: value
       - name: ldapRealm
         authentication:
           ldap:
@@ -2324,9 +2326,9 @@ hazelcast:
                 principal: hz/127.0.0.1@HAZELCAST.COM
                 keyTab: /opt/hz-localhost.keytab
     member-authentication:
-      realm: mr
+      realm: jaasRealm
     client-authentication:
-      realm: cr
+      realm: simpleRealm
     client-permission-policy:
       class-name: com.hazelcast.examples.MyPermissionPolicy
       properties:

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testJoinValidation();
 
     @Test
-    public abstract void testSecurityInterceptorConfig();
+    public abstract void testSecurityConfig();
 
     @Test
     public abstract void readAwsConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.LdapRoleMappingMode;
 import com.hazelcast.config.security.LdapSearchScope;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.config.security.SimpleAuthenticationConfig;
 import com.hazelcast.config.security.TlsAuthenticationConfig;
 import com.hazelcast.config.security.TokenEncoding;
 import com.hazelcast.config.security.TokenIdentityConfig;
@@ -640,6 +641,20 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         SecurityConfig expectedConfig = new SecurityConfig().setClientRealmConfig("tlsRealm", realmConfig);
         cfg.setSecurityConfig(expectedConfig);
 
+        SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getSecurityConfig();
+        assertEquals(expectedConfig, actualConfig);
+    }
+
+    @Test
+    public void testSimpleAuthenticationConfig() {
+        Config cfg = new Config();
+        RealmConfig realmConfig = new RealmConfig().setSimpleAuthenticationConfig(new SimpleAuthenticationConfig()
+                .setRoleSeparator(":")
+                .addUser("test", "1234", "monitor", "hazelcast")
+                .addUser("dev", "secret", "root")
+                );
+        SecurityConfig expectedConfig = new SecurityConfig().setMemberRealmConfig("simpleRealm", realmConfig);
+        cfg.setSecurityConfig(expectedConfig);
         SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getSecurityConfig();
         assertEquals(expectedConfig, actualConfig);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.config.security.SimpleAuthenticationConfig;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.config.SchemaViolationConfigurationException;
 import com.hazelcast.internal.nio.IOUtil;
@@ -164,7 +165,7 @@ public class YamlConfigBuilderTest
 
     @Override
     @Test
-    public void testSecurityInterceptorConfig() {
+    public void testSecurityConfig() {
         String yaml = ""
                 + "hazelcast:\n"
                 + "  security:\n"
@@ -223,6 +224,20 @@ public class YamlConfigBuilderTest
                 + "            principal: jduke@HAZELCAST.COM\n"
                 + "            keytab-file: /opt/jduke.keytab\n"
                 + "            use-canonical-hostname: true\n"
+                + "      - name: simple\n"
+                + "        authentication:\n"
+                + "          simple:\n"
+                + "            skip-role: true\n"
+                + "            users:\n"
+                + "              - username: test\n"
+                + "                password: 'a1234'\n"
+                + "                roles:\n"
+                + "                  - monitor\n"
+                + "                  - hazelcast\n"
+                + "              - username: dev\n"
+                + "                password: secret\n"
+                + "                roles:\n"
+                + "                  - root\n"
                 + "    client-permission-policy:\n"
                 + "      class-name: MyPermissionPolicy\n"
                 + "      properties:\n"
@@ -299,6 +314,19 @@ public class YamlConfigBuilderTest
         LdapAuthenticationConfig kerbLdapAuthentication = kerbAuthentication.getLdapAuthenticationConfig();
         assertNotNull(kerbLdapAuthentication);
         assertEquals("ldap://127.0.0.1", kerbLdapAuthentication.getUrl());
+
+        RealmConfig simpleRealm = securityConfig.getRealmConfig("simple");
+        assertNotNull(simpleRealm);
+        SimpleAuthenticationConfig simpleAuthnCfg = simpleRealm.getSimpleAuthenticationConfig();
+        assertNotNull(simpleAuthnCfg);
+        assertEquals(2, simpleAuthnCfg.getUsernames().size());
+        assertTrue(simpleAuthnCfg.getUsernames().contains("test"));
+        assertEquals("a1234", simpleAuthnCfg.getPassword("test"));
+        Set<String> expectedRoles = new HashSet<>();
+        expectedRoles.add("monitor");
+        expectedRoles.add("hazelcast");
+        assertEquals(expectedRoles, simpleAuthnCfg.getRoles("test"));
+        assertEquals(Boolean.TRUE, simpleAuthnCfg.getSkipRole());
 
         // client-permission-policy
         PermissionPolicyConfig permissionPolicyConfig = securityConfig.getClientPolicyConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/security/SimpleAuthenticationConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/security/SimpleAuthenticationConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.security.SimpleAuthenticationConfig.UserDto;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelJVMTest.class })
+public class SimpleAuthenticationConfigTest {
+
+    @Test
+    public void testAddUserAtMostOnce() {
+        SimpleAuthenticationConfig c = new SimpleAuthenticationConfig();
+        c.addUser("user", "password");
+        assertThrows(IllegalArgumentException.class, () -> c.addUser("user", "password2"));
+        assertThrows(IllegalArgumentException.class, () -> c.addUser("user", new UserDto("password3")));
+        assertTrue(c.getUsernames().contains("user"));
+    }
+
+    @Test
+    public void testAddUser() {
+        SimpleAuthenticationConfig c = new SimpleAuthenticationConfig();
+        c.addUser("user1", "password1");
+        c.addUser("user2", "password2", "role1");
+        c.addUser("user3", "password3", "role1", "role2", "role3");
+        assertEquals(3, c.getUsernames().size());
+        assertEquals("password1", c.getPassword("user1"));
+        assertTrue(c.getRoles("user3").contains("role3"));
+    }
+
+    @Test
+    public void testAddUserWithEmptyPassword() {
+        SimpleAuthenticationConfig c = new SimpleAuthenticationConfig();
+        assertThrows(IllegalArgumentException.class, () -> c.addUser("user", ""));
+        assertThrows(IllegalArgumentException.class, () -> c.addUser("user", (String) null));
+    }
+
+    @Test
+    public void testRoleSeparator() {
+        SimpleAuthenticationConfig c = new SimpleAuthenticationConfig();
+        assertThrows(IllegalArgumentException.class, () -> c.setRoleSeparator(""));
+        c.setRoleSeparator(":");
+        assertEquals(":", c.getRoleSeparator());
+        c.setRoleSeparator(null);
+        assertNull(c.getRoleSeparator());
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -627,7 +627,20 @@
 
     <security enabled="false">
         <realms>
-            <realm name="mr">
+            <realm name="simpleRealm">
+                <authentication>
+                    <simple>
+                        <user username="test" password="a1234">
+                            <role>monitor</role>
+                            <role>hazelcast</role>
+                        </user>
+                        <user username="dev" password="secret">
+                            <role>root</role>
+                        </user>
+                    </simple>
+                </authentication>
+            </realm>
+            <realm name="jaasRealm">
                 <authentication>
                     <jaas>
                         <login-module class-name="com.hazelcast.examples.MyRequiredLoginModule" usage="REQUIRED">
@@ -644,22 +657,6 @@
                         </properties>
                     </credentials-factory>
                 </identity>
-            </realm>
-            <realm name="cr">
-                <authentication>
-                    <jaas>
-                        <login-module class-name="com.hazelcast.examples.MyOptionalLoginModule" usage="OPTIONAL">
-                            <properties>
-                                <property name="property">value</property>
-                            </properties>
-                        </login-module>
-                        <login-module class-name="com.hazelcast.examples.MyRequiredLoginModule" usage="REQUIRED">
-                            <properties>
-                                <property name="property">value</property>
-                            </properties>
-                        </login-module>
-                    </jaas>
-                </authentication>
             </realm>
             <realm name="ldapRealm">
                 <authentication>
@@ -778,8 +775,8 @@
                 </authentication>
             </realm>
         </realms>
-        <member-authentication realm="mr"/>
-        <client-authentication realm="cr"/>
+        <member-authentication realm="jaasRealm"/>
+        <client-authentication realm="simpleRealm"/>
         <client-permission-policy class-name="com.hazelcast.examples.MyPermissionPolicy">
             <properties>
                 <property name="property">value</property>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -612,7 +612,20 @@ hazelcast:
   security:
     enabled: false
     realms:
-      - name: mr
+      - name: simpleRealm
+        authentication:
+          simple:
+            users:
+              - username: test
+                password: 'a1234'
+                roles:
+                  - monitor
+                  - hazelcast
+              - username: dev
+                password: 'secret'
+                roles:
+                  - root
+      - name: jaasRealm
         authentication:
           jaas:
             - class-name: com.hazelcast.examples.MyRequiredLoginModule
@@ -624,17 +637,6 @@ hazelcast:
             class-name: com.hazelcast.examples.MyCredentialsFactory
             properties:
               property: value
-      - name: cr
-        authentication:
-          jaas:
-            - class-name: com.hazelcast.examples.MyOptionalLoginModule
-              usage: OPTIONAL
-              properties:
-                property: value
-            - class-name: com.hazelcast.examples.MyRequiredLoginModule
-              usage: REQUIRED
-              properties:
-                property: value
       - name: ldapRealm
         authentication:
           ldap:
@@ -729,9 +731,9 @@ hazelcast:
                 principal: hz/127.0.0.1@HAZELCAST.COM
                 keyTab: /opt/hz-localhost.keytab
     member-authentication:
-      realm: mr
+      realm: jaasRealm
     client-authentication:
-      realm: cr
+      realm: simpleRealm
     client-permission-policy:
       class-name: com.hazelcast.examples.MyPermissionPolicy
       properties:


### PR DESCRIPTION
This PR introduces the simple authentication configuration. It allows to have users and their assigned roles stored together with other Hazelcast configuration.

Sample XML config:
```xml
    <security enabled="true">
        <realms>
            <realm name="simpleRealm">
                <authentication>
                    <simple>
                        <user username="test" password="a1234">
                            <role>monitor</role>
                            <role>hazelcast</role>
                        </user>
                        <user username="root" password="secret">
                            <role>admin</role>
                        </user>
                    </simple>
                </authentication>
            </realm>
        </realms>
        <client-authentication realm="simpleRealm"/>
        <client-permissions>
            <all-permissions principal="admin">
            </all-permissions>
            <map-permission name="*" principal="monitor">
                <actions>
                    <action>read</action>
                </actions>
            </map-permission>
        </client-permissions>
    </security>
```

Sample YAML config:
```yaml
  security:
    enabled: true
    realms:
      - name: simpleRealm
        authentication:
          simple:
            users:
              - username: test
                password: 'a1234'
                roles:
                  - monitor
                  - hazelcast
              - username: root
                password: 'secret'
                roles:
                  - admin
    client-authentication:
      realm: simpleRealm
    client-permissions:
      all:
        principal: admin
      map:
        - name: "*"
          principal: monitor
          actions:
            - read
```