### PR TITLE
Close client for remoteReliableTopic sink

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -18,12 +18,12 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.collection.IList;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.BinaryOperatorEx;
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.security.impl.function.SecuredFunctions;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.Observable;
@@ -34,6 +34,7 @@ import com.hazelcast.jet.impl.pipeline.SinkImpl;
 import com.hazelcast.jet.json.JsonUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
+import com.hazelcast.security.impl.function.SecuredFunctions;
 import com.hazelcast.security.permission.ReliableTopicPermission;
 import com.hazelcast.topic.ITopic;
 
@@ -64,6 +65,7 @@ import static com.hazelcast.jet.core.processor.SinkProcessors.writeRemoteCacheP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeRemoteListP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeRemoteMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeSocketP;
+import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.impl.util.ImdgUtil.asClientConfig;
 import static com.hazelcast.jet.impl.util.ImdgUtil.asXmlString;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
@@ -889,9 +891,15 @@ public final class Sinks {
     @Nonnull
     public static <T> Sink<T> remoteReliableTopic(@Nonnull String reliableTopicName, @Nonnull ClientConfig clientConfig) {
         String clientXml = asXmlString(clientConfig); //conversion needed for serializability
-        return SinkBuilder.<ITopic<T>>sinkBuilder("reliableTopicSink(" + reliableTopicName + "))",
-                ctx -> newHazelcastClient(asClientConfig(clientXml)).getReliableTopic(reliableTopicName))
-                .<T>receiveFn(ITopic::publish)
+        return SinkBuilder
+                .sinkBuilder("reliableTopicSink(" + reliableTopicName + "))",
+                        ctx -> {
+                            HazelcastInstance client = newHazelcastClient(asClientConfig(clientXml));
+                            ITopic<T> topic = client.getReliableTopic(reliableTopicName);
+                            return tuple2(client, topic);
+                        })
+                .<T>receiveFn((clientTopicTuple, message) -> clientTopicTuple.f1().publish(message))
+                .destroyFn(clientTopicTuple -> clientTopicTuple.f0().shutdown())
                 .build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -49,7 +49,6 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
@@ -48,6 +49,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -69,6 +71,7 @@ import static com.hazelcast.jet.impl.pipeline.AbstractStage.transformOf;
 import static com.hazelcast.jet.json.JsonUtil.hazelcastJsonValue;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -913,6 +916,19 @@ public class SinksTest extends PipelineTestSupport {
 
         // Then
         assertTrueEventually(() -> assertEquals(itemCount, receivedList.size()));
+    }
+
+    @Test
+    public void remoteReliableTopicSinkClosesClient() {
+        // Check we are in a clean state
+        assertThat(HazelcastClient.getAllHazelcastClients()).hasSize(0);
+
+        // When
+        Sink<Object> sink = Sinks.remoteReliableTopic(sinkName, clientConfig);
+        p.readFrom(Sources.list(srcName)).writeTo(sink);
+        execute();
+
+        assertThat(HazelcastClient.getAllHazelcastClients()).hasSize(0);
     }
 
     @Test


### PR DESCRIPTION

Fixes #18847
(failure in ClientCacheConfigTest.cacheManagerByLocationClasspathTest which tests 0 clients at the beginning of the test)
