### PR TITLE
[HZ-432] Change security defaults in the Hazelcast JAR

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/SqlOrderByTest.java
@@ -182,6 +182,7 @@ public class SqlOrderByTest extends SqlTestSupport {
 
     protected Config memberConfig() {
         Config config = new Config().setSerializationConfig(serializationConfig());
+        config.getJetConfig().setEnabled(true);
 
         config
                 .addMapConfig(new MapConfig(MAP_OBJECT).setInMemoryFormat(InMemoryFormat.OBJECT))

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JetConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JetConfig.java
@@ -29,7 +29,7 @@ public class JetConfig {
 
     private InstanceConfig instanceConfig = new InstanceConfig();
     private EdgeConfig defaultEdgeConfig = new EdgeConfig();
-    private boolean enabled = true;
+    private boolean enabled;
     private boolean resourceUploadEnabled;
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastBootstrapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/HazelcastBootstrapTest.java
@@ -25,9 +25,11 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,6 +41,9 @@ import java.util.List;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class HazelcastBootstrapTest {
+
+    @ClassRule
+    public static OverridePropertyRule enableJetRule = OverridePropertyRule.set("hz.jet.enabled", "true");
 
     @AfterClass
     public static void teardown() throws NoSuchFieldException, IllegalAccessException {

--- a/hazelcast/src/test/java/com/hazelcast/jet/JetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/JetTest.java
@@ -20,11 +20,11 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.config.JobConfig;
-import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class JetTest extends JetTestSupport {
+public class JetTest extends HazelcastTestSupport {
 
     @Test
     public void when_defaultMapConfig_then_notUsed() {

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JetConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JetConfigTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.config;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -26,6 +27,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -54,5 +56,11 @@ public class JetConfigTest {
 
         // Then
         assertEquals(edgeConfig, config.getDefaultEdgeConfig());
+    }
+
+    @Test
+    public void testJetIsDisabledByDefault() {
+        assertFalse(new JetConfig().isEnabled());
+        assertFalse(new Config().getJetConfig().isEnabled());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
@@ -108,7 +108,7 @@ public class JobConfigTest extends JetTestSupport {
     public void when_losslessRestartEnabled_then_openSourceMemberDoesNotStart() {
         // When
         Config config = new Config();
-        config.getJetConfig().getInstanceConfig().setLosslessRestartEnabled(true);
+        config.getJetConfig().setEnabled(true).getInstanceConfig().setLosslessRestartEnabled(true);
 
         // Then
         exception.expect(IllegalStateException.class);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -38,6 +38,8 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.rules.Timeout;
@@ -68,6 +70,9 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
      */
     @ClassRule
     public static Timeout globalTimeout = Timeout.seconds(15 * 60);
+
+    @ClassRule
+    public static OverridePropertyRule enableJetRule = OverridePropertyRule.set("hz.jet.enabled", "true");
 
     private static final ILogger SUPPORT_LOGGER = Logger.getLogger(JetTestSupport.class);
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
@@ -63,7 +63,7 @@ public class SnapshotFailureTest extends JetTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
 
         // force snapshots to fail by adding a failing map store configuration for snapshot data maps
         MapConfig mapConfig = new MapConfig(JobRepository.SNAPSHOT_DATA_MAP_PREFIX + '*');

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -69,6 +69,7 @@ public class JobRepositoryTest extends JetTestSupport {
     public void setup() {
         Config config = new Config();
         config.setProperty(JOB_RESULTS_MAX_SIZE.getName(), Integer.toString(MAX_JOB_RESULTS_COUNT));
+        config.getJetConfig().setEnabled(true);
 
         instance = createHazelcastInstance(config);
         jobRepository = new JobRepository(instance);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeployment_StandaloneClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeployment_StandaloneClusterTest.java
@@ -51,6 +51,7 @@ public class ClientDeployment_StandaloneClusterTest extends JetTestSupport {
                        .addClass(personClz);
 
         Config config = new Config();
+        config.getJetConfig().setEnabled(true);
         config.getUserCodeDeploymentConfig().setEnabled(true);
 
         HazelcastInstance instance = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
@@ -48,7 +48,7 @@ public class DetermineLocalParallelismTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void before() {
         Config config = new Config();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(DEFAULT_PARALLELISM);
+        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(DEFAULT_PARALLELISM);
         initialize(1, config);
         nodeEngine = getNode(instance()).getNodeEngine();
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
@@ -87,6 +87,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
               .getMapStoreConfig()
               .setEnabled(true)
               .setImplementation(new AlwaysFailingMapStore());
+        config.getJetConfig().setEnabled(true);
 
         HazelcastInstance instance = createHazelcastInstance(config);
         nodeEngine = Util.getNodeEngine(instance);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
@@ -44,6 +44,7 @@ public class ImdgUtilTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void setupCluster() {
         Config config = new Config();
+        config.getJetConfig().setEnabled(true);
         config.getMapConfig(NEAR_CACHED_SERIALIZED_MAP).setNearCacheConfig(
                 new NearCacheConfig().setInMemoryFormat(InMemoryFormat.BINARY)
         );

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.pipeline.test.Assertions;
 import com.hazelcast.jet.pipeline.test.ParallelBatchP;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
@@ -70,6 +70,7 @@ public abstract class StreamSourceStageTestBase extends JetTestSupport {
         Config config = new Config();
         config.getMapConfig("*")
               .getEventJournalConfig().setEnabled(true);
+        config.getJetConfig().setEnabled(true);
         // use 1 partition for the map journal to have an item in each ption
         config.setProperty(PARTITION_COUNT.getName(), "1");
         instance = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/SqlTestSupport.java
@@ -45,6 +45,7 @@ import com.hazelcast.sql.impl.state.QueryStateCallback;
 import com.hazelcast.sql.impl.worker.QueryFragmentContext;
 import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +56,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
+import org.junit.ClassRule;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -64,6 +67,10 @@ import static org.junit.Assert.assertTrue;
  * Helper test classes.
  */
 public class SqlTestSupport extends HazelcastTestSupport {
+
+    @ClassRule
+    public static OverridePropertyRule enableJetRule = OverridePropertyRule.set("hz.jet.enabled", "true");
+
     /**
      * Check object equality with additional hash code check.
      *

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -194,7 +194,7 @@ public abstract class HazelcastTestSupport {
                 .setProperty(ClusterProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.EVENT_THREAD_COUNT.getName(), "1");
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(2);
+        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(2);
 
         config.getSqlConfig().setExecutorPoolSize(2);
 
@@ -202,7 +202,9 @@ public abstract class HazelcastTestSupport {
     }
 
     public static Config regularInstanceConfig() {
-        return new Config();
+        Config config = new Config();
+        config.getJetConfig().setEnabled(true);
+        return config;
     }
 
     // disables auto-detection/tcp-ip network discovery on the given config and returns the same

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -438,6 +438,7 @@ public class TestHazelcastInstanceFactory {
     public static Config initOrCreateConfig(Config config) {
         if (config == null) {
             config = new XmlConfigBuilder().build();
+            config.getJetConfig().setEnabled(true);
         }
         config.setProperty(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
         String gracefulShutdownMaxWaitValue = System.getProperty(ClusterProperty.GRACEFUL_SHUTDOWN_MAX_WAIT.getName(), "120");


### PR DESCRIPTION
This PR sets Jet service disabled in the default JAR configuration.
It resolves the first part of the [HZ-432](https://hazelcast.atlassian.net/browse/HZ-432).
