### PR TITLE
Remove reference to discovery plugins from assembly

### DIFF
--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -30,10 +30,6 @@
             <includes>
                 <include>com.hazelcast:hazelcast</include>
                 <include>com.hazelcast:hazelcast-sql</include>
-                <include>com.hazelcast:hazelcast-aws</include>
-                <include>com.hazelcast:hazelcast-kubernetes</include>
-                <include>com.hazelcast:hazelcast-gcp</include>
-                <include>com.hazelcast:hazelcast-azure</include>
                 <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>com.hazelcast:hazelcast-wm</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -29,10 +29,6 @@
             <includes>
                 <include>com.hazelcast:hazelcast</include>
                 <include>com.hazelcast:hazelcast-sql</include>
-                <include>com.hazelcast:hazelcast-aws</include>
-                <include>com.hazelcast:hazelcast-kubernetes</include>
-                <include>com.hazelcast:hazelcast-gcp</include>
-                <include>com.hazelcast:hazelcast-azure</include>
                 <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>com.hazelcast:hazelcast-wm</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>


### PR DESCRIPTION
In #19033 we merged the discovery plugins to the main repository.
This removes the leftover reference to these jars from the assembly.
