### PR TITLE
fixing MC-838 by using lenient scalar/primitive validation

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -449,7 +449,7 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.12.3</version>
+            <version>1.13.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.re2j</groupId>

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlConfigSchemaValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlConfigSchemaValidator.java
@@ -84,7 +84,6 @@ public class YamlConfigSchemaValidator {
                     .build()
                     .performValidation(SCHEMA, YamlToJsonConverter.convert(rootNode));
         } catch (ValidationException e) {
-            e.printStackTrace();
             throw wrap(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlConfigSchemaValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlConfigSchemaValidator.java
@@ -19,8 +19,10 @@ package com.hazelcast.internal.config;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlToJsonConverter;
+import org.everit.json.schema.PrimitiveValidationStrategy;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.Validator;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -77,8 +79,12 @@ public class YamlConfigSchemaValidator {
                                 + " root schema document, " + definedRootNodeCount + " are present",
                         "#", "#", emptyList());
             }
-            SCHEMA.validate(YamlToJsonConverter.convert(rootNode));
+            Validator.builder()
+                    .primitiveValidationStrategy(PrimitiveValidationStrategy.LENIENT)
+                    .build()
+                    .performValidation(SCHEMA, YamlToJsonConverter.convert(rootNode));
         } catch (ValidationException e) {
+            e.printStackTrace();
             throw wrap(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlToJsonConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlToJsonConverter.java
@@ -48,38 +48,8 @@ public final class YamlToJsonConverter {
             }
             return resultArray;
         } else if (yamlNode instanceof YamlScalar) {
-            return convertScalar((YamlScalar) yamlNode);
+            return ((YamlScalar) yamlNode).nodeValue();
         }
         throw new IllegalArgumentException("Unknown type " + yamlNode.getClass().getName());
     }
-
-    /**
-     * This method makes the json schema validation lenient in a sense that it converts string values to booleans and integers,
-     * if they are parseable as such. This is necessary to support configreplacers in the YAML config: when a placeholder is
-     * replaced with an actual value, then the replacement is always a string, even if it holds an integer or boolean value, so we
-     * convert it here on a best-effort basis, otherwise the schema validation would fail errors like "expected type: integer,
-     * actual: string" even in cases when eg. ${backup-count} is substituted with "1".
-     */
-    private static Object convertScalar(YamlScalar yamlNode) {
-        Object rawNodeValue = yamlNode.nodeValue();
-        if (rawNodeValue instanceof String) {
-            String stringValue = (String) rawNodeValue;
-            if (stringValue.equals("true")) {
-                return Boolean.TRUE;
-            } else if (stringValue.equals("false")) {
-                return Boolean.FALSE;
-            }
-            try {
-                return new Integer(stringValue);
-            } catch (NumberFormatException e) {
-                try {
-                    return new Float(stringValue);
-                } catch (NumberFormatException e2) {
-                    // returning rawNodeValue
-                }
-            }
-        }
-        return rawNodeValue;
-    }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -82,7 +82,8 @@ public class YamlConfigImportVariableReplacementTest extends AbstractConfigImpor
                 + "hazelcast:\n"
                 + "  map:\n"
                 + "    ${name}:\n"
-                + "      backup-count: ${async.backup.count}${backup.count}\n";
+                + "      backup-count: ${backup.count}\n"
+                + "      async-backup-count: ${async.backup.count}\n";
 
         Properties properties = new Properties();
         properties.setProperty("name", "s");

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigSchemaValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigSchemaValidatorTest.java
@@ -72,6 +72,11 @@ public class YamlConfigSchemaValidatorTest {
         }
     }
 
+    @Test
+    public void lenientPrimitiveValidationIsEnabled() {
+        new YamlConfigBuilder(getClass().getResourceAsStream("/com/hazelcast/config/lenient-primitives.yaml")).build();
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void emptyObject() {
         new YamlConfigBuilder(getClass().getResourceAsStream("/com/hazelcast/config/empty-object.yaml")).build();

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlToJsonConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlToJsonConverterTest.java
@@ -68,15 +68,6 @@ public class YamlToJsonConverterTest {
     }
 
     @Test
-    public void floatConversion() {
-        YamlMappingImpl hazelcastNode = new YamlMappingImpl(null, "hazelcast");
-        hazelcastNode.addChild("myFloat", new YamlScalarImpl(hazelcastNode, "myFloat", "0.5"));
-
-        JSONObject actual = (JSONObject) YamlToJsonConverter.convert(hazelcastNode);
-        assertTrue(actual.get("myFloat") instanceof Float);
-    }
-
-    @Test
     public void convertUnknownNode() {
         YamlMappingImpl parentNode = createYamlMapping();
         YamlMappingImpl hazelcast = (YamlMappingImpl) parentNode.childAsMapping("hazelcast");

--- a/hazelcast/src/test/resources/com/hazelcast/config/lenient-primitives.yaml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/lenient-primitives.yaml
@@ -1,0 +1,8 @@
+hazelcast:
+  cluster-name: '1234'
+  instance-name: 'true'
+  map:
+    my-map:
+      split-brain-protection-ref: 'true'
+      backup-count: '2'
+      statistics-enabled: 'y'


### PR DESCRIPTION
## Removing automatic conversion of string values and using lenient validation for scalars

Fixes #18939 (MC-838)

### The original problem

While working on #18441 , there was a problem related to config replacers: the replacers (correctly) were running before the yaml schema validation, and the config replacers always put string values into the yaml DOM, regardless if the string values actually presented other scalar values. This problem was highlighted by `YamlConfigImportVariableReplacementTest#readVariables()` failing.

### The first workaround

In #18441 it was worked around [by converting all string scalars to corresponding Booleans / Numbers](https://github.com/hazelcast/hazelcast/pull/18441/files?file-filters%5B%5D=.java&file-filters%5B%5D=.xml&file-filters%5B%5D=.yaml#diff-aaec45fad254a40b71de573974c556e1812c8229f147a92c7e0dd455280a9a9aR56), whenever the string was parse-able. This conversion was performed after the config replacers, but before the schema validation invocation, and it seemingly solved the problem.

### The regression

As reported by @kwart in #18939 , the workaround introduced a new problem: the automatic string-to-other-scalar conversion was performed in cases when it was unnecessary, moreover, it actually broke the subsequent schema validation, because a yaml like `cluster-name: '1234'` failed to validate, because the `'1234'` string literal got converted into an integer, but the schema expects a string as the `cluster-name`, therefore it resulted in a schema validation exception.

### The second workaround

This PR removes the first workaround (automatic string-to-other-scalar conversion). Instead, a lenient validation mode was introduced for primitives, in which mode the validator accepts strings as numbers or booleans, if they are parseable. This was done in https://github.com/everit-org/json-schema/pull/429 and is included in version `1.13.0` of the library. The documentation of the lenient validation is [here](https://github.com/everit-org/json-schema#lenient-mode).

This current PR upgrades to version 1.13.0 of the validator library, uses the lenient validation, and adds a test making sure that this regression doesn't happen again.