### PR TITLE
Specify explicitly commons-codec dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <bytebuddy.version>1.10.21</bytebuddy.version>
         <reflections.version>0.9.10</reflections.version>
         <jmh.version>1.27</jmh.version>
+        <commons-codec.version>1.15</commons-codec.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <felix.utils.version>1.11.6</felix.utils.version>
         <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
@@ -343,6 +344,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <profiles>
         <profile>


### PR DESCRIPTION
The `commons-codec` transitive dependency of the `hazelcast-sql-core` (through `calcite`) is reported as vulnerable (see https://issues.apache.org/jira/browse/CODEC-134)

This PR explicitly specifies a newer (fixed) `commons-codec` version in the dependency management.

[Diff for Apache Commons Codec versions 1.12 and 1.15](https://github.com/apache/commons-codec/compare/commons-codec-1.12...rel/commons-codec-1.15)

To me, it looks like a minor risk. The only reference to `commons-codec` classes is from `org/apache/calcite/runtime/SqlFunctions.java` There are 2 classes used - `DigestUtils` and `Soundex`. I didn't find any changes in the methods used by the Calcite. Moreover,
* The `DigestUtils` is used for `MD5(string)` and `SHA1(string)` SQL functions - AFAIK we don't support them in Hazelcast.
* The `Soundex` is used for `SOUNDEX(string)` and `DIFFERENCE(string,string)` SQL functions - AFAIK we don't support them in Hazelcast.