### PR TITLE
Restore current directory after findScriptDir is finished

### DIFF
--- a/distribution/src/bin-filemode-755/hz-cli
+++ b/distribution/src/bin-filemode-755/hz-cli
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 function findScriptDir() {
+  CURRENT=$PWD
+
   DIR=$(dirname "$0")
   cd "$DIR" || exit
   TARGET_FILE=$(basename "$0")
@@ -15,6 +17,8 @@ function findScriptDir() {
   done
 
   SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
 }
 
 findScriptDir

--- a/distribution/src/bin-filemode-755/hz-start
+++ b/distribution/src/bin-filemode-755/hz-start
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 function findScriptDir() {
+  CURRENT=$PWD
+
   DIR=$(dirname "$0")
   cd "$DIR" || exit
   TARGET_FILE=$(basename "$0")
@@ -15,6 +17,8 @@ function findScriptDir() {
   done
 
   SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
 }
 
 findScriptDir


### PR DESCRIPTION
The findScriptDir changed the current directory, creating an issue when
refering to a jar file in `hz-cli submit` using relative path

Fixes #19196
