### PR TITLE
Use CreateDagVisitor's localMemberAddress on root relation

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlBackend.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlBackend.java
@@ -360,7 +360,7 @@ public class JetSqlBackend implements SqlBackend {
                     permissions
             );
         } else {
-            CreateDagVisitor visitor = traverseRel(new JetRootRel(physicalRel, nodeEngine.getThisAddress()), parameterMetadata);
+            CreateDagVisitor visitor = traverseRel(new JetRootRel(physicalRel), parameterMetadata);
             SqlRowMetadata rowMetadata = createRowMetadata(fieldNames, physicalRel.schema(parameterMetadata).getTypes());
             return new SelectPlan(
                     planKey,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
@@ -76,7 +76,7 @@ public class CreateDagVisitor {
 
     public CreateDagVisitor(NodeEngine nodeEngine, QueryParameterMetadata parameterMetadata) {
         this.nodeEngine = nodeEngine;
-        this.localMemberAddress = nodeEngine.getLocalMember().getAddress();
+        this.localMemberAddress = nodeEngine.getThisAddress();
         this.parameterMetadata = parameterMetadata;
     }
 
@@ -330,7 +330,7 @@ public class CreateDagVisitor {
 
         Vertex vertex = dag.newUniqueVertex(
                 "ClientSink",
-                rootResultConsumerSink(rootRel.getInitiatorAddress(), fetch, offset)
+                rootResultConsumerSink(localMemberAddress, fetch, offset)
         );
 
         // We use distribute-to-one edge to send all the items to the initiator member.

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/JetRootRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/JetRootRel.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.sql.impl.opt.physical;
 
-import com.hazelcast.cluster.Address;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.calcite.opt.AbstractRootRel;
@@ -26,16 +25,8 @@ import org.apache.calcite.rel.RelNode;
 
 public class JetRootRel extends AbstractRootRel implements PhysicalRel {
 
-    private final Address initiatorAddress;
-
-    public JetRootRel(RelNode input, Address initiatorAddress) {
+    public JetRootRel(RelNode input) {
         super(input.getCluster(), RelTraitSet.createEmpty(), input);
-
-        this.initiatorAddress = initiatorAddress;
-    }
-
-    public Address getInitiatorAddress() {
-        return initiatorAddress;
     }
 
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -95,7 +95,9 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
         SqlStatement statement = new SqlStatement(sql);
         statement.setParameters(arguments);
 
-        instance().getSql().execute(statement);
+        //noinspection EmptyTryBlock
+        try (@SuppressWarnings("unused") SqlResult result = instance().getSql().execute(statement)) {
+        }
 
         Map<K, V> map = instance().getMap(mapName);
         assertTrueEventually(() ->
@@ -178,7 +180,9 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
 
         SqlService sqlService = instance().getSql();
         List<Row> actualRows = new ArrayList<>();
-        sqlService.execute(statement).iterator().forEachRemaining(row -> actualRows.add(new Row(row)));
+        try (SqlResult result = sqlService.execute(statement)) {
+            result.iterator().forEachRemaining(row -> actualRows.add(new Row(row)));
+        }
         assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectedRows);
     }
 
@@ -192,7 +196,9 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
     public static void assertRowsOrdered(String sql, List<Row> expectedRows) {
         SqlService sqlService = instance().getSql();
         List<Row> actualRows = new ArrayList<>();
-        sqlService.execute(sql).iterator().forEachRemaining(r -> actualRows.add(new Row(r)));
+        try (SqlResult result = sqlService.execute(sql)) {
+            result.iterator().forEachRemaining(row -> actualRows.add(new Row(row)));
+        }
         assertThat(actualRows).containsExactlyElementsOf(expectedRows);
     }
 


### PR DESCRIPTION
Removed superfluous `initiatorAddress` from `JetRoolRel`.
Ensured `SqlResult`s are closed in tests.