### PR TITLE
Clean up leftover SPI plugins config

### DIFF
--- a/.github/terraform/aws/scripts/start_aws_hazelcast_member.sh
+++ b/.github/terraform/aws/scripts/start_aws_hazelcast_member.sh
@@ -11,7 +11,7 @@ sed -i -e "s/REGION/${REGION}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast.yaml
 
-CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/jars/hazelcast-aws.jar:${HOME}/hazelcast.yaml"
+CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/hazelcast.yaml"
 
 nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter >> ${HOME}/logs/hazelcast.stderr.log 2>> ${HOME}/logs/hazelcast.stdout.log &
 

--- a/.github/terraform/azure/scripts/start_azure_hazelcast_member.sh
+++ b/.github/terraform/azure/scripts/start_azure_hazelcast_member.sh
@@ -8,7 +8,7 @@ TAG_VALUE=$2
 sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast.yaml
 
-CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/jars/hazelcast-azure.jar:${HOME}/hazelcast.yaml"
+CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/hazelcast.yaml"
 
 nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
 

--- a/.github/terraform/gcp/scripts/start_gcp_hazelcast_member.sh
+++ b/.github/terraform/gcp/scripts/start_gcp_hazelcast_member.sh
@@ -8,7 +8,7 @@ LABEL_VALUE=$2
 sed -i -e "s/LABEL_KEY/${LABEL_KEY}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/LABEL_VALUE/${LABEL_VALUE}/g" ${HOME}/hazelcast.yaml
 
-CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/jars/hazelcast-gcp.jar:${HOME}/hazelcast.yaml"
+CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/hazelcast.yaml"
 
 nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
 


### PR DESCRIPTION
Cleanup leftover configs after SPI plugin merging

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
