### PR TITLE
[CN-118] change order of classpath folder list for docker's image custom jar setup

### DIFF
--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -55,7 +55,7 @@ else
   export JAVA_OPTS="${JAVA_OPTS_DEFAULT}"
 fi
 
-CLASSPATH="$HAZELCAST_HOME/lib:$HAZELCAST_HOME/lib/*:$HAZELCAST_HOME/bin/user-lib:$HAZELCAST_HOME/bin/user-lib/*:$CLASSPATH"
+CLASSPATH="$CLASSPATH:$HAZELCAST_HOME/lib:$HAZELCAST_HOME/lib/*:$HAZELCAST_HOME/bin/user-lib:$HAZELCAST_HOME/bin/user-lib/*"
 
 function readJvmOptionsFile {
     # Read jvm.options file


### PR DESCRIPTION
To use classes from custom Hazelcast jar whose path is ${HZ_HOME}/....jar, we need define this path first so OpenJDK's classloader that we used at docker image can pick them. Here is the related docker usages:
https://github.com/hazelcast/hazelcast-docker#extending-hazelcast-base-image
https://github.com/hazelcast/hazelcast-docker#building-your-hazelcast-image
