### PR TITLE
Don't use processor classloaders for light jobs 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -208,7 +208,7 @@ public class JobExecutionService implements DynamicMetricsProvider {
         if (processorClsForJob != null) {
             return processorClsForJob.get(name);
         } else {
-            throw new HazelcastException("Processor classloader for jobId=" + jobId
+            throw new HazelcastException("Processor classloader for jobId=" + Util.idToString(jobId)
                     + " requested, but it does not exists");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -333,15 +333,12 @@ public class JobExecutionService implements DynamicMetricsProvider {
         }
 
         try {
-            prepareProcessorClassLoaders(jobId, plan.getJobConfig());
             Set<Address> addresses = participants.stream().map(MemberInfo::getAddress).collect(toSet());
             ClassLoader jobCl = getClassLoader(plan.getJobConfig(), jobId);
             doWithClassLoader(jobCl, () -> execCtx.initialize(coordinator, addresses, plan));
         } catch (Throwable e) {
             completeExecution(execCtx, new CancellationException());
             throw e;
-        } finally {
-            clearProcessorClassLoaders();
         }
 
         // initial log entry with all of jobId, jobName, executionId

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -180,7 +180,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             memberConnections.put(destAddr, getMemberConnection(nodeEngine, destAddr));
         }
         for (VertexDef vertex : vertices) {
-            ClassLoader processorClassLoader = jobExecutionService.getProcessorClassLoader(jobId, vertex.name());
+            ClassLoader processorClassLoader = isLightJob ? null :
+                    jobExecutionService.getProcessorClassLoader(jobId, vertex.name());
             Collection<? extends Processor> processors = doWithClassLoader(
                     processorClassLoader,
                     () -> createProcessors(vertex, vertex.localParallelism())
@@ -329,7 +330,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                                    ConcurrentHashMap<String, File> tempDirectories,
                                    InternalSerializationService jobSerializationService) {
         for (VertexDef vertex : vertices) {
-            ClassLoader processorClassLoader = jobExecutionService.getProcessorClassLoader(jobId, vertex.name());
+            ClassLoader processorClassLoader = isLightJob ? null :
+                    jobExecutionService.getProcessorClassLoader(jobId, vertex.name());
             ProcessorSupplier supplier = vertex.processorSupplier();
             String prefix = prefix(jobConfig.getName(), jobId, vertex.name(), "#PS");
             ILogger logger = prefixedLogger(nodeEngine.getLogger(supplier.getClass()), prefix);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderCleanupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderCleanupTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
 import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.Util;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.impl.JetServiceBackend;
@@ -74,7 +75,7 @@ public class ProcessorClassLoaderCleanupTest extends JetTestSupport {
 
         assertThatThrownBy(() -> jobExecutionService.getProcessorClassLoader(job.getId(), source.name()))
                 .isInstanceOf(HazelcastException.class)
-                .hasMessageContaining("Processor classloader for jobId=" + job.getId()
+                .hasMessageContaining("Processor classloader for jobId=" + Util.idToString(job.getId())
                         + " requested, but it does not exists");
     }
 }


### PR DESCRIPTION
Support for processor classloader in light jobs is not trivial. This PR disables the processor classloader in light jobs.