### PR TITLE
Remove hz.home system property from scripts

### DIFF
--- a/distribution/src/bin-filemode-755/hz-start
+++ b/distribution/src/bin-filemode-755/hz-start
@@ -29,7 +29,6 @@ JAVA_OPTS_ARRAY=(\
 $JDK_OPTS \
 "-Dhazelcast.logging.type=log4j2" \
 "-Dlog4j.configurationFile=file:$HAZELCAST_HOME/config/log4j2.properties" \
-"-Dhz.home=$HAZELCAST_HOME" \
 "-Dhazelcast.config=$HAZELCAST_HOME/$HAZELCAST_CONFIG" \
 "-Djet.custom.lib.dir=$HAZELCAST_HOME/custom-lib" \
 $PROMETHEUS \

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -1,5 +1,5 @@
 SCRIPT_DIR="$(dirname "$0")"
-HAZELCAST_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
+export HAZELCAST_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 if [ "$JAVA_HOME" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -47,8 +47,7 @@ if "x%HAZELCAST_CONFIG%" == "x" (
 set JAVA_OPTS=%JAVA_OPTS%^
  "-Dhazelcast.logging.type=log4j2"^
  "-Dlog4j.configurationFile=file:%HAZELCAST_HOME%\config\log4j2.properties"^
- "-Dhazelcast.config=%HAZELCAST_HOME%\%HAZELCAST_CONFIG%"^
- "-Dhz.home=%HAZELCAST_HOME%"
+ "-Dhazelcast.config=%HAZELCAST_HOME%\%HAZELCAST_CONFIG%"
 
 set CLASSPATH="%HAZELCAST_HOME%\lib\*;%HAZELCAST_HOME%\bin\user-lib;%HAZELCAST_HOME%\bin\user-lib\*";%CLASSPATH%
 

--- a/distribution/src/root/config/log4j2.properties
+++ b/distribution/src/root/config/log4j2.properties
@@ -22,8 +22,8 @@ appender.console.layout.pattern=${env:LOGGING_PATTERN}
 
 appender.rolling.type=RollingFile
 appender.rolling.name=RollingFile
-appender.rolling.fileName=${sys:hz.home}/logs/hazelcast.log
-appender.rolling.filePattern=${sys:hz.home}/logs/hazelcast.log.%d{yyyy-MM-dd}
+appender.rolling.fileName=${env:HAZELCAST_HOME}/logs/hazelcast.log
+appender.rolling.filePattern=${env:HAZELCAST_HOME}/logs/hazelcast.log.%d{yyyy-MM-dd}
 appender.rolling.layout.type=PatternLayout
 appender.rolling.layout.pattern=%d [%5p] [%t] [%c{.1}]: %m%n
 appender.rolling.policies.type = Policies


### PR DESCRIPTION
The property was used in logging configuration. Replaced with
environment property, which we already had in our script.

Fixes #19127
