### PR TITLE
Enhance Jet cleanup logic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
@@ -83,8 +83,7 @@ public class CreateProxyMessageTask extends AbstractInvocationMessageTask<Client
     @Override
     public Permission getRequiredPermission() {
         ProxyService proxyService = clientEngine.getProxyService();
-        Collection<String> distributedObjectNames = proxyService.getDistributedObjectNames(parameters.serviceName);
-        if (distributedObjectNames.contains(parameters.name)) {
+        if (proxyService.existsDistributedObject(parameters.serviceName, parameters.name)) {
             return null;
         }
         return ActionConstants.getPermission(parameters.name, parameters.serviceName, ActionConstants.ACTION_CREATE);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.impl.operation.GetJobIdsOperation;
 import com.hazelcast.jet.impl.operation.GetJobIdsOperation.GetJobIdsResult;
-import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -143,7 +142,7 @@ public class JetInstanceImpl extends AbstractJetInstance<Address> {
      */
     @Override
     public boolean existsDistributedObject(@Nonnull String serviceName, @Nonnull String objectName) {
-        return ImdgUtil.existsDistributedObject(nodeEngine, serviceName, objectName);
+        return nodeEngine.getProxyService().existsDistributedObject(serviceName, objectName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -483,6 +483,7 @@ public class JobRepository {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void cleanupJobResults(NodeEngine nodeEngine) {
         int maxNoResults = Math.max(1, nodeEngine.getProperties().getInteger(JetProperties.JOB_RESULTS_MAX_SIZE));
         // delete oldest job results
@@ -493,8 +494,8 @@ public class JobRepository {
                     .map(JobResult::getJobId)
                     .collect(toSet());
 
-            jobMetrics.get().submitToKeys(jobIds, ENTRY_REMOVING_PROCESSOR);
-            jobResults.get().submitToKeys(jobIds, ENTRY_REMOVING_PROCESSOR);
+            jobMetrics.get().submitToKeys(jobIds, (EntryProcessor) ENTRY_REMOVING_PROCESSOR);
+            jobResults.get().submitToKeys(jobIds, (EntryProcessor) ENTRY_REMOVING_PROCESSOR);
 
             jobIds.forEach(jobId -> {
                 String resourcesMapName = jobResourcesMapName(jobId);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetExistsDistributedObjectMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetExistsDistributedObjectMessageTask.java
@@ -20,8 +20,8 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetExistsDistributedObjectCodec;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.proxyservice.InternalProxyService;
 
 public class JetExistsDistributedObjectMessageTask
         extends AbstractJetMessageTask<JetExistsDistributedObjectCodec.RequestParameters, Boolean> {
@@ -34,7 +34,8 @@ public class JetExistsDistributedObjectMessageTask
 
     @Override
     protected void processMessage() {
-        sendResponse(ImdgUtil.existsDistributedObject(nodeEngine, parameters.serviceName, parameters.objectName));
+        InternalProxyService proxyService = nodeEngine.getProxyService();
+        sendResponse(proxyService.existsDistributedObject(parameters.serviceName, parameters.objectName));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
@@ -57,12 +57,6 @@ public final class ImdgUtil {
     private ImdgUtil() {
     }
 
-    public static boolean existsDistributedObject(NodeEngine nodeEngine, String serviceName, String objectName) {
-        return nodeEngine.getProxyService()
-                         .getDistributedObjectNames(serviceName)
-                         .contains(objectName);
-    }
-
     public static <K, V> EntryProcessor<K, V, V> entryProcessor(
             BiFunctionEx<? super K, ? super V, ? extends V> remappingFunction
     ) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/ProxyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/ProxyService.java
@@ -45,6 +45,8 @@ public interface ProxyService extends CoreService {
 
     Collection<DistributedObject> getAllDistributedObjects();
 
+    boolean existsDistributedObject(String serviceName, String objectId);
+
     /**
      * Returns the total number of created proxies for the given {@code serviceName},
      * even if some have already been destroyed.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -115,6 +115,10 @@ public final class ProxyRegistry {
         return proxies.keySet();
     }
 
+    public boolean existsDistributedObject(String name) {
+        return proxies.containsKey(name);
+    }
+
     /**
      * Gets the ProxyInfo of all fully initialized proxies in this registry.
      * The result is written into 'result'.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -293,10 +293,10 @@ public class ProxyServiceImpl
     }
 
     private static void checkServiceNameNotNull(@Nonnull String serviceName) {
-        checkNotNull(serviceName, "Service name is required!");
+        checkNotNull(serviceName, "Service name is required");
     }
 
     private static void checkObjectNameNotNull(@Nonnull String name) {
-        checkNotNull(name, "Object name is required!");
+        checkNotNull(name, "Object name is required");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -217,6 +217,17 @@ public class ProxyServiceImpl
     }
 
     @Override
+    public boolean existsDistributedObject(String serviceName, String objectId) {
+        checkServiceNameNotNull(serviceName);
+
+        ProxyRegistry registry = registries.get(serviceName);
+        if (registry == null) {
+            return false;
+        }
+        return registry.existsDistributedObject(objectId);
+    }
+
+    @Override
     public Collection<DistributedObject> getAllDistributedObjects() {
         Collection<DistributedObject> result = new LinkedList<>();
         for (ProxyRegistry registry : registries.values()) {
@@ -281,13 +292,11 @@ public class ProxyServiceImpl
         listeners.clear();
     }
 
-    private static @Nonnull
-    String checkServiceNameNotNull(@Nonnull String serviceName) {
-        return checkNotNull(serviceName, "Service name is required!");
+    private static void checkServiceNameNotNull(@Nonnull String serviceName) {
+        checkNotNull(serviceName, "Service name is required!");
     }
 
-    private static @Nonnull
-    String checkObjectNameNotNull(@Nonnull String name) {
-        return checkNotNull(name, "Object name is required!");
+    private static void checkObjectNameNotNull(@Nonnull String name) {
+        checkNotNull(name, "Object name is required!");
     }
 }


### PR DESCRIPTION
In the cleanup logic, if a job completes between cleanup-resources and
cleanup-job-results phase, it is possible that the result is removed
before the resources which leads to a 2 hours delay to destroying the
resources map.

With the changes, we are destroying the resources map when removing the
job-result.

We've introduced a `existsDistributedObject` method to ProxyService to
check if a distributed object exists without creating a lot of litter.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
