### PR TITLE
Deprecate STATISTICS properties (#19219)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -122,7 +122,7 @@ public final class ClientProperty {
 
     /**
      * Controls the number of IO input threads. Defaults to -1, so the system will decide.
-     *
+     * <p>
      * If client is a smart client and processor count larger than 8, it will default to 3 otherwise it will default to 1.
      */
     public static final HazelcastProperty IO_INPUT_THREAD_COUNT
@@ -130,7 +130,7 @@ public final class ClientProperty {
 
     /**
      * Controls the number of IO output threads. Defaults to -1, so the system will decide.
-     *
+     * <p>
      * If client is a smart client and processor count larger than 8 , it will default to 3 otherwise it will default to 1.
      */
     public static final HazelcastProperty IO_OUTPUT_THREAD_COUNT
@@ -151,7 +151,7 @@ public final class ClientProperty {
     /**
      * Optimization that allows sending of packets over the network to be done on the calling thread if the
      * conditions are right. This can reduce latency and increase performance for low threaded environments.
-     *
+     * <p>
      * It is enabled by default.
      */
     public static final HazelcastProperty IO_WRITE_THROUGH_ENABLED
@@ -161,10 +161,10 @@ public final class ClientProperty {
      * Property needed for concurrency detection so that write through and dynamic response handling
      * can be done correctly. This property sets the window the concurrency detection will signalling
      * that concurrency has been detected, even if there are no further updates in that window.
-     *
+     * <p>
      * Normally in a concurrent system the window keeps sliding forward so it will always remain
      * concurrent.
-     *
+     * <p>
      * Setting it too high effectively disables the optimization because once concurrency has been detected
      * it will keep that way. Setting it too low could lead to suboptimal performance because the system
      * will try write through and other optimizations even though the system is concurrent.
@@ -174,13 +174,13 @@ public final class ClientProperty {
 
     /**
      * The number of response threads.
-     *
+     * <p>
      * By default there are 2 response threads; this gives stable and good performance.
-     *
+     * <p>
      * If set to 0, the response threads are bypassed and the response handling is done
      * on the IO threads. Under certain conditions this can give a higher throughput, but
      * setting to 0 should be regarded an experimental feature.
-     *
+     * <p>
      * If set to 0, the IO_OUTPUT_THREAD_COUNT is really going to matter because the
      * inbound thread will have more work to do. By default when TLS isn't enable,
      * there is just 1 inbound thread.
@@ -191,7 +191,7 @@ public final class ClientProperty {
     /**
      * Enabled dynamic switching between processing responses on the io threads
      * and offloading the response threads.
-     *
+     * <p>
      * Under certain conditions (single threaded clients) processing on the io
      * thread can increase performance because useless handover to the response
      * thread is removed. Also the response thread isn't created until it is needed
@@ -224,16 +224,36 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.client.operation.fail.on.indeterminate.state", false);
 
     /**
-     * Use to enable the client statistics collection.
+     * Enables the client statistics collection.
      * <p>
-     * The default is false.
+     * The default is {@code false}.
+     * <p>
+     * Setting this enables Metrics since 4.0.
+     * <p>
+     * If both this and {@link #METRICS_ENABLED} are configured, this is
+     * ignored.
+     * <p>
+     * Note that when this is enabled, the default value of
+     * {@link #METRICS_COLLECTION_FREQUENCY} (5 seconds) will be used instead
+     * of {@link #STATISTICS_PERIOD_SECONDS} (3 seconds), when not set
+     * explicitly.
+     * @deprecated since 4.0. Use {@link #METRICS_ENABLED}
+     * ({@code "hazelcast.client.metrics.enabled"}) instead.
      */
+    @Deprecated
     public static final HazelcastProperty STATISTICS_ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled",
             false);
 
     /**
      * The period in seconds the statistics run.
+     * <p>
+     * The values set here is used as {@link #METRICS_COLLECTION_FREQUENCY} as instead.
+     * If both this and {@link #METRICS_COLLECTION_FREQUENCY} are configured,
+     * this is ignored.
+     * @deprecated since 4.0. Use {@link #METRICS_COLLECTION_FREQUENCY}
+     * ({@code "hazelcast.client.metrics.collection.frequency"}) instead.
      */
+    @Deprecated
     public static final HazelcastProperty STATISTICS_PERIOD_SECONDS = new HazelcastProperty(
             "hazelcast.client.statistics.period.seconds", 3, SECONDS);
 
@@ -288,7 +308,7 @@ public final class ClientProperty {
      * potentially embedded into a signed artifact.
      */
     public static final HazelcastProperty METRICS_COLLECTION_FREQUENCY
-            = new HazelcastProperty("hazelcast.client.metrics.collection.frequency");
+            = new HazelcastProperty("hazelcast.client.metrics.collection.frequency", 5);
 
 
     private ClientProperty() {

--- a/hazelcast/src/main/java/com/hazelcast/config/BaseMetricsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/BaseMetricsConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.spi.properties.ClusterProperty;
 
@@ -53,8 +54,12 @@ public abstract class BaseMetricsConfig<T extends BaseMetricsConfig> {
      * enabled, Hazelcast Management Center will be able to connect to this
      * member. It's enabled by default.
      * <p>
-     * May be overridden by {@link ClusterProperty#METRICS_ENABLED}
-     * system property.
+     * May be overridden by {@link ClusterProperty#METRICS_ENABLED} system property for the member.
+     * <p>
+     * May be overridden by {@link ClientProperty#METRICS_ENABLED} and
+     * {@link ClientProperty#STATISTICS_ENABLED} system properties for the client.
+     * <p>
+     * When both of them configured for the client {@link ClientProperty#STATISTICS_ENABLED} is ignored.
      */
     @Nonnull
     public T setEnabled(boolean enabled) {
@@ -85,8 +90,12 @@ public abstract class BaseMetricsConfig<T extends BaseMetricsConfig> {
      * used for collection for Management Center and for JMX publisher. By default,
      * metrics are collected every 5 seconds.
      * <p>
-     * May be overridden by {@link ClusterProperty#METRICS_COLLECTION_FREQUENCY}
-     * system property.
+     * May be overridden by {@link ClusterProperty#METRICS_COLLECTION_FREQUENCY} system property for the member.
+     * <p>
+     * May be overridden by {@link ClientProperty#METRICS_COLLECTION_FREQUENCY} and
+     * {@link ClientProperty#STATISTICS_PERIOD_SECONDS} system properties for the client
+     * <p>
+     * When both of them is configured for the client, {@link ClientProperty#STATISTICS_PERIOD_SECONDS} is ignored.
      */
     @Nonnull
     public T setCollectionFrequencySeconds(int intervalSeconds) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsConfigHelper.java
@@ -55,30 +55,30 @@ public final class MetricsConfigHelper {
 
         // MetricsConfig.enabled
         tryOverride(ClusterProperty.METRICS_ENABLED, config::getProperty,
-            prop -> metricsConfig.setEnabled(Boolean.parseBoolean(prop)),
-            () -> Boolean.toString(metricsConfig.isEnabled()), "MetricsConfig.enabled", logger);
+                prop -> metricsConfig.setEnabled(Boolean.parseBoolean(prop)),
+                () -> Boolean.toString(metricsConfig.isEnabled()), "MetricsConfig.enabled", logger);
 
         // MetricsManagementCenterConfig.enabled
         tryOverride(ClusterProperty.METRICS_MC_ENABLED, config::getProperty,
-            prop -> managementCenterConfig.setEnabled(Boolean.parseBoolean(prop)),
-            () -> Boolean.toString(managementCenterConfig.isEnabled()), "MetricsManagementCenterConfig.enabled", logger);
+                prop -> managementCenterConfig.setEnabled(Boolean.parseBoolean(prop)),
+                () -> Boolean.toString(managementCenterConfig.isEnabled()), "MetricsManagementCenterConfig.enabled", logger);
 
         // MetricsManagementCenterConfig.retentionSeconds
         tryOverride(ClusterProperty.METRICS_MC_RETENTION, config::getProperty,
-            prop -> managementCenterConfig.setRetentionSeconds(Integer.parseInt(prop)),
-            () -> Integer.toString(managementCenterConfig.getRetentionSeconds()),
-            "MetricsManagementCenterConfig.retentionSeconds", logger);
+                prop -> managementCenterConfig.setRetentionSeconds(Integer.parseInt(prop)),
+                () -> Integer.toString(managementCenterConfig.getRetentionSeconds()),
+                "MetricsManagementCenterConfig.retentionSeconds", logger);
 
         // MetricsJmxConfig.enabled
         tryOverride(ClusterProperty.METRICS_JMX_ENABLED, config::getProperty,
-            prop -> jmxConfig.setEnabled(Boolean.parseBoolean(prop)),
-            () -> Boolean.toString(jmxConfig.isEnabled()), "MetricsJmxConfig.enabled", logger);
+                prop -> jmxConfig.setEnabled(Boolean.parseBoolean(prop)),
+                () -> Boolean.toString(jmxConfig.isEnabled()), "MetricsJmxConfig.enabled", logger);
 
         // MetricsConfig.collectionFrequencySeconds
         tryOverride(ClusterProperty.METRICS_COLLECTION_FREQUENCY, config::getProperty,
-            prop -> metricsConfig.setCollectionFrequencySeconds(Integer.parseInt(prop)),
-            () -> Integer.toString(metricsConfig.getCollectionFrequencySeconds()),
-            "MetricsConfig.collectionFrequencySeconds", logger);
+                prop -> metricsConfig.setCollectionFrequencySeconds(Integer.parseInt(prop)),
+                () -> Integer.toString(metricsConfig.getCollectionFrequencySeconds()),
+                "MetricsConfig.collectionFrequencySeconds", logger);
     }
 
     /**
@@ -93,21 +93,30 @@ public final class MetricsConfigHelper {
         ClientMetricsConfig metricsConfig = config.getMetricsConfig();
         MetricsJmxConfig jmxConfig = metricsConfig.getJmxConfig();
 
+        //Check old deprecated STATISTICS settings first.
+        // MetricsConfig.collectionFrequencySeconds
+        tryOverride(ClientProperty.STATISTICS_PERIOD_SECONDS, config::getProperty,
+                prop -> metricsConfig.setCollectionFrequencySeconds(Integer.parseInt(prop)),
+                () -> Integer.toString(metricsConfig.getCollectionFrequencySeconds()),
+                "ClientMetricsConfig.collectionFrequencySeconds", logger);
+        // MetricsConfig.enabled
+        tryOverride(ClientProperty.STATISTICS_ENABLED, config::getProperty,
+                prop -> metricsConfig.setEnabled(Boolean.parseBoolean(prop)),
+                () -> Boolean.toString(metricsConfig.isEnabled()), "ClientMetricsConfig.enabled", logger);
+
         // MetricsConfig.enabled
         tryOverride(ClientProperty.METRICS_ENABLED, config::getProperty,
-            prop -> metricsConfig.setEnabled(Boolean.parseBoolean(prop)),
-            () -> Boolean.toString(metricsConfig.isEnabled()), "ClientMetricsConfig.enabled", logger);
-
+                prop -> metricsConfig.setEnabled(Boolean.parseBoolean(prop)),
+                () -> Boolean.toString(metricsConfig.isEnabled()), "ClientMetricsConfig.enabled", logger);
         // MetricsJmxConfig.enabled
         tryOverride(ClientProperty.METRICS_JMX_ENABLED, config::getProperty,
-            prop -> jmxConfig.setEnabled(Boolean.parseBoolean(prop)),
-            () -> Boolean.toString(jmxConfig.isEnabled()), "MetricsJmxConfig.enabled", logger);
-
+                prop -> jmxConfig.setEnabled(Boolean.parseBoolean(prop)),
+                () -> Boolean.toString(jmxConfig.isEnabled()), "MetricsJmxConfig.enabled", logger);
         // MetricsConfig.collectionFrequencySeconds
         tryOverride(ClientProperty.METRICS_COLLECTION_FREQUENCY, config::getProperty,
-            prop -> metricsConfig.setCollectionFrequencySeconds(Integer.parseInt(prop)),
-            () -> Integer.toString(metricsConfig.getCollectionFrequencySeconds()),
-            "ClientMetricsConfig.collectionFrequencySeconds", logger);
+                prop -> metricsConfig.setCollectionFrequencySeconds(Integer.parseInt(prop)),
+                () -> Integer.toString(metricsConfig.getCollectionFrequencySeconds()),
+                "ClientMetricsConfig.collectionFrequencySeconds", logger);
     }
 
     private static void tryOverride(HazelcastProperty property, Function<String, String> getPropertyValueFn,

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
@@ -164,6 +164,36 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(DEBUG, metricsRegistry.minimumLevel());
     }
 
+    @Test
+    public void testDeprecatedPropertiesStillEffective() {
+        // setting non-defaults
+        clientConfig.setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "false");
+        clientConfig.setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), "24");
+
+        HazelcastClientProxy client = createClient();
+        ClientConfig clientConfig = client.getClientConfig();
+
+        ClientMetricsConfig metricsConfig = clientConfig.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
+    }
+
+    @Test
+    public void testDeprecatedPropertiesIgnored_whenNewPropertiesGiven() {
+        clientConfig.setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "true");
+        clientConfig.setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), "24");
+
+        clientConfig.setProperty(ClientProperty.METRICS_ENABLED.getName(), "false");
+        clientConfig.setProperty(ClientProperty.METRICS_COLLECTION_FREQUENCY.getName(), "30");
+
+        HazelcastClientProxy client = createClient();
+        ClientConfig clientConfig = client.getClientConfig();
+
+        ClientMetricsConfig metricsConfig = clientConfig.getMetricsConfig();
+        assertFalse(metricsConfig.isEnabled());
+        assertEquals(30, metricsConfig.getCollectionFrequencySeconds());
+    }
+
     private HazelcastClientProxy createClient() {
         return (HazelcastClientProxy) factory.newHazelcastClient(clientConfig);
     }


### PR DESCRIPTION
* Deprecate STATISTICS properties

The following properties are not used anymore since 4.0

```
  public static final HazelcastProperty STATISTICS_ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled",
            false);
    /**
     * The period in seconds the statistics run.
     */
    public static final HazelcastProperty STATISTICS_PERIOD_SECONDS = new HazelcastProperty(
            "hazelcast.client.statistics.period.seconds", 3, SECONDS);
```
I traced it back to this pr. It seems that we are checking metricsConfig instead.

This pr:

1. puts `@Deprecated` to the property documents on ClientProperties class.
2. If user sets statistics, make sure it will set metrics config as well. This is because there
were no warning or documentation about the removal. According to doc, these properties still used.
So we fix the behaviour.
3. If both properties are set, ignore old STATISTICS properties.
4. Adds javadoc to ClientProperty and MetricsConfig to explain the effects of using these properties

fixes https://github.com/hazelcast/hazelcast/issues/18579

* fix javadoc styling and add test to verify new behaviour

(cherry picked from commit fde1a42f93233858f206f660b048abfa3a7ac51a)

backport of https://github.com/hazelcast/hazelcast/pull/19219