### PR TITLE
TopologyChangeTest.when_nodeIsNotJobParticipant_then_initFails fix 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -513,7 +513,7 @@ public class TopologyChangeTest extends JetTestSupport {
         JobRecord jobRecord = new JobRecord(version, jobId, null, "", new JobConfig(), Collections.emptySet(), null);
         instances[0].getMap(JOB_RECORDS_MAP_NAME).put(jobId, jobRecord);
 
-        InitExecutionOperation op = new InitExecutionOperation(jobId, executionId, memberListVersion, null, memberInfos, null, false);
+        InitExecutionOperation op = new InitExecutionOperation(jobId, executionId, memberListVersion, version, memberInfos, null, false);
         Future<Object> future = Accessors.getOperationService(master)
                 .createInvocationBuilder(JetServiceBackend.SERVICE_NAME, op, Accessors.getAddress(master))
                 .invoke();


### PR DESCRIPTION
Added coordinator version passing to the InitExecutionOp. Fixes #19084.