### PR TITLE
Fix Python service test failures

### DIFF
--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -60,7 +60,7 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void beforeClass() {
         Config config = smallInstanceWithResourceUploadConfig();
-        initialize(2, config);
+        initialize(1, config);
         assumeThatNoWindowsOS();
     }
 

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
@@ -65,7 +65,7 @@ public class PythonServiceTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void beforeClass() {
         Config config = smallInstanceWithResourceUploadConfig();
-        initialize(2, config);
+        initialize(1, config);
         assumeThatNoWindowsOS();
     }
 


### PR DESCRIPTION
<PR description here>

Fixes https://github.com/hazelcast/hazelcast/issues/18715

The test blows up because, since the introduction of light jobs, job cleanup happens on each member independently, whenever execution finishes on that particular member. The old behaviour was that the master coordinated the clean-ups, so they happened after the execution finished on all members.

The failure is clearly a test failure, prod code doesn't need changes (have double checked with the original author). The fix consists of running the tests on a single member, because even in general, running the Python service on multiple LOCAL members is not a good idea. 
