### PR TITLE
MC-855 setting map memory cost metrics to -1 if in-memory-format is OBJECT

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -104,7 +104,6 @@ import com.hazelcast.client.map.impl.iterator.ClientMapQueryPartitionIterable;
 import com.hazelcast.client.map.impl.iterator.ClientMapQueryPartitionIterator;
 import com.hazelcast.client.map.impl.querycache.ClientQueryCacheContext;
 import com.hazelcast.cluster.Member;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
@@ -165,7 +164,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -104,6 +104,7 @@ import com.hazelcast.client.map.impl.iterator.ClientMapQueryPartitionIterable;
 import com.hazelcast.client.map.impl.iterator.ClientMapQueryPartitionIterator;
 import com.hazelcast.client.map.impl.querycache.ClientQueryCacheContext;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
@@ -164,6 +165,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalMapStatsImpl.java
@@ -167,8 +167,19 @@ public class LocalMapStatsImpl implements LocalMapStats {
     @Probe(name = MAP_METRIC_INDEXED_QUERY_COUNT)
     private volatile long indexedQueryCount;
 
-    public LocalMapStatsImpl() {
+    private final boolean ignoreMemoryCosts;
+
+    public LocalMapStatsImpl(boolean ignoreMemoryCosts) {
+        this.ignoreMemoryCosts = ignoreMemoryCosts;
         creationTime = Clock.currentTimeMillis();
+        if (ignoreMemoryCosts) {
+            ownedEntryMemoryCost = -1;
+            backupEntryMemoryCost = -1;
+        }
+    }
+
+    public LocalMapStatsImpl() {
+        this(false);
     }
 
     @Override
@@ -204,7 +215,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void setOwnedEntryMemoryCost(long ownedEntryMemoryCost) {
-        this.ownedEntryMemoryCost = ownedEntryMemoryCost;
+        if (!ignoreMemoryCosts) {
+            this.ownedEntryMemoryCost = ownedEntryMemoryCost;
+        }
     }
 
     @Override
@@ -213,7 +226,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void setBackupEntryMemoryCost(long backupEntryMemoryCost) {
-        this.backupEntryMemoryCost = backupEntryMemoryCost;
+        if (!ignoreMemoryCosts) {
+            this.backupEntryMemoryCost = backupEntryMemoryCost;
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -72,12 +72,7 @@ public class LocalMapStatsProvider {
     private final MapNearCacheManager mapNearCacheManager;
     private final IPartitionService partitionService;
     private final ConcurrentMap<String, LocalMapStatsImpl> statsMap;
-    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction =
-            this::createLocalMapStatsImpl;
-
-    private LocalMapStatsImpl createLocalMapStatsImpl(String mapName) {
-        return new LocalMapStatsImpl(mapServiceContext.getMapContainer(mapName).getMapConfig().getInMemoryFormat() == OBJECT);
-    }
+    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction = this::createLocalMapStatsImpl;
 
     public LocalMapStatsProvider(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
@@ -88,6 +83,10 @@ public class LocalMapStatsProvider {
         this.partitionService = nodeEngine.getPartitionService();
         this.localAddress = clusterService.getThisAddress();
         this.statsMap = MapUtil.createConcurrentHashMap(nodeEngine.getConfig().getMapConfigs().size());
+    }
+
+    private LocalMapStatsImpl createLocalMapStatsImpl(String mapName) {
+        return new LocalMapStatsImpl(mapServiceContext.getMapContainer(mapName).getMapConfig().getInMemoryFormat() == OBJECT);
     }
 
     protected MapServiceContext getMapServiceContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.internal.cluster.ClusterService;
@@ -86,7 +87,16 @@ public class LocalMapStatsProvider {
     }
 
     private LocalMapStatsImpl createLocalMapStatsImpl(String mapName) {
-        return new LocalMapStatsImpl(nodeEngine.getConfig().getMapConfig(mapName).getInMemoryFormat() == OBJECT);
+        // intentionally not using nodeEngine.getConfig().getMapConfig(mapName)
+        // since that breaks TestFullApplicationContext#testMapConfig()
+        MapConfig mapConfig = nodeEngine.getConfig().getMapConfigs().get(mapName);
+        InMemoryFormat inMemoryFormat;
+        if (mapConfig == null) {
+            inMemoryFormat = InMemoryFormat.BINARY;
+        } else {
+            inMemoryFormat = mapConfig.getInMemoryFormat();
+        }
+        return new LocalMapStatsImpl(inMemoryFormat == OBJECT);
     }
 
     protected MapServiceContext getMapServiceContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -86,7 +86,7 @@ public class LocalMapStatsProvider {
     }
 
     private LocalMapStatsImpl createLocalMapStatsImpl(String mapName) {
-        return new LocalMapStatsImpl(mapServiceContext.getMapContainer(mapName).getMapConfig().getInMemoryFormat() == OBJECT);
+        return new LocalMapStatsImpl(nodeEngine.getConfig().getMapConfig(mapName).getInMemoryFormat() == OBJECT);
     }
 
     protected MapServiceContext getMapServiceContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -72,7 +73,11 @@ public class LocalMapStatsProvider {
     private final IPartitionService partitionService;
     private final ConcurrentMap<String, LocalMapStatsImpl> statsMap;
     private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction =
-            key -> new LocalMapStatsImpl();
+            this::createLocalMapStatsImpl;
+
+    private LocalMapStatsImpl createLocalMapStatsImpl(String mapName) {
+        return new LocalMapStatsImpl(mapServiceContext.getMapContainer(mapName).getMapConfig().getInMemoryFormat() == OBJECT);
+    }
 
     public LocalMapStatsProvider(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
@@ -41,7 +41,7 @@ public class ClientMapStatsTest extends LocalMapStatsTest {
 
     @Before
     public void setUp() {
-        member = factory.newHazelcastInstance();
+        member = factory.newHazelcastInstance(createMemberConfig());
         client = factory.newHazelcastClient();
     }
 
@@ -51,7 +51,7 @@ public class ClientMapStatsTest extends LocalMapStatsTest {
     }
 
     @Override
-    protected LocalMapStats getMapStats() {
+    protected LocalMapStats getMapStats(String mapName) {
         return member.getMap(mapName).getLocalMapStats();
     }
 
@@ -61,7 +61,7 @@ public class ClientMapStatsTest extends LocalMapStatsTest {
     }
 
     @Override
-    protected <K, V> IMap<K, V> getMap() {
+    protected <K, V> IMap<K, V> getMap(String mapName) {
         return client.getMap(mapName);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
@@ -54,30 +55,40 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        Config config = getConfig().addMapConfig(new MapConfig()
-                .setName(mapWithObjectFormat)
-                .setInMemoryFormat(InMemoryFormat.OBJECT)
-        );
-        instance = createHazelcastInstance(config);
+        instance = createHazelcastInstance(createMemberConfig());
     }
 
-    protected LocalMapStats getMapStats() {
+    protected final LocalMapStats getMapStats() {
+        return getMapStats(mapName);
+    }
+
+    protected LocalMapStats getMapStats(String mapName) {
         return instance.getMap(mapName).getLocalMapStats();
     }
 
-    protected <K, V> IMap<K, V> getMap() {
+    protected final <K, V> IMap<K, V> getMap() {
+        return getMap(mapName);
+    }
+
+    protected <K, V> IMap<K, V> getMap(String mapName) {
         warmUpPartitions(instance);
         return instance.getMap(mapName);
     }
 
+    protected Config createMemberConfig() {
+        return getConfig().addMapConfig(new MapConfig()
+                .setName(mapWithObjectFormat)
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+        );
+    }
+
     @Test
     public void memoryCostIsMinusOne_ifInMemoryFormat_is_OBJECT() {
-        warmUpPartitions(instance);
-        IMap<Object, Object> map = instance.getMap(mapWithObjectFormat);
+        IMap<Object, Object> map = getMap(mapWithObjectFormat);
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
         }
-        LocalMapStats localMapStats = instance.getMap(mapWithObjectFormat).getLocalMapStats();
+        LocalMapStats localMapStats = getMapStats(mapWithObjectFormat);
         assertEquals(-1, localMapStats.getOwnedEntryMemoryCost());
         assertEquals(-1, localMapStats.getBackupEntryMemoryCost());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;


### PR DESCRIPTION
Setting the `map.ownedEntryMemoryCost`  and `map.backupEntryMemoryCost` to -1 if in-memory-format is `OBJECT`, instead of current `0` value.

The rationale is that if in-memory-format is `OBJECT`, then the memory cost is not 0, we just don't know it. 

Related jira tickets:
https://hazelcast.atlassian.net/browse/MC-341
https://hazelcast.atlassian.net/browse/MC-855


Breaking changes (list specific methods/types/messages):
* the `map.ownedEntryMemoryCost`  and `map.backupEntryMemoryCost` metrics change slightly

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
