### PR TITLE
[FORWARD-PORT] Fix getJobSummaryList when Jet is disabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobSummaryListMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobSummaryListMessageTask.java
@@ -52,6 +52,9 @@ public class JetGetJobSummaryListMessageTask extends AbstractMultiTargetMessageT
 
     @Override
     public Collection<Member> getTargets() {
+        if (!nodeEngine.getConfig().getJetConfig().isEnabled()) {
+            throw new IllegalArgumentException("Jet is disabled, see JetConfig#setEnabled.");
+        }
         return nodeEngine.getClusterService().getMembers(DATA_MEMBER_SELECTOR);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/JetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/JetTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
@@ -76,6 +77,17 @@ public class JetTest extends JetTestSupport {
                 .writeTo(Sinks.noop());
 
         assertThrows(IllegalArgumentException.class, () -> client.getJet().newJob(p).join());
+    }
+
+    @Test
+    public void when_jetDisabled_and_usingClient_then_getSummaryListThrowsException() {
+        Config config = smallInstanceConfig();
+        config.getJetConfig().setEnabled(false);
+        createHazelcastInstance(config);
+        HazelcastInstance client = createHazelcastClient();
+        JetClientInstanceImpl jet = (JetClientInstanceImpl) client.getJet();
+
+        assertThrows(IllegalArgumentException.class, jet::getJobSummaryList);
     }
 
     @Test


### PR DESCRIPTION
forward-port of https://github.com/hazelcast/hazelcast/pull/19067

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
