### PR TITLE
Fix composite index tests and improve query engine error reporting

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
@@ -99,7 +99,6 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         map.put(101, new Person(null));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testCompositeQueries() {
         check(null, 0, 0, 0, 0);
@@ -123,7 +122,6 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         check("name = '010' and age = 110", 0, 5, 7, 0);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testFirstComponentQuerying() {
         check(null, 0, 0, 0, 0);
@@ -175,7 +173,6 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         check("height != null", 100, 0, 0, 0);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testNulls() {
         check(null, 0, 0, 0, 0);
@@ -328,7 +325,7 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
 
     private static class NoIndexPredicate implements IndexAwarePredicate, VisitablePredicate {
 
-        private Predicate delegate;
+        private volatile Predicate delegate;
 
         NoIndexPredicate(Predicate delegate) {
             this.delegate = delegate;
@@ -336,8 +333,9 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
 
         @Override
         public Predicate accept(Visitor visitor, Indexes indexes) {
+            Predicate delegate = this.delegate;
             if (delegate instanceof VisitablePredicate) {
-                delegate = ((VisitablePredicate) delegate).accept(visitor, indexes);
+                this.delegate = ((VisitablePredicate) delegate).accept(visitor, indexes);
             }
             return this;
         }


### PR DESCRIPTION
OpenJ9 is apparently less aggressive with optimizations and that's why
the test was only (mostly?) failing in OpenJ9 builds. The failure is
specific to the test itself: the custom predicate used in the test
didn't expect it can be invoked concurrently across threads.
As a result, `ClassCastException` was produced, which then was silenced
in `QueryEngineImpl`.

Also, this PR improves error reporting in `QueryEngineImpl` when
`disableMigrationFallback` is `true` (used for testing purposes only).
Now a proper exception is reported to a caller instead of a cryptic
"could not execute query for all partitions" exception.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/4080
Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/4091