### PR TITLE
Do not (re)create MapContainer on validating cached SQL plans

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -124,7 +124,7 @@ public class IMapSqlConnector implements SqlConnector {
 
         MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
         MapServiceContext context = service.getMapServiceContext();
-        MapContainer container = context.getMapContainer(externalName);
+        MapContainer container = context.getExistingMapContainer(externalName);
 
         long estimatedRowCount = estimatePartitionedMapRowCount(nodeEngine, context, externalName);
         boolean hd = container != null && container.getMapConfig().getInMemoryFormat() == InMemoryFormat.NATIVE;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -80,6 +80,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
 
     MapContainer getMapContainer(String mapName);
 
+    MapContainer getExistingMapContainer(String mapName);
+
     Map<String, MapContainer> getMapContainers();
 
     PartitionContainer getPartitionContainer(int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -287,6 +287,11 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
+    public MapContainer getExistingMapContainer(String mapName) {
+        return mapContainers.get(mapName);
+    }
+
+    @Override
     public Map<String, MapContainer> getMapContainers() {
         return mapContainers;
     }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTableResolver.java
@@ -103,7 +103,7 @@ public class PartitionedMapTableResolver extends AbstractMapTableResolver {
         String name
     ) {
         try {
-            MapContainer mapContainer = context.getMapContainer(name);
+            MapContainer mapContainer = context.getExistingMapContainer(name);
 
             // Handle concurrent map destroy.
             if (mapContainer == null) {


### PR DESCRIPTION
Following execution is possible:
1. `PlanCacheChecker.check()` is run, we start building SQL catalog, `for (String mapName : context.getMapContainers().keySet()) {` in `PartitionedMapTableResolver` is executed
2. a test completes and all distributed objects are destroyed in `SimpleTestInClusterSupport.supportAfter()`
3. `PartitionedMapTableResolver.createTable()` calls `context.getMapContainer()` for one of the maps fetched in step one, as the result `MapContainer` is recreated

To remediate the race, added `MapServiceContext.getExistingMapContainer()` which does not implicitly create `MapContainer` if one does not exist.

Fixes #19211