### PR TITLE
Exclude log4j-api dependency from the elastic fat jars

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-5/pom.xml
@@ -56,6 +56,13 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                        </excludes>
+                    </artifactSet>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -56,6 +56,13 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                        </excludes>
+                    </artifactSet>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -56,6 +56,13 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                        </excludes>
+                    </artifactSet>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We already have logj4-api jar in the server distribution, so it is not
needed.
Also log4j-api is a multi-release jar and the shade plugin didn't
repackage the jar correctly, causing the following message to be printed
at startup:

```
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
```

This commit fixes this issue.
