### PR TITLE
Fix TopologyChangeTest failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -272,8 +272,15 @@ public class TopologyChangeTest extends JetTestSupport {
             NoOutputSourceP.executionStarted.await();
 
             instances[0].getLifecycleService().terminate();
+            // Wait for job executions terminated in non-terminated instances
+            // before proceeding. Otherwise, job executions on these members
+            // may complete successfully without exception and without calling
+            // Processor#close.
+            for (int i = 1; i < 3; i++) {
+                JetServiceBackend jetServiceBackend = getJetServiceBackend(instances[i]);
+                jetServiceBackend.getJobExecutionService().waitAllExecutionsTerminated();
+            }
             NoOutputSourceP.proceedLatch.countDown();
-
             future.get();
             fail();
         } catch (ExecutionException expected) {

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -276,7 +276,7 @@ public class TopologyChangeTest extends JetTestSupport {
             // before proceeding. Otherwise, job executions on these members
             // may complete successfully without exception and without calling
             // Processor#close.
-            for (int i = 1; i < 3; i++) {
+            for (int i = 1; i < instances.length; i++) {
                 JetServiceBackend jetServiceBackend = getJetServiceBackend(instances[i]);
                 jetServiceBackend.getJobExecutionService().waitAllExecutionsTerminated();
             }


### PR DESCRIPTION
In the test, we shutdown the coordinator of the job and then we remove
the completion barrier of the test processor. This member shutdown makes
the job fails in the coordinator member, but on other local members the
job executions may complete successfully since the barrier removal is
not wait for them to complete with the cancellation exception. Hence,
Processor#close is not called in these members and assertions fail.
With this PR, I added a wait for jobs terminated on all members before
proceeding/removing this barrier. 
See: https://github.com/hazelcast/hazelcast/issues/19001#issuecomment-886464636 to reproduce the failure.

Fixes #19001

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

