### PR TITLE
Decrease logging level when no strategy is auto-discovered

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -150,7 +150,7 @@ public class DefaultDiscoveryService
                     discoveryStrategies
                             .add(autoDetectedFactory.newDiscoveryStrategy(discoveryNode, logger, Collections.emptyMap()));
                 } else {
-                    logger.info("No discovery strategy is applicable for auto-detection");
+                    logger.fine("No discovery strategy is applicable for auto-detection");
                 }
             }
             return discoveryStrategies;


### PR DESCRIPTION
This is meant to prevent logs like this:
```
2021-06-18 12:52:39,175 [ INFO] [main] [c.h.s.d.i.DiscoveryService]: [172.17.0.2]:5701 [dev] [5.0-SNAPSHOT] No discovery strategy is applicable for auto-detection
2021-06-18 12:52:39,328 [ INFO] [main] [c.h.i.i.Node]: [172.17.0.2]:5701 [dev] [5.0-SNAPSHOT] Using Multicast discovery
```

Reasoning:
Default logs should show only WHAT strategy is used. Not necessary HOW the decision was made.
You need to understand HOW only when you are troubleshooting it.