### PR TITLE
Fixes SplitBrainTest start issues

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/AbstractSplitBrainProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/AbstractSplitBrainProtectionTest.java
@@ -239,7 +239,7 @@ public abstract class AbstractSplitBrainProtectionTest extends HazelcastTestSupp
             config.addSetConfig(newSetConfig(splitBrainProtectionOn, splitBrainProtectionName));
             config.addPNCounterConfig(newPNCounterConfig(splitBrainProtectionOn, splitBrainProtectionName));
         }
-        cluster.createFiveMemberCluster(config);
+        cluster.createFiveMemberCluster(config, splitBrainProtectionNames);
         for (SplitBrainProtectionOn splitBrainProtectionOn : types) {
             LOGGER.info("Queue size before data initialization for "
                     + splitBrainProtectionOn

--- a/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/splitbrainprotection/PartitionedCluster.java
@@ -74,8 +74,12 @@ public class PartitionedCluster {
         return instance[index];
     }
 
-    public void createFiveMemberCluster(Config config) {
+    public void createFiveMemberCluster(Config config, String[] splitBrainProtectionIds) {
         createInstances(config);
+        verifySplitBrainProtectionsPresentEventually(SUCCESSFUL_SPLIT_BRAIN_PROTECTION_TEST_NAME);
+        for (String splitBrainProtectionId : splitBrainProtectionIds) {
+            verifySplitBrainProtectionsPresentEventually(splitBrainProtectionId);
+        }
     }
 
     public void splitFiveMembersThreeAndTwo(String... splitBrainProtectionIds) {
@@ -131,6 +135,14 @@ public class PartitionedCluster {
         closeConnectionBetween(instance[4], instance[2]);
         closeConnectionBetween(instance[4], instance[1]);
         closeConnectionBetween(instance[4], instance[0]);
+    }
+
+    private void verifySplitBrainProtectionsPresentEventually(String splitBrainProtectionId) {
+        assertSplitBrainProtectionIsPresentEventually(instance[0], splitBrainProtectionId);
+        assertSplitBrainProtectionIsPresentEventually(instance[1], splitBrainProtectionId);
+        assertSplitBrainProtectionIsPresentEventually(instance[2], splitBrainProtectionId);
+        assertSplitBrainProtectionIsPresentEventually(instance[3], splitBrainProtectionId);
+        assertSplitBrainProtectionIsPresentEventually(instance[4], splitBrainProtectionId);
     }
 
     private void verifySplitBrainProtections(String splitBrainProtectionId) {


### PR DESCRIPTION
SplitBrainStatus is set by a single thread at the hazelcast instance
start in an async manner. Therefore, we are not sure that a the
status is set when the test starts.

Adding an eventually check at the start so that we make sure we
have the min-size cluster for all split brain protections before
we actually split the cluster

fixes #18950
fixes #18777
fixes #18766
fixes #18765
fixes #18764
fixes #18930