### PR TITLE
Ensure correct build order for hazelcast-3 connector modules

### DIFF
--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
@@ -41,9 +41,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
-                <configuration>
-                    <classpathDependencyExcludes>com.hazelcast:hazelcast-3-connector-impl</classpathDependencyExcludes>
-                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.hazelcast</groupId>
+                        <artifactId>hazelcast-3-connector-impl</artifactId>
+                        <version>5.0-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The tests for hazelcast-3 connector are in the common module,
but we need hazelcast-3-connector-impl module to be built first, but we
can't introduce a direct dependency, because then the module would
appeare on regular classpath, along with hazelcast 3 classes.

Instead we this adds hazelcast-3-connector-impl as a dependency to the
surefire plugin of the hazelcast-3-connector-common module.

Fixes #19129
