### PR TITLE
MC-647 sending phonehome data in POST request body instead of GET query params

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -33,7 +33,7 @@ import static java.lang.Math.min;
  */
 class BuildInfoCollector implements MetricsCollector {
 
-    static final int CLASSPATH_MAX_LENGTH = 10_000;
+    static final int CLASSPATH_MAX_LENGTH = 100_000;
 
     @Override
     public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -20,6 +20,11 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.ClusterProperty;
 
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +33,9 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.internal.util.phonehome.MetricsCollector.RESPONSE_OK;
+import static com.hazelcast.internal.util.phonehome.MetricsCollector.TIMEOUT;
 import static java.lang.System.getenv;
 
 /**
@@ -81,6 +89,37 @@ public class PhoneHome {
         }
     }
 
+    private void postPhoneHomeData(String requestBody) {
+        HttpURLConnection conn = null;
+        OutputStreamWriter writer = null;
+        try {
+            URL url = new URL(basePhoneHomeUrl);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(TIMEOUT);
+            conn.setReadTimeout(TIMEOUT);
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.connect();
+            writer = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
+            writer.write(requestBody);
+            writer.flush();
+            conn.getContent();
+        } catch (Exception ignored) {
+            ignore(ignored);
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    ignore(e);
+                }
+            }
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
     /**
      * Performs a phone request for {@code node} and returns the generated request
      * parameters. If {@code pretend} is {@code true}, only returns the parameters
@@ -92,8 +131,7 @@ public class PhoneHome {
     public Map<String, String> phoneHome(boolean pretend) {
         PhoneHomeParameterCreator parameterCreator = createParameters();
         if (!pretend) {
-            String urlStr = basePhoneHomeUrl + parameterCreator.build();
-            MetricsCollector.fetchWebService(urlStr);
+            postPhoneHomeData(parameterCreator.build());
         }
         return parameterCreator.getParameters();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeParameterCreator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeParameterCreator.java
@@ -34,7 +34,6 @@ public class PhoneHomeParameterCreator {
 
     public PhoneHomeParameterCreator() {
         builder = new StringBuilder();
-        builder.append("?");
     }
 
     Map<String, String> getParameters() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.internal.util.phonehome;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.ContainsPattern;
+import com.github.tomakehurst.wiremock.matching.ContentPattern;
 import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -43,6 +45,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 
@@ -66,6 +71,10 @@ import static org.mockito.Mockito.when;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
+
+    private static ContainsPattern containingParam(String paramName, String expectedValue) {
+        return new ContainsPattern(paramName + "=" + expectedValue);
+    }
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().jettyHeaderBufferSize(16384));
@@ -99,7 +108,7 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
     }
 
     public void stubUrls(String phoneHomeStatus, String awsStatus, String azureStatus, String gcpStatus) {
-        stubFor(get(urlPathEqualTo("/ping"))
+        stubFor(post(urlPathEqualTo("/ping"))
                 .willReturn(checkStatusConditional(phoneHomeStatus.equals("200"))));
         stubFor(get(urlPathEqualTo("/latest/meta-data"))
                 .willReturn(checkStatusConditional(awsStatus.equals("200"))));
@@ -131,17 +140,17 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
 
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("mpct", equalTo("2"))
-                .withQueryParam("mpbrct", equalTo("1"))
-                .withQueryParam("mpmsct", equalTo("1"))
-                .withQueryParam("mpaoqcct", equalTo("1"))
-                .withQueryParam("mpaoict", equalTo("1"))
-                .withQueryParam("mphect", equalTo("1"))
-                .withQueryParam("mpwact", equalTo("1"))
-                .withQueryParam("mpaocct", equalTo("1"))
-                .withQueryParam("mpevct", equalTo("1"))
-                .withQueryParam("mpnmct", equalTo("1")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("mpct", "2"))
+                .withRequestBody(containingParam("mpbrct", "1"))
+                .withRequestBody(containingParam("mpmsct", "1"))
+                .withRequestBody(containingParam("mpaoqcct", "1"))
+                .withRequestBody(containingParam("mpaoict", "1"))
+                .withRequestBody(containingParam("mphect", "1"))
+                .withRequestBody(containingParam("mpwact", "1"))
+                .withRequestBody(containingParam("mpaocct", "1"))
+                .withRequestBody(containingParam("mpevct", "1"))
+                .withRequestBody(containingParam("mpnmct", "1")));
     }
 
     @Test
@@ -160,18 +169,18 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
 
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("mpct", equalTo("1"))
-                .withQueryParam("sect", equalTo("1"))
-                .withQueryParam("quct", equalTo("1"))
-                .withQueryParam("mmct", equalTo("1"))
-                .withQueryParam("lict", equalTo("1"))
-                .withQueryParam("rbct", equalTo("1"))
-                .withQueryParam("tpct", equalTo("1"))
-                .withQueryParam("rpct", equalTo("1"))
-                .withQueryParam("cect", equalTo("1"))
-                .withQueryParam("pncct", equalTo("1"))
-                .withQueryParam("figct", equalTo("1")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("mpct", "1"))
+                .withRequestBody(containingParam("sect", "1"))
+                .withRequestBody(containingParam("quct", "1"))
+                .withRequestBody(containingParam("mmct", "1"))
+                .withRequestBody(containingParam("lict", "1"))
+                .withRequestBody(containingParam("rbct", "1"))
+                .withRequestBody(containingParam("tpct", "1"))
+                .withRequestBody(containingParam("rpct", "1"))
+                .withRequestBody(containingParam("cect", "1"))
+                .withRequestBody(containingParam("pncct", "1"))
+                .withRequestBody(containingParam("figct", "1")));
     }
 
     @Test
@@ -186,9 +195,9 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
 
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("cact", equalTo("1"))
-                .withQueryParam("cawact", equalTo("1")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("cact", "1"))
+                .withRequestBody(containingParam("cawact", "1")));
     }
 
     @Test
@@ -209,9 +218,9 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
 
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("mpptlams", equalTo(String.valueOf(totalPutLatency / totalPutOperationCount)))
-                .withQueryParam("mpgtlams", equalTo(String.valueOf(totalGetLatency / totalGetOperationCount))));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("mpptlams", String.valueOf(totalPutLatency / totalPutOperationCount)))
+                .withRequestBody(containingParam("mpgtlams", String.valueOf(totalGetLatency / totalGetOperationCount))));
 
         assertGreaterOrEquals("mpptlams", totalPutLatency / totalPutOperationCount, 200);
         assertGreaterOrEquals("mpgtlams", totalGetLatency / totalGetOperationCount, 200);
@@ -230,9 +239,9 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         localMapStats2.incrementGetLatencyNanos(1000000000L);
 
         phoneHome.phoneHome(false);
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("mpptla", equalTo("1666"))
-                .withQueryParam("mpgtla", equalTo("1000")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("mpptla", "1666"))
+                .withRequestBody(containingParam("mpgtla", "1000")));
     }
 
     @Test
@@ -240,8 +249,8 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         stubUrls("200", "200", "4XX", "4XX");
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("cld", equalTo("A")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("cld", "A")));
     }
 
     @Test
@@ -249,8 +258,8 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         stubUrls("200", "4XX", "200", "4XX");
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("cld", equalTo("Z")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("cld", "Z")));
     }
 
     @Test
@@ -258,15 +267,15 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         stubUrls("200", "4XX", "4XX", "200");
         phoneHome.phoneHome(false);
 
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("cld", equalTo("G")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("cld", "G")));
     }
 
     @Test
     public void testDockerStateIfKuberNetes() {
         phoneHome.phoneHome(false);
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("dck", equalTo("K")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("dck", "K")));
     }
 
     @Test
@@ -274,8 +283,8 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
             throws IOException {
         when(kubernetesTokenPath.toRealPath()).thenThrow(new IOException());
         phoneHome.phoneHome(false);
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("dck", equalTo("D")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("dck", "D")));
     }
 
     @Test
@@ -283,8 +292,8 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
             throws IOException {
         when(dockerPath.toRealPath()).thenThrow(new IOException());
         phoneHome.phoneHome(false);
-        verify(1, getRequestedFor(urlPathEqualTo("/ping"))
-                .withQueryParam("dck", equalTo("N")));
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("dck", "N")));
     }
 
     @Test
@@ -294,7 +303,8 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         phoneHome.phoneHome(false);
         phoneHome.phoneHome(false);
 
-        verify(2, getRequestedFor(urlPathEqualTo("/ping")).withQueryParam("mpct", equalTo("1")));
+        verify(2, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("mpct", "1")));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeParameterCreatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeParameterCreatorTest.java
@@ -43,7 +43,7 @@ public class PhoneHomeParameterCreatorTest {
         phoneHomeParameterCreator.addParam("1", "hazelcast");
         phoneHomeParameterCreator.addParam("2", "phonehome");
         Map<String, String> map = phoneHomeParameterCreator.getParameters();
-        assertEquals("?1=hazelcast&2=phonehome", phoneHomeParameterCreator.build());
+        assertEquals("1=hazelcast&2=phonehome", phoneHomeParameterCreator.build());
         assertEquals(ImmutableMap.of("1", "hazelcast", "2", "phonehome"), map);
     }
 
@@ -52,7 +52,7 @@ public class PhoneHomeParameterCreatorTest {
         PhoneHomeParameterCreator phoneHomeParameterCreator = new PhoneHomeParameterCreator();
         Map<String, String> map = phoneHomeParameterCreator.getParameters();
         assertEquals(Collections.emptyMap(), map);
-        assertEquals(phoneHomeParameterCreator.build(), "?");
+        assertEquals(phoneHomeParameterCreator.build(), "");
     }
 
     @Test


### PR DESCRIPTION
Changing PhoneHome to send parameters in a POST request body instead of GET request with query parameters.
Also increasing maximum sent classpath from 10k characters to 100k.

Fixes MC-647


PhoneHome server side change: no change is needed: the controller already [accepts both POST and GET requests](https://github.com/hazelcast/phone-home/blob/master/src/main/kotlin/com/hazelcast/phonehome/controller/PhoneHomeController.kt#L47), and we use [HttpServletRequest#getParameter()](https://github.com/hazelcast/phone-home/blob/master/src/main/kotlin/com/hazelcast/phonehome/controller/PhoneHomeController.kt#L98) to read request params, which can read both query params and body params. Actually, the corresponding integration test [already uses body parameters](https://github.com/hazelcast/phone-home/blob/master/src/test/kotlin/com/hazelcast/phonehome/controller/PingPhoneHomeTest.kt#L132) instead of query parameters by accident.