### PR TITLE
Prevent null near-cache name

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/ClientDomConfigProcessor.java
@@ -276,7 +276,7 @@ public class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected void handleNearCacheNode(Node node) {
         String name = getName(node);
-        name = name == null ? "default" : name;
+        name = name == null ? NearCacheConfig.DEFAULT_NAME : name;
         NearCacheConfig nearCacheConfig = new NearCacheConfig(name);
         Boolean serializeKeys = null;
         for (Node child : childElements(node)) {

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -66,6 +66,11 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     public static final int DEFAULT_MAX_IDLE_SECONDS = 0;
 
     /**
+     * Default name when it is not set explicitly.
+     */
+    public static final String DEFAULT_NAME = "default";
+
+    /**
      * Defines how to reflect local updates to the Near Cache.
      */
     public enum LocalUpdatePolicy {
@@ -87,7 +92,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     private boolean invalidateOnChange = DEFAULT_INVALIDATE_ON_CHANGE;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private int maxIdleSeconds = DEFAULT_MAX_IDLE_SECONDS;
-    private String name = "default";
+    private String name = DEFAULT_NAME;
     private EvictionConfig evictionConfig = new EvictionConfig();
     private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
     private LocalUpdatePolicy localUpdatePolicy = DEFAULT_LOCAL_UPDATE_POLICY;
@@ -129,7 +134,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
      * @return this Near Cache config instance
      */
     public NearCacheConfig setName(String name) {
-        this.name = name;
+        this.name = isNotNull(name, "name");
         return this;
     }
 
@@ -165,13 +170,13 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
      * @return this Near Cache config instance
      */
     public NearCacheConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
-        this.inMemoryFormat = isNotNull(inMemoryFormat, "In-Memory format cannot be null!");
+        this.inMemoryFormat = isNotNull(inMemoryFormat, "inMemoryFormat");
         return this;
     }
 
     // this setter is for reflection based configuration building
     public NearCacheConfig setInMemoryFormat(String inMemoryFormat) {
-        checkNotNull(inMemoryFormat, "In-Memory format cannot be null!");
+        isNotNull(inMemoryFormat, "In-Memory format cannot be null!");
 
         this.inMemoryFormat = InMemoryFormat.valueOf(inMemoryFormat);
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -29,6 +29,7 @@ import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConsistencyCheckStrategy;
 import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.config.DataPersistenceConfig;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -77,7 +78,6 @@ import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionConfig.PermissionType;
 import com.hazelcast.config.PermissionPolicyConfig;
-import com.hazelcast.config.DataPersistenceConfig;
 import com.hazelcast.config.PersistenceClusterDataRecoveryPolicy;
 import com.hazelcast.config.PersistenceConfig;
 import com.hazelcast.config.PredicateConfig;
@@ -1845,6 +1845,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     private NearCacheConfig handleNearCacheConfig(Node node, NearCacheConfig existingNearCacheConfig) {
         String name = getAttribute(node, "name");
+        name = name == null ? NearCacheConfig.DEFAULT_NAME : name;
         NearCacheConfig nearCacheConfig = existingNearCacheConfig != null
                 ? existingNearCacheConfig
                 : new NearCacheConfig(name);

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -93,7 +93,7 @@ public class NearCacheConfigTest {
         config.setInMemoryFormat("UNKNOWN");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testSetInMemoryFormat_withString_whenNull() {
         config.setInMemoryFormat((String) null);
     }
@@ -171,4 +171,17 @@ public class NearCacheConfigTest {
         assertEquals(config.getLocalUpdatePolicy(), deserialized.getLocalUpdatePolicy());
         assertEquals(config.toString(), deserialized.toString());
     }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_null_name_throws_exception() {
+        config.setName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_constructor_with_null_name_throws_exception() {
+        String nullName = null;
+        new NearCacheConfig(nullName);
+    }
+
 }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/4036

**Modifications:**
- Used "default" as a name when `name` is not set explicitly in xml/yaml. This also aligns server and client side declarative config. When name is not given client sets name to "default".

- Also synced thrown exception from `setInMemoryFormat` methods. Now both throw `IllegalArgumentException`