### PR TITLE
Fix client leaks in ClientAutoDetectionDiscoveryTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
@@ -39,6 +39,7 @@ public class ClientAutoDetectionDiscoveryTest extends HazelcastTestSupport {
     @After
     public void tearDown() {
         Hazelcast.shutdownAll();
+        HazelcastClient.shutdownAll();
     }
 
     @Test


### PR DESCRIPTION
This PR shutdowns the leaking clients of
`ClientAutoDetectionDiscoveryTest`. See the logs of #18876. The tests of
`ClientAutoDetectionDiscoveryTest` are interfering with
`ClientInvocation_ExceptionTest`.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

