### PR TITLE
internal/config/: log conflict warning at most once

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DataPersistenceAndHotRestartMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DataPersistenceAndHotRestartMerger.java
@@ -78,7 +78,7 @@ public final class DataPersistenceAndHotRestartMerger {
     }
 
     private static boolean equals(HotRestartConfig hotRestartConfig, DataPersistenceConfig dataPersistenceConfig) {
-        return hotRestartConfig.isEnabled() == dataPersistenceConfig.isEnabled() &&
-                hotRestartConfig.isFsync() == dataPersistenceConfig.isFsync();
+        return hotRestartConfig.isEnabled() == dataPersistenceConfig.isEnabled()
+                && hotRestartConfig.isFsync() == dataPersistenceConfig.isFsync();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/DataPersistenceAndHotRestartMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/DataPersistenceAndHotRestartMerger.java
@@ -49,8 +49,14 @@ public final class DataPersistenceAndHotRestartMerger {
      * if hot-restart: enabled="false" and data-persistence: enabled="false"
      * => we still do override hot-restart using data-persistence.
      * It is necessary to maintain equality consistency.
+     *
+     * @param hotRestartConfig hotRestartConfig to use in the merge
+     * @param dataPersistenceConfig dataPersistenceConfig to use in the merge
      */
     public static void merge(HotRestartConfig hotRestartConfig, DataPersistenceConfig dataPersistenceConfig) {
+        if (equals(hotRestartConfig, dataPersistenceConfig)) {
+            return;
+        }
 
         if (hotRestartConfig.isEnabled() && !dataPersistenceConfig.isEnabled()) {
             dataPersistenceConfig.setEnabled(true).setFsync(hotRestartConfig.isFsync());
@@ -69,5 +75,10 @@ public final class DataPersistenceAndHotRestartMerger {
                     + "and thus there is a conflict, the latter is used in persistence configuration."
             );
         }
+    }
+
+    private static boolean equals(HotRestartConfig hotRestartConfig, DataPersistenceConfig dataPersistenceConfig) {
+        return hotRestartConfig.isEnabled() == dataPersistenceConfig.isEnabled() &&
+                hotRestartConfig.isFsync() == dataPersistenceConfig.isFsync();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/PersistenceAndHotRestartPersistenceMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/PersistenceAndHotRestartPersistenceMerger.java
@@ -23,6 +23,8 @@ import com.hazelcast.config.PersistenceConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
+import java.util.Objects;
+
 public final class PersistenceAndHotRestartPersistenceMerger {
 
     private static final ILogger LOGGER = Logger.getLogger(PersistenceAndHotRestartPersistenceMerger.class);
@@ -99,16 +101,17 @@ public final class PersistenceAndHotRestartPersistenceMerger {
         if (hotRestartPersistenceConfig.isEnabled() != persistenceConfig.isEnabled()) {
             return false;
         }
-        if (! hotRestartPersistenceConfig.getBaseDir().equals(persistenceConfig.getBaseDir())) {
+        if (! Objects.equals(hotRestartPersistenceConfig.getBaseDir(), persistenceConfig.getBaseDir())) {
             return false;
         }
-        if (! hotRestartPersistenceConfig.getBackupDir().equals(persistenceConfig.getBackupDir())) {
+        if (! Objects.equals(hotRestartPersistenceConfig.getBackupDir(), persistenceConfig.getBackupDir())) {
             return false;
         }
-        if (hotRestartPersistenceConfig.isAutoRemoveStaleData() != persistenceConfig.isAutoRemoveStaleData()) {
+        if (! Objects.equals(hotRestartPersistenceConfig.isAutoRemoveStaleData(), persistenceConfig.isAutoRemoveStaleData())) {
             return false;
         }
-        if (! hotRestartPersistenceConfig.getEncryptionAtRestConfig().equals(persistenceConfig.getEncryptionAtRestConfig())) {
+        if (! Objects.equals(hotRestartPersistenceConfig.getEncryptionAtRestConfig(),
+                persistenceConfig.getEncryptionAtRestConfig())) {
             return false;
         }
         if (hotRestartPersistenceConfig.getClusterDataRecoveryPolicy().ordinal()

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/PersistenceAndHotRestartPersistenceMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/PersistenceAndHotRestartPersistenceMerger.java
@@ -51,8 +51,14 @@ public final class PersistenceAndHotRestartPersistenceMerger {
      * if hot-restart-persistence: enabled="false" and persistence: enabled="false"
      * => we still do override hot-restart-persistence using persistence.
      * It is necessary to maintain equality consistency.
+     *
+     * @param hotRestartPersistenceConfig hotRestartPersistenceConfig to use in the merge
+     * @param persistenceConfig persistenceConfig to use in the merge
      */
     public static void merge(HotRestartPersistenceConfig hotRestartPersistenceConfig, PersistenceConfig persistenceConfig) {
+        if (equals(hotRestartPersistenceConfig, persistenceConfig)) {
+            return;
+        }
         if (hotRestartPersistenceConfig.isEnabled() && !persistenceConfig.isEnabled()) {
             persistenceConfig.setEnabled(true)
                     .setBaseDir(hotRestartPersistenceConfig.getBaseDir())
@@ -87,5 +93,17 @@ public final class PersistenceAndHotRestartPersistenceMerger {
                             + "and thus there is a conflict, the latter is used in persistence configuration."
             );
         }
+    }
+
+    private static boolean equals(HotRestartPersistenceConfig l, PersistenceConfig r) {
+        return l.isEnabled() == r.isEnabled() &&
+                l.getBaseDir().equals(r.getBaseDir()) &&
+                l.getBackupDir().equals(r.getBackupDir()) &&
+                l.isAutoRemoveStaleData() == r.isAutoRemoveStaleData() &&
+                l.getEncryptionAtRestConfig().equals(r.getEncryptionAtRestConfig()) &&
+                l.getDataLoadTimeoutSeconds() == r.getDataLoadTimeoutSeconds() &&
+                l.getParallelism() == r.getParallelism() &&
+                l.getValidationTimeoutSeconds() == r.getValidationTimeoutSeconds() &&
+                l.getClusterDataRecoveryPolicy().ordinal() == r.getClusterDataRecoveryPolicy().ordinal();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/PersistenceAndHotRestartPersistenceMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/PersistenceAndHotRestartPersistenceMerger.java
@@ -95,15 +95,28 @@ public final class PersistenceAndHotRestartPersistenceMerger {
         }
     }
 
-    private static boolean equals(HotRestartPersistenceConfig l, PersistenceConfig r) {
-        return l.isEnabled() == r.isEnabled() &&
-                l.getBaseDir().equals(r.getBaseDir()) &&
-                l.getBackupDir().equals(r.getBackupDir()) &&
-                l.isAutoRemoveStaleData() == r.isAutoRemoveStaleData() &&
-                l.getEncryptionAtRestConfig().equals(r.getEncryptionAtRestConfig()) &&
-                l.getDataLoadTimeoutSeconds() == r.getDataLoadTimeoutSeconds() &&
-                l.getParallelism() == r.getParallelism() &&
-                l.getValidationTimeoutSeconds() == r.getValidationTimeoutSeconds() &&
-                l.getClusterDataRecoveryPolicy().ordinal() == r.getClusterDataRecoveryPolicy().ordinal();
+    private static boolean equals(HotRestartPersistenceConfig hotRestartPersistenceConfig, PersistenceConfig persistenceConfig) {
+        if (hotRestartPersistenceConfig.isEnabled() != persistenceConfig.isEnabled()) {
+            return false;
+        }
+        if (! hotRestartPersistenceConfig.getBaseDir().equals(persistenceConfig.getBaseDir())) {
+            return false;
+        }
+        if (! hotRestartPersistenceConfig.getBackupDir().equals(persistenceConfig.getBackupDir())) {
+            return false;
+        }
+        if (hotRestartPersistenceConfig.isAutoRemoveStaleData() != persistenceConfig.isAutoRemoveStaleData()) {
+            return false;
+        }
+        if (! hotRestartPersistenceConfig.getEncryptionAtRestConfig().equals(persistenceConfig.getEncryptionAtRestConfig())) {
+            return false;
+        }
+        if (hotRestartPersistenceConfig.getClusterDataRecoveryPolicy().ordinal()
+                != persistenceConfig.getClusterDataRecoveryPolicy().ordinal()) {
+            return false;
+        }
+        return hotRestartPersistenceConfig.getDataLoadTimeoutSeconds() == persistenceConfig.getDataLoadTimeoutSeconds()
+                && hotRestartPersistenceConfig.getParallelism() == persistenceConfig.getParallelism()
+                && hotRestartPersistenceConfig.getValidationTimeoutSeconds() == persistenceConfig.getValidationTimeoutSeconds();
     }
 }


### PR DESCRIPTION
As reported here https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1626343498323300
persistence config conflict warning gets logged multiple times, where most of them are unnecessary or misleading.
One simple scenario is when we try to copy map config, and in the copy process `hot-restart` and `data-persistence` get remerged.