### PR TITLE
Adjust error message when trying to query JSON without mapping created

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolver.java
@@ -72,7 +72,8 @@ public final class MapSampleMetadataResolver {
                 if (data.isPortable()) {
                     return resolvePortable(ss.getPortableContext().lookupClassDefinition(data), key, jetMapMetadataResolver);
                 } else if (data.isJson()) {
-                    throw new UnsupportedOperationException("JSON objects are not supported.");
+                    throw new UnsupportedOperationException("To query JSON objects, "
+                            + "you have to define the data model using CREATE MAPPING.");
                 } else {
                     return resolveClass(ss.toObject(data).getClass(), key, jetMapMetadataResolver);
                 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/sample/MapSampleMetadataResolverTest.java
@@ -422,7 +422,7 @@ public class MapSampleMetadataResolverTest extends MapSchemaTestSupport {
             MapSampleMetadataResolver.resolve(ss, jetMapMetadataResolver, ss.toData(new HazelcastJsonValue("{ \"test\": 10 }")), true);
         } catch (QueryException e) {
             assertEquals(SqlErrorCode.GENERIC, e.getCode());
-            assertTrue(e.getMessage().contains("JSON objects are not supported"));
+            assertTrue(e.getMessage().contains("To query JSON objects, you have to define the data model using CREATE MAPPING."));
         }
     }
 


### PR DESCRIPTION
Minor error message adjustment to make it clear whan you need to do when you want to query JSON objects.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
