### PR TITLE
Fix default yaml config leftover from hz-cli

### DIFF
--- a/distribution/src/bin-filemode-755/hz-cli
+++ b/distribution/src/bin-filemode-755/hz-cli
@@ -7,7 +7,6 @@ readJvmOptionsFile "jvm-client.options"
 
 JAVA_OPTS_ARRAY=(\
 $JDK_OPTS \
-"-Dhazelcast.client.config=$HAZELCAST_HOME/config/hazelcast-client.yaml" \
 $JVM_OPTIONS \
 $JAVA_OPTS \
 )


### PR DESCRIPTION
Remove leftover default config setting from `hz-cli`

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

