### PR TITLE
Remove NULLS FIRST and NULLS LAST support from SQL

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/ExpressionUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/ExpressionUtil.java
@@ -25,7 +25,6 @@ import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.HeapRow;
 import com.hazelcast.sql.impl.row.Row;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
-import org.apache.calcite.rel.RelFieldCollation.NullDirection;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -59,19 +58,14 @@ public final class ExpressionUtil {
             for (FieldCollation fieldCollation : fieldCollationList) {
                 // For each collation:
                 // - Get collation index and use it to fetch values from the rows.
-                // - Get direction (ASCENDING, DESCENDING) and null direction
-                //   (NULLS FIRST, NULLS LAST). If no null direction is given, then
-                //   it will be inferred from the direction. Since NULL is sorted as
-                //   the +Inf, ASCENDING implies NULL LAST whereas DESCENDING implies
-                //   NULLS FIRST.
+                // - Get direction (ASCENDING, DESCENDING)
                 // - Comparison of field values:
-                //   - If both of them are NULL, then return 0.
+                //   - If both of them are NULL, then result is 0.
                 //   - Otherwise, if one of them is NULL, then return:
-                //     - null direction value if LHS is NULL.
-                //     - or negative null direction if RHS is NULL.
-                //   - If none of them is NULL, then:
-                //     - If direction is ASCENDING, then return the comparison result.
-                //     - If direction is DESCENDING, return the negation of comparison result.
+                //     - result is -1 if LHS is NULL.
+                //     - result is 1 if RHS is NULL.
+                // - Return the result if ASCENDING
+                //   Return the reverted result if DESCENDING
                 int index = fieldCollation.getIndex();
 
                 Comparable o1 = (Comparable) row1[index];
@@ -79,21 +73,23 @@ public final class ExpressionUtil {
 
                 Direction direction = fieldCollation.getDirection();
 
-                NullDirection nullDirection = fieldCollation.getNullDirection();
-                if (nullDirection == null) {
-                    nullDirection = direction.defaultNullDirection();
-                }
-
                 int result;
                 if (o1 == null && o2 == null) {
                     result = 0;
                 } else if (o1 == null) {
-                    result = nullDirection.nullComparison;
+                    result = -1;
                 } else if (o2 == null) {
-                    result = -nullDirection.nullComparison;
+                    result = 1;
                 } else {
                     result = o1.compareTo(o2);
-                    result = direction.isDescending() ? -result : result;
+                }
+
+                if (direction.isDescending()) {
+                    if (result < 0) {
+                        result = 1;
+                    } else if (result > 0) {
+                        result = -1;
+                    }
                 }
 
                 if (result != 0) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlOperatorTable.java
@@ -75,9 +75,6 @@ public final class JetSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlFunction AVRO_FILE = new FileTableFunction("AVRO_FILE", AvroFileFormat.FORMAT_AVRO);
     public static final SqlFunction PARQUET_FILE = new FileTableFunction("PARQUET_FILE", ParquetFileFormat.FORMAT_PARQUET);
 
-    public static final SqlPostfixOperator NULLS_FIRST = HazelcastDescOperator.NULLS_FIRST;
-    public static final SqlPostfixOperator NULLS_LAST = HazelcastDescOperator.NULLS_LAST;
-
     private static final JetSqlOperatorTable INSTANCE = new JetSqlOperatorTable();
 
     static {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/JetSqlOperatorTable.java
@@ -31,13 +31,11 @@ import com.hazelcast.jet.sql.impl.validate.operators.HazelcastCollectionTableOpe
 import com.hazelcast.jet.sql.impl.validate.operators.HazelcastMapValueConstructor;
 import com.hazelcast.jet.sql.impl.validate.operators.HazelcastRowOperator;
 import com.hazelcast.jet.sql.impl.validate.operators.HazelcastValuesOperator;
-import com.hazelcast.sql.impl.calcite.validate.operators.misc.HazelcastDescOperator;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.SqlPostfixOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
@@ -145,8 +145,6 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
         SUPPORTED_KINDS.add(SqlKind.ARGUMENT_ASSIGNMENT);
 
         // Ordering
-        SUPPORTED_KINDS.add(SqlKind.NULLS_FIRST);
-        SUPPORTED_KINDS.add(SqlKind.NULLS_LAST);
         SUPPORTED_KINDS.add(SqlKind.DESCENDING);
 
         // Supported operators

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/misc/HazelcastDescOperator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/misc/HazelcastDescOperator.java
@@ -26,8 +26,6 @@ import org.apache.calcite.sql.type.SqlOperandCountRanges;
 public final class HazelcastDescOperator extends HazelcastPostfixOperator {
 
     public static final HazelcastDescOperator DESC = new HazelcastDescOperator(SqlStdOperatorTable.DESC);
-    public static final HazelcastDescOperator NULLS_FIRST = new HazelcastDescOperator(SqlStdOperatorTable.NULLS_FIRST);
-    public static final HazelcastDescOperator NULLS_LAST = new HazelcastDescOperator(SqlStdOperatorTable.NULLS_LAST);
 
     private HazelcastDescOperator(SqlPostfixOperator base) {
         super(base.getName(),

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSortTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSortTest.java
@@ -89,10 +89,10 @@ public class SqlSortTest extends SqlTestSupport {
         assertRowsOrdered(
                 String.format("SELECT name, distance FROM %s ORDER BY distance ASC, name ASC", tableName),
                 asList(
-                        new Row("A", 1),
-                        new Row("B", 1),
                         new Row("A", null),
-                        new Row("B", null)
+                        new Row("B", null),
+                        new Row("A", 1),
+                        new Row("B", 1)
                 )
         );
     }
@@ -109,78 +109,58 @@ public class SqlSortTest extends SqlTestSupport {
         assertRowsOrdered(
                 String.format("SELECT name, distance FROM %s ORDER BY distance DESC, name DESC", tableName),
                 asList(
-                        new Row("B", null),
-                        new Row("A", null),
                         new Row("B", 1),
-                        new Row("A", 1)
-                )
-        );
-    }
-
-    @Test
-    public void test_nullsFirstAscending() {
-        String tableName = createTable(
-                new String[]{"B", null},
-                new String[]{"B", "1"},
-                new String[]{"A", null},
-                new String[]{"A", "1"},
-                new String[]{"C", "1"}
-        );
-
-        assertRowsOrdered(
-                String.format("SELECT name, distance FROM %s ORDER BY distance ASC NULLS FIRST, name ASC", tableName),
-                asList(
-                        new Row("A", null),
-                        new Row("B", null),
                         new Row("A", 1),
-                        new Row("B", 1),
-                        new Row("C", 1)
-                )
-        );
-    }
-
-    @Test
-    public void test_nullsLastAscending() {
-        String tableName = createTable(
-                new String[]{"B", null},
-                new String[]{"B", "1"},
-                new String[]{"A", null},
-                new String[]{"A", "1"},
-                new String[]{"C", "1"}
-        );
-
-        assertRowsOrdered(
-                String.format("SELECT name, distance FROM %s ORDER BY distance ASC NULLS LAST, name ASC", tableName),
-                asList(
-                        new Row("A", 1),
-                        new Row("B", 1),
-                        new Row("C", 1),
-                        new Row("A", null),
-                        new Row("B", null)
-                )
-        );
-    }
-
-    @Test
-    public void test_nullsFirstDescending() {
-        String tableName = createTable(
-                new String[]{"B", null},
-                new String[]{"B", "1"},
-                new String[]{"A", null},
-                new String[]{"A", "1"},
-                new String[]{"C", "1"}
-        );
-
-        assertRowsOrdered(
-                String.format("SELECT name, distance FROM %s ORDER BY distance DESC NULLS FIRST, name DESC", tableName),
-                asList(
                         new Row("B", null),
-                        new Row("A", null),
-                        new Row("C", 1),
-                        new Row("B", 1),
-                        new Row("A", 1)
+                        new Row("A", null)
                 )
         );
+    }
+
+    @Test
+    public void test_nullsFirstAscending_notSupported() {
+        String tableName = createTable(
+                new String[]{"B", null},
+                new String[]{"B", "1"},
+                new String[]{"A", null},
+                new String[]{"A", "1"},
+                new String[]{"C", "1"}
+        );
+
+        assertThatThrownBy(() -> sqlService.execute(
+                String.format("SELECT name, distance FROM %s ORDER BY distance ASC NULLS FIRST, name ASC", tableName)
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS FIRST' does not exist");
+    }
+
+    @Test
+    public void test_nullsLastAscending_notSupported() {
+        String tableName = createTable(
+                new String[]{"B", null},
+                new String[]{"B", "1"},
+                new String[]{"A", null},
+                new String[]{"A", "1"},
+                new String[]{"C", "1"}
+        );
+
+        assertThatThrownBy(() -> sqlService.execute(
+                String.format("SELECT name, distance FROM %s ORDER BY distance ASC NULLS LAST, name ASC", tableName)
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS LAST' does not exist");
+    }
+
+    @Test
+    public void test_nullsFirstDescending_notSupported() {
+        String tableName = createTable(
+                new String[]{"B", null},
+                new String[]{"B", "1"},
+                new String[]{"A", null},
+                new String[]{"A", "1"},
+                new String[]{"C", "1"}
+        );
+
+        assertThatThrownBy(() -> sqlService.execute(
+                String.format("SELECT name, distance FROM %s ORDER BY distance DESC NULLS FIRST, name DESC", tableName)
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS FIRST' does not exist");
+
     }
 
     @Test
@@ -192,16 +172,10 @@ public class SqlSortTest extends SqlTestSupport {
                 new String[]{"A", "1"},
                 new String[]{"C", "1"}
         );
-        assertRowsOrdered(
-                String.format("SELECT name, distance FROM %s ORDER BY distance DESC NULLS LAST, name DESC", tableName),
-                asList(
-                        new Row("C", 1),
-                        new Row("B", 1),
-                        new Row("A", 1),
-                        new Row("B", null),
-                        new Row("A", null)
-                )
-        );
+
+        assertThatThrownBy(() -> sqlService.execute(
+                String.format("SELECT name, distance FROM %s ORDER BY distance DESC NULLS LAST, name DESC", tableName)
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS LAST' does not exist");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -28,7 +28,6 @@ import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.SqlStatement;
-import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.plan.cache.PlanCache;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -28,6 +28,7 @@ import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.SqlStatement;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.plan.cache.PlanCache;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/calcite/parse/ParserOperationsTest.java
@@ -130,8 +130,8 @@ public class ParserOperationsTest extends SqlTestSupport {
 
     @Test
     public void testNullsFirstLast() {
-        checkSuccess("SELECT a, b FROM t ORDER BY a DESC NULLS FIRST");
-        checkSuccess("SELECT a, b FROM t ORDER BY a DESC NULLS LAST");
+        checkFailure("SELECT a, b FROM t ORDER BY a DESC NULLS FIRST", "Function 'NULLS FIRST' does not exist");
+        checkFailure("SELECT a, b FROM t ORDER BY a DESC NULLS LAST", "Function 'NULLS LAST' does not exist");
     }
 
     @Test


### PR DESCRIPTION
Disables NULLS FIRST and NULLS LAST support from SQL

Currently, the indices treat NULL as the smallest value in ordering, therefore we need to disable temporarily these constructs.

