### PR TITLE
Remove use of maven.multiModuleProjectDirectory property in build

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <configs.from.jar>${project.build.directory}/config</configs.from.jar>
-        <main.basedir>${maven.multiModuleProjectDirectory}</main.basedir>
+        <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
     <build>

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -37,7 +37,7 @@
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
+        <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
     </properties>
 
     <licenses>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -37,7 +37,7 @@
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
+        <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
     </properties>
 
     <licenses>

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -37,7 +37,7 @@
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
+        <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
     </properties>
 
     <licenses>

--- a/extensions/elasticsearch/elasticsearch-5/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-5/pom.xml
@@ -34,6 +34,10 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <main.basedir>${project.basedir}/../../..</main.basedir>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -34,6 +34,10 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <main.basedir>${project.basedir}/../../..</main.basedir>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -34,6 +34,10 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <main.basedir>${project.basedir}/../../..</main.basedir>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -32,6 +32,10 @@
         <version>5.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <main.basedir>${project.basedir}/../../..</main.basedir>
+    </properties>
+
     <modules>
         <module>files-azure</module>
         <module>files-gcs</module>

--- a/extensions/hazelcast-3-connector/pom.xml
+++ b/extensions/hazelcast-3-connector/pom.xml
@@ -18,10 +18,10 @@
 
     <properties>
         <!-- needed for CheckStyle (we need to repeat this here because this module has hazelcast-root as parent) -->
-        <main.basedir>${maven.multiModuleProjectDirectory}</main.basedir>
-        <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
-        <checkstyle.configLocation>${maven.multiModuleProjectDirectory}/checkstyle/checkstyle_jet.xml</checkstyle.configLocation>
-        <checkstyle.supressionsLocation>${maven.multiModuleProjectDirectory}/checkstyle/suppressions_jet.xml</checkstyle.supressionsLocation>
+        <main.basedir>${project.basedir}/../../..</main.basedir>
+        <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
+        <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle_jet.xml</checkstyle.configLocation>
+        <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions_jet.xml</checkstyle.supressionsLocation>
     </properties>
 
     <dependencies>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -68,10 +68,10 @@
         </argLine>
 
         <!-- needed for CheckStyle -->
-        <main.basedir>${maven.multiModuleProjectDirectory}</main.basedir>
-        <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
-        <checkstyle.configLocation>${maven.multiModuleProjectDirectory}/checkstyle/checkstyle_jet.xml</checkstyle.configLocation>
-        <checkstyle.supressionsLocation>${maven.multiModuleProjectDirectory}/checkstyle/suppressions_jet.xml</checkstyle.supressionsLocation>
+        <main.basedir>${project.basedir}/../..</main.basedir>
+        <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
+        <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle_jet.xml</checkstyle.configLocation>
+        <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions_jet.xml</checkstyle.supressionsLocation>
     </properties>
 
     <licenses>


### PR DESCRIPTION
The property `maven.multiModuleProjectDirectory` should not actually be used in the pom.xml.

We already have a property `main.basedir` serving the same purpose.

Fixes #18767