### PR TITLE
Simplify optimizer tests

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/OptimizerTestSupport.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.sql.impl.JetPlanExecutor;
 import com.hazelcast.jet.sql.impl.JetSqlBackend;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorCache;
+import com.hazelcast.jet.sql.impl.opt.logical.LogicalRel;
 import com.hazelcast.jet.sql.impl.opt.logical.LogicalRules;
 import com.hazelcast.jet.sql.impl.schema.MappingCatalog;
 import com.hazelcast.jet.sql.impl.schema.MappingStorage;
@@ -29,8 +30,6 @@ import com.hazelcast.sql.impl.QueryUtils;
 import com.hazelcast.sql.impl.calcite.HazelcastSqlBackend;
 import com.hazelcast.sql.impl.calcite.OptimizerContext;
 import com.hazelcast.sql.impl.calcite.TestMapTable;
-import com.hazelcast.sql.impl.calcite.opt.logical.LogicalRel;
-import com.hazelcast.sql.impl.calcite.opt.logical.RootLogicalRel;
 import com.hazelcast.sql.impl.calcite.parse.QueryParseResult;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastSchema;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastSchemaUtils;
@@ -99,8 +98,7 @@ public abstract class OptimizerTestSupport extends SimpleTestInClusterSupport {
     }
 
     private static LogicalRel optimizeLogicalInternal(OptimizerContext context, RelNode node) {
-        RelNode logicalRel = context.optimize(node, LogicalRules.getRuleSet(), OptUtils.toLogicalConvention(node.getTraitSet()));
-        return new RootLogicalRel(logicalRel.getCluster(), logicalRel.getTraitSet(), logicalRel);
+        return (LogicalRel) context.optimize(node, LogicalRules.getRuleSet(), OptUtils.toLogicalConvention(node.getTraitSet()));
     }
 
     protected static HazelcastTable partitionedTable(String name, List<TableField> fields, long rowCount) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalDeleteTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalDeleteTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.jet.sql.impl.opt.OptimizerTestSupport;
-import com.hazelcast.sql.impl.calcite.opt.logical.RootLogicalRel;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import junitparams.JUnitParamsRunner;
@@ -46,9 +45,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -59,9 +57,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE this = '1'", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -72,9 +69,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = 1 AND this = '1'", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -85,9 +81,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = 1 AND __key = 2", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, ValuesLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, ValuesLogicalRel.class)
                 )
         );
     }
@@ -98,9 +93,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = 1 OR __key = 2", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -111,9 +105,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE 1 = 1", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -146,15 +139,13 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = " + literalValue, table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteByKeyMapLogicalRel.class)
+                        planRow(0, DeleteByKeyMapLogicalRel.class)
                 )
         );
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE " + literalValue + " = __key", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteByKeyMapLogicalRel.class)
+                        planRow(0, DeleteByKeyMapLogicalRel.class)
                 )
         );
     }
@@ -165,8 +156,7 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = 1 + 1", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteByKeyMapLogicalRel.class)
+                        planRow(0, DeleteByKeyMapLogicalRel.class)
                 )
         );
     }
@@ -198,8 +188,7 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = ?", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteByKeyMapLogicalRel.class)
+                        planRow(0, DeleteByKeyMapLogicalRel.class)
                 )
         );
     }
@@ -210,9 +199,8 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = ? + 1", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, DeleteLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -223,8 +211,7 @@ public class LogicalDeleteTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("DELETE FROM m WHERE __key = CAST(? + 1 AS INT)", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, DeleteByKeyMapLogicalRel.class)
+                        planRow(0, DeleteByKeyMapLogicalRel.class)
                 )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalInsertTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalInsertTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.jet.sql.impl.opt.OptimizerTestSupport;
-import com.hazelcast.sql.impl.calcite.opt.logical.RootLogicalRel;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import junitparams.JUnitParamsRunner;
 import org.junit.BeforeClass;
@@ -44,8 +43,7 @@ public class LogicalInsertTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("INSERT INTO m VALUES (1, '1')", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, InsertMapLogicalRel.class)
+                        planRow(0, InsertMapLogicalRel.class)
                 )
         );
     }
@@ -56,9 +54,8 @@ public class LogicalInsertTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("INSERT INTO m VALUES (1, '1'), (2, '2')", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, InsertLogicalRel.class),
-                        planRow(2, ValuesLogicalRel.class)
+                        planRow(0, InsertLogicalRel.class),
+                        planRow(1, ValuesLogicalRel.class)
                 )
         );
     }
@@ -70,9 +67,8 @@ public class LogicalInsertTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("INSERT INTO m1 SELECT * FROM m2", target, source),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, InsertLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, InsertLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalSinkTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalSinkTest.java
@@ -44,8 +44,7 @@ public class LogicalSinkTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("SINK INTO m VALUES (1, '1'), (2, '2')", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, SinkMapLogicalRel.class)
+                        planRow(0, SinkMapLogicalRel.class)
                 )
         );
     }
@@ -57,9 +56,8 @@ public class LogicalSinkTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("SINK INTO m1 SELECT * FROM m2", target, source),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, SinkLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, SinkLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalSinkTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalSinkTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.jet.sql.impl.opt.OptimizerTestSupport;
-import com.hazelcast.sql.impl.calcite.opt.logical.RootLogicalRel;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import junitparams.JUnitParamsRunner;
 import org.junit.BeforeClass;

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalUpdateTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalUpdateTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.jet.sql.impl.opt.OptimizerTestSupport;
-import com.hazelcast.sql.impl.calcite.opt.logical.RootLogicalRel;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import junitparams.JUnitParamsRunner;
@@ -46,9 +45,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2'", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -59,9 +57,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE this = '1'", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -72,9 +69,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = 1 AND this = '1'", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -85,9 +81,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = 1 AND __key = 2", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, ValuesLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, ValuesLogicalRel.class)
                 )
         );
     }
@@ -98,9 +93,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = 1 OR __key = 2", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -111,9 +105,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE 1 = 1", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -146,15 +139,13 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = " + literalValue, table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateByKeyMapLogicalRel.class)
+                        planRow(0, UpdateByKeyMapLogicalRel.class)
                 )
         );
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE " + literalValue + " = __key", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateByKeyMapLogicalRel.class)
+                        planRow(0, UpdateByKeyMapLogicalRel.class)
                 )
         );
     }
@@ -165,8 +156,7 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = 1 + 1", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateByKeyMapLogicalRel.class)
+                        planRow(0, UpdateByKeyMapLogicalRel.class)
                 )
         );
     }
@@ -198,8 +188,7 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = ?", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateByKeyMapLogicalRel.class)
+                        planRow(0, UpdateByKeyMapLogicalRel.class)
                 )
         );
     }
@@ -210,9 +199,8 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = ? + 1", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateLogicalRel.class),
-                        planRow(2, FullScanLogicalRel.class)
+                        planRow(0, UpdateLogicalRel.class),
+                        planRow(1, FullScanLogicalRel.class)
                 )
         );
     }
@@ -223,8 +211,7 @@ public class LogicalUpdateTest extends OptimizerTestSupport {
         assertPlan(
                 optimizeLogical("UPDATE m SET this = '2' WHERE __key = CAST(? + 1 AS INT)", table),
                 plan(
-                        planRow(0, RootLogicalRel.class),
-                        planRow(1, UpdateByKeyMapLogicalRel.class)
+                        planRow(0, UpdateByKeyMapLogicalRel.class)
                 )
         );
     }


### PR DESCRIPTION
Removed wrapping logical result into `RootLogicalRel` which was a copy-paste leftover.