### PR TITLE
Cancel jobs after cluster upgrade

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -240,7 +240,8 @@ public class JobCoordinationService {
                     serializedDag = serializedJobDefinition;
                 }
                 Set<String> ownedObservables = ownedObservables(dag);
-                JobRecord jobRecord = new JobRecord(jobId, serializedDag, dagToJson(dag), jobConfig, ownedObservables);
+                JobRecord jobRecord = new JobRecord(nodeEngine.getClusterService().getClusterVersion(), jobId, serializedDag,
+                        dagToJson(dag), jobConfig, ownedObservables);
                 JobExecutionRecord jobExecutionRecord = new JobExecutionRecord(jobId, quorumSize);
                 masterContext = createMasterContext(jobRecord, jobExecutionRecord);
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRecord.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.version.Version;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Set;
 
@@ -51,7 +52,7 @@ public class JobRecord implements IdentifiedDataSerializable {
     public JobRecord() {
     }
 
-    public JobRecord(Version clusterVersion, long jobId, Data dag, String dagJson, JobConfig config,
+    public JobRecord(@Nonnull Version clusterVersion, long jobId, Data dag, String dagJson, JobConfig config,
                      Set<String> ownedObservables) {
         this.clusterVersion = clusterVersion;
         this.jobId = jobId;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRecord.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Set;
@@ -38,6 +39,7 @@ import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
  */
 public class JobRecord implements IdentifiedDataSerializable {
 
+    private Version clusterVersion;
     private long jobId;
     private long creationTime;
     private Data dag;
@@ -49,13 +51,19 @@ public class JobRecord implements IdentifiedDataSerializable {
     public JobRecord() {
     }
 
-    public JobRecord(long jobId, Data dag, String dagJson, JobConfig config, Set<String> ownedObservables) {
+    public JobRecord(Version clusterVersion, long jobId, Data dag, String dagJson, JobConfig config,
+                     Set<String> ownedObservables) {
+        this.clusterVersion = clusterVersion;
         this.jobId = jobId;
         this.creationTime = Clock.currentTimeMillis();
         this.dag = dag;
         this.dagJson = dagJson;
         this.config = config;
         this.ownedObservables = ownedObservables;
+    }
+
+    public Version getClusterVersion() {
+        return clusterVersion;
     }
 
     public long getJobId() {
@@ -99,6 +107,7 @@ public class JobRecord implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(clusterVersion);
         out.writeLong(jobId);
         out.writeLong(creationTime);
         IOUtil.writeData(out, dag);
@@ -109,6 +118,7 @@ public class JobRecord implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+        clusterVersion = in.readObject();
         jobId = in.readLong();
         creationTime = in.readLong();
         dag = IOUtil.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -51,6 +51,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.version.Version;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -257,6 +258,13 @@ public class MasterJobContext {
             }
             if (scheduleRestartIfQuorumAbsent() || scheduleRestartIfClusterIsNotSafe()) {
                 return null;
+            }
+            Version jobClusterVersion = mc.jobRecord().getClusterVersion();
+            Version currentClusterVersion = mc.nodeEngine().getClusterService().getClusterVersion();
+            if (!jobClusterVersion.equals(currentClusterVersion)) {
+                throw new JetException("Cancelling job " + mc.jobName() + ": the cluster was upgraded since the job was "
+                        + "submitted. Submitted to version: " + jobClusterVersion + ", current cluster version: "
+                        + currentClusterVersion);
             }
             mc.setJobStatus(STARTING);
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -39,6 +39,7 @@ import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.version.Version;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -508,7 +509,7 @@ public class TopologyChangeTest extends JetTestSupport {
             memberInfos.add(new MemberInfo(getNode(instances[i]).getLocalMember()));
         }
 
-        JobRecord jobRecord = new JobRecord(null, jobId, null, "", new JobConfig(), Collections.emptySet());
+        JobRecord jobRecord = new JobRecord(Version.of(2, 4), jobId, null, "", new JobConfig(), Collections.emptySet());
         instances[0].getMap(JOB_RECORDS_MAP_NAME).put(jobId, jobRecord);
 
         InitExecutionOperation op = new InitExecutionOperation(jobId, executionId, memberListVersion, memberInfos, null, false);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -508,7 +508,7 @@ public class TopologyChangeTest extends JetTestSupport {
             memberInfos.add(new MemberInfo(getNode(instances[i]).getLocalMember()));
         }
 
-        JobRecord jobRecord = new JobRecord(jobId, null, "", new JobConfig(), Collections.emptySet());
+        JobRecord jobRecord = new JobRecord(null, jobId, null, "", new JobConfig(), Collections.emptySet());
         instances[0].getMap(JOB_RECORDS_MAP_NAME).put(jobId, jobRecord);
 
         InitExecutionOperation op = new InitExecutionOperation(jobId, executionId, memberListVersion, memberInfos, null, false);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -222,7 +223,7 @@ public class JobRepositoryTest extends JetTestSupport {
     }
 
     private JobRecord createJobRecord(long jobId, Data dag) {
-        return new JobRecord(jobId, dag, "", jobConfig, Collections.emptySet());
+        return new JobRecord(Version.of(2, 4), jobId, dag, "", jobConfig, Collections.emptySet());
     }
 
     private void sleepUntilJobExpires() {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.impl.JobRecord;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -71,7 +72,7 @@ public class JetInitDataSerializerHookTest {
         return asList(
                 new Object[]{
                         "JobRecord",
-                        new JobRecord(1, new HeapData(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9}),
+                        new JobRecord(Version.of(2, 4), 1, new HeapData(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9}),
                                 "dagJson", new JobConfig(), Collections.emptySet()),
                         singleton("config")},
 


### PR DESCRIPTION
If a job is submitted to a cluster of version V and the cluster is upgraded to V+1, the job should be cancelled because Jet doesn't provide backwards compatibility.