### PR TITLE
Skip modules using protoc for Solaris

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -42,16 +42,29 @@
         <module>elasticsearch/elasticsearch-5</module>
         <module>elasticsearch/elasticsearch-6</module>
         <module>elasticsearch/elasticsearch-7</module>
-        <module>grpc</module>
         <module>hadoop</module>
         <module>hadoop-dist</module>
         <module>hazelcast-3-connector</module>
         <module>kafka</module>
         <module>kinesis</module>
-        <module>protobuf</module>
-        <module>python</module>
         <module>s3</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>protoc-supported</id>
+            <activation>
+                <os>
+                    <family>!sunos</family>
+                </os>
+            </activation>
+            <modules>
+                <module>grpc</module>
+                <module>protobuf</module>
+                <module>python</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <properties>
         <argLine> <!-- surefire parameters -->


### PR DESCRIPTION
The artifact com.google.protobuf:protoc is not available for Solaris
https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.13.0/

This allows the Solaris compatibility build to run for the rest
of the modules.

Fixes #19047
