### PR TITLE
Change the MulticastConfig.DEFAULT_LOOPBACK_MODE_ENABLED value to false

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -799,7 +799,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertFalse(networkConfig.getJoin().getMulticastConfig().isEnabled());
         assertEquals(networkConfig.getJoin().getMulticastConfig().getMulticastTimeoutSeconds(), 8);
         assertEquals(networkConfig.getJoin().getMulticastConfig().getMulticastTimeToLive(), 16);
-        assertFalse(networkConfig.getJoin().getMulticastConfig().isLoopbackModeEnabled());
+        assertEquals(Boolean.FALSE, networkConfig.getJoin().getMulticastConfig().getLoopbackModeEnabled());
         Set<String> tis = networkConfig.getJoin().getMulticastConfig().getTrustedInterfaces();
         assertEquals(1, tis.size());
         assertEquals("10.10.10.*", tis.iterator().next());

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.0.xsd
@@ -2040,7 +2040,7 @@
         <xs:attribute name="multicast-port" type="xs:string" default="54327"/>
         <xs:attribute name="multicast-timeout-seconds" type="xs:string" default="2"/>
         <xs:attribute name="multicast-time-to-live" type="xs:string" default="32"/>
-        <xs:attribute name="loopback-mode-enabled" type="parameterized-boolean" default="false"/>
+        <xs:attribute name="loopback-mode-enabled" type="parameterized-boolean"/>
     </xs:complexType>
 
     <xs:complexType name="aliased-discovery-strategy">

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1303,7 +1303,7 @@ public class ConfigXmlGenerator {
 
     private static void multicastConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {
         MulticastConfig mcConfig = join.getMulticastConfig();
-        gen.open("multicast", "enabled", mcConfig.isEnabled(), "loopbackModeEnabled", mcConfig.isLoopbackModeEnabled())
+        gen.open("multicast", "enabled", mcConfig.isEnabled(), "loopbackModeEnabled", mcConfig.getLoopbackModeEnabled())
                 .node("multicast-group", mcConfig.getMulticastGroup())
                 .node("multicast-port", mcConfig.getMulticastPort())
                 .node("multicast-timeout-seconds", mcConfig.getMulticastTimeoutSeconds())

--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -296,7 +296,8 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
         if (multicastTimeToLive != that.multicastTimeToLive) {
             return false;
         }
-        if (loopbackModeEnabled != that.loopbackModeEnabled) {
+        if (loopbackModeEnabled != null ? !loopbackModeEnabled.equals(that.loopbackModeEnabled)
+                : that.loopbackModeEnabled != null) {
             return false;
         }
         if (multicastGroup != null ? !multicastGroup.equals(that.multicastGroup) : that.multicastGroup != null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -54,10 +54,11 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
      */
     public static final int DEFAULT_MULTICAST_TTL = 32;
     /**
-     * Default flag that indicates if the loopback mode
-     * is turned on or off.
+     * Default flag that indicates if the loopback mode is turned on or off.
+     * <p>
+     * When changing this default value, update the default in {@code hazelcast-config-*.xsd} file too.
      */
-    public static final boolean DEFAULT_LOOPBACK_MODE_ENABLED = true;
+    public static final boolean DEFAULT_LOOPBACK_MODE_ENABLED = false;
 
     private static final int MULTICAST_TTL_UPPER_BOUND = 255;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -53,12 +53,6 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
      * Default value of time to live of multicast.
      */
     public static final int DEFAULT_MULTICAST_TTL = 32;
-    /**
-     * Default flag that indicates if the loopback mode is turned on or off.
-     * <p>
-     * When changing this default value, update the default in {@code hazelcast-config-*.xsd} file too.
-     */
-    public static final boolean DEFAULT_LOOPBACK_MODE_ENABLED = false;
 
     private static final int MULTICAST_TTL_UPPER_BOUND = 255;
 
@@ -74,7 +68,7 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
 
     private final Set<String> trustedInterfaces = new HashSet<String>();
 
-    private boolean loopbackModeEnabled = DEFAULT_LOOPBACK_MODE_ENABLED;
+    private Boolean loopbackModeEnabled;
 
     /**
      * Check if the multicast discovery mechanism has been enabled.
@@ -250,18 +244,30 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
      * Check if the loopback mode is enabled in the multicast discovery mechanism.
      *
      * @return {@code true} if the the loopback mode is enabled, {@code false} otherwise
+     * @deprecated Use the {@link #getLoopbackModeEnabled()}.
      */
+    @Deprecated
     public boolean isLoopbackModeEnabled() {
+        return loopbackModeEnabled == null || loopbackModeEnabled;
+    }
+
+    /**
+     * Returns if explicit loopback mode configuration was requested (by {@link #setLoopbackModeEnabled(Boolean)}).
+     *
+     * @return {@code TRUE} if the the loopback mode should be enabled, {@code FALSE} disabled, {@code null} when
+     * it's left up to platform to decide.
+     */
+    public Boolean getLoopbackModeEnabled() {
         return loopbackModeEnabled;
     }
 
     /**
-     * Enables or disables the loopback mode in the multicast discovery mechanism.
+     * Explicitly enables or disables the loopback mode in the multicast discovery mechanism.
      *
      * @param enabled {@code true} to enable the loopback mode, {@code false} to disable
      * @return the updated MulticastConfig
      */
-    public MulticastConfig setLoopbackModeEnabled(boolean enabled) {
+    public MulticastConfig setLoopbackModeEnabled(Boolean enabled) {
         this.loopbackModeEnabled = enabled;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -33,6 +33,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.internal.util.ByteArrayProcessor;
+import com.hazelcast.internal.util.OsHelper;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -133,9 +134,12 @@ public final class MulticastService implements Runnable {
         multicastSocket.setTimeToLive(multicastConfig.getMulticastTimeToLive());
         try {
             boolean loopbackBind = bindAddress.getInetAddress().isLoopbackAddress();
-            // setting loopbackmode is just a hint - and the argument means "disable"!
-            // to check the real value value we call getLoopbackMode() (and again - return value means "disabled")
-            multicastSocket.setLoopbackMode(!multicastConfig.isLoopbackModeEnabled());
+            Boolean loopbackModeEnabled = multicastConfig.getLoopbackModeEnabled();
+            if (loopbackModeEnabled != null) {
+                // setting loopbackmode is just a hint - and the argument means "disable"!
+                // to check the real value value we call getLoopbackMode() (and again - return value means "disabled")
+                multicastSocket.setLoopbackMode(!loopbackModeEnabled);
+            }
             // If LoopBack mode is not enabled (i.e. getLoopbackMode return true) and bind address is a loopback one,
             // then print a warning
             if (loopbackBind && multicastSocket.getLoopbackMode()) {
@@ -148,7 +152,8 @@ public final class MulticastService implements Runnable {
             // warning: before modifying lines below, take a look at these links:
             // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4417033
             // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6402758
-            boolean callSetInterface = loopbackBind || !multicastConfig.isLoopbackModeEnabled();
+            // https://github.com/hazelcast/hazelcast/pull/19251#issuecomment-891375270
+            boolean callSetInterface = OsHelper.isMac() || !loopbackBind;
             String propSetInterface = hzProperties.getString(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE);
             if (propSetInterface != null) {
                 callSetInterface = Boolean.parseBoolean(propSetInterface);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -46,4 +46,13 @@ public final class OsHelper {
     public static boolean isUnixFamily() {
         return (OS.contains("nix") || OS.contains("nux") || OS.contains("aix"));
     }
+
+    /**
+     * Returns {@code true} if the system is a Mac OS.
+     *
+     * @return {@code true} if the current system is Mac.
+     */
+    public static boolean isMac() {
+        return (OS.contains("mac") || OS.contains("darwin"));
+    }
 }

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
@@ -1495,7 +1495,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="loopbackModeEnabled" type="xs:boolean" default="false"/>
+        <xs:attribute name="loopbackModeEnabled" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    Allows explicitly specifying the loopbackMode on multicast sockets.
+                    It enables or disables local loopback of multicast datagrams.
+                    The option is used by the platform's networking code as a "hint" for setting whether
+                    multicast data will be looped back to the local socket.
+                    As it's a hint, the underlying platform code doesn't need to respect the setting.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="trusted-interfaces">
         <xs:sequence>

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -86,7 +86,6 @@ public class CachingProviderTest extends HazelcastTestSupport {
     protected HazelcastInstance createHazelcastInstance(String instanceName) {
         Config config = new Config();
         config.setInstanceName(instanceName);
-        config.getNetworkConfig().getJoin().getMulticastConfig().setLoopbackModeEnabled(true);
         config.setClusterName("test-cluster1");
         return instanceFactory.newHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.cluster;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
-import static com.hazelcast.test.TestEnvironment.isSolaris;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -45,6 +44,7 @@ import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
+import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
@@ -121,10 +121,8 @@ public class MulticastDeserializationTest {
                 .setEnabled(true)
                 .setMulticastPort(MULTICAST_PORT)
                 .setMulticastGroup(MULTICAST_GROUP)
-                .setMulticastTimeToLive(MULTICAST_TTL);
-        if (isSolaris()) {
-            config.setProperty(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE.getName(), "false");
-        }
+                .setMulticastTimeToLive(MULTICAST_TTL)
+                ;
         return config;
     }
 
@@ -140,10 +138,10 @@ public class MulticastDeserializationTest {
         MulticastSocket multicastSocket = null;
         try {
             multicastSocket = new MulticastSocket(MULTICAST_PORT);
-            if (!isSolaris()) {
+            multicastSocket.setTimeToLive(MULTICAST_TTL);
+            if (OsHelper.isMac()) {
                 multicastSocket.setInterface(InetAddress.getByName("127.0.0.1"));
             }
-            multicastSocket.setTimeToLive(MULTICAST_TTL);
             InetAddress group = InetAddress.getByName(MULTICAST_GROUP);
             multicastSocket.joinGroup(group);
             int msgSize = data.length;

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1712,7 +1712,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         MulticastConfig multicastConfig = config.getNetworkConfig().getJoin().getMulticastConfig();
 
         assertFalse(multicastConfig.isEnabled());
-        assertTrue(multicastConfig.isLoopbackModeEnabled());
+        assertEquals(Boolean.TRUE, multicastConfig.getLoopbackModeEnabled());
         assertEquals("224.2.2.4", multicastConfig.getMulticastGroup());
         assertEquals(65438, multicastConfig.getMulticastPort());
         assertEquals(4, multicastConfig.getMulticastTimeoutSeconds());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1705,7 +1705,7 @@ public class YamlConfigBuilderTest
         MulticastConfig multicastConfig = config.getNetworkConfig().getJoin().getMulticastConfig();
 
         assertFalse(multicastConfig.isEnabled());
-        assertTrue(multicastConfig.isLoopbackModeEnabled());
+        assertEquals(Boolean.TRUE, multicastConfig.getLoopbackModeEnabled());
         assertEquals("224.2.2.4", multicastConfig.getMulticastGroup());
         assertEquals(65438, multicastConfig.getMulticastPort());
         assertEquals(4, multicastConfig.getMulticastTimeoutSeconds());

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MulticastServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MulticastServiceTest.java
@@ -102,6 +102,22 @@ public class MulticastServiceTest {
         verify(multicastSocket).setInterface(address.getInetAddress());
     }
 
+    /**
+     * Verifes the {@link MulticastSocket#setInterface(InetAddress)} is called by default if non-loopback address is used.
+     * This is a regression test for the <a href="https://github.com/hazelcast/hazelcast/issues/19192">issue #19192</a>
+     * (hit on Mac OS).
+     */
+    @Test
+    public void testSetInterfaceDefaultWhenNonLoopbackAddrAndDefaultLoopbackMode() throws Exception {
+        Config config = createConfig(null);
+        MulticastConfig multicastConfig = config.getNetworkConfig().getJoin().getMulticastConfig();
+        MulticastSocket multicastSocket = mock(MulticastSocket.class);
+        Address address = new Address("10.0.0.2",  5701);
+        HazelcastProperties hzProperties = new HazelcastProperties(config);
+        MulticastService.configureMulticastSocket(multicastSocket, address, hzProperties , multicastConfig, mock(ILogger.class));
+        verify(multicastSocket).setInterface(address.getInetAddress());
+    }
+
     @Test
     public void testMulticastParams() throws Exception {
         Config config = createConfig(null);


### PR DESCRIPTION
Fixes #19192.

This PR changes the `MulticastConfig.loopbackModeEnabled` default to `false`. (i.e. it has to be explicitly enabled when required). The change also gets the default aligned with the value defined in the `hazelcast-config` XSD.

This change is related to #18669 which says the `MulticastSocket.setInterface()` must not be called when we bind to a loopback address or the `loopbackModeEnabled` is `true`. But we had the  `loopbackModeEnabled` set to `true` by default. And if `setInterface()` is not called, then some Java versions on Mac OS are not able to join the multicast group (as described in #19192).

We have to retest the change on all our supported platforms.