### PR TITLE
Create empty directory for both slim and full distribution

### DIFF
--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -134,5 +134,11 @@
             <outputDirectory>bin</outputDirectory>
             <filtered>true</filtered>
         </fileSet>
+        <fileSet> <!-- Create empty directory -->
+            <outputDirectory>bin/user-lib</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -156,5 +156,11 @@
             <directory>${project.build.directory}/custom-lib</directory>
             <outputDirectory>custom-lib</outputDirectory>
         </fileSet>
+        <fileSet> <!-- Create empty directory -->
+            <outputDirectory>bin/user-lib</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
Create an empty user-lib directory inside bin folder for both slim and full distribution

Fixes #18982

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible