### PR TITLE
Don't blacklist if forcibly closed by remote host

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -34,6 +34,7 @@ import com.hazelcast.internal.util.executor.StripedRunnable;
 import com.hazelcast.logging.ILogger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -63,7 +64,6 @@ import static java.util.Collections.newSetFromMap;
 abstract class TcpServerConnectionManagerBase implements ServerConnectionManager {
     private static final int RETRY_NUMBER = 5;
     private static final long DELAY_FACTOR = 100L;
-    private static final String FORCIBLY_CLOSED = "An existing connection was forcibly closed by the remote host";
 
     @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_OPENED_COUNT)
     protected final MwCounter openedCount = newMwCounter();
@@ -290,7 +290,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
             long lastReadTime = connection.getChannel().lastReadTimeMillis();
             boolean hadNoDataTraffic = lastReadTime < 0;
             if (hadNoDataTraffic) {
-                if (!(cause.getMessage().equals(FORCIBLY_CLOSED))) {
+                if (!(cause instanceof IOException)) {
                     serverContext.onFailedConnection(remoteAddress);
                 }
                 if (!silent && plane != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -244,6 +244,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
         }
     }
 
+    @SuppressWarnings("checkstyle:npathcomplexity")
     private final class ConnectionLifecycleListenerImpl implements ConnectionLifecycleListener<TcpServerConnection> {
         @Override
         public void onConnectionClose(TcpServerConnection connection, Throwable cause, boolean silent) {


### PR DESCRIPTION
This issue is caused by https://github.com/hazelcast/hazelcast/pull/18673.

- Before this PR `TcpServerContext#TcpServerContext` is only called when cause is not null. 
- This makes it so that remote(7000) isn't blacklisted when forcibly shutdown. 
- Since it(7000) isn't blacklisted, member(8000) can't join cluster in `TcpIpJoiner#joinViaPossibleMembers`.
- Then in `Node#join` `shutdownNodeByFiringEvents` is called and node is shutdown.
- Lastly `HazelcastInstanceImpl` constructor throws, `IllegalStateException` if node is not running.

After given PR, remote(7000) is blacklisted, member(8000) makes itself new another master because all possible addresses are blaclisted in `TcpIpJoiner#joinViaPossibleMembers`.

This PR fixes this issue by blacklisting only if remote isn't forcibly closing the connection.

Fixes #18753

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
