### PR TITLE
Fix JobLifecycleMetricsTest.executionRelatedMetrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
@@ -139,7 +139,7 @@ public final class MetricNames {
      * Tracks the start time of a given execution of a specific job.
      * The execution and the job can be identified based on the
      * {@link MetricTags#EXECUTION} & {@link MetricTags#JOB} tags of
-     * the metric. It uses {@link System#currentTimeMillis} to measure
+     * the metric. It uses {@link System#currentTimeMillis} to get
      * the time on the job start.
      *
      * @since Jet 4.0

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
@@ -139,7 +139,8 @@ public final class MetricNames {
      * Tracks the start time of a given execution of a specific job.
      * The execution and the job can be identified based on the
      * {@link MetricTags#EXECUTION} & {@link MetricTags#JOB} tags of
-     * the metric.
+     * the metric. It uses {@link System#currentTimeMillis} to measure
+     * the time on the job start.
      *
      * @since Jet 4.0
      */
@@ -149,7 +150,8 @@ public final class MetricNames {
      * Tracks the completion time of a given execution of a specific job.
      * The execution and the job can be identified based on the
      * {@link MetricTags#EXECUTION} & {@link MetricTags#JOB} tags of
-     * the metric.
+     * the metric. It uses {@link System#currentTimeMillis} to measure
+     * the time on the job completion.
      *
      * @since Jet 4.0
      */

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
@@ -150,7 +150,7 @@ public final class MetricNames {
      * Tracks the completion time of a given execution of a specific job.
      * The execution and the job can be identified based on the
      * {@link MetricTags#EXECUTION} & {@link MetricTags#JOB} tags of
-     * the metric. It uses {@link System#currentTimeMillis} to measure
+     * the metric. It uses {@link System#currentTimeMillis} to get
      * the time on the job completion.
      *
      * @since Jet 4.0

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -43,7 +43,6 @@ import static com.hazelcast.jet.core.TestProcessors.MockPMS;
 import static com.hazelcast.jet.core.TestProcessors.MockPS;
 import static com.hazelcast.jet.core.TestProcessors.reset;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -156,11 +156,8 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
         job.join();
 
         JobMetricsChecker checker = new JobMetricsChecker(job);
-        long startTime = checker.assertRandomMetricValueAtLeast(MetricNames.EXECUTION_START_TIME, 1);
-        long completionTime = checker.assertRandomMetricValueAtLeast(MetricNames.EXECUTION_COMPLETION_TIME, 1);
-
-        assertTrue("startTime=" + startTime + ", completionTime=" + completionTime,
-                startTime <= completionTime);
+        checker.assertRandomMetricValueAtLeast(MetricNames.EXECUTION_START_TIME, 1);
+        checker.assertRandomMetricValueAtLeast(MetricNames.EXECUTION_COMPLETION_TIME, 1);
     }
 
     private Pipeline batchPipeline() {


### PR DESCRIPTION
This PR removes `jobStartTime` < `jobCompletionTime` assertion from the
test since we don't have any synchronization between job start time
setting and job completion time setting (and these settings are
performed via using multiple threads). Also, this time measurement is
done via calling `System.currentTimeMillis()` which don't have a
monotonicity guarantee.

See:
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java#L213
and
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java#L223.
Also, https://stackoverflow.com/a/2979239/4793261. Otherwise, if we want
to provide the monotonicity, we need to synchronize these time settings
and use one of the monotonic clock impl.

Fixes #19025 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

