### PR TITLE
Enable jet in nightly tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -69,7 +69,7 @@ public class BackpressureTest extends JetTestSupport {
 
     @Before
     public void setUp() {
-        Config config = new Config();
+        Config config = defaultInstanceConfigWithJetEnabled();
         config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM_PER_MEMBER);
         hz1 = createHazelcastInstance(config);
         hz2 = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
@@ -27,13 +27,13 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Util;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -71,7 +71,7 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-public class WordCountTest extends HazelcastTestSupport implements Serializable {
+public class WordCountTest extends JetTestSupport implements Serializable {
 
     private static final int NODE_COUNT = 1;
     private static final int PARALLELISM = Runtime.getRuntime().availableProcessors() / NODE_COUNT;
@@ -93,7 +93,7 @@ public class WordCountTest extends HazelcastTestSupport implements Serializable 
 
     @Before
     public void before() {
-        Config config = new Config();
+        Config config = defaultInstanceConfigWithJetEnabled();
         config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
         config.setClusterName(randomName());
         final JoinConfig join = config.getNetworkConfig().getJoin();

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -166,6 +166,12 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
         return config;
     }
 
+    public static Config defaultInstanceConfigWithJetEnabled() {
+        Config config = new Config();
+        config.getJetConfig().setEnabled(true);
+        return config;
+    }
+
     /**
      * Asserts that a job status is eventually RUNNING. When it's running,
      * checks that the execution ID is different from the given {@code

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -61,7 +61,7 @@ public class MemberReconnectionStressTest extends JetTestSupport {
         typically at most 1 restart per job. We assert that the jobs
         eventually successfully complete.
          */
-        Config config = new Config();
+        Config config = defaultInstanceConfigWithJetEnabled();
         // The connection drop often causes regular IMap operations to fail - shorten the timeout so that
         // it recovers more quickly
         config.setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "2000");

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
@@ -63,7 +63,7 @@ public class JobMetrics_StressTest extends JetTestSupport {
         IncrementingProcessor.initCount.set(0);
         IncrementingProcessor.completeCount.set(0);
 
-        Config config = new Config();
+        Config config = defaultInstanceConfigWithJetEnabled();
         config.getMetricsConfig().setCollectionFrequencySeconds(1);
         instance = createHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -67,7 +67,7 @@ public final class JobSubmissionSlownessRegressionTest extends JetTestSupport {
 
     @Before
     public void setup() {
-        Config config = new Config();
+        Config config = defaultInstanceConfigWithJetEnabled();
         config.setProperty("hazelcast.logging.type", "none");
         createHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StatefulMappingStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/StatefulMappingStressTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.pipeline;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.JetTestSupport;
@@ -50,7 +49,7 @@ public class StatefulMappingStressTest extends JetTestSupport {
 
     @Before
     public void setup() {
-        instance = createHazelcastInstances(new Config(), 2)[0];
+        instance = createHazelcastInstances(defaultInstanceConfigWithJetEnabled(), 2)[0];
     }
 
     @Test


### PR DESCRIPTION
This PR enables jet in the nightly jet tests.
Fixes #19082

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

