### PR TITLE
add rbac.yaml file

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -523,7 +523,7 @@ class KubernetesClient {
             if (!isKnownExceptionAlreadyLogged) {
                 LOGGER.warning("Kubernetes API access is forbidden! Starting standalone. To use Hazelcast Kubernetes discovery,"
                         + " configure the required RBAC. For 'default' service account in 'default' namespace execute: "
-                        + "`kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml`");
+                        + "`kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast/master/kubernetes-rbac.yaml`");
                 isKnownExceptionAlreadyLogged = true;
             }
         } else {

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -811,9 +811,8 @@ public class KubernetesClientTest {
     }
 
     @Test
-    @Ignore
     public void rbacYamlFileExists() {
         // rbac.yaml file is mentioned in logs, so the file must exist in the repo
-        assertTrue(new File("rbac.yaml").exists());
+        assertTrue(new File("../kubernetes-rbac.yaml").exists());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -20,7 +20,6 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.hazelcast.kubernetes.KubernetesClient.Endpoint;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/kubernetes-rbac.yaml
+++ b/kubernetes-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hazelcast-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+      - services
+    verbs:
+      - get
+      - list
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hazelcast-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hazelcast-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default


### PR DESCRIPTION
Add `kubernetes-rbac.yaml` file from `hazelcast-kubernetes`
Issue: [CN-113]

Checklist:
- [+] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [+] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [+] Request reviewers if possible
- [+] New public APIs have `@Nonnull/@Nullable` annotations
- [+] New public APIs have `@since` tags in Javadoc
- [+] Send backports/forwardports if fix needs to be applied to past/future releases


[CN-113]: https://hazelcast.atlassian.net/browse/CN-113