### PR TITLE
Isolate WAN clusters in tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockClusterProperty.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockClusterProperty.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.mocknetwork;
+
+import com.hazelcast.spi.properties.HazelcastProperty;
+
+import static com.hazelcast.spi.properties.ClusterProperty.TCP_JOIN_PORT_TRY_COUNT;
+
+/**
+ * The cluster properties that define the behavior of the mock networking of
+ * Hazelcast's test network infrastructure.
+ */
+public final class MockClusterProperty {
+
+    /**
+     * Test config property to set if {@link MockJoiner} is desired to prevent
+     * attempting to join members that are expected to be members of different
+     * clusters. If the two members are member of the same cluster is determined
+     * by checking the ports of the members.
+     *
+     * @see MockJoiner
+     */
+    public static final HazelcastProperty MOCK_JOIN_SHOULD_ISOLATE_CLUSTERS
+            = new HazelcastProperty("hazelcast.mock.join.should.isolate.clusters", false);
+
+    /**
+     * The number of incremental ports, starting with port number defined in
+     * network configuration, that will be used to connect to a host which is
+     * defined without a port in the TCP-IP member list while a node is searching
+     * for a cluster.
+     */
+    public static final HazelcastProperty MOCK_JOIN_PORT_TRY_COUNT
+            = new HazelcastProperty("hazelcast.mock.join.port.try.count",
+            TCP_JOIN_PORT_TRY_COUNT.getDefaultValue());
+
+    private MockClusterProperty() {
+    }
+}


### PR DESCRIPTION
WAN tests use the mock network that has `MockJoiner` joiner
implementation that tries to join all members created with the same
factory. This change extends the functionality of `MockJoiner` with
support for cluster isolation, specifically for WAN tests. If isolation
is enabled by a test - disabled by default, no tests should be affected
by this change apart from WAN tests - `MockJoiner` prevents members
outside of a port range from attempting to join to each other. With
other words, this change makes `MockJoiner` to behave like `TcpJoiner`
that looks up for possible cluster members within a limited port range
only.

Attempting to join members of WAN source and target clusters may fail
WAN sync and consistency check tests in edge cases. If there is an
ongoing join request - that establishes a connection - when the sync or
consistency check request is made, the request will find a connection
between the parties and will try to perform the requested action over
that connection. But the connection will be closed once the two members
realize they are members of two separate clusters. This closes the
connection under the ongoing WAN sync/consistency check operation and
fails the test.

Fixes:
https://github.com/hazelcast/hazelcast-enterprise/issues/3180
https://github.com/hazelcast/hazelcast-enterprise/issues/4037
https://github.com/hazelcast/hazelcast-enterprise/issues/4038
https://github.com/hazelcast/hazelcast-enterprise/issues/4072
https://github.com/hazelcast/hazelcast-enterprise/issues/4086
https://github.com/hazelcast/hazelcast-enterprise/issues/4087
https://github.com/hazelcast/hazelcast-enterprise/issues/4088
https://github.com/hazelcast/hazelcast-enterprise/issues/4106

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4173