### PR TITLE
Handle correctly merkleTreeConfig existence for compatibility 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/holder/CacheConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/holder/CacheConfigHolder.java
@@ -244,7 +244,9 @@ public class CacheConfigHolder {
 
         config.setMergePolicyConfig(mergePolicyConfig);
         config.setDisablePerEntryInvalidationEvents(disablePerEntryInvalidationEvents);
-        config.setMerkleTreeConfig(merkleTreeConfig);
+        if (merkleTreeConfigExists) {
+            config.setMerkleTreeConfig(merkleTreeConfig);
+        }
 
         if (cachePartitionLostListenerConfigs != null) {
             List<CachePartitionLostListenerConfig> partitionLostListenerConfigs = new ArrayList<>(
@@ -288,7 +290,7 @@ public class CacheConfigHolder {
                 config.isStoreByValue(), config.isManagementEnabled(), config.isStatisticsEnabled(), config.getHotRestartConfig(),
                 config.getEventJournalConfig(), config.getSplitBrainProtectionName(), listenerConfigurations,
                 config.getMergePolicyConfig(), config.isDisablePerEntryInvalidationEvents(),
-                cachePartitionLostListenerConfigs, config.getMerkleTreeConfig().isEnabled(), config.getMerkleTreeConfig());
+                cachePartitionLostListenerConfigs, config.getMerkleTreeConfig() != null, config.getMerkleTreeConfig());
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -484,7 +484,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> implements Vers
      * @param merkleTreeConfig merkle tree config
      */
     public void setMerkleTreeConfig(MerkleTreeConfig merkleTreeConfig) {
-        this.merkleTreeConfig = merkleTreeConfig;
+        this.merkleTreeConfig = checkNotNull(merkleTreeConfig, "merkleTreeConfig cannot be null!");
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -493,6 +493,12 @@ public class CacheConfigTest extends HazelcastTestSupport {
         config.setBackupCount(200); //max allowed is 6..
     }
 
+    @Test(expected = NullPointerException.class)
+    public void givenNullMerkleTreeConfig_throws_NPE() {
+        new CacheConfig()
+                .setMerkleTreeConfig(null);
+    }
+
     @Test
     public void createCache_WhenCacheConfigIsNull() {
         String cacheName = "cacheNull";

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -82,6 +82,14 @@ public class CacheSimpleConfigTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void givenNullMerkleTreeConfig_throws_NPE() {
+        expectedException.expect(NullPointerException.class);
+
+        new CacheSimpleConfig()
+                .setMerkleTreeConfig(null);
+    }
+
+    @Test
     public void testEqualsAndHashCode() {
         assumeDifferentHashCodes();
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/19044

Created configs by older versions(< 5.0) have `null` `merkleTreeConfig` hence `merkleTreeConfig#isEnabled` throws NPE. `config.getMerkleTreeConfig() != null` should be used instead to check existence of `merkleTreeConfig`.