### PR TITLE
Fix free metadata memory report of health monitor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -19,19 +19,19 @@ package com.hazelcast.internal.diagnostics;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.memory.MemoryStats;
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.internal.memory.MemoryStats;
 import com.hazelcast.spi.properties.ClusterProperty;
 
 import static com.hazelcast.internal.diagnostics.HealthMonitorLevel.OFF;
 import static com.hazelcast.internal.diagnostics.HealthMonitorLevel.valueOf;
+import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
 import static com.hazelcast.spi.properties.ClusterProperty.HEALTH_MONITORING_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE;
 import static com.hazelcast.spi.properties.ClusterProperty.HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE;
-import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
 import static java.lang.String.format;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -460,9 +460,10 @@ public class HealthMonitor {
                 sb.append("native.meta.memory.used=")
                         .append(numberToUnit(usedMeta)).append(", ");
                 sb.append("native.meta.memory.free=")
-                        .append(numberToUnit(maxMeta - usedMeta)).append(", ");
+                        .append(usedMeta >= maxMeta ? 0 : numberToUnit(maxMeta - usedMeta)).append(", ");
                 sb.append("native.meta.memory.percentage=")
-                        .append(percentageString(PERCENTAGE_MULTIPLIER * usedMeta / (usedNative + usedMeta))).append(", ");
+                        .append(usedMeta >= maxMeta ? percentageString(PERCENTAGE_MULTIPLIER)
+                                : percentageString(PERCENTAGE_MULTIPLIER * usedMeta / (usedNative + usedMeta))).append(", ");
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -445,7 +445,10 @@ public class HealthMonitor {
                 return;
             }
 
+            final long maxNative = memoryStats.getMaxNative();
             final long usedNative = memoryStats.getUsedNative();
+            final long usedMeta = memoryStats.getUsedMetadata();
+
             sb.append("native.memory.used=")
                     .append(numberToUnit(usedNative)).append(", ");
             sb.append("native.memory.free=")
@@ -453,18 +456,13 @@ public class HealthMonitor {
             sb.append("native.memory.total=")
                     .append(numberToUnit(memoryStats.getCommittedNative())).append(", ");
             sb.append("native.memory.max=")
-                    .append(numberToUnit(memoryStats.getMaxNative())).append(", ");
-            final long maxMeta = memoryStats.getMaxMetadata();
-            if (maxMeta > 0) {
-                final long usedMeta = memoryStats.getUsedMetadata();
-                sb.append("native.meta.memory.used=")
-                        .append(numberToUnit(usedMeta)).append(", ");
-                sb.append("native.meta.memory.free=")
-                        .append(usedMeta >= maxMeta ? 0 : numberToUnit(maxMeta - usedMeta)).append(", ");
-                sb.append("native.meta.memory.percentage=")
-                        .append(usedMeta >= maxMeta ? percentageString(PERCENTAGE_MULTIPLIER)
-                                : percentageString(PERCENTAGE_MULTIPLIER * usedMeta / (usedNative + usedMeta))).append(", ");
-            }
+                    .append(numberToUnit(maxNative)).append(", ");
+            sb.append("native.meta.memory.used=")
+                    .append(numberToUnit(usedMeta)).append(", ");
+            sb.append("native.meta.memory.free=")
+                    .append(numberToUnit(maxNative - usedMeta)).append(", ");
+            sb.append("native.meta.memory.percentage=")
+                    .append(percentageString(PERCENTAGE_MULTIPLIER * usedMeta / maxNative)).append(", ");
         }
 
         private void renderExecutors() {


### PR DESCRIPTION
In 4.2 `maxMetadata` is a soft limit used for informative purposes, when needed we exceed beyond that pre-configured `maxMetadata`. But health monitor doesn't log this truly. This PR fixes it. What health monitor currently prints is like this:

```
...
 native.meta.memory.used=1.0G, native.meta.memory.free=-825077632, native.meta.memory.percentage=33.92%,
...
```