### PR TITLE
Change hazelcast-client.xml in zip

### DIFF
--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -75,8 +75,10 @@
             <destName>hazelcast.xml</destName>
             <outputDirectory>config</outputDirectory>
         </file>
+        <!-- We use a different default file for the assembly
+             because of different settings, e.g. smart routing is disabled -->
         <file>
-            <source>${configs.from.jar}/hazelcast-client-default.xml</source>
+            <source>${configs.from.jar}/hazelcast-client-default-assembly.xml</source>
             <destName>hazelcast-client.xml</destName>
             <outputDirectory>config</outputDirectory>
         </file>
@@ -89,8 +91,10 @@
             <destName>hazelcast.yaml</destName>
             <outputDirectory>config/examples</outputDirectory>
         </file>
+        <!-- We use a different default file for the assembly
+             because of different settings, e.g. smart routing is disabled -->
         <file>
-            <source>${configs.from.jar}/hazelcast-client-default.yaml</source>
+            <source>${configs.from.jar}/hazelcast-client-default-assembly.yaml</source>
             <destName>hazelcast-client.yaml</destName>
             <outputDirectory>config/examples</outputDirectory>
         </file>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -92,8 +92,10 @@
             <destName>hazelcast.xml</destName>
             <outputDirectory>config</outputDirectory>
         </file>
+        <!-- We use a different default file for the assembly
+             because of different settings, e.g. smart routing is disabled -->
         <file>
-            <source>${configs.from.jar}/hazelcast-client-default.xml</source>
+            <source>${configs.from.jar}/hazelcast-client-default-assembly.xml</source>
             <destName>hazelcast-client.xml</destName>
             <outputDirectory>config</outputDirectory>
         </file>
@@ -106,8 +108,10 @@
             <destName>hazelcast.yaml</destName>
             <outputDirectory>config/examples</outputDirectory>
         </file>
+        <!-- We use a different default file for the assembly
+             because of different settings, e.g. smart routing is disabled -->
         <file>
-            <source>${configs.from.jar}/hazelcast-client-default.yaml</source>
+            <source>${configs.from.jar}/hazelcast-client-default-assembly.yaml</source>
             <destName>hazelcast-client.yaml</destName>
             <outputDirectory>config/examples</outputDirectory>
         </file>

--- a/hazelcast/src/main/resources/hazelcast-client-default-assembly.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-default-assembly.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  The default Hazelcast client configuration used in hz-cli script.
+
+  This file differs from hazelcast-client-default.xml in some settings
+  and it is used in the ZIP/TAR distributions,
+  which are the basis for other distributions like docker & package managers.
+
+  To learn how to configure Hazelcast, please see the schema at
+  https://hazelcast.com/schema/client-config/hazelcast-client-config-5.0.xsd
+  or the Reference Manual at https://docs.hazelcast.com/
+-->
+
+<!--suppress XmlDefaultAttributeValue -->
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.0.xsd">
+
+    <network>
+        <cluster-members>
+            <!--
+            List of addresses for the client to try to connect to.
+            All members of a Hazelcast cluster accept client connections.
+            Use the format <hostname>:<port>
+            If a port number is not specified, port range 5701-5703 will
+            be tried.
+            -->
+            <address>127.0.0.1</address>
+        </cluster-members>
+        <!--
+        Whether client should discover and connect other members in the
+        cluster and route requests to them or only connects to the members
+        listed above.
+        -->
+        <smart-routing>false</smart-routing>
+    </network>
+    <connection-strategy>
+        <connection-retry>
+            <!--
+            How long the client should keep trying connecting to the server.
+            -->
+            <cluster-connect-timeout-millis>1000</cluster-connect-timeout-millis>
+        </connection-retry>
+    </connection-strategy>
+</hazelcast-client>

--- a/hazelcast/src/main/resources/hazelcast-client-default-assembly.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-default-assembly.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The default Hazelcast client configuration used in hz-cli script.
+#
+# This file differs from hazelcast-client-default.yaml in some settings
+# and it is used in the ZIP/TAR distributions,
+# which are the basis for other distributions like docker & package managers.
+#
+# To learn how to configure Hazelcast, please see the Reference Manual
+# at https://docs.hazelcast.com/
+
+hazelcast-client:
+  network:
+    # List of addresses for the client to try to connect to. All members of
+    # a Hazelcast cluster accept client connections.
+    # Use the format <hostname>:<port>
+    # If a port number is not specified, port range 5701-5703 will be tried.
+    cluster-members:
+      - 127.0.0.1
+    # Whether client should discover and connect other members in the cluster
+    # and route requests to them or only connects to the members listed
+    # above.
+    smart-routing: false
+  connection-strategy:
+    connection-retry:
+      # how long the client should keep trying connecting to the server
+      cluster-connect-timeout-millis: 1000

--- a/hazelcast/src/main/resources/hazelcast-default-assembly.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default-assembly.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # The default Hazelcast YAML configuration. This configuration is identical
-# to hazelcast-default.xml.
+# to hazelcast-default-assembly.xml.
 #
 # This file differs from hazelcast-default.yaml in some settings
 # and it is used by the scripts in the ZIP/TAR distributions,


### PR DESCRIPTION
In #19037 we removed the default config files and used
hazelcast-client.xml from the main jar. This files contains different
defaults than what was used in the Jet default config.

This adds hazelcast-client-default-assembly.xml/yaml file, which is used
as hazelcast-client.xml config file for `hz-cli` tool. This file is used
in zip/tar archive and downstream distributions (docker, package
managers).

Fixes #19102
