### PR TITLE
Fix processor classloader related issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -525,11 +525,13 @@ public class JobExecutionService implements DynamicMetricsProvider {
             doWithClassLoader(removedClassLoader, () -> executionContext.completeExecution(error));
         } finally {
             Map<String, ClassLoader> cls = processorCls.remove(executionContext.jobId());
-            for (ClassLoader cl : cls.values()) {
-                try {
-                    ((ChildFirstClassLoader) cl).close();
-                } catch (IOException e) {
-                    logger.fine("Exception when closing processor classloader", e);
+            if (cls != null) {
+                for (ClassLoader cl : cls.values()) {
+                    try {
+                        ((ChildFirstClassLoader) cl).close();
+                    } catch (IOException e) {
+                        logger.fine("Exception when closing processor classloader", e);
+                    }
                 }
             }
             executionCompleted.inc();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -520,27 +520,35 @@ public class JobExecutionService implements DynamicMetricsProvider {
      */
     public void completeExecution(@Nonnull ExecutionContext executionContext, Throwable error) {
         executionContexts.remove(executionContext.executionId());
-        JetDelegatingClassLoader removedClassLoader = classLoaders.remove(executionContext.jobId());
+        JetDelegatingClassLoader jobClassLoader = classLoaders.get(executionContext.jobId());
         try {
-            doWithClassLoader(removedClassLoader, () -> executionContext.completeExecution(error));
+            doWithClassLoader(jobClassLoader, () -> executionContext.completeExecution(error));
         } finally {
-            Map<String, ClassLoader> cls = processorCls.remove(executionContext.jobId());
-            if (cls != null) {
-                for (ClassLoader cl : cls.values()) {
-                    try {
-                        ((ChildFirstClassLoader) cl).close();
-                    } catch (IOException e) {
-                        logger.fine("Exception when closing processor classloader", e);
-                    }
-                }
+            // If this is the coordinator we need to keep the classloader around for ProcesorMetaSupplier#close
+            if (!nodeEngine.getLocalMember().getAddress().equals(executionContext.coordinator())) {
+                removeClassloadersForJob(executionContext.jobId());
             }
             executionCompleted.inc();
-            // the class loader might not have been initialized if the job failed before that
-            if (removedClassLoader != null) {
-                removedClassLoader.shutdown();
-            }
             executionContextJobIds.remove(executionContext.jobId());
             logger.fine("Completed execution of " + executionContext.jobNameAndExecutionId());
+        }
+    }
+
+    public void removeClassloadersForJob(long jobId) {
+        Map<String, ClassLoader> cls = processorCls.remove(jobId);
+        if (cls != null) {
+            for (ClassLoader cl : cls.values()) {
+                try {
+                    ((ChildFirstClassLoader) cl).close();
+                } catch (IOException e) {
+                    logger.fine("Exception when closing processor classloader", e);
+                }
+            }
+        }
+        // the class loader might not have been initialized if the job failed before that
+        JetDelegatingClassLoader jobClassLoader = classLoaders.remove(jobId);
+        if (jobClassLoader != null) {
+            jobClassLoader.shutdown();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.JobStatus;
-import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.metrics.JobMetrics;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -105,6 +105,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
+import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static com.hazelcast.jet.impl.util.Util.formatJobDuration;
 import static com.hazelcast.jet.impl.util.Util.toList;
 import static java.util.Collections.emptyList;
@@ -283,7 +284,7 @@ public class MasterJobContext {
             }
             ClassLoader classLoader = mc.getJetServiceBackend().getClassLoader(mc.jobId());
             DAG dag;
-            JobExecutionService jobExecutionService = mc.coordinationService().getJetServiceBackend().getJobExecutionService();
+            JobExecutionService jobExecutionService = mc.getJetServiceBackend().getJobExecutionService();
             try {
                 jobExecutionService.prepareProcessorClassLoaders(mc.jobId(), mc.jobConfig());
                 dag = deserializeWithCustomClassLoader(
@@ -767,15 +768,19 @@ public class MasterJobContext {
 
     private void completeVertices(@Nullable Throwable failure) {
         if (vertices != null) {
-            for (Vertex vertex : vertices) {
-                try {
-                    ProcessorMetaSupplier metaSupplier = vertex.getMetaSupplier();
-                    Util.doWithClassLoader(metaSupplier.getClass().getClassLoader(), () -> metaSupplier.close(failure));
-                } catch (Throwable e) {
-                    logger.severe(mc.jobIdString()
-                            + " encountered an exception in ProcessorMetaSupplier.close(), ignoring it", e);
+            JobExecutionService jobExecutionService = mc.getJetServiceBackend().getJobExecutionService();
+            ClassLoader jobCL = jobExecutionService.getClassLoader(mc.jobConfig(), mc.jobId());
+            doWithClassLoader(jobCL, () -> {
+                for (Vertex v : vertices) {
+                    try {
+                        ClassLoader processorCL = jobExecutionService.getProcessorClassLoader(mc.jobId(), v.getName());
+                        Util.doWithClassLoader(processorCL, () -> v.getMetaSupplier().close(failure));
+                    } catch (Throwable e) {
+                        logger.severe(mc.jobIdString()
+                                      + " encountered an exception in ProcessorMetaSupplier.close(), ignoring it", e);
+                    }
                 }
-            }
+            });
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -634,6 +634,7 @@ public class MasterJobContext {
                     return;
                 }
                 completeVertices(failure);
+                mc.getJetServiceBackend().getJobExecutionService().removeClassloadersForJob(mc.jobId());
 
                 ActionAfterTerminate terminationModeAction = failure instanceof JobTerminateRequestedException
                         ? ((JobTerminateRequestedException) failure).mode().actionAfterTerminate() : null;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoader.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class ChildFirstClassLoader extends URLClassLoader {
 
-    private boolean closed;
+    private volatile boolean closed;
 
     public ChildFirstClassLoader(@Nonnull URL[] urls, @Nonnull ClassLoader parent) {
         super(urls, parent);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoader.java
@@ -145,6 +145,12 @@ public class ChildFirstClassLoader extends URLClassLoader {
         closed = true;
     }
 
+    /**
+     * Returns if this classloader has been already closed.
+     * <p>
+     * Visible for testing because there is no easy way to find out if
+     * {@link URLClassLoader} has been closed.
+     */
     public boolean isClosed() {
         return closed;
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoader.java
@@ -33,6 +33,8 @@ import java.util.List;
  */
 public class ChildFirstClassLoader extends URLClassLoader {
 
+    private boolean closed;
+
     public ChildFirstClassLoader(@Nonnull URL[] urls, @Nonnull ClassLoader parent) {
         super(urls, parent);
 
@@ -135,5 +137,15 @@ public class ChildFirstClassLoader extends URLClassLoader {
             res = super.getResource(name);
         }
         return res;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -66,7 +66,6 @@ import static com.hazelcast.jet.core.metrics.MetricNames.EXECUTION_START_TIME;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -257,7 +257,8 @@ public class ExecutionContext implements DynamicMetricsProvider {
 
             for (Tuple2<ProcessorSupplier, String> s : procSuppliers) {
                 try {
-                    ClassLoader processorCl = jobExecutionService.getProcessorClassLoader(jobId, s.f1());
+                    ClassLoader processorCl = isLightJob ?
+                            null : jobExecutionService.getProcessorClassLoader(jobId, s.f1());
                     doWithClassLoader(processorCl, () -> s.f0().close(error));
                 } catch (Throwable e) {
                     logger.severe(jobNameAndExecutionId()

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -31,6 +31,7 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Edge.RoutingPolicy;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.jet.impl.JobExecutionService;
 import com.hazelcast.jet.impl.execution.ConcurrentInboundEdgeStream;
@@ -78,6 +79,7 @@ import java.util.stream.Stream;
 import static com.hazelcast.internal.util.concurrent.ConcurrentConveyor.concurrentConveyor;
 import static com.hazelcast.jet.config.EdgeConfig.DEFAULT_QUEUE_SIZE;
 import static com.hazelcast.jet.core.Edge.DISTRIBUTE_TO_ALL;
+import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.impl.execution.OutboundCollector.compositeCollector;
 import static com.hazelcast.jet.impl.execution.TaskletExecutionService.TASKLET_INIT_CLOSE_EXECUTOR_NAME;
 import static com.hazelcast.jet.impl.util.ImdgUtil.getMemberConnection;
@@ -88,6 +90,7 @@ import static com.hazelcast.jet.impl.util.PrefixedLogger.prefixedLogger;
 import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static com.hazelcast.jet.impl.util.Util.memoize;
 import static com.hazelcast.jet.impl.util.Util.toList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -262,8 +265,10 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         tasklets.addAll(allReceivers);
     }
 
-    public List<ProcessorSupplier> getProcessorSuppliers() {
-        return toList(vertices, VertexDef::processorSupplier);
+    public List<Tuple2<ProcessorSupplier, String>> getProcessorSuppliers() {
+        return unmodifiableList(toList(
+                vertices, vertexDef -> tuple2(vertexDef.processorSupplier(), vertexDef.name())
+        ));
     }
 
     public Map<Integer, Map<Integer, Map<Address, ReceiverTasklet>>> getReceiverMap() {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -31,7 +31,6 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Edge.RoutingPolicy;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.jet.impl.JobExecutionService;
 import com.hazelcast.jet.impl.execution.ConcurrentInboundEdgeStream;
@@ -79,7 +78,6 @@ import java.util.stream.Stream;
 import static com.hazelcast.internal.util.concurrent.ConcurrentConveyor.concurrentConveyor;
 import static com.hazelcast.jet.config.EdgeConfig.DEFAULT_QUEUE_SIZE;
 import static com.hazelcast.jet.core.Edge.DISTRIBUTE_TO_ALL;
-import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.impl.execution.OutboundCollector.compositeCollector;
 import static com.hazelcast.jet.impl.execution.TaskletExecutionService.TASKLET_INIT_CLOSE_EXECUTOR_NAME;
 import static com.hazelcast.jet.impl.util.ImdgUtil.getMemberConnection;
@@ -89,7 +87,6 @@ import static com.hazelcast.jet.impl.util.PrefixedLogger.prefix;
 import static com.hazelcast.jet.impl.util.PrefixedLogger.prefixedLogger;
 import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static com.hazelcast.jet.impl.util.Util.memoize;
-import static com.hazelcast.jet.impl.util.Util.toList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -263,12 +260,6 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                                                         .collect(toList());
 
         tasklets.addAll(allReceivers);
-    }
-
-    public List<Tuple2<ProcessorSupplier, String>> getProcessorSuppliers() {
-        return unmodifiableList(toList(
-                vertices, vertexDef -> tuple2(vertexDef.processorSupplier(), vertexDef.name())
-        ));
     }
 
     public Map<Integer, Map<Integer, Map<Address, ReceiverTasklet>>> getReceiverMap() {
@@ -706,8 +697,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         return VertexDef.getHigherPriorityVertices(vertices).size();
     }
 
-    // for test
-    List<VertexDef> getVertices() {
-        return vertices;
+    public List<VertexDef> getVertices() {
+        return unmodifiableList(vertices);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -112,7 +112,7 @@ public final class ExecutionPlanBuilder {
             }
 
             Function<? super Address, ? extends ProcessorSupplier> procSupplierFn =
-                    doWithClassLoader(metaSupplier.getClass().getClassLoader(), () -> metaSupplier.get(addresses));
+                    doWithClassLoader(processorClassLoader, () -> metaSupplier.get(addresses));
             for (Entry<MemberInfo, ExecutionPlan> e : plans.entrySet()) {
                 final ProcessorSupplier processorSupplier =
                         doWithClassLoader(processorClassLoader, () -> procSupplierFn.apply(e.getKey().getAddress()));

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/VertexDef.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/VertexDef.java
@@ -52,11 +52,11 @@ public class VertexDef implements IdentifiedDataSerializable {
         this.localParallelism = localParallelism;
     }
 
-    String name() {
+    public String name() {
         return name;
     }
 
-    int localParallelism() {
+    public int localParallelism() {
         return localParallelism;
     }
 
@@ -80,7 +80,7 @@ public class VertexDef implements IdentifiedDataSerializable {
         return outboundEdges;
     }
 
-    ProcessorSupplier processorSupplier() {
+    public ProcessorSupplier processorSupplier() {
         return processorSupplier;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoaderTest.java
@@ -16,11 +16,17 @@
 
 package com.hazelcast.jet.impl.deployment;
 
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.JarUtil;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,6 +42,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ChildFirstClassLoaderTest {
 
     private static URL jarUrl;
@@ -52,6 +60,14 @@ public class ChildFirstClassLoaderTest {
     public static void afterClass() throws Exception {
         if (jarUrl != null) {
             Files.delete(Paths.get(jarUrl.toURI()));
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (cl != null) {
+            cl.close();
+            cl = null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.Watermark;
-import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.processor.NoopP;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -34,7 +34,7 @@ import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.impl.processor.NoopP;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -56,7 +56,7 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JetClassLoaderTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderCleanupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderCleanupTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.Util;
 import com.hazelcast.jet.config.JobConfig;
-import com.hazelcast.jet.core.JetProperties;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetServiceBackend;
@@ -33,6 +32,7 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.test.SimpleEvent;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.JarUtil;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -63,7 +63,7 @@ public class ProcessorClassLoaderCleanupTest extends JetTestSupport {
         jarFile = File.createTempFile("resources_", ".jar");
         JarUtil.createResourcesJarFile(jarFile);
 
-        System.setProperty(JetProperties.PROCESSOR_CUSTOM_LIB_DIR.getName(), System.getProperty("java.io.tmpdir"));
+        System.setProperty(ClusterProperty.PROCESSOR_CUSTOM_LIB_DIR.getName(), System.getProperty("java.io.tmpdir"));
     }
 
     @AfterClass


### PR DESCRIPTION
The ChildFirstClassLoader is a subclass of URLClassLoader,
which needs to be closed. This was the case in
ChildFirstClassLoaderTest.

Also added call to close to com.hazelcast.jet.impl.JobExecutionService.completeExecution
when the processor classloaders are removed.

Fixes #19173
Fixes #19174
Fixes #19185
