### PR TITLE
Fix Kubernetes API discovery

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -51,7 +51,7 @@ final class HazelcastKubernetesDiscoveryStrategy
             endpointResolver = new KubernetesApiEndpointResolver(logger, config.getServiceName(), config.getServicePort(),
                     config.getServiceLabelName(), config.getServiceLabelValue(),
                     config.getPodLabelName(), config.getPodLabelValue(),
-                    config.getMatchServicePodNames(), config.getLbLabelName(), config.getLbLabelValue(),
+                    config.getDiscoveryLabelName(), config.getDiscoveryLabelValue(),
                     config.isResolveNotReadyAddresses(), client);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -51,6 +51,7 @@ final class HazelcastKubernetesDiscoveryStrategy
             endpointResolver = new KubernetesApiEndpointResolver(logger, config.getServiceName(), config.getServicePort(),
                     config.getServiceLabelName(), config.getServiceLabelValue(),
                     config.getPodLabelName(), config.getPodLabelValue(),
+                    config.getMatchServicePodNames(), config.getLbLabelName(), config.getLbLabelValue(),
                     config.isResolveNotReadyAddresses(), client);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
@@ -36,8 +36,8 @@ class KubernetesApiEndpointResolver
     private final String podLabel;
     private final String podLabelValue;
     private final boolean matchNames;
-    private final String lbLabel;
-    private final String lbLabelValue;
+    private final String discoveryLabel;
+    private final String discoveryLabelValue;
     private final Boolean resolveNotReadyAddresses;
     private final int port;
     private final KubernetesClient client;
@@ -45,7 +45,7 @@ class KubernetesApiEndpointResolver
     KubernetesApiEndpointResolver(ILogger logger, String serviceName, int port,
                                   String serviceLabel, String serviceLabelValue,
                                   String podLabel, String podLabelValue,
-                                  boolean matchNames, String lbLabel, String lbLabelValue,
+                                  String discoveryLabel, String discoveryLabelValue,
                                   Boolean resolveNotReadyAddresses, KubernetesClient client) {
 
         super(logger);
@@ -56,9 +56,9 @@ class KubernetesApiEndpointResolver
         this.serviceLabelValue = serviceLabelValue;
         this.podLabel = podLabel;
         this.podLabelValue = podLabelValue;
-        this.matchNames = matchNames;
-        this.lbLabel = lbLabel;
-        this.lbLabelValue = lbLabelValue;
+        this.matchNames = discoveryLabel == null || discoveryLabel.isEmpty();
+        this.discoveryLabel = discoveryLabel;
+        this.discoveryLabelValue = discoveryLabelValue;
         this.resolveNotReadyAddresses = resolveNotReadyAddresses;
         this.client = client;
     }
@@ -67,15 +67,15 @@ class KubernetesApiEndpointResolver
     List<DiscoveryNode> resolve() {
         if (serviceName != null && !serviceName.isEmpty()) {
             logger.fine("Using service name to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByName(serviceName, matchNames, lbLabel, lbLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByName(serviceName, matchNames, discoveryLabel, discoveryLabelValue));
         } else if (serviceLabel != null && !serviceLabel.isEmpty()) {
             logger.fine("Using service label to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByServiceLabel(serviceLabel, serviceLabelValue, matchNames, lbLabel, lbLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByServiceLabel(serviceLabel, serviceLabelValue, matchNames, discoveryLabel, discoveryLabelValue));
         } else if (podLabel != null && !podLabel.isEmpty()) {
             logger.fine("Using pod label to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByPodLabel(podLabel, podLabelValue, matchNames, lbLabel, lbLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByPodLabel(podLabel, podLabelValue, matchNames, discoveryLabel, discoveryLabelValue));
         }
-        return getSimpleDiscoveryNodes(client.endpoints(matchNames, lbLabel, lbLabelValue));
+        return getSimpleDiscoveryNodes(client.endpoints(matchNames, discoveryLabel, discoveryLabelValue));
     }
 
     private List<DiscoveryNode> getSimpleDiscoveryNodes(List<Endpoint> endpoints) {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
@@ -35,12 +35,17 @@ class KubernetesApiEndpointResolver
     private final String serviceLabelValue;
     private final String podLabel;
     private final String podLabelValue;
+    private final boolean matchNames;
+    private final String lbLabel;
+    private final String lbLabelValue;
     private final Boolean resolveNotReadyAddresses;
     private final int port;
     private final KubernetesClient client;
 
     KubernetesApiEndpointResolver(ILogger logger, String serviceName, int port,
-                                  String serviceLabel, String serviceLabelValue, String podLabel, String podLabelValue,
+                                  String serviceLabel, String serviceLabelValue,
+                                  String podLabel, String podLabelValue,
+                                  boolean matchNames, String lbLabel, String lbLabelValue,
                                   Boolean resolveNotReadyAddresses, KubernetesClient client) {
 
         super(logger);
@@ -51,6 +56,9 @@ class KubernetesApiEndpointResolver
         this.serviceLabelValue = serviceLabelValue;
         this.podLabel = podLabel;
         this.podLabelValue = podLabelValue;
+        this.matchNames = matchNames;
+        this.lbLabel = lbLabel;
+        this.lbLabelValue = lbLabelValue;
         this.resolveNotReadyAddresses = resolveNotReadyAddresses;
         this.client = client;
     }
@@ -59,15 +67,15 @@ class KubernetesApiEndpointResolver
     List<DiscoveryNode> resolve() {
         if (serviceName != null && !serviceName.isEmpty()) {
             logger.fine("Using service name to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByName(serviceName));
+            return getSimpleDiscoveryNodes(client.endpointsByName(serviceName, matchNames, lbLabel, lbLabelValue));
         } else if (serviceLabel != null && !serviceLabel.isEmpty()) {
             logger.fine("Using service label to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByServiceLabel(serviceLabel, serviceLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByServiceLabel(serviceLabel, serviceLabelValue, matchNames, lbLabel, lbLabelValue));
         } else if (podLabel != null && !podLabel.isEmpty()) {
             logger.fine("Using pod label to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByPodLabel(podLabel, podLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByPodLabel(podLabel, podLabelValue, matchNames, lbLabel, lbLabelValue));
         }
-        return getSimpleDiscoveryNodes(client.endpoints());
+        return getSimpleDiscoveryNodes(client.endpoints(matchNames, lbLabel, lbLabelValue));
     }
 
     private List<DiscoveryNode> getSimpleDiscoveryNodes(List<Endpoint> endpoints) {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -45,6 +45,9 @@ import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
 import static com.hazelcast.kubernetes.KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS;
+import static com.hazelcast.kubernetes.KubernetesProperties.MATCH_SERVICE_POD_NAMES;
+import static com.hazelcast.kubernetes.KubernetesProperties.LB_LABEL_NAME;
+import static com.hazelcast.kubernetes.KubernetesProperties.LB_LABEL_VALUE;
 
 /**
  * Responsible for fetching, parsing, and validating Hazelcast Kubernetes Discovery Strategy input properties.
@@ -66,6 +69,9 @@ final class KubernetesConfig {
     private final String namespace;
     private final String podLabelName;
     private final String podLabelValue;
+    private final boolean matchServicePodNames;
+    private final String lbLabelName;
+    private final String lbLabelValue;
     private final boolean resolveNotReadyAddresses;
     private final boolean useNodeNameAsExternalAddress;
     private final int kubernetesApiRetries;
@@ -85,6 +91,9 @@ final class KubernetesConfig {
         this.serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         this.podLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, POD_LABEL_NAME);
         this.podLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, POD_LABEL_VALUE);
+        this.matchServicePodNames = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, MATCH_SERVICE_POD_NAMES, true);
+        this.lbLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_NAME);
+        this.lbLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_VALUE);
         this.resolveNotReadyAddresses = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, RESOLVE_NOT_READY_ADDRESSES, true);
         this.useNodeNameAsExternalAddress
                 = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, USE_NODE_NAME_AS_EXTERNAL_ADDRESS, false);
@@ -295,6 +304,16 @@ final class KubernetesConfig {
         return podLabelValue;
     }
 
+    public boolean getMatchServicePodNames() { return matchServicePodNames; }
+
+    public String getLbLabelName() {
+        return lbLabelName;
+    }
+
+    public String getLbLabelValue() {
+        return lbLabelValue;
+    }
+
     boolean isResolveNotReadyAddresses() {
         return resolveNotReadyAddresses;
     }
@@ -335,6 +354,9 @@ final class KubernetesConfig {
                 + "namespace: " + namespace + ", "
                 + "pod-label: " + podLabelName + ", "
                 + "pod-label-value: " + podLabelValue + ", "
+				+ "match-service-pod-names: " + matchServicePodNames + ", "
+                + "lb-label: " + lbLabelName + ", "
+                + "lb-label-value: " + lbLabelValue + ", "
                 + "resolve-not-ready-addresses: " + resolveNotReadyAddresses + ", "
                 + "use-node-name-as-external-address: " + useNodeNameAsExternalAddress + ", "
                 + "kubernetes-api-retries: " + kubernetesApiRetries + ", "

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -69,9 +69,8 @@ final class KubernetesConfig {
     private final String namespace;
     private final String podLabelName;
     private final String podLabelValue;
-    private final boolean matchServicePodNames;
-    private final String lbLabelName;
-    private final String lbLabelValue;
+    private final String discoveryLabelName;
+    private final String discoveryLabelValue;
     private final boolean resolveNotReadyAddresses;
     private final boolean useNodeNameAsExternalAddress;
     private final int kubernetesApiRetries;
@@ -91,9 +90,8 @@ final class KubernetesConfig {
         this.serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         this.podLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, POD_LABEL_NAME);
         this.podLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, POD_LABEL_VALUE);
-        this.matchServicePodNames = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, MATCH_SERVICE_POD_NAMES, true);
-        this.lbLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_NAME);
-        this.lbLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_VALUE);
+        this.discoveryLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_NAME);
+        this.discoveryLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_VALUE);
         this.resolveNotReadyAddresses = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, RESOLVE_NOT_READY_ADDRESSES, true);
         this.useNodeNameAsExternalAddress
                 = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, USE_NODE_NAME_AS_EXTERNAL_ADDRESS, false);
@@ -304,14 +302,12 @@ final class KubernetesConfig {
         return podLabelValue;
     }
 
-    public boolean getMatchServicePodNames() { return matchServicePodNames; }
-
-    public String getLbLabelName() {
-        return lbLabelName;
+    public String getDiscoveryLabelName() {
+        return discoveryLabelName;
     }
 
-    public String getLbLabelValue() {
-        return lbLabelValue;
+    public String getDiscoveryLabelValue() {
+        return discoveryLabelValue;
     }
 
     boolean isResolveNotReadyAddresses() {
@@ -354,9 +350,8 @@ final class KubernetesConfig {
                 + "namespace: " + namespace + ", "
                 + "pod-label: " + podLabelName + ", "
                 + "pod-label-value: " + podLabelValue + ", "
-				+ "match-service-pod-names: " + matchServicePodNames + ", "
-                + "lb-label: " + lbLabelName + ", "
-                + "lb-label-value: " + lbLabelValue + ", "
+                + "lb-label: " + discoveryLabelName + ", "
+                + "lb-label-value: " + discoveryLabelValue + ", "
                 + "resolve-not-ready-addresses: " + resolveNotReadyAddresses + ", "
                 + "use-node-name-as-external-address: " + useNodeNameAsExternalAddress + ", "
                 + "kubernetes-api-retries: " + kubernetesApiRetries + ", "

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -97,21 +97,15 @@ public final class KubernetesProperties {
     public static final PropertyDefinition POD_LABEL_VALUE = property("pod-label-value", STRING);
 
     /**
-     * <p>Configuration key: <code>match-service-pod-names</code></p>
-     * Whether to match the service and pod names.
-     */
-    public static final PropertyDefinition MATCH_SERVICE_POD_NAMES = property("match-service-pod-names", BOOLEAN);
-
-    /**
-     * <p>Configuration key: <code>lb-label-name</code></p>
+     * <p>Configuration key: <code>discovery-label-name</code></p>
      * Defines the load balancer label name.
      */
-    public static final PropertyDefinition LB_LABEL_NAME = property("lb-label-name", STRING);
+    public static final PropertyDefinition DISCOVERY_LABEL_NAME = property("discovery-label-name", STRING);
     /**
-     * <p>Configuration key: <code>lb-label-value</code></p>
+     * <p>Configuration key: <code>discovery-label-value</code></p>
      * Defines the load balancer label value.
      */
-    public static final PropertyDefinition LB_LABEL_VALUE = property("lb-label-value", STRING);
+    public static final PropertyDefinition DISCOVERY_LABEL_VALUE = property("discovery-label-value", STRING);
 
     /**
      * <p>Configuration key: <code>resolve-not-ready-addresses</code></p>

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -97,6 +97,23 @@ public final class KubernetesProperties {
     public static final PropertyDefinition POD_LABEL_VALUE = property("pod-label-value", STRING);
 
     /**
+     * <p>Configuration key: <code>match-service-pod-names</code></p>
+     * Whether to match the service and pod names.
+     */
+    public static final PropertyDefinition MATCH_SERVICE_POD_NAMES = property("match-service-pod-names", BOOLEAN);
+
+    /**
+     * <p>Configuration key: <code>lb-label-name</code></p>
+     * Defines the load balancer label name.
+     */
+    public static final PropertyDefinition LB_LABEL_NAME = property("lb-label-name", STRING);
+    /**
+     * <p>Configuration key: <code>lb-label-value</code></p>
+     * Defines the load balancer label value.
+     */
+    public static final PropertyDefinition LB_LABEL_VALUE = property("lb-label-value", STRING);
+
+    /**
      * <p>Configuration key: <code>resolve-not-ready-addresses</code></p>
      * Defines if not ready addresses should be evaluated to be discovered on startup.
      */


### PR DESCRIPTION
This is a port of [this hazelcast-kubernetes PR](https://github.com/hazelcast/hazelcast-kubernetes/pull/331) now that repos are merged. Copied from the original PR:

When following [this guide](https://guides.hazelcast.org/kubernetes-external-client/) to get the .NET client to connect to a Kubernetes-hosted cluster, in *Smart Client* mode, I came onto an issue when the cluster is composed of only one member. At that point, there are two services:
* `hz-hazelcast` is the "discovery" service - which at that moment points to only 1 address (of pod `hz-hazelcast-0`)
* `hz-hazelcast-0` is the service corresponding to the `hz-hazelcast-0` pod 

Because the "discovery" service points to only 1 address, it is considered as a "member" service *and* its public IP can be returned as the public IP of service `hz-hazelcast-0`, or not, depending on the order of the services, and this lead to great confusion at the client side. Especially if for some reason the cluster keeps toggling between 1 and 2 members, in which case the client ends up receiving totally confusing data about members.

This PR is totally experimental, but it's what I had to implement in order to keep testing the .NET client with some success. What it does is:
* add a `match-service-pod-names` configuration property which is `true` by default and gets the `KubernetesClient` to match the service name with the pod name (e.g. `hz-hazelcast` would not match `hz-hazelcast-0` and therefore the "discovery" service would be discarded)
* add a `lb-label-name` and `lb-label-value` pair of configuration properties (empty by default) which can be used to specify services which need to be *excluded* when looking for members - to be used when the names-matching is not enough and we want to be even more specific

Now, with the default configuration (`match-service-pod-names` being `true`) the .NET client receives correct data about members even in the case when the cluster toggles between 1 and more members erratically.

This PR is not meant to be merged "as is". I am creating it to explain the issue and the fix that I am using, but the actual proper fix may be totally different. I am certainly no k8s expert ;)

@leszko commented on the original PR:

> I wonder that maybe it'd be more user friendly to have a parameter like: `external-service-label-name` and `external-service-label-value` - And if set up, then all services not marked with these labels will be ignored. Then, I guess we won't need `match-service-pod-names` or `lb-label-name` / `lb-label-value`. What do you think?

To which I responded:

> I thought about this. Now if you follow the guide, there is nothing you need to do to configure the members (just fire pods with the default Hazelcast image). If we want to preserve that capability, we would need to agree on a convention-based configuration for `external-service-label` e.g. `role=hazelcast` or something?
> 
> Oh and the guide we don't mark member services with a label IIRC. We'd need to add this somehow.
> 
> Also... what is weird is that there *is* a setting to get the (member) services by label, but that only applies when selecting the list of (member) services, and not when enriching with a public IP. Which I find slightly confusing. I agree with you that my hack is not really user friendly, but I have this feeling that the whole logic is kinda weird. Will try to think about it.

Happy to discuss what's the best approach.
