### PR TITLE
Cleanup DML rules and rels

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DeleteLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DeleteLogicalRel.java
@@ -22,9 +22,10 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
-import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
+
+import static org.apache.calcite.rel.core.TableModify.Operation.DELETE;
 
 public class DeleteLogicalRel extends TableModify implements LogicalRel {
 
@@ -34,36 +35,13 @@ public class DeleteLogicalRel extends TableModify implements LogicalRel {
             RelOptTable table,
             Prepare.CatalogReader catalogReader,
             RelNode input,
-            Operation operation,
-            List<String> updateColumnList,
-            List<RexNode> sourceExpressionList,
             boolean flattened
     ) {
-        super(
-                cluster,
-                traitSet,
-                table,
-                catalogReader,
-                input,
-                operation,
-                updateColumnList,
-                sourceExpressionList,
-                flattened
-        );
+        super(cluster, traitSet, table, catalogReader, input, DELETE, null, null, flattened);
     }
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new DeleteLogicalRel(
-                getCluster(),
-                traitSet,
-                getTable(),
-                getCatalogReader(),
-                sole(inputs),
-                getOperation(),
-                getUpdateColumnList(),
-                getSourceExpressionList(),
-                isFlattened()
-        );
+        return new DeleteLogicalRel(getCluster(), traitSet, getTable(), getCatalogReader(), sole(inputs), isFlattened());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DeleteLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DeleteLogicalRule.java
@@ -39,7 +39,7 @@ public final class DeleteLogicalRule extends ConverterRule {
 
     @Override
     public RelNode convert(RelNode rel) {
-        TableModify delete = (TableModify) rel;
+        LogicalTableModify delete = (LogicalTableModify) rel;
 
         return new DeleteLogicalRel(
                 delete.getCluster(),
@@ -47,9 +47,6 @@ public final class DeleteLogicalRule extends ConverterRule {
                 delete.getTable(),
                 delete.getCatalogReader(),
                 OptUtils.toLogicalInput(delete.getInput()),
-                delete.getOperation(),
-                delete.getUpdateColumnList(),
-                delete.getSourceExpressionList(),
                 delete.isFlattened()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/InsertLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/InsertLogicalRel.java
@@ -22,9 +22,10 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
-import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
+
+import static org.apache.calcite.rel.core.TableModify.Operation.INSERT;
 
 public class InsertLogicalRel extends TableModify implements LogicalRel {
 
@@ -34,36 +35,13 @@ public class InsertLogicalRel extends TableModify implements LogicalRel {
             RelOptTable table,
             Prepare.CatalogReader catalogReader,
             RelNode input,
-            Operation operation,
-            List<String> updateColumnList,
-            List<RexNode> sourceExpressionList,
             boolean flattened
     ) {
-        super(
-                cluster,
-                traitSet,
-                table,
-                catalogReader,
-                input,
-                operation,
-                updateColumnList,
-                sourceExpressionList,
-                flattened
-        );
+        super(cluster, traitSet, table, catalogReader, input, INSERT, null, null, flattened);
     }
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new InsertLogicalRel(
-                getCluster(),
-                traitSet,
-                getTable(),
-                getCatalogReader(),
-                sole(inputs),
-                getOperation(),
-                getUpdateColumnList(),
-                getSourceExpressionList(),
-                isFlattened()
-        );
+        return new InsertLogicalRel(getCluster(), traitSet, getTable(), getCatalogReader(), sole(inputs), isFlattened());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/InsertLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/InsertLogicalRule.java
@@ -39,7 +39,7 @@ final class InsertLogicalRule extends ConverterRule {
 
     @Override
     public RelNode convert(RelNode rel) {
-        TableModify insert = (TableModify) rel;
+        LogicalTableModify insert = (LogicalTableModify) rel;
 
         return new InsertLogicalRel(
                 insert.getCluster(),
@@ -47,9 +47,6 @@ final class InsertLogicalRule extends ConverterRule {
                 insert.getTable(),
                 insert.getCatalogReader(),
                 OptUtils.toLogicalInput(insert.getInput()),
-                insert.getOperation(),
-                insert.getUpdateColumnList(),
-                insert.getSourceExpressionList(),
                 insert.isFlattened()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/UpdateLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/UpdateLogicalRel.java
@@ -26,6 +26,8 @@ import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
 
+import static org.apache.calcite.rel.core.TableModify.Operation.UPDATE;
+
 public class UpdateLogicalRel extends TableModify implements LogicalRel {
 
     UpdateLogicalRel(
@@ -34,12 +36,11 @@ public class UpdateLogicalRel extends TableModify implements LogicalRel {
             RelOptTable table,
             Prepare.CatalogReader catalogReader,
             RelNode input,
-            Operation operation,
             List<String> updateColumnList,
             List<RexNode> sourceExpressionList,
             boolean flattened
     ) {
-        super(cluster, traitSet, table, catalogReader, input, operation, updateColumnList, sourceExpressionList, flattened);
+        super(cluster, traitSet, table, catalogReader, input, UPDATE, updateColumnList, sourceExpressionList, flattened);
     }
 
     @Override
@@ -50,7 +51,6 @@ public class UpdateLogicalRel extends TableModify implements LogicalRel {
                 getTable(),
                 getCatalogReader(),
                 sole(inputs),
-                getOperation(),
                 getUpdateColumnList(),
                 getSourceExpressionList(),
                 isFlattened()

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/UpdateLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/UpdateLogicalRule.java
@@ -61,7 +61,6 @@ final class UpdateLogicalRule extends RelOptRule {
                 update.getTable(),
                 update.getCatalogReader(),
                 rewriteScan(scan),
-                update.getOperation(),
                 update.getUpdateColumnList(),
                 update.getSourceExpressionList(),
                 update.isFlattened()

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRel.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.sql.impl.opt.physical;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
-import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
@@ -29,7 +28,6 @@ import org.apache.calcite.rel.core.TableModify;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.apache.calcite.rel.core.TableModify.Operation.DELETE;
 
 public class DeletePhysicalRel extends TableModify implements PhysicalRel {
@@ -47,7 +45,7 @@ public class DeletePhysicalRel extends TableModify implements PhysicalRel {
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        return new PlanNodeSchema(singletonList(QueryDataType.BIGINT));
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRel.java
@@ -17,18 +17,20 @@
 package com.hazelcast.jet.sql.impl.opt.physical;
 
 import com.hazelcast.jet.core.Vertex;
-import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
+import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
-import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.apache.calcite.rel.core.TableModify.Operation.DELETE;
 
 public class DeletePhysicalRel extends TableModify implements PhysicalRel {
 
@@ -38,18 +40,14 @@ public class DeletePhysicalRel extends TableModify implements PhysicalRel {
             RelOptTable table,
             Prepare.CatalogReader catalogReader,
             RelNode input,
-            Operation operation,
-            List<String> updateColumnList,
-            List<RexNode> sourceExpressionList,
             boolean flattened
     ) {
-        super(cluster, traitSet, table, catalogReader, input, operation,
-                updateColumnList, sourceExpressionList, flattened);
+        super(cluster, traitSet, table, catalogReader, input, DELETE, null, null, flattened);
     }
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        return OptUtils.schema(getTable());
+        return new PlanNodeSchema(singletonList(QueryDataType.BIGINT));
     }
 
     @Override
@@ -59,16 +57,6 @@ public class DeletePhysicalRel extends TableModify implements PhysicalRel {
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new DeletePhysicalRel(
-                getCluster(),
-                traitSet,
-                getTable(),
-                getCatalogReader(),
-                sole(inputs),
-                getOperation(),
-                getUpdateColumnList(),
-                getSourceExpressionList(),
-                isFlattened()
-        );
+        return new DeletePhysicalRel(getCluster(), traitSet, getTable(), getCatalogReader(), sole(inputs), isFlattened());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DeletePhysicalRule.java
@@ -46,9 +46,6 @@ public final class DeletePhysicalRule extends ConverterRule {
                 logicalDelete.getTable(),
                 logicalDelete.getCatalogReader(),
                 OptUtils.toPhysicalInput(logicalDelete.getInput()),
-                logicalDelete.getOperation(),
-                logicalDelete.getUpdateColumnList(),
-                logicalDelete.getSourceExpressionList(),
                 logicalDelete.isFlattened()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRel.java
@@ -17,18 +17,20 @@
 package com.hazelcast.jet.sql.impl.opt.physical;
 
 import com.hazelcast.jet.core.Vertex;
-import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
+import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
-import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.apache.calcite.rel.core.TableModify.Operation.INSERT;
 
 public class InsertPhysicalRel extends TableModify implements PhysicalRel {
 
@@ -38,18 +40,14 @@ public class InsertPhysicalRel extends TableModify implements PhysicalRel {
             RelOptTable table,
             Prepare.CatalogReader catalogReader,
             RelNode input,
-            Operation operation,
-            List<String> updateColumnList,
-            List<RexNode> sourceExpressionList,
             boolean flattened
     ) {
-        super(cluster, traitSet, table, catalogReader, input, operation,
-                updateColumnList, sourceExpressionList, flattened);
+        super(cluster, traitSet, table, catalogReader, input, INSERT, null, null, flattened);
     }
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        return OptUtils.schema(getTable());
+        return new PlanNodeSchema(singletonList(QueryDataType.BIGINT));
     }
 
     @Override
@@ -59,16 +57,6 @@ public class InsertPhysicalRel extends TableModify implements PhysicalRel {
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new InsertPhysicalRel(
-                getCluster(),
-                traitSet,
-                getTable(),
-                getCatalogReader(),
-                sole(inputs),
-                getOperation(),
-                getUpdateColumnList(),
-                getSourceExpressionList(),
-                isFlattened()
-        );
+        return new InsertPhysicalRel(getCluster(), traitSet, getTable(), getCatalogReader(), sole(inputs), isFlattened());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRel.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.sql.impl.opt.physical;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
-import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
@@ -29,7 +28,6 @@ import org.apache.calcite.rel.core.TableModify;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.apache.calcite.rel.core.TableModify.Operation.INSERT;
 
 public class InsertPhysicalRel extends TableModify implements PhysicalRel {
@@ -47,7 +45,7 @@ public class InsertPhysicalRel extends TableModify implements PhysicalRel {
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        return new PlanNodeSchema(singletonList(QueryDataType.BIGINT));
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/InsertPhysicalRule.java
@@ -46,9 +46,6 @@ final class InsertPhysicalRule extends ConverterRule {
                 logicalInsert.getTable(),
                 logicalInsert.getCatalogReader(),
                 OptUtils.toPhysicalInput(logicalInsert.getInput()),
-                logicalInsert.getOperation(),
-                logicalInsert.getUpdateColumnList(),
-                logicalInsert.getSourceExpressionList(),
                 logicalInsert.isFlattened()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
+import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
@@ -33,7 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.calcite.rel.core.TableModify.Operation.UPDATE;
 
 public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
 
@@ -43,12 +46,11 @@ public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
             RelOptTable table,
             Prepare.CatalogReader catalogReader,
             RelNode input,
-            Operation operation,
             List<String> updateColumnList,
             List<RexNode> sourceExpressionList,
             boolean flattened
     ) {
-        super(cluster, traitSet, table, catalogReader, input, operation, updateColumnList, sourceExpressionList, flattened);
+        super(cluster, traitSet, table, catalogReader, input, UPDATE, updateColumnList, sourceExpressionList, flattened);
     }
 
     public Map<String, Expression<?>> updates(QueryParameterMetadata parameterMetadata) {
@@ -59,7 +61,7 @@ public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        return OptUtils.schema(getTable());
+        return new PlanNodeSchema(singletonList(QueryDataType.BIGINT));
     }
 
     @Override
@@ -75,7 +77,6 @@ public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
                 getTable(),
                 getCatalogReader(),
                 sole(inputs),
-                getOperation(),
                 getUpdateColumnList(),
                 getSourceExpressionList(),
                 isFlattened()

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
-import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.calcite.rel.core.TableModify.Operation.UPDATE;
 
@@ -61,7 +59,7 @@ public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        return new PlanNodeSchema(singletonList(QueryDataType.BIGINT));
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRule.java
@@ -46,7 +46,6 @@ final class UpdatePhysicalRule extends ConverterRule {
                 logicalUpdate.getTable(),
                 logicalUpdate.getCatalogReader(),
                 OptUtils.toPhysicalInput(logicalUpdate.getInput()),
-                logicalUpdate.getOperation(),
                 logicalUpdate.getUpdateColumnList(),
                 logicalUpdate.getSourceExpressionList(),
                 logicalUpdate.isFlattened()


### PR DESCRIPTION
Simplified DML rules and rels - `updateColumnList ` & `sourceExpressionList` are ever present only for `UPDATE`s + inferring operation from type.
Fixed the schema for DML physical rels (it was simply wrong) - the output should be number of affected rows, it isn't used yet though.