### PR TITLE
migrationCommitServiceTest: shall wait until all nodes receive their …

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
@@ -575,7 +575,7 @@ public class MigrationCommitServiceTest extends HazelcastTestSupport {
     }
 
     private Config createConfig() {
-        Config config = new Config();
+        Config config = smallInstanceConfig();
 
         ServiceConfig serviceConfig = TestMigrationAwareService.createServiceConfig(BACKUP_COUNT);
         ConfigAccessor.getServicesConfig(config).addServiceConfig(serviceConfig);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
@@ -102,12 +102,18 @@ public class MigrationCommitServiceTest extends HazelcastTestSupport {
                 for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
                     InternalPartitionService partitionService = getPartitionService(instances[0]);
                     InternalPartition partition = partitionService.getPartition(partitionId);
-                    for (int i = 0; i <= BACKUP_COUNT; i++) {
+
+                    // given that NODE_COUNT < BACKUP_COUNT, there can be at most
+                    // NODE_COUNT replicas overall.
+                    final int replicasCount = Math.min(BACKUP_COUNT + 1, NODE_COUNT);
+                    for (int i = 0; i < replicasCount; i++) {
+                        // replica assignment should complete, so that when we later
+                        // reference a replica, we do not get NPE.
                         Address replicaAddress = partition.getReplicaAddress(i);
-                        if (replicaAddress != null) {
-                            TestMigrationAwareService service = getService(replicaAddress);
-                            assertNotNull(service.get(partitionId));
-                        }
+                        assertNotNull(replicaAddress);
+
+                        TestMigrationAwareService service = getService(replicaAddress);
+                        assertNotNull(service.get(partitionId));
                     }
                 }
             }


### PR DESCRIPTION
Fixes #18740 

4 of the failures are due to NPE, where we reference owner of partition, which has not yet been set and thus is null. Solution: in the test setup phase make sure all replica ownerships are set.

Regarding one other failure, it is due to network split and then rejoin, where in the meantime our `assertEventually()` times out. Here, we have master member `M1` that tries to roll back a migration, but according to logs at time `22:42:23,940` we have cluster split and masters member list is `{M1 (this), M4}` rollback operation has to be applied to `M3`, which does not join `M1` until `22:44:10,101`, then it tries to finish migration tasks and do repartitioning where the test failure occurs at `22:45:37,328` at which instant `M1` has not yet initiated jobs. 

Failure reason: `assertEventually()` timeout, which has default timeout of 120 seconds and we have network split followed by an intermediate state on the master. These timings are not accurate of course, but in order of minutes they should be.

    ReplicaVersions: [1, 1, 1, 1, 1, 1] at index: 1 expected:<0> but was:<1>" at "testPartitionBackupShiftUpRollbackWithNonNullOwnerOfReplicaIndex"

Here `ReplicaVersions[0] == 0` on the replicaOwner/master/`M1` is also 1, which would be zero had the master applied migration.
