### PR TITLE
[HZ-264 HZ-265 HZ-188 HZ-204] Enhancements/5.0/persistence

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -71,6 +71,7 @@ import static com.hazelcast.internal.cluster.impl.MemberMap.SINGLETON_MEMBER_LIS
 import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.CANNOT_MERGE;
 import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE;
 import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
+import static com.hazelcast.internal.hotrestart.InternalHotRestartService.PERSISTENCE_ENABLED_ATTRIBUTE;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -115,7 +116,6 @@ public class ClusterJoinManager {
     private final long maxWaitMillisBeforeJoin;
     private final long waitMillisBeforeJoin;
     private final long staleJoinPreventionDuration;
-    private final boolean isPersistenceEnabled;
 
     private long firstJoinRequest;
     private long timeToStartJoin;
@@ -134,7 +134,6 @@ public class ClusterJoinManager {
         maxWaitMillisBeforeJoin = node.getProperties().getMillis(ClusterProperty.MAX_WAIT_SECONDS_BEFORE_JOIN);
         waitMillisBeforeJoin = node.getProperties().getMillis(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN);
         staleJoinPreventionDuration = TimeUnit.SECONDS.toMillis(STALE_JOIN_PREVENTION_DURATION_SECONDS);
-        isPersistenceEnabled = node.getConfig().getHotRestartPersistenceConfig().isEnabled();
     }
 
     boolean isJoinInProgress() {
@@ -706,8 +705,8 @@ public class ClusterJoinManager {
     }
 
     private boolean isMemberRestartingWithPersistence(Member member) {
-        return member.getAttributes().get("hot-restart") != null
-                && member.getAttributes().get("hot-restart").equals("true")
+        return member.getAttributes().get(PERSISTENCE_ENABLED_ATTRIBUTE) != null
+                && member.getAttributes().get(PERSISTENCE_ENABLED_ATTRIBUTE).equals("true")
                 // may be already detected as crashed member or probably it is still in member list because
                 // connection timeout hasn't been reached yet
                 && (hasMemberLeft(member.getUuid())
@@ -715,8 +714,8 @@ public class ClusterJoinManager {
     }
 
     private boolean isMemberRestartingWithPersistence(MemberInfo member) {
-        return member.getAttributes().get("hot-restart") != null
-                && member.getAttributes().get("hot-restart").equals("true")
+        return member.getAttributes().get(PERSISTENCE_ENABLED_ATTRIBUTE) != null
+                && member.getAttributes().get(PERSISTENCE_ENABLED_ATTRIBUTE).equals("true")
                 // may be already detected as crashed member or probably it is still in member list because
                 // connection timeout hasn't been reached yet
                 && (hasMemberLeft(member.getUuid())
@@ -1015,5 +1014,9 @@ public class ClusterJoinManager {
 
     public boolean hasMemberLeft(UUID memberUuid) {
         return leftMembersUuids.containsKey(memberUuid);
+    }
+
+    public void removeLeftMember(UUID memberUuid) {
+        leftMembersUuids.remove(memberUuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -690,6 +690,7 @@ public class MembershipManager {
                 .addParameter("address", address)
                 .addParameter("reason", reason)
                 .log();
+            clusterService.getClusterJoinManager().addLeftMember(suspectedMember);
         }
 
         if (shouldCloseConn) {
@@ -724,6 +725,7 @@ public class MembershipManager {
 
             logger.info("Removing " + member);
             clusterService.getClusterJoinManager().removeJoin(address);
+            clusterService.getClusterJoinManager().addLeftMember(member);
             clusterService.getClusterHeartbeatManager().removeMember(member);
             partialDisconnectionHandler.removeMember(member);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -16,35 +16,38 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersView;
+import com.hazelcast.internal.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.services.PreJoinAwareService;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.OperationService;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.TargetAware;
-import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
 
+import static com.hazelcast.internal.cluster.Versions.V5_0;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createEmptyResponseHandler;
 
 /**
  * Sent by the master to all members to finalize the join operation from a joining/returning node.
  */
-public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
+public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware, Versioned {
     /**
      * Operations to be executed before node is marked as joined.
      * @see PreJoinAwareService
@@ -57,6 +60,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
     private long clusterStartTime;
     private ClusterState clusterState;
     private Version clusterVersion;
+    private boolean deferPartitionProcessing;
 
     private transient boolean finalized;
     private transient Exception deserializationFailure;
@@ -67,7 +71,8 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
     @SuppressWarnings("checkstyle:parameternumber")
     public FinalizeJoinOp(UUID targetUuid, MembersView members, OnJoinOp preJoinOp, OnJoinOp postJoinOp,
                           long masterTime, UUID clusterId, long clusterStartTime, ClusterState clusterState,
-                          Version clusterVersion, PartitionRuntimeState partitionRuntimeState) {
+                          Version clusterVersion, PartitionRuntimeState partitionRuntimeState,
+                          boolean deferPartitionProcessing) {
         super(targetUuid, members, masterTime, partitionRuntimeState, true);
         this.preJoinOp = preJoinOp;
         this.postJoinOp = postJoinOp;
@@ -75,6 +80,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         this.clusterStartTime = clusterStartTime;
         this.clusterState = clusterState;
         this.clusterVersion = clusterVersion;
+        this.deferPartitionProcessing = deferPartitionProcessing;
     }
 
     @Override
@@ -94,7 +100,16 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
             return;
         }
 
-        processPartitionState();
+        if (deferPartitionProcessing && getInternalHotRestartService().isEnabled() && partitionRuntimeState != null) {
+            partitionRuntimeState.setMaster(getCallerAddress());
+            getInternalHotRestartService().deferApplyPartitionState(partitionRuntimeState);
+        } else {
+            processPartitionState();
+        }
+    }
+
+    private InternalHotRestartService getInternalHotRestartService() {
+        return getNodeEngine().getService(InternalHotRestartService.SERVICE_NAME);
     }
 
     private void checkDeserializationFailure(ClusterServiceImpl clusterService) {
@@ -114,8 +129,14 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
             return;
         }
 
+        final boolean shouldExecutePostJoinOp = preparePostOp(postJoinOp);
+        if (deferPartitionProcessing) {
+            getInternalHotRestartService().deferPostJoinOps(postJoinOp);
+            return;
+        }
+
         sendPostJoinOperationsBackToMaster();
-        if (preparePostOp(postJoinOp)) {
+        if (shouldExecutePostJoinOp) {
             getNodeEngine().getOperationService().run(postJoinOp);
         }
     }
@@ -162,6 +183,9 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         out.writeObject(clusterVersion);
         out.writeObject(preJoinOp);
         out.writeObject(postJoinOp);
+        if (out.getVersion().isGreaterOrEqual(V5_0)) {
+            out.writeBoolean(deferPartitionProcessing);
+        }
     }
 
     @Override
@@ -174,6 +198,9 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         clusterVersion = in.readObject();
         preJoinOp = readOnJoinOp(in);
         postJoinOp = readOnJoinOp(in);
+        if (clusterVersion.isGreaterOrEqual(V5_0)) {
+            deferPartitionProcessing = in.readBoolean();
+        }
     }
 
     private OnJoinOp readOnJoinOp(ObjectDataInput in) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -42,12 +42,12 @@ import static java.util.Collections.unmodifiableList;
 public class MembersUpdateOp extends AbstractClusterOperation {
     /** The master cluster clock time. */
     long masterTime = Clock.currentTimeMillis();
+    PartitionRuntimeState partitionRuntimeState;
     /** The updated member info collection. */
     private List<MemberInfo> memberInfos;
     /** The UUID of the receiving member. */
     private UUID targetUuid;
     private boolean returnResponse;
-    private PartitionRuntimeState partitionRuntimeState;
     private int memberListVersion;
 
     public MembersUpdateOp() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
@@ -127,6 +127,8 @@ public interface InternalHotRestartService {
      */
     void waitPartitionReplicaSyncOnCluster(long timeout, TimeUnit unit);
 
+    void setRejoiningActiveCluster(boolean rejoiningActiveCluster);
+
     /**
      * Apply given {@link PartitionRuntimeState} after recovery is successfully completed.
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
@@ -37,6 +37,13 @@ public interface InternalHotRestartService {
     String SERVICE_NAME = "hz:ee:internalHotRestartService";
 
     /**
+     * Key of internal member attribute for persistence.
+     * When the attribute is present and its value is {@code true},
+     * persistence is enabled.
+     */
+    String PERSISTENCE_ENABLED_ATTRIBUTE = "hazelcast.persistence.enabled";
+
+    /**
      * Returns whether hot-restart is enabled or not.
      */
     boolean isEnabled();

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
@@ -17,8 +17,10 @@
 package com.hazelcast.internal.hotrestart;
 
 import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.partition.PartitionRuntimeState;
 
 import java.util.Set;
 import java.util.UUID;
@@ -28,6 +30,11 @@ import java.util.concurrent.TimeUnit;
  * Internal service for interacting with hot restart related functionalities (e.g. force and partial start)
  */
 public interface InternalHotRestartService {
+
+    /**
+     * Name of the Hot Restart service.
+     */
+    String SERVICE_NAME = "hz:ee:internalHotRestartService";
 
     /**
      * Returns whether hot-restart is enabled or not.
@@ -112,4 +119,17 @@ public interface InternalHotRestartService {
      * @throws IllegalStateException when timeout happens or a member leaves the cluster while waiting
      */
     void waitPartitionReplicaSyncOnCluster(long timeout, TimeUnit unit);
+
+    /**
+     * Apply given {@link PartitionRuntimeState} after recovery is successfully completed.
+     *
+     * @param partitionRuntimeState
+     */
+    void deferApplyPartitionState(PartitionRuntimeState partitionRuntimeState);
+
+    /**
+     * Apply given {@link OnJoinOp} after recovery is successfully completed.
+     * @param postJoinOp
+     */
+    void deferPostJoinOps(OnJoinOp postJoinOp);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/NoopInternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/NoopInternalHotRestartService.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.internal.hotrestart;
 
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.partition.PartitionRuntimeState;
 
 import java.util.Collections;
 import java.util.Set;
@@ -78,5 +80,13 @@ public class NoopInternalHotRestartService implements InternalHotRestartService 
 
     @Override
     public void waitPartitionReplicaSyncOnCluster(long timeout, TimeUnit unit) {
+    }
+
+    @Override
+    public void deferApplyPartitionState(PartitionRuntimeState partitionRuntimeState) {
+    }
+
+    @Override
+    public void deferPostJoinOps(OnJoinOp postJoinOp) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/NoopInternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/NoopInternalHotRestartService.java
@@ -83,6 +83,10 @@ public class NoopInternalHotRestartService implements InternalHotRestartService 
     }
 
     @Override
+    public void setRejoiningActiveCluster(boolean rejoiningActiveCluster) {
+    }
+
+    @Override
     public void deferApplyPartitionState(PartitionRuntimeState partitionRuntimeState) {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -251,6 +251,12 @@ public final class MetricDescriptorConstants {
     public static final String MAP_METRIC_INDEX_REMOVE_COUNT = "removeCount";
     public static final String MAP_METRIC_INDEX_TOTAL_REMOVE_LATENCY = "totalRemoveLatency";
     public static final String MAP_METRIC_INDEX_MEMORY_COST = "memoryCost";
+    public static final String MAP_METRIC_FULL_PARTITION_REPLICATION_COUNT = "fullPartitionReplicationCount";
+    public static final String MAP_METRIC_DIFF_PARTITION_REPLICATION_COUNT = "differentialPartitionReplicationCount";
+    public static final String MAP_METRIC_FULL_PARTITION_REPLICATION_RECORDS_COUNT
+            = "fullPartitionReplicationRecordsCount";
+    public static final String MAP_METRIC_DIFF_PARTITION_REPLICATION_RECORDS_COUNT
+            = "differentialPartitionReplicationRecordsCount";
     // ===[/MAP]========================================================
 
     // ===[MEMORY]======================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStats.java
@@ -195,6 +195,26 @@ public class EmptyLocalReplicatedMapStats implements LocalReplicatedMapStats {
     }
 
     @Override
+    public long getDifferentialPartitionReplicationCount() {
+        return 0;
+    }
+
+    @Override
+    public long getFullPartitionReplicationCount() {
+        return 0;
+    }
+
+    @Override
+    public long getDifferentialReplicationRecordCount() {
+        return 0;
+    }
+
+    @Override
+    public long getFullReplicationRecordCount() {
+        return 0;
+    }
+
+    @Override
     public String toString() {
         return "LocalReplicatedMapStatsImpl{"
                 + "lastAccessTime=0"

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
@@ -32,7 +32,11 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRI
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_BACKUP_ENTRY_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_BACKUP_ENTRY_MEMORY_COST;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_CREATION_TIME;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_DIFF_PARTITION_REPLICATION_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_DIFF_PARTITION_REPLICATION_RECORDS_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_DIRTY_ENTRY_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_FULL_PARTITION_REPLICATION_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_FULL_PARTITION_REPLICATION_RECORDS_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_GET_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_HEAP_COST;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_HITS;
@@ -103,6 +107,14 @@ public class LocalMapStatsImpl implements LocalMapStats {
             newUpdater(LocalMapStatsImpl.class, "maxSetLatency");
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_REMOVE_LATENCY =
             newUpdater(LocalMapStatsImpl.class, "maxRemoveLatency");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> FULL_PARTITION_REPLICATION_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "fullPartitionReplicationCount");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> DIFF_PARTITION_REPLICATION_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "diffPartitionReplicationCount");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> FULL_PARTITION_REPLICATION_RECORDS_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "fullPartitionReplicationRecordsCount");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> DIFF_PARTITION_REPLICATION_RECORDS_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "diffPartitionReplicationRecordsCount");
 
     private final ConcurrentMap<String, LocalIndexStatsImpl> mutableIndexStats =
             new ConcurrentHashMap<>();
@@ -166,6 +178,15 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long queryCount;
     @Probe(name = MAP_METRIC_INDEXED_QUERY_COUNT)
     private volatile long indexedQueryCount;
+
+    @Probe(name = MAP_METRIC_FULL_PARTITION_REPLICATION_COUNT)
+    private volatile long fullPartitionReplicationCount;
+    @Probe(name = MAP_METRIC_DIFF_PARTITION_REPLICATION_COUNT)
+    private volatile long diffPartitionReplicationCount;
+    @Probe(name = MAP_METRIC_FULL_PARTITION_REPLICATION_RECORDS_COUNT)
+    private volatile long fullPartitionReplicationRecordsCount;
+    @Probe(name = MAP_METRIC_DIFF_PARTITION_REPLICATION_RECORDS_COUNT)
+    private volatile long diffPartitionReplicationRecordsCount;
 
     private final boolean ignoreMemoryCosts;
 
@@ -425,6 +446,26 @@ public class LocalMapStatsImpl implements LocalMapStats {
         return indexStats;
     }
 
+    @Override
+    public long getDifferentialReplicationRecordCount() {
+        return diffPartitionReplicationRecordsCount;
+    }
+
+    @Override
+    public long getFullReplicationRecordCount() {
+        return fullPartitionReplicationRecordsCount;
+    }
+
+    @Override
+    public long getDifferentialPartitionReplicationCount() {
+        return diffPartitionReplicationCount;
+    }
+
+    @Override
+    public long getFullPartitionReplicationCount() {
+        return fullPartitionReplicationCount;
+    }
+
     /**
      * Sets the per-index stats of this map stats to the given per-index stats.
      *
@@ -475,6 +516,16 @@ public class LocalMapStatsImpl implements LocalMapStats {
 
     public void incrementReceivedEvents() {
         NUMBER_OF_EVENTS.incrementAndGet(this);
+    }
+
+    public void incrementFullPartitionReplicationRecordsCount(long delta) {
+        FULL_PARTITION_REPLICATION_COUNT.incrementAndGet(this);
+        FULL_PARTITION_REPLICATION_RECORDS_COUNT.addAndGet(this, delta);
+    }
+
+    public void incrementDiffPartitionReplicationRecordsCount(long delta) {
+        DIFF_PARTITION_REPLICATION_COUNT.incrementAndGet(this);
+        DIFF_PARTITION_REPLICATION_RECORDS_COUNT.addAndGet(this, delta);
     }
 
     public void updateIndexStats(Map<String, OnDemandIndexStats> freshIndexStats) {
@@ -534,6 +585,10 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", queryCount=" + queryCount
                 + ", indexedQueryCount=" + indexedQueryCount
                 + ", indexStats=" + indexStats
+                + ", fullPartitionReplicationCount=" + fullPartitionReplicationCount
+                + ", fullPartitionReplicationRecordsCount=" + fullPartitionReplicationRecordsCount
+                + ", diffPartitionReplicationCount=" + diffPartitionReplicationCount
+                + ", diffPartitionReplicationRecordsCount=" + diffPartitionReplicationRecordsCount
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -364,6 +364,26 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     @Override
+    public long getDifferentialPartitionReplicationCount() {
+        return 0;
+    }
+
+    @Override
+    public long getFullPartitionReplicationCount() {
+        return 0;
+    }
+
+    @Override
+    public long getDifferentialReplicationRecordCount() {
+        return 0;
+    }
+
+    @Override
+    public long getFullReplicationRecordCount() {
+        return 0;
+    }
+
+    @Override
     public String toString() {
         return "LocalReplicatedMapStatsImpl{"
                 + "lastAccessTime=" + lastAccessTime

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -27,7 +27,9 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.services.GracefulShutdownAwareService;
 import com.hazelcast.internal.services.ManagedService;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.UUID;
 
 public interface InternalPartitionService extends IPartitionService, ManagedService, GracefulShutdownAwareService {
 
@@ -133,4 +135,7 @@ public interface InternalPartitionService extends IPartitionService, ManagedServ
     PartitionServiceProxy getPartitionServiceProxy();
 
     PartitionReplicaStateChecker getPartitionReplicaStateChecker();
+
+    @Nullable
+    PartitionTableView getLeftMemberSnapshot(UUID uuid);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/OffloadedReplicationPreparation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/OffloadedReplicationPreparation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition;
+
+import java.util.Collection;
+
+/**
+ * Interface for {@link FragmentedMigrationAwareService}
+ * implementations which may wish to offload execution of
+ * {@link FragmentedMigrationAwareService#prepareReplicationOperation(PartitionReplicationEvent, Collection)}
+ * method. The default execution model is to invoke this method
+ * on the partition thread. When this interface is implemented,
+ * {@link #shouldOffload()} method is consulted while preparing
+ * replication operations. If {@link #shouldOffload()} returns {@code true},
+ * then {@code prepareReplicationOperation} execution is offloaded
+ * to Hazelcast internal async executor instead of the partition
+ * thread. This can help avoid deadlocks when replication
+ * operation preparation requires network communication.
+ */
+public interface OffloadedReplicationPreparation {
+
+    /**
+     * @return  {@code true} to offload execution of {@code prepareReplicationOperation}
+     *          to Hazelcast internal async executor or {@code false} to execute on
+     *          partition thread.
+     */
+    default boolean shouldOffload() {
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplicationEvent.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.internal.partition;
 
+import com.hazelcast.cluster.Address;
+
+import javax.annotation.Nullable;
+
 /**
  * An event send to {@link MigrationAwareService} when partition changes happen.
  */
@@ -25,13 +29,17 @@ public class PartitionReplicationEvent {
 
     private final int replicaIndex;
 
+    @Nullable
+    private final Address target;
+
     /**
      * Creates a PartitionReplicationEvent
      *
      * @param partitionId  the partition ID
      * @param replicaIndex the replica index
      */
-    public PartitionReplicationEvent(int partitionId, int replicaIndex) {
+    public PartitionReplicationEvent(Address target, int partitionId, int replicaIndex) {
+        this.target = target;
         this.partitionId = partitionId;
         this.replicaIndex = replicaIndex;
     }
@@ -52,6 +60,10 @@ public class PartitionReplicationEvent {
      */
     public int getReplicaIndex() {
         return replicaIndex;
+    }
+
+    public Address getTarget() {
+        return target;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -64,7 +64,7 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
     // works only on primary. backups are retained
     // in PartitionBackupReplicaAntiEntropyTask
     final Collection<ServiceNamespace> retainAndGetNamespaces() {
-        PartitionReplicationEvent event = new PartitionReplicationEvent(partitionId, 0);
+        PartitionReplicationEvent event = new PartitionReplicationEvent(null, partitionId, 0);
         Collection<FragmentedMigrationAwareService> services
                 = nodeEngine.getServices(FragmentedMigrationAwareService.class);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -366,6 +366,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         }
     }
 
+    // react to member leaving unexpectedly -- members leaving with graceful shutdown
+    // have had their migrations already done before removal
     @Override
     public void memberRemoved(Member member) {
         logger.fine("Removing " + member);
@@ -387,6 +389,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                     assert !shouldFetchPartitionTables;
                     shouldFetchPartitionTables = true;
                 }
+                // keep partition table snapshot as member leaves
+                if (logger.isFineEnabled()) {
+                    logger.fine("Storing partition assignments snapshot for " + member + " from memberRemoved");
+                }
+                partitionStateManager.storeSnapshot(member.getUuid());
                 if (isMaster) {
                     migrationManager.triggerControlTask();
                 }
@@ -598,12 +605,17 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
      * @return {@code true} if the partition state was applied
      */
     public boolean processPartitionRuntimeState(PartitionRuntimeState partitionState) {
-        Address sender = partitionState.getMaster();
         if (!node.getNodeExtension().isStartCompleted()) {
-            logger.warning("Ignoring received partition table, startup is not completed yet. Sender: " + sender);
+            logger.warning("Ignoring received partition table, startup is not completed yet. Sender: "
+                    + partitionState.getMaster());
             return false;
         }
 
+        return applyPartitionRuntimeState(partitionState);
+    }
+
+    public boolean applyPartitionRuntimeState(PartitionRuntimeState partitionState) {
+        Address sender = partitionState.getMaster();
         if (!validateSenderIsMaster(sender, "partition table update")) {
             return false;
         }
@@ -1216,6 +1228,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         }
     }
 
+    public PartitionTableView getLeftMemberSnapshot(UUID uuid) {
+        return partitionStateManager.getSnapshot(uuid);
+    }
+
     /**
      * Returns true only if local member is the last known master by
      * {@code InternalPartitionServiceImpl}.
@@ -1305,7 +1321,6 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             lock.unlock();
         }
     }
-
 
     /**
      * Invoked on a node when it becomes master. It will receive partition states from all members and consolidate them into one.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -395,7 +395,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                 }
                 partitionStateManager.storeSnapshot(member.getUuid());
                 if (isMaster) {
-                    migrationManager.triggerControlTask();
+                    migrationManager.triggerControlTaskWithDelay();
                 }
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -106,7 +106,7 @@ import static com.hazelcast.internal.metrics.ProbeUnit.BOOLEAN;
 import static com.hazelcast.internal.partition.IPartitionService.SERVICE_NAME;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.spi.impl.executionservice.ExecutionService.ASYNC_EXECUTOR;
-import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_REBALANCE_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_REBALANCE_AFTER_MEMBER_LEFT_DELAY_SECONDS;
 
 /**
  * Maintains migration system state and manages migration operations performed within the cluster.
@@ -181,9 +181,9 @@ public class MigrationManager {
                 executionService, migrationPauseDelayMs, 2 * migrationPauseDelayMs, this::resumeMigration);
         this.memberHeartbeatTimeoutMillis = properties.getMillis(ClusterProperty.MAX_NO_HEARTBEAT_SECONDS);
         nodeEngine.getMetricsRegistry().registerStaticMetrics(stats, PARTITIONS_PREFIX);
-        this.autoRebalanceDelaySeconds = properties.getInteger(PARTITION_REBALANCE_DELAY_SECONDS);
+        this.autoRebalanceDelaySeconds = properties.getInteger(PARTITION_REBALANCE_AFTER_MEMBER_LEFT_DELAY_SECONDS);
         checkNotNegative(autoRebalanceDelaySeconds,
-                PARTITION_REBALANCE_DELAY_SECONDS.getName() + " must be not negative");
+                PARTITION_REBALANCE_AFTER_MEMBER_LEFT_DELAY_SECONDS.getName() + " must be not negative");
         this.asyncExecutor = node.getNodeEngine().getExecutionService().getExecutor(ASYNC_EXECUTOR);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -87,7 +87,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -102,6 +104,9 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MIGRATION
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_PREFIX;
 import static com.hazelcast.internal.metrics.ProbeUnit.BOOLEAN;
 import static com.hazelcast.internal.partition.IPartitionService.SERVICE_NAME;
+import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
+import static com.hazelcast.spi.impl.executionservice.ExecutionService.ASYNC_EXECUTOR;
+import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_REBALANCE_DELAY_SECONDS;
 
 /**
  * Maintains migration system state and manages migration operations performed within the cluster.
@@ -143,7 +148,17 @@ public class MigrationManager {
     private final int maxParallelMigrations;
     private final AtomicInteger migrationCount = new AtomicInteger();
     private final Set<MigrationInfo> finalizingMigrationsRegistry = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Executor asyncExecutor;
 
+    /**
+     * the positive number of seconds to delay triggering rebalancing
+     * or 0 when no delay should be applied
+     */
+    private final int autoRebalanceDelaySeconds;
+    private volatile boolean delayNextRepartitioningExecution;
+    private volatile ScheduledFuture<Void> scheduledControlTaskFuture;
+
+    @SuppressWarnings("checkstyle:executablestatementcount")
     MigrationManager(Node node, InternalPartitionServiceImpl service, Lock partitionServiceLock) {
         this.node = node;
         this.nodeEngine = node.getNodeEngine();
@@ -166,6 +181,10 @@ public class MigrationManager {
                 executionService, migrationPauseDelayMs, 2 * migrationPauseDelayMs, this::resumeMigration);
         this.memberHeartbeatTimeoutMillis = properties.getMillis(ClusterProperty.MAX_NO_HEARTBEAT_SECONDS);
         nodeEngine.getMetricsRegistry().registerStaticMetrics(stats, PARTITIONS_PREFIX);
+        this.autoRebalanceDelaySeconds = properties.getInteger(PARTITION_REBALANCE_DELAY_SECONDS);
+        checkNotNegative(autoRebalanceDelaySeconds,
+                PARTITION_REBALANCE_DELAY_SECONDS.getName() + " must be not negative");
+        this.asyncExecutor = node.getNodeEngine().getExecutionService().getExecutor(ASYNC_EXECUTOR);
     }
 
     @Probe(name = MIGRATION_METRIC_MIGRATION_MANAGER_MIGRATION_ACTIVE, unit = BOOLEAN)
@@ -448,7 +467,7 @@ public class MigrationManager {
      * was applied on the destination.
      */
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity", "checkstyle:methodlength"})
-    private CompletionStage<Boolean> commitMigrationToDestinationAsync(MigrationInfo migration) {
+    private CompletionStage<Boolean> commitMigrationToDestinationAsync(final MigrationInfo migration) {
         PartitionReplica destination = migration.getDestination();
 
         if (destination.isIdentical(node.getLocalMember())) {
@@ -477,7 +496,7 @@ public class MigrationManager {
                     .setTryCount(Integer.MAX_VALUE)
                     .setCallTimeout(memberHeartbeatTimeoutMillis).invoke();
 
-            return future.handle((done, t) -> {
+            return future.handleAsync((done, t) -> {
                 // Inspect commit result;
                 // - if there's an exception, either retry or fail
                 // - if result is true then success, otherwise failure
@@ -490,7 +509,7 @@ public class MigrationManager {
                     return COMMIT_FAILURE;
                 }
                 return done ? COMMIT_SUCCESS : COMMIT_FAILURE;
-            }).thenComposeAsync(result -> {
+            }, asyncExecutor).thenComposeAsync(result -> {
                 switch (result) {
                     case COMMIT_SUCCESS:
                         return CompletableFuture.completedFuture(true);
@@ -502,7 +521,7 @@ public class MigrationManager {
                     default:
                         throw new IllegalArgumentException("Unknown migration commit result: " + result);
                 }
-            }).handle((result, t) -> {
+            }, asyncExecutor).handleAsync((result, t) -> {
                 if (t != null) {
                     logMigrationCommitFailure(migration, t);
                     return false;
@@ -511,7 +530,7 @@ public class MigrationManager {
                     logger.fine("Migration commit result " + result + " from " + destination + " for " + migration);
                 }
                 return result;
-            });
+            }, asyncExecutor);
 
         } catch (Throwable t) {
             logMigrationCommitFailure(migration, t);
@@ -614,6 +633,13 @@ public class MigrationManager {
         }
     }
 
+    public void triggerControlTaskWithDelay() {
+        if (autoRebalanceDelaySeconds > 0) {
+            delayNextRepartitioningExecution = true;
+        }
+        triggerControlTask();
+    }
+
     MigrationInterceptor getMigrationInterceptor() {
         return migrationInterceptor;
     }
@@ -690,6 +716,13 @@ public class MigrationManager {
     }
 
     void reset() {
+        try {
+            if (scheduledControlTaskFuture != null) {
+                scheduledControlTaskFuture.cancel(true);
+            }
+        } catch (Throwable t) {
+            logger.fine("Cancelling a scheduled control task threw an exception", t);
+        }
         migrationQueue.clear();
         migrationCount.set(0);
         activeMigrations.clear();
@@ -792,7 +825,7 @@ public class MigrationManager {
                     logger.fine("Failure while publishing completed migrations to " + member, t);
                     partitionService.sendPartitionRuntimeState(member.getAddress());
                 }
-            });
+            }, asyncExecutor);
         }
     }
 
@@ -1133,7 +1166,7 @@ public class MigrationManager {
             waitOngoingMigrations();
 
             if (failed || aborted) {
-                logger.info("Rebalance process was " + (failed ? " failed" : "aborted")
+                logger.info("Rebalance process was " + (failed ? "failed" : "aborted")
                         + ". Ignoring remaining migrations. Will recalculate the new migration plan. ("
                         + stats.formatToString(logger.isFineEnabled()) + ")");
                 migrationCount.set(0);
@@ -1392,7 +1425,7 @@ public class MigrationManager {
                 future = InternalCompletableFuture.completedExceptionally(t);
             }
 
-            return future.handle((done, t) -> {
+            return future.handleAsync((done, t) -> {
                 stats.recordMigrationOperationTime(Timer.nanosElapsed(start));
                 logger.fine("Migration operation response received -> " + migration + ", success: " + done + ", failure: " + t);
 
@@ -1407,7 +1440,7 @@ public class MigrationManager {
                     return Boolean.FALSE;
                 }
                 return done;
-            }).thenComposeAsync(result -> {
+            }, asyncExecutor).thenComposeAsync(result -> {
                 if (result) {
                     if (logger.isFineEnabled()) {
                         logger.fine("Finished Migration: " + migration);
@@ -1421,7 +1454,7 @@ public class MigrationManager {
                     migrationOperationFailed(fromMember);
                     return CompletableFuture.completedFuture(false);
                 }
-            }).handle((result, t) -> {
+            }, asyncExecutor).handleAsync((result, t) -> {
                 long elapsed = Timer.nanosElapsed(start);
                 stats.recordMigrationTaskTime(elapsed);
 
@@ -1435,7 +1468,7 @@ public class MigrationManager {
                     return false;
                 }
                 return result;
-            });
+            }, asyncExecutor);
         }
 
         /**
@@ -1568,7 +1601,7 @@ public class MigrationManager {
                     partitionServiceLock.unlock();
                 }
                 return commitSuccessful;
-            });
+            }, asyncExecutor);
             return f;
         }
     }
@@ -1597,6 +1630,20 @@ public class MigrationManager {
                 // when our partition table is stale.
                 logger.fine("Will not repair partition table at the moment. "
                         + "Cluster state does not allow to modify partition table.");
+                return;
+            }
+
+            // Schedule a control task after configured delay.
+            // Since backups are not promoted, if a member crashed then
+            // its previously owned partitions are not available.
+            // Recovery however will be faster as no partition migrations will occur
+            // when crashed member rejoins.
+            if (delayNextRepartitioningExecution) {
+                logger.fine("Delaying next repartitioning execution");
+                delayNextRepartitioningExecution = false;
+                ExecutionService executionService = nodeEngine.getExecutionService();
+                scheduledControlTaskFuture = (ScheduledFuture<Void>) executionService.schedule(() -> triggerControlTask(),
+                        autoRebalanceDelaySeconds, TimeUnit.SECONDS);
                 return;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
@@ -31,6 +31,7 @@ import com.hazelcast.internal.partition.operation.MigrationOperation;
 import com.hazelcast.internal.partition.operation.MigrationRequestOperation;
 import com.hazelcast.internal.partition.operation.PartitionBackupReplicaAntiEntropyOperation;
 import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRequest;
+import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRequestOffloadable;
 import com.hazelcast.internal.partition.operation.PartitionReplicaSyncResponse;
 import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRetryResponse;
 import com.hazelcast.internal.partition.operation.PartitionStateOperation;
@@ -78,8 +79,9 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
     public static final int REPLICA_MIGRATION_EVENT = 22;
     public static final int MIGRATION_EVENT = 23;
     public static final int PARTITION_LOST_EVENT = 24;
+    public static final int REPLICA_SYNC_REQUEST_OFFLOADABLE = 25;
 
-    private static final int LEN = PARTITION_LOST_EVENT + 1;
+    private static final int LEN = REPLICA_SYNC_REQUEST_OFFLOADABLE + 1;
 
     @Override
     public int getFactoryId() {
@@ -114,6 +116,7 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
         constructors[REPLICA_MIGRATION_EVENT] = arg -> new ReplicaMigrationEventImpl();
         constructors[MIGRATION_EVENT] = arg -> new MigrationStateImpl();
         constructors[PARTITION_LOST_EVENT] = arg -> new PartitionLostEventImpl();
+        constructors[REPLICA_SYNC_REQUEST_OFFLOADABLE] = arg -> new PartitionReplicaSyncRequestOffloadable();
         return new ArrayDataSerializableFactory(constructors);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -18,12 +18,14 @@ package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
 import com.hazelcast.internal.partition.PartitionReplica;
 import com.hazelcast.internal.partition.PartitionReplicaVersionManager;
 import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRequest;
+import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRequestOffloadable;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.services.ServiceNamespaceAware;
 import com.hazelcast.internal.util.CollectionUtil;
@@ -66,6 +68,11 @@ import static java.util.Collections.newSetFromMap;
  * Maintains the version values for the partition replicas and manages the replica-related operations for partitions
  */
 public class PartitionReplicaManager implements PartitionReplicaVersionManager {
+
+    // Allow running partition replica sync on generic operation threads? Default is no,
+    // requires explicitly setting system property hazelcast.partition.replica.offload to true
+    private static final String PARTITION_REPLICA_ALLOW_OFFLOAD = "hazelcast.partition.replica.offload";
+    private static final boolean ALLOW_OFFLOAD = Boolean.getBoolean(PARTITION_REPLICA_ALLOW_OFFLOAD);
 
     private final Node node;
     private final NodeEngineImpl nodeEngine;
@@ -217,7 +224,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         }
 
         // Select only permitted number of namespaces
-        List<ServiceNamespace> namespaces =
+        Collection<ServiceNamespace> namespaces =
                 registerSyncInfoForNamespaces(partitionId, requestedNamespaces, replicaIndex, target, permits);
 
         // release unused permits
@@ -235,11 +242,17 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         }
         replicaSyncRequestsCounter.inc();
 
-        PartitionReplicaSyncRequest syncRequest = new PartitionReplicaSyncRequest(partitionId, namespaces, replicaIndex);
+        PartitionReplicaSyncRequest syncRequest = shouldOffload()
+                        ? new PartitionReplicaSyncRequestOffloadable(partitionId, namespaces, replicaIndex)
+                        : new PartitionReplicaSyncRequest(partitionId, namespaces, replicaIndex);
         nodeEngine.getOperationService().send(syncRequest, target.address());
     }
 
-    private List<ServiceNamespace> registerSyncInfoForNamespaces(int partitionId,
+    private boolean shouldOffload() {
+        return ALLOW_OFFLOAD && nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V5_0);
+    }
+
+    private Collection<ServiceNamespace> registerSyncInfoForNamespaces(int partitionId,
                                                                  Collection<ServiceNamespace> requestedNamespaces,
                                                                  int replicaIndex, PartitionReplica target, int permits) {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
@@ -16,21 +16,34 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
-import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
 import com.hazelcast.internal.partition.MigrationAwareService;
+import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
+import com.hazelcast.internal.partition.OffloadedReplicationPreparation;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
-import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.ThreadUtil;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
+import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
+import static com.hazelcast.internal.util.ThreadUtil.assertRunningOnPartitionThread;
+import static com.hazelcast.internal.util.ThreadUtil.isRunningOnPartitionThread;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.singleton;
 
 abstract class AbstractPartitionOperation extends Operation implements IdentifiedDataSerializable {
@@ -44,8 +57,16 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
         return createReplicationOperations(event, false);
     }
 
+    /** non-fragmented service replication operation preparation is always executed on partition operation thread */
     final Collection<Operation> createNonFragmentedReplicationOperations(PartitionReplicationEvent event) {
-        return createReplicationOperations(event, true);
+        if (ThreadUtil.isRunningOnPartitionThread()) {
+            return createReplicationOperations(event, true);
+        }  else {
+            UrgentPartitionRunnable<Collection<Operation>> runnable = new UrgentPartitionRunnable<>(
+                    event.getPartitionId(), () -> createReplicationOperations(event, true));
+            getNodeEngine().getOperationService().execute(runnable);
+            return runnable.future.joinInternal();
+        }
     }
 
     private Collection<Operation> createReplicationOperations(PartitionReplicationEvent event, boolean nonFragmentedOnly) {
@@ -69,24 +90,11 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
         return operations;
     }
 
-    final Collection<Operation> createFragmentReplicationOperations(PartitionReplicationEvent event, ServiceNamespace ns,
-            Collection<String> serviceNames) {
-        assert !(ns instanceof NonFragmentedServiceNamespace) : ns + " should be used only for non-fragmented services!";
-
-        Collection<Operation> operations = emptySet();
-        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        for (String serviceName : serviceNames) {
-            FragmentedMigrationAwareService service = nodeEngine.getService(serviceName);
-            assert service.isKnownServiceNamespace(ns) : ns + " should be known by " + service;
-
-            operations = prepareAndAppendReplicationOperation(event, ns, service, serviceName, operations);
-        }
-
-        return operations;
-    }
-
+    // must be invoked on partition thread; prepares replication operations within partition thread
+    // does not support differential sync
     final Collection<Operation> createFragmentReplicationOperations(PartitionReplicationEvent event, ServiceNamespace ns) {
-        assert !(ns instanceof NonFragmentedServiceNamespace) : ns + " should be used only for non-fragmented services!";
+        assert !(ns instanceof NonFragmentedServiceNamespace) : ns + " should be used only for fragmented services!";
+        assertRunningOnPartitionThread();
 
         Collection<Operation> operations = emptySet();
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
@@ -103,6 +111,115 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
         return operations;
     }
 
+    /** used for offloaded replication op preparation while executing a migration request */
+    final Collection<Operation> createFragmentReplicationOperationsOffload(PartitionReplicationEvent event, ServiceNamespace ns,
+                                                                           Collection<String> serviceNames) {
+        assert !(ns instanceof NonFragmentedServiceNamespace) : ns + " should be used only for fragmented services!";
+
+        Collection<Operation> operations = emptySet();
+        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+        for (String serviceName : serviceNames) {
+            FragmentedMigrationAwareService service = nodeEngine.getService(serviceName);
+            assert service.isKnownServiceNamespace(ns) : ns + " should be known by " + service;
+
+            operations = collectReplicationOperations(event, ns, isRunningOnPartitionThread(), operations, serviceName, service);
+        }
+
+        return operations;
+    }
+
+    /** used for partition replica sync, supporting offloaded replication op preparation */
+    final Collection<Operation> createFragmentReplicationOperationsOffload(PartitionReplicationEvent event, ServiceNamespace ns) {
+        assert !(ns instanceof NonFragmentedServiceNamespace) : ns + " should be used only for fragmented services!";
+
+        Collection<Operation> operations = emptySet();
+        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+        Collection<ServiceInfo> services = nodeEngine.getServiceInfos(FragmentedMigrationAwareService.class);
+
+        for (ServiceInfo serviceInfo : services) {
+            FragmentedMigrationAwareService service = serviceInfo.getService();
+            if (!service.isKnownServiceNamespace(ns)) {
+                continue;
+            }
+            operations = collectReplicationOperations(event, ns, isRunningOnPartitionThread(), operations,
+                    serviceInfo.getName(), service);
+        }
+        return operations;
+    }
+
+    /**
+     * Collect replication operations of a single fragmented service.
+     * If the service implements {@link OffloadedReplicationPreparation} interface, then
+     * that service's {@link FragmentedMigrationAwareService#prepareReplicationOperation(PartitionReplicationEvent, Collection)}
+     * method will be invoked from the internal {@code ASYNC_EXECUTOR},
+     * otherwise it will be invoked from the partition thread.
+     */
+    @Nullable
+    private Collection<Operation> collectReplicationOperations(PartitionReplicationEvent event, ServiceNamespace ns,
+                                         boolean runsOnPartitionThread, Collection<Operation> operations,
+                                         String serviceName, FragmentedMigrationAwareService service) {
+        // execute on current thread if (shouldOffload() ^ runsOnPartitionThread)
+        // otherwise explicitly request execution on partition or async executor thread.
+        if (runsOnPartitionThread
+            ^ (service instanceof OffloadedReplicationPreparation
+               && ((OffloadedReplicationPreparation) service).shouldOffload())) {
+            operations = prepareAndAppendReplicationOperation(event, ns, service, serviceName, operations);
+        } else if (runsOnPartitionThread) {
+            // migration aware service requested offload but we are on partition thread
+            // execute on async executor
+            Future<Operation> future =
+                    getNodeEngine().getExecutionService().submit(ExecutionService.ASYNC_EXECUTOR,
+                            () -> prepareReplicationOperation(event, ns, service, serviceName));
+            try {
+                Operation op = future.get();
+                operations = appendOperation(operations, op);
+            } catch (ExecutionException | CancellationException e) {
+                ExceptionUtil.rethrow(e.getCause());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                ExceptionUtil.rethrow(e);
+            }
+        } else {
+            // migration aware service did not request offload but execution is not on partition thread
+            // must execute replication operation preparation on partition thread
+            UrgentPartitionRunnable<Operation> partitionThreadRunnable = new UrgentPartitionRunnable<>(
+                    event.getPartitionId(),
+                    () -> prepareReplicationOperation(event, ns, service, serviceName));
+            getNodeEngine().getOperationService().execute(partitionThreadRunnable);
+            Operation op = partitionThreadRunnable.future.joinInternal();
+            operations = appendOperation(operations, op);
+        }
+        return operations;
+    }
+
+    private Collection<Operation> appendOperation(Collection<Operation> previous, Operation additional) {
+        if (additional == null) {
+            return previous;
+        }
+        if (previous.isEmpty()) {
+            previous = singleton(additional);
+        } else if (previous.size() == 1) {
+            // previous is an immutable singleton list
+            previous = newOperationSet(previous);
+            previous.add(additional);
+        } else {
+            previous.add(additional);
+        }
+        return previous;
+    }
+
+    private Operation prepareReplicationOperation(PartitionReplicationEvent event, ServiceNamespace ns,
+                    FragmentedMigrationAwareService service, String serviceName) {
+
+        Operation op = service.prepareReplicationOperation(event, singleton(ns));
+        if (op == null) {
+            return null;
+        }
+
+        op.setServiceName(serviceName);
+        return op;
+    }
+
     private Collection<Operation> prepareAndAppendReplicationOperation(PartitionReplicationEvent event, ServiceNamespace ns,
             FragmentedMigrationAwareService service, String serviceName, Collection<Operation> operations) {
 
@@ -117,7 +234,7 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
             // generally a namespace belongs to a single service only
             operations = singleton(op);
         } else if (operations.size() == 1) {
-            operations = new ArrayList<>(operations);
+            operations = newOperationSet(operations);
             operations.add(op);
         } else {
             operations.add(op);
@@ -128,5 +245,12 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
     @Override
     public final int getFactoryId() {
         return PartitionDataSerializerHook.F_ID;
+    }
+
+    // return a new thread-safe Set populated with all elements from previouis
+    Set<Operation> newOperationSet(Collection<Operation> previous) {
+        Set<Operation> newSet = newSetFromMap(new ConcurrentHashMap<>());
+        newSet.addAll(previous);
+        return newSet;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
@@ -247,7 +247,7 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
         return PartitionDataSerializerHook.F_ID;
     }
 
-    // return a new thread-safe Set populated with all elements from previouis
+    // return a new thread-safe Set populated with all elements from previous
     Set<Operation> newOperationSet(Collection<Operation> previous) {
         Set<Operation> newSet = newSetFromMap(new ConcurrentHashMap<>());
         newSet.addAll(previous);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
@@ -39,7 +39,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
 import static com.hazelcast.internal.util.ThreadUtil.isRunningOnPartitionThread;
-import static java.lang.Thread.currentThread;
 
 /**
  * The request sent from a replica to the partition owner to synchronize the replica data. The partition owner can send a
@@ -117,11 +116,7 @@ public final class PartitionReplicaSyncRequestOffloadable
             UrgentPartitionRunnable partitionRunnable = new UrgentPartitionRunnable(partitionId(),
                     () -> sendOperations(operations, ns));
             getNodeEngine().getOperationService().execute(partitionRunnable);
-            try {
-                partitionRunnable.done.await();
-            } catch (InterruptedException e) {
-                currentThread().interrupt();
-            }
+            partitionRunnable.future.joinInternal();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.operation;
+
+import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
+import com.hazelcast.internal.partition.PartitionReplicationEvent;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.internal.partition.impl.PartitionStateManager;
+import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.operationservice.CallStatus;
+import com.hazelcast.spi.impl.operationservice.Offload;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
+import static com.hazelcast.internal.util.ThreadUtil.isRunningOnPartitionThread;
+import static java.lang.Thread.currentThread;
+
+/**
+ * The request sent from a replica to the partition owner to synchronize the replica data. The partition owner can send a
+ * response to the replica to retry the sync operation when:
+ * <ul>
+ * <li>the replica sync is not allowed (because migrations are not allowed)</li>
+ * <li>the operation was received by a node which is not the partition owner</li>
+ * <li>the maximum number of parallel synchronizations has already been reached</li>
+ * </ul>
+ * An empty response can be sent if the current replica version is 0.
+ *
+ * @since   5.0
+ */
+public final class PartitionReplicaSyncRequestOffloadable
+        extends PartitionReplicaSyncRequest {
+
+    private volatile int partitionId;
+
+    public PartitionReplicaSyncRequestOffloadable() {
+        namespaces = Collections.emptyList();
+    }
+
+    public PartitionReplicaSyncRequestOffloadable(int partitionId, Collection<ServiceNamespace> namespaces, int replicaIndex) {
+        this.namespaces = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        this.namespaces.addAll(namespaces);
+        this.partitionId = partitionId;
+        setPartitionId(-1);
+        setReplicaIndex(replicaIndex);
+    }
+
+    @Override
+    public CallStatus call()
+            throws Exception {
+        return new ReplicaSyncRequestOffload();
+    }
+
+    /**
+     * Send responses for first number of {@code permits} namespaces and remove them from the list.
+     */
+    protected void sendOperationsForNamespaces(int permits) {
+        InternalPartitionServiceImpl partitionService = getService();
+        try {
+            PartitionReplicationEvent event = new PartitionReplicationEvent(getCallerAddress(), partitionId,
+                    getReplicaIndex());
+            final Iterator<ServiceNamespace> iterator = namespaces.iterator();
+            for (int i = 0; i < permits; i++) {
+                ServiceNamespace namespace = iterator.next();
+                Collection<Operation> operations = null;
+                if (NonFragmentedServiceNamespace.INSTANCE.equals(namespace)) {
+                    operations = createNonFragmentedReplicationOperations(event);
+                } else {
+                    operations = createFragmentReplicationOperationsOffload(event, namespace);
+                }
+                // operations can be null if await-ing for non-fragmented services' repl operations failed due to interruption
+                if (operations != null) {
+                    operations = new CopyOnWriteArrayList<>(operations);
+                    sendOperationsOnPartitionThread(operations, namespace);
+                    iterator.remove();
+                }
+            }
+        } finally {
+            partitionService.getReplicaManager().releaseReplicaSyncPermits(permits);
+        }
+    }
+
+    @Override
+    protected int partitionId() {
+        return this.partitionId;
+    }
+
+    private void sendOperationsOnPartitionThread(Collection<Operation> operations, ServiceNamespace ns) {
+        if (isRunningOnPartitionThread()) {
+            sendOperations(operations, ns);
+        } else {
+            UrgentPartitionRunnable partitionRunnable = new UrgentPartitionRunnable(partitionId(),
+                    () -> sendOperations(operations, ns));
+            getNodeEngine().getOperationService().execute(partitionRunnable);
+            try {
+                partitionRunnable.done.await();
+            } catch (InterruptedException e) {
+                currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public int getClassId() {
+        return PartitionDataSerializerHook.REPLICA_SYNC_REQUEST_OFFLOADABLE;
+    }
+
+    final class ReplicaSyncRequestOffload extends Offload {
+
+        ReplicaSyncRequestOffload() {
+            super(PartitionReplicaSyncRequestOffloadable.this);
+        }
+
+        @Override
+        public void start() throws Exception {
+            InternalPartitionServiceImpl partitionService = getService();
+            PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
+            // set partition as migrating to disable mutating operations
+            // while preparing replication operations
+            if (!partitionStateManager.trySetMigratingFlag(partitionId)
+                    && !partitionStateManager.isMigrating(partitionId)) {
+                throw new RetryableHazelcastException("Cannot set migrating flag, "
+                        + "probably previous migration's finalization is not completed yet.");
+            }
+
+            try {
+                // executed on generic operation thread
+                Integer permits = getPermits();
+                if (permits == null) {
+                    return;
+                }
+
+                sendOperationsForNamespaces(permits);
+                // send retry response for remaining namespaces
+                if (!namespaces.isEmpty()) {
+                    logNotEnoughPermits();
+                    sendRetryResponse();
+                }
+            } finally {
+                partitionStateManager.clearMigratingFlag(partitionId);
+            }
+        }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        writeCollection(namespaces, out);
+        out.writeInt(partitionId);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        namespaces = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        namespaces.addAll(readCollection(in));
+        partitionId = in.readInt();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/UrgentPartitionRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/UrgentPartitionRunnable.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.operation;
+
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+final class UrgentPartitionRunnable<T>
+        implements PartitionSpecificRunnable, UrgentSystemOperation {
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final InternalCompletableFuture<T> future = new InternalCompletableFuture<>();
+    private final int partitionId;
+    private final Callable<T> callable;
+
+    UrgentPartitionRunnable(int partitionId, Runnable runnable) {
+        this.partitionId = partitionId;
+        this.callable = () -> {
+            runnable.run();
+            return null;
+        };
+    }
+
+    UrgentPartitionRunnable(int partitionId, Callable callable) {
+        this.partitionId = partitionId;
+        this.callable = callable;
+    }
+
+    @Override
+    public int getPartitionId() {
+        return partitionId;
+    }
+
+    @Override
+    public void run() {
+        try {
+            future.complete(callable.call());
+        } catch (Exception e) {
+            future.completeExceptionally(e);
+        } finally {
+            done.countDown();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/UrgentPartitionRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/UrgentPartitionRunnable.java
@@ -21,12 +21,10 @@ import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 
 final class UrgentPartitionRunnable<T>
         implements PartitionSpecificRunnable, UrgentSystemOperation {
 
-    final CountDownLatch done = new CountDownLatch(1);
     final InternalCompletableFuture<T> future = new InternalCompletableFuture<>();
     private final int partitionId;
     private final Callable<T> callable;
@@ -55,8 +53,6 @@ final class UrgentPartitionRunnable<T>
             future.complete(callable.call());
         } catch (Exception e) {
             future.completeExceptionally(e);
-        } finally {
-            done.countDown();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadUtil.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.util;
 
+import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
+
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -84,6 +86,10 @@ public final class ThreadUtil {
     }
 
     public static void assertRunningOnPartitionThread() {
-        assert Thread.currentThread().getName().contains("partition-operation");
+        assert Thread.currentThread() instanceof PartitionOperationThread;
+    }
+
+    public static boolean isRunningOnPartitionThread() {
+        return Thread.currentThread() instanceof PartitionOperationThread;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/LocalMapStats.java
@@ -274,4 +274,11 @@ public interface LocalMapStats extends LocalInstanceStats {
      */
     Map<String, LocalIndexStats> getIndexStats();
 
+    // todo reconsider exposure of replication stats, probably better encapsulated in separate "LocalReplicationStats"?
+    // these stats reflect full/diff partition replication stats with local map partitions as the migration source
+    long getDifferentialPartitionReplicationCount();
+    long getFullPartitionReplicationCount();
+    long getDifferentialReplicationRecordCount();
+    long getFullReplicationRecordCount();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -253,6 +253,9 @@ public class LocalMapStatsProvider {
             int partitionId = recordStore.getPartitionId();
             Address replicaAddress = getReplicaAddress(partitionId, replicaNumber, totalBackupCount);
             if (!isReplicaAvailable(replicaAddress, totalBackupCount)) {
+                // todo consider if this should be logged as a warning
+                //  it is normal to have some replicas unassigned under various circumstances
+                //  depending on cluster state and membership changes
                 printWarning(partitionId, replicaNumber);
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
 import com.hazelcast.internal.partition.IPartitionLostEvent;
+import com.hazelcast.internal.partition.OffloadedReplicationPreparation;
 import com.hazelcast.internal.partition.PartitionAwareService;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
@@ -92,11 +93,11 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_TAG_I
  */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:MethodCount"})
 public class MapService implements ManagedService, FragmentedMigrationAwareService, TransactionalService, RemoteService,
-        EventPublishingService<Object, ListenerAdapter>, PostJoinAwareService,
-        SplitBrainHandlerService, WanSupportingService, StatisticsAwareService<LocalMapStats>,
-        PartitionAwareService, ClientAwareService, SplitBrainProtectionAwareService,
-        NotifiableEventListener, ClusterStateListener, LockInterceptorService<Data>,
-        DynamicMetricsProvider, TenantContextAwareService {
+                                   EventPublishingService<Object, ListenerAdapter>, PostJoinAwareService,
+                                   SplitBrainHandlerService, WanSupportingService, StatisticsAwareService<LocalMapStats>,
+                                   PartitionAwareService, ClientAwareService, SplitBrainProtectionAwareService,
+                                   NotifiableEventListener, ClusterStateListener, LockInterceptorService<Data>,
+                                   DynamicMetricsProvider, TenantContextAwareService, OffloadedReplicationPreparation {
 
     public static final String SERVICE_NAME = "hz:impl:mapService";
 
@@ -334,5 +335,10 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
                     .withDiscriminator(MAP_DISCRIMINATOR_NAME, name);
             context.collect(nearCacheDescriptor, offloadedExecutorStats);
         });
+    }
+
+    @Override
+    public boolean shouldOffload() {
+        return migrationAwareService.shouldOffload();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
 
 import static com.hazelcast.map.impl.MapKeyLoaderUtil.getMaxSizePerNode;
 
@@ -124,6 +125,10 @@ public class PartitionContainer {
     }
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
+        return getNamespaces(ignored -> true, replicaIndex);
+    }
+
+    public Collection<ServiceNamespace> getNamespaces(Predicate<MapConfig> predicate, int replicaIndex) {
         if (maps.isEmpty()) {
             return Collections.emptyList();
         }
@@ -133,7 +138,8 @@ public class PartitionContainer {
             MapContainer mapContainer = recordStore.getMapContainer();
             MapConfig mapConfig = mapContainer.getMapConfig();
 
-            if (mapConfig.getTotalBackupCount() < replicaIndex) {
+            if (mapConfig.getTotalBackupCount() < replicaIndex
+                    || !predicate.test(mapConfig)) {
                 continue;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -32,14 +32,14 @@ import java.io.IOException;
 import java.util.Collection;
 
 /**
- * Replicates all IMap-states of this partition to a repReservedCapacityCounterTestlica partition.
+ * Replicates all IMap-states of this partition to a replica partition.
  */
 public class MapReplicationOperation extends Operation
         implements IdentifiedDataSerializable {
 
-    private MapReplicationStateHolder mapReplicationStateHolder;
-    private WriteBehindStateHolder writeBehindStateHolder;
-    private MapNearCacheStateHolder mapNearCacheStateHolder;
+    protected MapReplicationStateHolder mapReplicationStateHolder;
+    protected WriteBehindStateHolder writeBehindStateHolder;
+    protected MapNearCacheStateHolder mapNearCacheStateHolder;
 
     private transient NativeOutOfMemoryError oome;
 
@@ -137,7 +137,7 @@ public class MapReplicationOperation extends Operation
         mapNearCacheStateHolder.setMapReplicationOperation(this);
     }
 
-    RecordStore getRecordStore(String mapName) {
+    public RecordStore getRecordStore(String mapName) {
         final boolean skipLoadingOnRecordStoreCreate = true;
         MapService mapService = getService();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.monitor.LocalRecordStoreStats;
+import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.monitor.impl.LocalRecordStoreStatsImpl;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.partition.IPartitionService;
@@ -55,10 +56,13 @@ import com.hazelcast.query.impl.MapIndexInfo;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.config.MaxSizePolicy.PER_NODE;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
@@ -67,11 +71,12 @@ import static com.hazelcast.internal.util.MapUtil.isNullOrEmpty;
 /**
  * Holder for raw IMap key-value pairs and their metadata.
  */
-// keep this `protected`, extended in another context.
 public class MapReplicationStateHolder implements IdentifiedDataSerializable, Versioned {
 
     // holds recordStore-references of this partitions' maps
     protected transient Map<String, RecordStore<Record>> storesByMapName;
+
+    protected transient Map<String, LocalMapStatsImpl> statsByMapName = new ConcurrentHashMap<>();
 
     // data for each map
     protected transient Map<String, List> data;
@@ -87,7 +92,12 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     // operations, which meant that the index did not include some data.
     protected transient List<MapIndexInfo> mapIndexInfos;
 
-    private MapReplicationOperation operation;
+    // mapName -> null = full sync required
+    // mapName -> int[0] = no difference
+    // mapName -> int[2*n] = mapName -> Merkle tree node order/value pairs
+    protected Map<String, int[]> merkleTreeDiffByMapName = Collections.emptyMap();
+
+    protected MapReplicationOperation operation;
     private Map<String, LocalRecordStoreStats> recordStoreStatsPerMapName;
 
     /**
@@ -95,6 +105,10 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
      * unless {@code operation} is set.
      */
     public MapReplicationStateHolder() {
+    }
+
+    public void setMerkleTreeDiffByMapName(Map<String, int[]> merkleTreeDiffByMapName) {
+        this.merkleTreeDiffByMapName = merkleTreeDiffByMapName == null ? Collections.emptyMap() : merkleTreeDiffByMapName;
     }
 
     public void setOperation(MapReplicationOperation operation) {
@@ -121,6 +135,8 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
 
             loaded.put(mapName, recordStore.isLoaded());
             storesByMapName.put(mapName, recordStore);
+            statsByMapName.put(mapName,
+                    mapContainer.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(mapName));
 
             Set<IndexConfig> indexConfigs = new HashSet<>();
             if (mapContainer.isGlobalIndexEnabled()) {
@@ -156,9 +172,10 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         if (!isNullOrEmpty(data)) {
             for (Map.Entry<String, List> dataEntry : data.entrySet()) {
                 String mapName = dataEntry.getKey();
+                final boolean isDifferentialReplication = merkleTreeDiffByMapName.containsKey(mapName);
                 List keyRecordExpiry = dataEntry.getValue();
                 RecordStore recordStore = operation.getRecordStore(mapName);
-                recordStore.reset();
+                initializeRecordStore(mapName, recordStore);
                 recordStore.setPreMigrationLoadedStatus(loaded.get(mapName));
 
                 MapContainer mapContainer = recordStore.getMapContainer();
@@ -177,45 +194,19 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                 if (populateIndexes) {
                     // defensively clear possible stale leftovers in non-global indexes from the previous failed promotion attempt
                     indexesSnapshot = indexes.getIndexes();
-
                     Indexes.beginPartitionUpdate(indexesSnapshot);
-
                     indexes.clearAll();
                 }
 
-
-                long ownedEntryCountOnThisNode = entryCountOnThisNode(mapContainer);
-                EvictionConfig evictionConfig = mapContainer.getMapConfig().getEvictionConfig();
-                boolean perNodeEvictionConfigured = mapContainer.getEvictor() != Evictor.NULL_EVICTOR
-                        && evictionConfig.getMaxSizePolicy() == PER_NODE;
-
                 long nowInMillis = Clock.currentTimeMillis();
-                for (int i = 0; i < keyRecordExpiry.size(); i += 3) {
-                    Data dataKey = (Data) keyRecordExpiry.get(i);
-                    Record record = (Record) keyRecordExpiry.get(i + 1);
-                    ExpiryMetadata expiryMetadata = (ExpiryMetadata) keyRecordExpiry.get(i + 2);
-
-                    if (perNodeEvictionConfigured) {
-                        if (ownedEntryCountOnThisNode >= evictionConfig.getSize()) {
-                            if (operation.getReplicaIndex() == 0) {
-                                recordStore.doPostEvictionOperations(dataKey, record.getValue(), ExpiryReason.NOT_EXPIRED);
-                            }
-                        } else {
-                            recordStore.putReplicatedRecord(dataKey, record, expiryMetadata, populateIndexes, nowInMillis);
-                            ownedEntryCountOnThisNode++;
-                        }
-                    } else {
-                        recordStore.putReplicatedRecord(dataKey, record, expiryMetadata, populateIndexes, nowInMillis);
-                        if (recordStore.shouldEvict()) {
-                            // No need to continue replicating records anymore.
-                            // We are already over eviction threshold, each put record will cause another eviction.
-                            recordStore.evictEntries(dataKey);
-                            break;
-                        }
-                    }
-
-                    recordStore.disposeDeferredBlocks();
+                if (isDifferentialReplication) {
+                    forEachReplicatedRecord(keyRecordExpiry, mapContainer, recordStore, populateIndexes, nowInMillis,
+                            recordStore::putOrUpdateReplicatedRecord);
+                } else {
+                    forEachReplicatedRecord(keyRecordExpiry, mapContainer, recordStore, populateIndexes, nowInMillis,
+                            recordStore::putReplicatedRecord);
                 }
+
 
                 if (populateIndexes) {
                     Indexes.markPartitionAsIndexed(partitionContainer.getPartitionId(), indexesSnapshot);
@@ -230,6 +221,49 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
             RecordStore recordStore = operation.getRecordStore(mapName);
             recordStore.setStats(stats);
 
+        }
+    }
+
+    private void forEachReplicatedRecord(List keyRecordExpiry,
+                                         MapContainer mapContainer,
+                                         RecordStore recordStore,
+                                         boolean populateIndexes, long nowInMillis,
+                                         ReplicatedRecordProcessor replicatedRecordProcessor) {
+        long ownedEntryCountOnThisNode = entryCountOnThisNode(mapContainer);
+        EvictionConfig evictionConfig = mapContainer.getMapConfig().getEvictionConfig();
+        boolean perNodeEvictionConfigured = mapContainer.getEvictor() != Evictor.NULL_EVICTOR
+                && evictionConfig.getMaxSizePolicy() == PER_NODE;
+        for (int i = 0; i < keyRecordExpiry.size(); i += 3) {
+            Data dataKey = (Data) keyRecordExpiry.get(i);
+            Record record = (Record) keyRecordExpiry.get(i + 1);
+            ExpiryMetadata expiryMetadata = (ExpiryMetadata) keyRecordExpiry.get(i + 2);
+
+            if (perNodeEvictionConfigured) {
+                if (ownedEntryCountOnThisNode >= evictionConfig.getSize()) {
+                    if (operation.getReplicaIndex() == 0) {
+                        recordStore.doPostEvictionOperations(dataKey, record.getValue(), ExpiryReason.NOT_EXPIRED);
+                    }
+                } else {
+                    replicatedRecordProcessor.processRecord(dataKey, record, expiryMetadata, populateIndexes, nowInMillis);
+                    ownedEntryCountOnThisNode++;
+                }
+            } else {
+                replicatedRecordProcessor.processRecord(dataKey, record, expiryMetadata, populateIndexes, nowInMillis);
+                if (recordStore.shouldEvict()) {
+                    // No need to continue replicating records anymore.
+                    // We are already over eviction threshold, each put record will cause another eviction.
+                    recordStore.evictEntries(dataKey);
+                    break;
+                }
+            }
+
+            recordStore.disposeDeferredBlocks();
+        }
+    }
+
+    protected void initializeRecordStore(String mapName, RecordStore recordStore) {
+        if (!merkleTreeDiffByMapName.containsKey(mapName)) {
+            recordStore.reset();
         }
     }
 
@@ -294,29 +328,21 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+
         out.writeInt(storesByMapName.size());
 
         for (Map.Entry<String, RecordStore<Record>> entry : storesByMapName.entrySet()) {
             String mapName = entry.getKey();
+            RecordStore<Record> recordStore = entry.getValue();
             out.writeString(mapName);
 
-            SerializationService ss = getSerializationService(operation.getRecordStore(mapName).getMapContainer());
-            RecordStore<Record> recordStore = entry.getValue();
-            out.writeInt(recordStore.size());
-            // No expiration should be done in forEach, since we have serialized size before.
-            recordStore.forEach((dataKey, record) -> {
-                try {
-                    IOUtil.writeData(out, dataKey);
-                    Records.writeRecord(out, record, ss.toData(record.getValue()),
-                            recordStore.getExpirySystem().getExpiredMetadata(dataKey));
-                } catch (IOException e) {
-                    throw ExceptionUtil.rethrow(e);
-                }
-            }, operation.getReplicaIndex() != 0, true);
-
-            if (out.getVersion().isGreaterOrEqual(Versions.V4_2)) {
-                recordStore.getStats().writeData(out);
+            // RU_COMPAT_42
+            if (out.getVersion().isGreaterOrEqual(Versions.V5_0)) {
+                writeRecordStoreV5(mapName, recordStore, out);
+            } else {
+                writeRecordStoreV42(mapName, recordStore, out);
             }
+            recordStore.getStats().writeData(out);
         }
 
         out.writeInt(loaded.size());
@@ -331,36 +357,65 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         }
     }
 
-    private static SerializationService getSerializationService(MapContainer mapContainer) {
+    private void writeRecordStoreV5(String mapName, RecordStore<Record> recordStore, ObjectDataOutput out)
+            throws IOException {
+        if (merkleTreeDiffByMapName.containsKey(mapName)) {
+            out.writeBoolean(true);
+            writeDifferentialData(mapName, recordStore, out);
+        } else {
+            out.writeBoolean(false);
+            writeRecordStoreData(recordStore, out);
+        }
+    }
+
+    private void writeRecordStoreV42(String mapName, RecordStore<Record> recordStore, ObjectDataOutput out)
+            throws IOException {
+        writeRecordStoreData(recordStore, out);
+    }
+
+    protected void writeDifferentialData(String mapName,
+                                         RecordStore<Record> recordStore, ObjectDataOutput out) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    private void writeRecordStoreData(RecordStore<Record> recordStore, ObjectDataOutput out)
+            throws IOException {
+        SerializationService ss = getSerializationService(recordStore.getMapContainer());
+        out.writeInt(recordStore.size());
+        // No expiration should be done in forEach, since we have serialized size before.
+        recordStore.forEach((dataKey, record) -> {
+            try {
+                IOUtil.writeData(out, dataKey);
+                Records.writeRecord(out, record, ss.toData(record.getValue()),
+                        recordStore.getExpirySystem().getExpiredMetadata(dataKey));
+            } catch (IOException e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }, operation.getReplicaIndex() != 0, true);
+        statsByMapName.get(recordStore.getName()).incrementFullPartitionReplicationRecordsCount(recordStore.size());
+    }
+
+    protected static SerializationService getSerializationService(MapContainer mapContainer) {
         return mapContainer.getMapServiceContext()
-                .getNodeEngine().getSerializationService();
+                           .getNodeEngine().getSerializationService();
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
         data = createHashMap(size);
+        merkleTreeDiffByMapName = new HashMap<>();
         recordStoreStatsPerMapName = createHashMap(size);
 
         for (int i = 0; i < size; i++) {
-            String name = in.readString();
-            int numOfRecords = in.readInt();
-            List keyRecordExpiry = new ArrayList<>(numOfRecords * 3);
-            for (int j = 0; j < numOfRecords; j++) {
-                Data dataKey = IOUtil.readData(in);
-                ExpiryMetadata expiryMetadata = new ExpiryMetadataImpl();
-                Record record = Records.readRecord(in, expiryMetadata);
+            String mapName = in.readString();
+            boolean differentialReplication = in.getVersion().isGreaterOrEqual(Versions.V5_0) && in.readBoolean();
 
-                keyRecordExpiry.add(dataKey);
-                keyRecordExpiry.add(record);
-                keyRecordExpiry.add(expiryMetadata);
+            if (differentialReplication) {
+                readDifferentialData(mapName, in);
+            } else {
+                readRecordStoreData(mapName, in);
             }
-            if (in.getVersion().isGreaterOrEqual(Versions.V4_2)) {
-                LocalRecordStoreStatsImpl stats = new LocalRecordStoreStatsImpl();
-                stats.readData(in);
-                recordStoreStatsPerMapName.put(name, stats);
-            }
-            data.put(name, keyRecordExpiry);
         }
 
         int loadedSize = in.readInt();
@@ -375,6 +430,34 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
             MapIndexInfo mapIndexInfo = in.readObject();
             mapIndexInfos.add(mapIndexInfo);
         }
+    }
+
+    protected void readDifferentialData(String mapName, ObjectDataInput in)
+            throws IOException {
+        int[] diffNodeOrder = in.readIntArray();
+        merkleTreeDiffByMapName.put(mapName, diffNodeOrder);
+        readRecordStoreData(mapName, in);
+    }
+
+    protected void readRecordStoreData(String mapName, ObjectDataInput in)
+            throws IOException {
+        int numOfRecords = in.readInt();
+        List keyRecord = new ArrayList<>(numOfRecords * 3);
+        for (int j = 0; j < numOfRecords; j++) {
+            Data dataKey = IOUtil.readData(in);
+            ExpiryMetadata expiryMetadata = new ExpiryMetadataImpl();
+            Record record = Records.readRecord(in, expiryMetadata);
+
+            keyRecord.add(dataKey);
+            keyRecord.add(record);
+            keyRecord.add(expiryMetadata);
+        }
+        if (in.getVersion().isGreaterOrEqual(Versions.V4_2)) {
+            LocalRecordStoreStatsImpl stats = new LocalRecordStoreStatsImpl();
+            stats.readData(in);
+            recordStoreStatsPerMapName.put(mapName, stats);
+        }
+        data.put(mapName, keyRecord);
     }
 
     @Override
@@ -404,5 +487,10 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         }
 
         return true;
+    }
+
+    private interface ReplicatedRecordProcessor {
+        void processRecord(Data dataKey, Record record, ExpiryMetadata expiryMetadata,
+              boolean indexesMustBePopulated, long now);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -204,6 +204,16 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
+    public void removeReplicatedRecord(Data dataKey) {
+        Record record = storage.get(dataKey);
+        if (record != null) {
+            mutationObserver.onRemoveRecord(dataKey, record);
+            removeKeyFromExpirySystem(dataKey);
+            storage.removeRecord(dataKey, record);
+        }
+    }
+
+    @Override
     public Record putBackup(Data dataKey, Record newRecord, ExpiryMetadata expiryMetadata,
                             boolean putTransient, CallerProvenance provenance) {
         return putBackupInternal(dataKey, newRecord.getValue(),

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -282,7 +282,10 @@ public interface RecordStore<R extends Record> {
 
     /**
      * Puts a data key and a record value to record-store.
-     * Used in replication operations.
+     * Used in replication operations: does not attempt
+     * loading from map store and is not intercepted by
+     * {@code MapInterceptor}.
+     *
      *
      * @param dataKey                the key to be put
      * @param record                 the value for record store.
@@ -293,6 +296,33 @@ public interface RecordStore<R extends Record> {
      */
     R putReplicatedRecord(Data dataKey, R record, ExpiryMetadata expiryMetadata,
                           boolean indexesMustBePopulated, long now);
+
+    /**
+     * Similarly to {@link #putReplicatedRecord(Data, Record, ExpiryMetadata, boolean, long)},
+     * this method is used in replication operations.
+     * If an existing record is located for the same key
+     * (as defined in {@link Storage#getIfSameKey(Object)}),
+     * then that record is updated instead of creating a
+     * new one.
+     *
+     * @param dataKey                   the key to put or update
+     * @param record                    the value for record store
+     * @param expiryMetadata            metadata relevant for expiry system
+     * @param indexesMustBePopulated    indicates if indexes must be updated
+     * @param now                       current time millis
+     * @return                          record after put or update
+     */
+    default R putOrUpdateReplicatedRecord(Data dataKey, R record, ExpiryMetadata expiryMetadata,
+                          boolean indexesMustBePopulated, long now) {
+        return putReplicatedRecord(dataKey, record, expiryMetadata, indexesMustBePopulated, now);
+    }
+
+    /**
+     * Remove record for given key. Does not load from MapLoader,
+     * does not intercept.
+     * @param dataKey   key to remove
+     */
+    void removeReplicatedRecord(Data dataKey);
 
     void forEach(BiConsumer<Data, R> consumer, boolean backup);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/CountingMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/CountingMigrationAwareService.java
@@ -18,10 +18,11 @@ package com.hazelcast.spi.impl;
 
 import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
 import com.hazelcast.internal.partition.MigrationAwareService;
+import com.hazelcast.internal.partition.OffloadedReplicationPreparation;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A {@link MigrationAwareService} that delegates to another {@link MigrationAwareService} and keeps track of the number of
  * migrations concerning the partition owner (either as current or new replica index) currently in-flight.
  */
-public class CountingMigrationAwareService implements FragmentedMigrationAwareService {
+public class CountingMigrationAwareService implements FragmentedMigrationAwareService, OffloadedReplicationPreparation {
 
     static final int PRIMARY_REPLICA_INDEX = 0;
     static final int IN_FLIGHT_MIGRATION_STAMP = -1;
@@ -133,5 +134,11 @@ public class CountingMigrationAwareService implements FragmentedMigrationAwareSe
         int completed = ownerMigrationsCompleted.get();
         int started = ownerMigrationsStarted.get();
         return stamp == completed && stamp == started;
+    }
+
+    @Override
+    public boolean shouldOffload() {
+        return migrationAwareService instanceof OffloadedReplicationPreparation
+                && ((OffloadedReplicationPreparation) migrationAwareService).shouldOffload();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -667,8 +667,8 @@ public final class ClusterProperty {
      * rebalancing will be triggered immediately (subject to limitations imposed
      * by current {@link com.hazelcast.cluster.ClusterState}).
      */
-    public static final HazelcastProperty PARTITION_REBALANCE_DELAY_SECONDS
-            = new HazelcastProperty("hazelcast.partition.rebalance.delay.seconds", 0, SECONDS);
+    public static final HazelcastProperty PARTITION_REBALANCE_AFTER_MEMBER_LEFT_DELAY_SECONDS
+            = new HazelcastProperty("hazelcast.partition.rebalance.after.member.left.delay.seconds", 0, SECONDS);
 
     /**
      * Class name implementing {@link com.hazelcast.partition.PartitioningStrategy}, which

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -649,6 +649,30 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.partition.max.parallel.replications", PARTITION_MAX_PARALLEL_MIGRATIONS);
 
     /**
+     * Time (in seconds) to wait before triggering automatic partition rebalancing
+     * after a member leaves the cluster unexpectedly. Unexpectedly in this context
+     * means that a member leaves the cluster by means other than graceful shutdown:
+     * programmatic termination (eg {@link LifecycleService#terminate()}), a
+     * process crash or network partition.
+     * Default is 0, which means rebalancing is triggered immediately.
+     * Rebalancing delay is only applied when using the automatic partition
+     * rebalancing mode. When in manual mode, explicit user trigger is required
+     * to initiate partition rebalancing and it will not be subject to delay.
+     *
+     * Setting this to a higher value will allow some time for members that are gone
+     * to rejoin the cluster. The benefit is that partition rebalancing in this
+     * case will be avoided, saving the burden of migrating partition data over
+     * the network. While members are gone, operations on partitions
+     * for which the owner is missing may fail immediately or will be retried until
+     * the member rejoins or operation timeout is exceeded.
+     * Notice that this delay only applies when cluster members leave the cluster;
+     * when the cluster is being scaled up and members are being added, partition
+     * rebalancing will be triggered immediately (assuming automatic rebalancing).
+     */
+    public static final HazelcastProperty PARTITION_REBALANCE_DELAY_SECONDS
+            = new HazelcastProperty("hazelcast.partition.rebalance.delay.seconds", 0, SECONDS);
+
+    /**
      * Class name implementing {@link com.hazelcast.partition.PartitioningStrategy}, which
      * defines key to partition mapping.
      */

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -655,9 +655,6 @@ public final class ClusterProperty {
      * programmatic termination (eg {@link LifecycleService#terminate()}), a
      * process crash or network partition.
      * Default is 0, which means rebalancing is triggered immediately.
-     * Rebalancing delay is only applied when using the automatic partition
-     * rebalancing mode. When in manual mode, explicit user trigger is required
-     * to initiate partition rebalancing and it will not be subject to delay.
      *
      * Setting this to a higher value will allow some time for members that are gone
      * to rejoin the cluster. The benefit is that partition rebalancing in this
@@ -667,7 +664,8 @@ public final class ClusterProperty {
      * the member rejoins or operation timeout is exceeded.
      * Notice that this delay only applies when cluster members leave the cluster;
      * when the cluster is being scaled up and members are being added, partition
-     * rebalancing will be triggered immediately (assuming automatic rebalancing).
+     * rebalancing will be triggered immediately (subject to limitations imposed
+     * by current {@link com.hazelcast.cluster.ClusterState}).
      */
     public static final HazelcastProperty PARTITION_REBALANCE_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.partition.rebalance.delay.seconds", 0, SECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTreeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/merkletree/MerkleTreeUtil.java
@@ -17,7 +17,9 @@
 package com.hazelcast.wan.impl.merkletree;
 
 import com.hazelcast.internal.util.QuickMath;
+import com.hazelcast.internal.util.collection.IntHashSet;
 
+import javax.annotation.Nonnull;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -376,4 +378,17 @@ public final class MerkleTreeUtil {
         return new RemoteMerkleTreeView(leaves, depth);
     }
 
+    /**
+     * @param merkleTreeOrderValuePairs an array of {@code [nodeOrder, hashValue]} pairs
+     * @return set of given Merkle tree node orders
+     */
+    @Nonnull
+    public static IntHashSet setOfNodeOrders(int[] merkleTreeOrderValuePairs) {
+        assert merkleTreeOrderValuePairs.length % 2 == 0;
+        IntHashSet merkleTreeOrderValues = new IntHashSet(merkleTreeOrderValuePairs.length / 2, -1);
+        for (int i = 0; i < merkleTreeOrderValuePairs.length; i = i + 2) {
+            merkleTreeOrderValues.add(merkleTreeOrderValuePairs[i]);
+        }
+        return merkleTreeOrderValues;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRebalanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRebalanceTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.internal.partition.TestPartitionUtils.assertAllPartitionsBelongTo;
+import static com.hazelcast.internal.partition.TestPartitionUtils.assertSomePartitionsBelongTo;
+import static com.hazelcast.internal.partition.TestPartitionUtils.dumpPartitionTable;
+import static com.hazelcast.test.Accessors.getPartitionService;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class PartitionRebalanceTest extends HazelcastTestSupport {
+
+    // maximum time to wait for assertions after partition rebalancing
+    // if tests fail on busy build machines, this may have to be increased
+    private static final int PARTITION_REBALANCE_TIMEOUT = 5;
+
+    @Rule
+    public final Timeout timeout = Timeout.seconds(20);
+
+    private HazelcastInstance instance1;
+    private HazelcastInstance instance2;
+    TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void configureWithNegativeDelay() {
+        instance1 = factory.newHazelcastInstance(getConfig(-3));
+    }
+
+    @Test
+    public void rebalanceOccursAfterDelay_whenDelayed() {
+        // this test will take > 10 seconds :(
+        instance1 = factory.newHazelcastInstance(getConfig(PARTITION_REBALANCE_TIMEOUT));
+        getPartitionService(instance1).firstArrangement();
+
+        AtomicBoolean done = new AtomicBoolean(true);
+
+        instance2 = factory.newHazelcastInstance(getConfig());
+        // assert partition rebalancing occurs automatically without delay on member join
+        assertTrueEventually(() -> assertSomePartitionsBelongTo(instance2), PARTITION_REBALANCE_TIMEOUT / 2);
+        instance2.getLifecycleService().terminate();
+
+        try {
+            sleepAtLeastSeconds(PARTITION_REBALANCE_TIMEOUT);
+            // after configured delay, partition rebalancing occurs automatically
+            assertTrueEventually(() -> assertAllPartitionsBelongTo(instance1), PARTITION_REBALANCE_TIMEOUT);
+        } finally {
+            done.set(false);
+        }
+    }
+
+    @Test
+    public void rebalanceMapWithoutBackups_whenDelayed()
+            throws ExecutionException, InterruptedException {
+        instance1 = factory.newHazelcastInstance(getConfig(5));
+        IMap<Integer, Integer> map = instance1.getMap("nobackup");
+        for (int i = 0; i < 1000; i++) {
+            map.set(i, i);
+        }
+        assertEquals(1000, map.size());
+
+        instance2 = factory.newHazelcastInstance(getConfig());
+        waitAllForSafeState(instance1, instance2);
+        instance2.getLifecycleService().terminate();
+
+        // map.size will complete after partition rebalancing
+        // since operation timeout is greater than auto partition
+        // rebalancing delay
+        Future<Integer> sizeFuture = spawn(() -> map.size());
+
+        // since there are no backups, some data are lost
+        assertTrue(sizeFuture.get() < 1000);
+    }
+
+    @Test
+    public void rebalanceMapWithBackups_whenDelayed()
+            throws ExecutionException, InterruptedException {
+        instance1 = factory.newHazelcastInstance(getConfig(5));
+        String mapName = randomMapName();
+        IMap<Integer, Integer> map = instance1.getMap(mapName);
+        for (int i = 0; i < 1000; i++) {
+            map.set(i, i);
+        }
+        assertEquals(1000, map.size());
+
+        instance2 = factory.newHazelcastInstance(getConfig());
+        waitAllForSafeState(instance1, instance2);
+        instance2.getLifecycleService().terminate();
+
+        // map.size will complete after partition rebalancing
+        // since operation timeout is greater than auto partition
+        // rebalancing delay
+        Future<Integer> sizeFuture = spawn(() -> map.size());
+
+        // map is expected to be intact, since backups partitions
+        // will be promoted on rebalance
+        assertEquals(1000, (int) sizeFuture.get());
+    }
+
+    @Test
+    public void rebalanceImmediatelyOnJoin_afterDelayedRebalancing() {
+        // start instances with high rebalance delay
+        instance1 = factory.newHazelcastInstance(getConfig(1000));
+        getPartitionService(instance1).firstArrangement();
+
+        AtomicBoolean done = new AtomicBoolean(true);
+
+        instance2 = factory.newHazelcastInstance(getConfig(1000));
+        assertTrueEventually(() -> assertSomePartitionsBelongTo(instance2), PARTITION_REBALANCE_TIMEOUT);
+        // terminate second member
+        instance2.getLifecycleService().terminate();
+        sleepSeconds(1);
+
+        try {
+            // when member rejoins, partition rebalancing happens immediately, before configured delay
+            instance2 = factory.newHazelcastInstance(getConfig(1000));
+            assertTrueEventually(() -> assertSomePartitionsBelongTo(instance2), PARTITION_REBALANCE_TIMEOUT);
+        } finally {
+            done.set(false);
+        }
+    }
+
+    /** Configuration with manual rebalance mode */
+    @Override
+    protected Config getConfig() {
+        Config config = smallInstanceConfig();
+        return config;
+    }
+
+    /** Configuration with auto rebalance mode and given rebalance delay */
+    protected Config getConfig(int rebalanceDelaySeconds) {
+        Config config = smallInstanceConfig()
+                .setProperty(ClusterProperty.PARTITION_REBALANCE_DELAY_SECONDS.getName(), "" + rebalanceDelaySeconds);
+        config.getMapConfig("nobackup").setBackupCount(0);
+        return config;
+    }
+
+    public static void spawnPartitionTableDumper(HazelcastInstance instance, AtomicBoolean done) {
+        spawn(() -> {
+            while (!done.get()) {
+                sleepMillis(700);
+                System.out.println(">\n" + dumpPartitionTable(getPartitionService(instance).createPartitionTableView()));
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRebalanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRebalanceTest.java
@@ -34,7 +34,6 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.partition.TestPartitionUtils.assertAllPartitionsBelongTo;
 import static com.hazelcast.internal.partition.TestPartitionUtils.assertSomePartitionsBelongTo;
@@ -73,20 +72,14 @@ public class PartitionRebalanceTest extends HazelcastTestSupport {
         instance1 = factory.newHazelcastInstance(getConfig(PARTITION_REBALANCE_TIMEOUT));
         getPartitionService(instance1).firstArrangement();
 
-        AtomicBoolean done = new AtomicBoolean(true);
-
         instance2 = factory.newHazelcastInstance(getConfig());
         // assert partition rebalancing occurs automatically without delay on member join
         assertTrueEventually(() -> assertSomePartitionsBelongTo(instance2), PARTITION_REBALANCE_TIMEOUT / 2);
         instance2.getLifecycleService().terminate();
 
-        try {
-            sleepAtLeastSeconds(PARTITION_REBALANCE_TIMEOUT);
-            // after configured delay, partition rebalancing occurs automatically
-            assertTrueEventually(() -> assertAllPartitionsBelongTo(instance1), PARTITION_REBALANCE_TIMEOUT);
-        } finally {
-            done.set(false);
-        }
+        sleepAtLeastSeconds(PARTITION_REBALANCE_TIMEOUT);
+        // after configured delay, partition rebalancing occurs automatically
+        assertTrueEventually(() -> assertAllPartitionsBelongTo(instance1), PARTITION_REBALANCE_TIMEOUT);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRebalanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRebalanceTest.java
@@ -156,7 +156,7 @@ public class PartitionRebalanceTest extends HazelcastTestSupport {
     /** Configuration with given rebalance delay */
     protected Config getConfig(int rebalanceDelaySeconds) {
         Config config = smallInstanceConfig()
-                .setProperty(ClusterProperty.PARTITION_REBALANCE_DELAY_SECONDS.getName(), "" + rebalanceDelaySeconds);
+                .setProperty(ClusterProperty.PARTITION_REBALANCE_AFTER_MEMBER_LEFT_DELAY_SECONDS.getName(), "" + rebalanceDelaySeconds);
         config.getMapConfig("nobackup").setBackupCount(0);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
@@ -26,12 +26,13 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.TestUtil;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.impl.PartitionReplicaStateChecker;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
@@ -194,5 +195,9 @@ public class Accessors {
         }
 
         return allIndexes;
+    }
+
+    public static PartitionReplicaStateChecker getPartitionReplicaStateChecker(HazelcastInstance instance) {
+        return getPartitionService(instance).getPartitionReplicaStateChecker();
     }
 }


### PR DESCRIPTION
Persistence for 5.0

* Adds cluster property for configurable partition rebalancing delay when members leave the cluster unexpectedly (not with graceful shutdown). [The design doc is added in EE PR](https://github.com/hazelcast/hazelcast-enterprise/blob/730e0b22bca4dbd2fa2cf237adf580e79b86f2ce/docs/design/persistence/01-partition-rebalancing-improvements.md).
* Tracks partition assignments when members leave unexpectedly.
* Accommodates members with persistence that are rejoining the cluster, by validating their partition table against stored snapshot. This allows members with persistence to proceed reloading data from disk, then perform a differential data sync.
* Adds support for EE-side differential data sync for `IMap`. [Design doc for differential partition replication is in EE PR](https://github.com/hazelcast/hazelcast-enterprise/blob/94dd2e4a4a7644708cafb574a4e688b3d9efe0ae/docs/design/persistence/02-differential-partition-migration.md)

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/4124