### PR TITLE
MC-821 - don't decode masked identity token

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -72,6 +72,9 @@ import static java.util.Arrays.asList;
 @SuppressWarnings({"checkstyle:methodcount"})
 public class ConfigXmlGenerator {
 
+    /**
+     * Mask to hide the sensitive values in configuration.
+     */
     public static final String MASK_FOR_SENSITIVE_DATA = "****";
 
     private static final int INDENT = 5;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -72,7 +72,7 @@ import static java.util.Arrays.asList;
 @SuppressWarnings({"checkstyle:methodcount"})
 public class ConfigXmlGenerator {
 
-    protected static final String MASK_FOR_SENSITIVE_DATA = "****";
+    public static final String MASK_FOR_SENSITIVE_DATA = "****";
 
     private static final int INDENT = 5;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/security/TokenEncoding.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/TokenEncoding.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config.security;
 
+import static com.hazelcast.config.ConfigXmlGenerator.MASK_FOR_SENSITIVE_DATA;
 import static com.hazelcast.internal.util.StringUtil.trim;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
@@ -33,7 +34,13 @@ public enum TokenEncoding {
     /**
      * Base64 token encoding.
      */
-    BASE64("base64", ba -> Base64.getEncoder().encodeToString(ba), s -> Base64.getDecoder().decode(s));
+    BASE64("base64", ba -> Base64.getEncoder().encodeToString(ba), s -> {
+        if (MASK_FOR_SENSITIVE_DATA.equals(s)) {
+            return MASK_FOR_SENSITIVE_DATA.getBytes(US_ASCII);
+        } else {
+            return Base64.getDecoder().decode(s);
+        }
+    });
 
     private static final TokenEncoding DEFAULT = TokenEncoding.NONE;
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -28,6 +28,8 @@ import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.SimpleAuthenticationConfig;
+import com.hazelcast.config.security.TokenEncoding;
+import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
@@ -69,6 +71,8 @@ import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
 import static com.hazelcast.config.WanQueueFullBehavior.THROW_EXCEPTION;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static java.io.File.createTempFile;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -219,6 +223,9 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          </login-module>\n"
                 + "        </jaas>"
                 + "      </authentication>"
+                + "      <identity>"
+                + "        <token encoding=\"base64\">****</token>"
+                + "      </identity>"
                 + "    </realm>"
                 + "    <realm name='kerberos'>"
                 + "      <authentication>"
@@ -317,6 +324,10 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(LoginModuleUsage.REQUIRED, clientLoginModuleCfg2.getUsage());
         assertEquals(1, clientLoginModuleCfg2.getProperties().size());
         assertEquals("client-value2", clientLoginModuleCfg2.getProperties().getProperty("client-property2"));
+
+        TokenIdentityConfig tokenIdentityConfig = clientRealm.getTokenIdentityConfig();
+        assertEquals(TokenEncoding.BASE64, tokenIdentityConfig.getEncoding());
+        assertArrayEquals(ConfigXmlGenerator.MASK_FOR_SENSITIVE_DATA.getBytes(US_ASCII), tokenIdentityConfig.getToken());
 
         RealmConfig kerberosRealm = securityConfig.getRealmConfig("kerberos");
         assertNotNull(kerberosRealm);


### PR DESCRIPTION
Fixes https://hazelcast.atlassian.net/browse/MC-821
This is a proper fix for https://hazelcast.atlassian.net/browse/MC-806
**What was the error on Management Center side:**
- the cluster returns member config in XML with some sensitive values (like identity tokens) masked with `****`
- then MC tries to parse XML with `com.hazelcast.config.XmlConfigBuilde`
-`XmlConfigBuilder` sees an identity token with Base64 encoding and tries to decode it
- token decoding fails because there is a mask`****` instead of Base64 string as a token

**How this change helps:**
`TokenEncoding` is now aware of the mask `****` and doesn't try to decode it from Base64

