### PR TITLE
[backport 3.12.z] don't use hazelcas-all in docker snaphost images

### DIFF
--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -50,8 +50,9 @@ jobs:
       - name: Build hazelcast with Maven
         run: |
           mvn -f hazelcast/pom.xml -B clean install -DskipTests
-          rm hazelcast/hazelcast-all/target/*-sources.jar
-          cp hazelcast/hazelcast-all/target/hazelcast-all-*.jar hazelcast-all.jar
+          rm hazelcast/hazelcast/target/*-sources.jar \
+            hazelcast/hazelcast/target/*-tests.jar || true
+          cp hazelcast/hazelcast/target/hazelcast-*.jar hazelcast.jar
 
       - name: Docker Build and Push hazelcast-snapshot image
         run: |
@@ -65,8 +66,9 @@ jobs:
       - name: Build hazelcast-enterprise with Maven
         run: |
           mvn -f hazelcast-enterprise/pom.xml -B clean install -DskipTests
-          rm hazelcast-enterprise/hazelcast-enterprise-all/target/*-tests.jar
-          cp hazelcast-enterprise/hazelcast-enterprise-all/target/hazelcast-enterprise-all-*.jar hazelcast-enterprise-all.jar
+          rm hazelcast-enterprise/hazelcast-enterprise/target/*-sources.jar \
+            hazelcast-enterprise/hazelcast-enterprise/target/*-tests.jar || true
+          cp hazelcast-enterprise/hazelcast-enterprise/target/hazelcast-enterprise-*.jar hazelcast-enterprise.jar
 
       - name: Docker Build and Push hazelcast-enterprise-snapshot image
         run: |

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -46,7 +46,7 @@
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
                         <artifactId>java16</artifactId>
-                        <version>1.0</version>
+                        <version>${maven.animal.sniffer.signature16.version}</version>
                     </signature>
                 </configuration>
                 <executions>

--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -44,7 +44,7 @@
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
                         <artifactId>java16</artifactId>
-                        <version>1.0</version>
+                        <version>${maven.animal.sniffer.signature16.version}</version>
                     </signature>
                 </configuration>
                 <executions>

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -48,7 +48,7 @@
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
                         <artifactId>java16</artifactId>
-                        <version>1.0</version>
+                        <version>${maven.animal.sniffer.signature16.version}</version>
                     </signature>
                 </configuration>
                 <executions>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -77,7 +77,7 @@
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
                         <artifactId>java16</artifactId>
-                        <version>1.0</version>
+                        <version>${maven.animal.sniffer.signature16.version}</version>
                     </signature>
                     <ignores>
                         <ignore>sun.misc.Unsafe</ignore>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,8 @@
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
-        <maven.animal.sniffer.plugin.version>1.19</maven.animal.sniffer.plugin.version>
+        <maven.animal.sniffer.plugin.version>1.20</maven.animal.sniffer.plugin.version>
+        <maven.animal.sniffer.signature16.version>1.1</maven.animal.sniffer.signature16.version>
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
         <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>


### PR DESCRIPTION
Backports part of the #19106 to allow building Docker snapshot images from patch branches.

See also: hazelcast-dockerfiles/hazelcast-enterprise-snapshot#1, hazelcast-dockerfiles/hazelcast-snapshot#1