### PR TITLE
Enable env-based configuration of custom properties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/YamlClientDomConfigProcessor.java
@@ -32,10 +32,8 @@ import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.internal.util.StringUtil;
-import com.hazelcast.internal.yaml.YamlMapping;
-import com.hazelcast.internal.yaml.YamlNode;
-import com.hazelcast.internal.yaml.YamlScalar;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import java.nio.ByteOrder;
 import java.util.Map;
@@ -46,8 +44,6 @@ import static com.hazelcast.internal.config.DomConfigHelper.childElements;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
 import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
-import static com.hazelcast.internal.config.yaml.W3cDomUtil.getWrappedYamlMapping;
-import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
 
 public class YamlClientDomConfigProcessor extends ClientDomConfigProcessor {
     public YamlClientDomConfigProcessor(boolean domLevel3, ClientConfig clientConfig) {
@@ -257,23 +253,19 @@ public class YamlClientDomConfigProcessor extends ClientDomConfigProcessor {
 
     @Override
     protected void fillProperties(Node node, Map<String, Comparable> properties) {
-        YamlMapping propertiesMapping = getWrappedYamlMapping(node);
-        for (YamlNode propNode : propertiesMapping.children()) {
-            YamlScalar propScalar = asScalar(propNode);
-            String key = propScalar.nodeName();
-            String value = propScalar.nodeValue().toString();
-            properties.put(key, value);
+        NodeList childNodes = node.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+            properties.put(childNode.getNodeName(), childNode.getNodeValue());
         }
     }
 
     @Override
     protected void fillProperties(Node node, Properties properties) {
-        YamlMapping propertiesMapping = getWrappedYamlMapping(node);
-        for (YamlNode propNode : propertiesMapping.children()) {
-            YamlScalar propScalar = asScalar(propNode);
-            String key = propScalar.nodeName();
-            String value = propScalar.nodeValue().toString();
-            properties.put(key, value);
+        NodeList childNodes = node.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+            properties.put(childNode.getNodeName(), childNode.getNodeValue());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -80,9 +80,7 @@ import com.hazelcast.config.security.TokenEncoding;
 import com.hazelcast.config.security.TokenIdentityConfig;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.util.StringUtil;
-import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
-import com.hazelcast.internal.yaml.YamlScalar;
 import com.hazelcast.internal.yaml.YamlSequence;
 import com.hazelcast.query.impl.IndexUtils;
 import org.w3c.dom.NamedNodeMap;
@@ -101,7 +99,6 @@ import static com.hazelcast.internal.config.DomConfigHelper.childElements;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
 import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
-import static com.hazelcast.internal.config.yaml.W3cDomUtil.getWrappedYamlMapping;
 import static com.hazelcast.internal.config.yaml.W3cDomUtil.getWrappedYamlSequence;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
@@ -555,23 +552,19 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
 
     @Override
     protected void fillProperties(Node node, Map<String, Comparable> properties) {
-        YamlMapping propertiesMapping = getWrappedYamlMapping(node);
-        for (YamlNode propNode : propertiesMapping.children()) {
-            YamlScalar propScalar = asScalar(propNode);
-            String key = propScalar.nodeName();
-            String value = propScalar.nodeValue().toString();
-            properties.put(key, value);
+        NodeList childNodes = node.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+            properties.put(childNode.getNodeName(), childNode.getNodeValue());
         }
     }
 
     @Override
     protected void fillProperties(Node node, Properties properties) {
-        YamlMapping propertiesMapping = getWrappedYamlMapping(node);
-        for (YamlNode propNode : propertiesMapping.children()) {
-            YamlScalar propScalar = asScalar(propNode);
-            String key = propScalar.nodeName();
-            String value = propScalar.nodeValue().toString();
-            properties.put(key, value);
+        NodeList childNodes = node.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+            properties.put(childNode.getNodeName(), childNode.getNodeValue());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/yaml/W3cDomUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/yaml/W3cDomUtil.java
@@ -17,9 +17,7 @@
 package com.hazelcast.internal.config.yaml;
 
 import com.hazelcast.internal.yaml.MutableYamlNode;
-import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
-import com.hazelcast.internal.yaml.YamlScalar;
 import com.hazelcast.internal.yaml.YamlSequence;
 import com.hazelcast.internal.yaml.YamlUtil;
 import org.w3c.dom.Node;
@@ -49,23 +47,6 @@ public final class W3cDomUtil {
     }
 
     /**
-     * Returns the the wrapped {@link YamlMapping} instance of the
-     * provided {@link Node} if the {@code node} is an instance of
-     * {@link YamlElementAdapter} and the YAML node wrapped by the {@code node}
-     * is a {@link YamlMapping}.
-     *
-     * @param node The W3C node wrapping a YAML node
-     * @return the wrapped YAML node as mapping
-     * @throws IllegalArgumentException if the provided node is not an
-     *                                  instance of {@link YamlElementAdapter}
-     */
-    public static YamlMapping getWrappedYamlMapping(Node node) {
-        checkNodeIsElementAdapter(node);
-
-        return asYamlType(node, YamlMapping.class);
-    }
-
-    /**
      * Returns the the wrapped {@link YamlSequence} instance of the
      * provided {@link Node} if the {@code node} is an instance of
      * {@link YamlElementAdapter} and the YAML node wrapped by the {@code node}
@@ -80,23 +61,6 @@ public final class W3cDomUtil {
         checkNodeIsElementAdapter(node);
 
         return asYamlType(node, YamlSequence.class);
-    }
-
-    /**
-     * Returns the the wrapped {@link YamlScalar} instance of the
-     * provided {@link Node} if the {@code node} is an instance of
-     * {@link YamlElementAdapter} and the YAML node wrapped by the {@code node}
-     * is a {@link YamlScalar}.
-     *
-     * @param node The W3C node wrapping a YAML node
-     * @return the wrapped YAML node as scalar
-     * @throws IllegalArgumentException if the provided node is not an
-     *                                  instance of {@link YamlElementAdapter}
-     */
-    public static YamlScalar getWrappedYamlScalar(Node node) {
-        checkNodeIsElementAdapter(node);
-
-        return asYamlType(node, YamlScalar.class);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalClientConfigurationOverrideTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalClientConfigurationOverrideTest.java
@@ -42,4 +42,14 @@ public class ExternalClientConfigurationOverrideTest extends HazelcastTestSuppor
         assertEquals("test", config.getInstanceName());
         assertFalse(config.getNetworkConfig().isAutoDetectionEnabled());
     }
+
+    @Test
+    public void shouldHandleCustomPropertiesConfig() throws Exception {
+        ClientConfig config = new ClientConfig();
+
+        withEnvironmentVariable("HZCLIENT_PROPERTIES_foo", "bar")
+          .execute(() -> new ExternalConfigurationOverride().overwriteClientConfig(config));
+
+        assertEquals("bar", config.getProperty("foo"));
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -73,6 +73,16 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     }
 
     @Test
+    public void shouldHandleCustomPropertiesConfig() throws Exception {
+        Config config = new Config();
+
+        withEnvironmentVariable("HZ_PROPERTIES_foo", "bar")
+          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        assertEquals("bar", config.getProperty("foo"));
+    }
+
+    @Test
     public void shouldHandleAdvancedNetworkEndpointConfiguration() throws Exception {
         Config config = new Config();
         config.getAdvancedNetworkConfig().setClientEndpointConfig(new ServerSocketEndpointConfig()


### PR DESCRIPTION
Due to unnecessary reliance on internal implementation details, it was not possible to provide custom properties via env/sysprops.

```
Caused by: java.lang.IllegalArgumentException: The provided node is not an instance of ElementAdapter, it is a com.hazelcast.internal.config.override.ConfigOverrideElementAdapter
	at com.hazelcast.internal.config.yaml.W3cDomUtil.checkNodeIsElementAdapter(W3cDomUtil.java:133)
	at com.hazelcast.internal.config.yaml.W3cDomUtil.getWrappedYamlMapping(W3cDomUtil.java:63)
        ...
```

Rewrote that logic using public APIs.