### PR TITLE
Fix NPE on FULL JOIN

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeFactory.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeFactory.java
@@ -237,6 +237,8 @@ public final class HazelcastTypeFactory extends SqlTypeFactoryImpl {
 
     @Override
     public RelDataType createJoinType(RelDataType... types) {
+        // Calcite's implementation of createJoinType() returns RelCrossType.
+        // RelCrossType.getSqlTypeName() returns null. We assume in several places that it's non null...
         return createUnknownType();
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeFactory.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/types/HazelcastTypeFactory.java
@@ -234,4 +234,9 @@ public final class HazelcastTypeFactory extends SqlTypeFactoryImpl {
 
         return HazelcastIntegerType.create((HazelcastIntegerType) maxBitWidthType, targetType.isNullable());
     }
+
+    @Override
+    public RelDataType createJoinType(RelDataType... types) {
+        return createUnknownType();
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
@@ -61,6 +61,21 @@ public class SqlUnsupportedFeaturesTest extends SqlTestSupport {
     }
 
     @Test
+    public void test_multiFullJoin() {
+        TestBatchSqlConnector.create(sqlService, "b", 0);
+
+        assertThatThrownBy(() -> sqlService.execute(
+                    "SELECT 1 FROM b AS b1 JOIN b AS b2 ON b1.v = b2.v FULL OUTER JOIN b AS b3 ON b2.v = b3.v"))
+                .hasCauseInstanceOf(QueryException.class)
+                .hasMessageContaining("FULL join not supported");
+
+        assertThatThrownBy(() -> sqlService.execute(
+                    "SELECT 1 FROM b AS b1 JOIN b AS b2 ON b1.v = b2.v FULL JOIN b AS b3 ON b2.v = b3.v"))
+                .hasCauseInstanceOf(QueryException.class)
+                .hasMessageContaining("FULL join not supported");
+    }
+
+    @Test
     public void test_semiJoin() {
         TestBatchSqlConnector.create(sqlService, "b", 0);
 


### PR DESCRIPTION
Calcite's implementation of `RelDataTypeFactoryImpl.createJoinType()` returns `RelCrossType`. `RelCrossType.getSqlTypeName()` returns `null`. We assume in several places that it's non null...

Replaced `RelCrossType` with unknown type to mitigate NPE.

Fixes #18869