### PR TITLE
[backport 4.1.z] don't use hazelcas-all in docker snaphost images

### DIFF
--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -50,8 +50,9 @@ jobs:
       - name: Build hazelcast with Maven
         run: |
           mvn -f hazelcast/pom.xml -B clean install -DskipTests
-          rm hazelcast/hazelcast-all/target/*-sources.jar
-          cp hazelcast/hazelcast-all/target/hazelcast-all-*.jar hazelcast-all.jar
+          rm hazelcast/hazelcast/target/*-sources.jar \
+            hazelcast/hazelcast/target/*-tests.jar || true
+          cp hazelcast/hazelcast/target/hazelcast-*.jar hazelcast.jar
 
       - name: Docker Build and Push hazelcast-snapshot image
         run: |
@@ -65,8 +66,9 @@ jobs:
       - name: Build hazelcast-enterprise with Maven
         run: |
           mvn -f hazelcast-enterprise/pom.xml -B clean install -DskipTests
-          rm hazelcast-enterprise/hazelcast-enterprise-all/target/*-tests.jar
-          cp hazelcast-enterprise/hazelcast-enterprise-all/target/hazelcast-enterprise-all-*.jar hazelcast-enterprise-all.jar
+          rm hazelcast-enterprise/hazelcast-enterprise/target/*-sources.jar \
+            hazelcast-enterprise/hazelcast-enterprise/target/*-tests.jar || true
+          cp hazelcast-enterprise/hazelcast-enterprise/target/hazelcast-enterprise-*.jar hazelcast-enterprise.jar
 
       - name: Docker Build and Push hazelcast-enterprise-snapshot image
         run: |


### PR DESCRIPTION
Backports part of the #19106 to allow building Docker snapshot images from patch branches.

See also: hazelcast-dockerfiles/hazelcast-enterprise-snapshot#1, hazelcast-dockerfiles/hazelcast-snapshot#1