### PR TITLE
Report client name in logs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -272,7 +272,8 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     public String toString() {
         return "ClientEndpoint{"
                 + "connection=" + connection
-                + ", clientUuid='" + clientUuid
+                + ", clientUuid=" + clientUuid
+                + ", clientName=" + clientName
                 + ", authenticated=" + authenticated
                 + ", clientVersion=" + clientVersion
                 + ", creationTime=" + creationTime

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -92,7 +92,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
                 break;
             case AUTHENTICATED:
                 if (logger.isFineEnabled()) {
-                    logger.fine("Processing authentication with clientUuid " + clientUuid);
+                    logger.fine("Processing authentication with clientUuid " + clientUuid
+                            + " and clientName " + clientName);
                 }
                 sendClientMessage(prepareAuthenticatedClientMessage());
                 break;
@@ -151,19 +152,20 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
     private AuthenticationStatus verifyEmptyCredentialsAndClusterName(PasswordCredentials passwordCredentials) {
         if (passwordCredentials.getName() != null || passwordCredentials.getPassword() != null) {
             logger.warning("Received auth from " + connection + " with clientUuid " + clientUuid
-                    + ",  authentication rejected because security is disabled on the member, "
-                    + "and client sends not-null username or password.");
+                    + " and clientName " + clientName + ", authentication rejected because security"
+                    + " is disabled on the member, and client sends not-null username or password.");
             return CREDENTIALS_FAILED;
         }
         String nodeClusterName = nodeEngine.getConfig().getClusterName();
-        boolean clusternameMatch = nodeClusterName.equals(clusterName);
-        return clusternameMatch ? AUTHENTICATED : CREDENTIALS_FAILED;
+        boolean clusterNameMatched = nodeClusterName.equals(clusterName);
+        return clusterNameMatched ? AUTHENTICATED : CREDENTIALS_FAILED;
     }
 
     private ClientMessage prepareUnauthenticatedClientMessage() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
         Connection connection = endpoint.getConnection();
-        logger.warning("Received auth from " + connection + " with clientUuid " + clientUuid + ", authentication failed");
+        logger.warning("Received auth from " + connection + " with clientUuid " + clientUuid
+                + " and clientName " + clientName + ", authentication failed");
         byte status = CREDENTIALS_FAILED.getId();
         return encodeAuth(status, null, null, serializationService.getVersion(),
                 clientEngine.getPartitionService().getPartitionCount(), clientEngine.getClusterService().getClusterId(),
@@ -202,8 +204,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
             return prepareNotAllowedInCluster();
         }
 
-        logger.info("Received auth from " + connection + ", successfully authenticated" + ", clientUuid: " + clientUuid
-                + ", client version: " + clientVersion);
+        logger.info("Received auth from " + connection + ", successfully authenticated, clientUuid: " + clientUuid
+                + ", client name: " + clientName + ", client version: " + clientVersion);
         final Address thisAddress = clientEngine.getThisAddress();
         UUID uuid = clientEngine.getClusterService().getLocalMember().getUuid();
         byte status = AUTHENTICATED.getId();


### PR DESCRIPTION
During authentication and while destroying client endpoint, we
print logs about the client such as UUID and version of it.

With this PR, we also add client name information to such logs
so that we would have an easier time while examining the logs.

Closes https://github.com/hazelcast/hazelcast/issues/15316