### PR TITLE
Fix race condition in StreamKafkaPTest

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -379,8 +379,12 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
          .writeTo(Sinks.list(sinkList));
 
         Job job = instance().getJet().newJob(p, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
+        // Wait for the job to be running, otherwise we might miss the event due to auto.offset.reset=latest
+        assertJobStatusEventually(job, JobStatus.RUNNING);
+
+        // Produce just a single event
+        kafkaTestSupport.produce(topic1Name, 0, "0").get();
         assertTrueEventually(() -> {
-            kafkaTestSupport.produce(topic1Name, 0, "0").get();
             assertFalse(sinkList.isEmpty());
             assertEquals(entry(0, "0"), sinkList.get(0));
         });


### PR DESCRIPTION
Because it takes some time for the event to appear in the sink list
sometimes multiple "0" events were published, but not all consumed
before the job was suspended.

With this change only 1 event is published.

Fixes #18785 