### PR TITLE
Remove the concept of tombstones from ReplicatedMap Record

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -441,7 +441,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         }
 
         private boolean testEntry(Map.Entry<K, ReplicatedRecord<K, V>> entry) {
-            return entry.getKey() != null && entry.getValue() != null && !entry.getValue().isTombstone();
+            return entry.getKey() != null && entry.getValue() != null;
         }
 
         private Map.Entry<K, ReplicatedRecord<K, V>> findNextEntry() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
@@ -91,7 +91,7 @@ class EntrySetIteratorFactory<K, V> implements IteratorFactory<K, V, Map.Entry<K
         }
 
         private boolean testEntry(Map.Entry<K, ReplicatedRecord<K, V>> entry) {
-            return entry.getKey() != null && entry.getValue() != null && !entry.getValue().isTombstone();
+            return entry.getKey() != null && entry.getValue() != null;
         }
 
         private Map.Entry<K, ReplicatedRecord<K, V>> findNextEntry() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/InternalReplicatedMapStorage.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/InternalReplicatedMapStorage.java
@@ -98,14 +98,7 @@ public class InternalReplicatedMapStorage<K, V> {
     }
 
     public int size() {
-        int count = 0;
-        for (ReplicatedRecord<K, V> record : storage.values()) {
-            if (record.isTombstone()) {
-                continue;
-            }
-            count++;
-        }
-        return count;
+        return storage.size();
     }
 
     public boolean isStale(long version) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -86,7 +86,7 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
         }
 
         private boolean testEntry(Map.Entry<K, ReplicatedRecord<K, V>> entry) {
-            return entry.getKey() != null && entry.getValue() != null && !entry.getValue().isTombstone();
+            return entry.getKey() != null && entry.getValue() != null;
         }
 
         private Map.Entry<K, ReplicatedRecord<K, V>> findNextEntry() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -45,6 +45,8 @@ public class ReplicatedRecord<K, V> {
     private volatile long creationTime = Clock.currentTimeMillis();
 
     public ReplicatedRecord(K key, V value, long ttlMillis) {
+        assert key != null;
+        assert value != null;
         this.key = key;
         this.value = value;
         this.ttlMillis = ttlMillis;
@@ -68,10 +70,6 @@ public class ReplicatedRecord<K, V> {
         return value;
     }
 
-    public boolean isTombstone() {
-        return value == null;
-    }
-
     public long getTtlMillis() {
         return ttlMillis;
     }
@@ -82,6 +80,7 @@ public class ReplicatedRecord<K, V> {
     }
 
     public V setValueInternal(V value, long ttlMillis) {
+        assert value != null;
         V oldValue = this.value;
         this.value = value;
         this.updateTime = Clock.currentTimeMillis();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
@@ -87,7 +87,7 @@ class ValuesIteratorFactory<K, V> implements IteratorFactory<K, V, V> {
         }
 
         private boolean testEntry(Map.Entry<K, ReplicatedRecord<K, V>> entry) {
-            return entry.getKey() != null && entry.getValue() != null && !entry.getValue().isTombstone();
+            return entry.getKey() != null && entry.getValue() != null;
         }
 
         private Map.Entry<K, ReplicatedRecord<K, V>> findNextEntry() {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastMillis;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -43,8 +42,6 @@ public class ReplicatedRecordTest {
     private ReplicatedRecord<String, String> replicatedRecordOtherValue;
     private ReplicatedRecord<String, String> replicatedRecordOtherTtl;
 
-    private ReplicatedRecord<String, String> tombStone;
-
     @Before
     public void setUp() {
         replicatedRecord = new ReplicatedRecord<String, String>("key", "value", 0);
@@ -53,8 +50,6 @@ public class ReplicatedRecordTest {
         replicatedRecordOtherKey = new ReplicatedRecord<String, String>("otherKey", "value", 0);
         replicatedRecordOtherValue = new ReplicatedRecord<String, String>("key", "otherValue", 0);
         replicatedRecordOtherTtl = new ReplicatedRecord<String, String>("key", "value", 1);
-
-        tombStone = new ReplicatedRecord<String, String>("key", null, 0);
     }
 
     @Test
@@ -83,12 +78,6 @@ public class ReplicatedRecordTest {
         assertEquals(0, replicatedRecord.getHits());
         assertEquals("value", replicatedRecord.getValueInternal());
         assertEquals(0, replicatedRecord.getHits());
-    }
-
-    @Test
-    public void testGetTombStone() {
-        assertFalse(replicatedRecord.isTombstone());
-        assertTrue(tombStone.isTombstone());
     }
 
     @Test


### PR DESCRIPTION
Reasoning:
Tombstones are a left-over from the old (before-2015) implementation of ReplicatedMap.
The old implementation supported updates on an arbitrary member and used VectorClock
to detect conflicts. Tombstones were needed because a plain entry removal would lose
the VectorClock state.

The current implementation does NOT use VectorClock at all. It routes all updates via
a partition owner which acts as a serialization point.

This is the PR introducing the current implementation: https://github.com/hazelcast/hazelcast/pull/6176

Given tombstones are never used we can also simplify the `repmap.size()` method - it no longer
has to check each record for being a tombstone or not. This improves time complexity of the `size()`
method from `O(n)` to `O(1)` where `n` is a size of a replicated map.

I removed the tests, which created replicated map records with a null
value. The old implemenation used this to indicate a record is a
tombstone, but this state is not possible in the current implementation.
Other tests are passing.

I'm not entirely sure about a backport. It sounds safe to me, but I'm interested what
reviewers think about it. 

Zendesk issue - https://hazelcast.zendesk.com/agent/tickets/7609