### PR TITLE
Add a new httpsClient for HTTPS connection to ElasticSearch

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -117,8 +117,8 @@ public final class ElasticClients {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(ANY, new UsernamePasswordCredentials(username, password));
         return RestClient.builder(new HttpHost(hostname, port, scheme))
-                .setHttpClientConfigCallback(httpClientBuilder ->
-                        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
-                );
+                         .setHttpClientConfigCallback(httpClientBuilder ->
+                                 httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+                         );
     }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -95,11 +95,30 @@ public final class ElasticClients {
             @Nonnull String hostname,
             int port
     ) {
+        return client(username, password, hostname, port, "http");
+    }
+    /**
+     * Convenience method to create {@link RestClientBuilder} with basic authentication
+     * and given hostname, port and scheme. Valid schemes are "http" and "https".
+     * <p>
+     * Usage:
+     * <pre>{@code
+     * BatchSource<SearchHit> source = elastic(() -> client("user", "password", "host", 9200, "https"));
+     * }</pre>
+     */
+    @Nonnull
+    public static RestClientBuilder client(
+            @Nonnull String username,
+            @Nonnull String password,
+            @Nonnull String hostname,
+            int port,
+            @Nonnull String scheme
+    ) {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(ANY, new UsernamePasswordCredentials(username, password));
-        return RestClient.builder(new HttpHost(hostname, port))
-                         .setHttpClientConfigCallback(httpClientBuilder ->
-                                 httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
-                         );
+        return RestClient.builder(new HttpHost(hostname, port, scheme))
+                .setHttpClientConfigCallback(httpClientBuilder ->
+                        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+                );
     }
 }


### PR DESCRIPTION
Adds a new `ElasticClients.httpsClient()` method.

Fixes #19138

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [X] Request reviewers if possible
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
