### PR TITLE
remove time dependent flaky test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RetryUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RetryUtilsTest.java
@@ -22,10 +22,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 
-import static com.hazelcast.spi.utils.RetryUtils.BACKOFF_MULTIPLIER;
-import static com.hazelcast.spi.utils.RetryUtils.INITIAL_BACKOFF_MS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RetryUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RetryUtilsTest.java
@@ -92,22 +92,6 @@ public class RetryUtilsTest {
         // throws exception
     }
 
-    @Test
-    public void retryRetriesWaitExponentialBackoff()
-            throws Exception {
-        // given
-        double twoBackoffIntervalsMs = INITIAL_BACKOFF_MS + (BACKOFF_MULTIPLIER * INITIAL_BACKOFF_MS);
-        given(callable.call()).willThrow(new RuntimeException()).willThrow(new RuntimeException()).willReturn(RESULT);
-
-        // when
-        long startTimeMs = System.currentTimeMillis();
-        RetryUtils.retry(callable, 5);
-        long endTimeMs = System.currentTimeMillis();
-
-        // then
-        assertTrue(twoBackoffIntervalsMs < (endTimeMs - startTimeMs));
-    }
-
     @Test(expected = HazelcastException.class)
     public void retryNonRetryableKeywords()
             throws Exception {


### PR DESCRIPTION
Removed the time-dependent flaky test

Fixes #19141

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
