### PR TITLE
Fix retrying for CallerNotMemberException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -480,13 +480,6 @@ public class MembershipManager {
         if (logger.isFineEnabled()) {
             logger.fine("Setting members " + memberMap.getMembers() + ", version: " + memberMap.getVersion());
         }
-        System.out.println("aaa before");
-        try {
-            Thread.sleep(5000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        System.out.println("aaa after");
         clusterServiceLock.lock();
         try {
             memberMapRef.set(memberMap);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -480,6 +480,13 @@ public class MembershipManager {
         if (logger.isFineEnabled()) {
             logger.fine("Setting members " + memberMap.getMembers() + ", version: " + memberMap.getVersion());
         }
+        System.out.println("aaa before");
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.out.println("aaa after");
         clusterServiceLock.lock();
         try {
             memberMapRef.set(memberMap);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologyException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.stackTraceToString;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
@@ -109,7 +109,7 @@ public abstract class AsyncOperation extends Operation implements IdentifiedData
 
     @Override
     public ExceptionAction onInvocationException(Throwable throwable) {
-        return isRestartableException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
+        return isTopologyException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/InitExecutionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/InitExecutionOperation.java
@@ -30,7 +30,6 @@ import com.hazelcast.jet.impl.util.LoggingUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 import com.hazelcast.version.Version;
 
 import java.io.IOException;
@@ -39,9 +38,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.deserializeWithCustomClassLoader;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologyException;
 import static com.hazelcast.jet.impl.util.Util.jobIdAndExecutionId;
-import static com.hazelcast.spi.impl.operationservice.ExceptionAction.THROW_EXCEPTION;
 
 /**
  * Operation sent from master to members to initialize execution of a job.
@@ -100,11 +97,6 @@ public class InitExecutionOperation extends AsyncJobOperation {
                     coordinatorMemberListVersion, participants, plan);
             return CompletableFuture.completedFuture(null);
         }
-    }
-
-    @Override
-    public ExceptionAction onInvocationException(Throwable throwable) {
-        return isTopologyException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/InitExecutionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/InitExecutionOperation.java
@@ -19,9 +19,9 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.nio.IOUtil;
-import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.jet.JetException;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.jet.impl.JobExecutionService;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
@@ -39,7 +39,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.deserializeWithCustomClassLoader;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologyException;
 import static com.hazelcast.jet.impl.util.Util.jobIdAndExecutionId;
 import static com.hazelcast.spi.impl.operationservice.ExceptionAction.THROW_EXCEPTION;
 
@@ -104,7 +104,7 @@ public class InitExecutionOperation extends AsyncJobOperation {
 
     @Override
     public ExceptionAction onInvocationException(Throwable throwable) {
-        return isRestartableException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
+        return isTopologyException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/TerminateExecutionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/TerminateExecutionOperation.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologyException;
 import static com.hazelcast.spi.impl.operationservice.ExceptionAction.THROW_EXCEPTION;
 
 /**
@@ -60,7 +60,7 @@ public class TerminateExecutionOperation extends AbstractJobOperation {
 
     @Override
     public ExceptionAction onInvocationException(Throwable throwable) {
-        return isRestartableException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
+        return isTopologyException(throwable) ? THROW_EXCEPTION : super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -34,7 +34,6 @@ import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
-import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 
 import javax.annotation.Nonnull;
@@ -78,7 +77,6 @@ public final class ExceptionUtil {
         return t instanceof TopologyChangedException
                 || t instanceof MemberLeftException
                 || t instanceof TargetNotMemberException
-                || t instanceof CallerNotMemberException
                 || t instanceof HazelcastInstanceNotActiveException
                 || t instanceof EnteringPassiveClusterStateException
                 || t instanceof OperationTimeoutException

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.exception;
 import com.hazelcast.core.HazelcastException;
 
 /**
- * A 'marker' exception that indicates that an operation can be retried. E.g. if map.get is send to a partition that
+ * A 'marker' exception that indicates that an operation can be retried. E.g. if map.get is sent to a partition that
  * is currently migrating, a subclass of this exception is thrown, so the caller can deal with it (e.g. sending the
  * request to the new partition owner).
  */

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -374,7 +374,7 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
             this.pendingResponse = new ExceptionalResult(cause);
 
             if (backupsAcksReceived != expectedBackups) {
-                // we are done since not all backups have completed. Therefor we should not notify the future
+                // we are done since not all backups have completed. Therefore we should not notify the future
                 return;
             }
         }


### PR DESCRIPTION
CallerNotMemberException is thrown, when the invocation target doesn't
yet know about the member calling the operation. This happens just after
join. It's a RetryableHazelcastException, therefore we rely that it will
be re-invoked and will eventually succeed. This PR removes it from the
`isTopologyException()` method.

We also changed `isRestartableException()` to `isTopologyException()` in
the `onInvocationException()` implementations - the two extra exceptions
aren't RetryableHazelcastException, so the operation won't be retried
anyway. With the other method, it doesn't look illogical: `if retryable
then throw`.

This PR doesn't contain a test that would fail without it. Such test
will be in #19169.

