### PR TITLE
Deprecate support of raw NULLs in IN operator

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
@@ -98,12 +98,12 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
     private final Set<SqlNode> callSet = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public HazelcastSqlToRelConverter(
-        RelOptTable.ViewExpander viewExpander,
-        SqlValidator validator,
-        Prepare.CatalogReader catalogReader,
-        RelOptCluster cluster,
-        SqlRexConvertletTable convertletTable,
-        Config config
+            RelOptTable.ViewExpander viewExpander,
+            SqlValidator validator,
+            Prepare.CatalogReader catalogReader,
+            RelOptCluster cluster,
+            SqlRexConvertletTable convertletTable,
+            Config config
     ) {
         super(viewExpander, validator, catalogReader, cluster, convertletTable, config);
     }
@@ -254,14 +254,14 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         if (rhs instanceof SqlNodeList) {
             SqlNodeList valueList = (SqlNodeList) rhs;
             return convertInToOr(
-                blackboard,
-                leftKeys,
-                valueList,
-                (SqlInOperator) call.getOperator()
+                    blackboard,
+                    leftKeys,
+                    valueList,
+                    (SqlInOperator) call.getOperator()
             );
         }
         throw QueryException.error(SqlErrorCode.GENERIC,
-            "Sub-queries are not supported for IN operator.");
+                "Sub-queries are not supported for IN operator.");
     }
 
     /**
@@ -277,7 +277,7 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         final RexBuilder rexBuilder = getRexBuilder();
         final HazelcastBetweenOperator betweenOp = (HazelcastBetweenOperator) currentOperator;
         final List<RexNode> list = convertExpressionList(
-            rexBuilder, blackboard, call.getOperandList(), betweenOp.getOperandTypeChecker().getConsistency()
+                rexBuilder, blackboard, call.getOperandList(), betweenOp.getOperandTypeChecker().getConsistency()
         );
         final RexNode valueOperand = list.get(SqlBetweenOperator.VALUE_OPERAND);
         final RexNode lowerOperand = list.get(SqlBetweenOperator.LOWER_OPERAND);
@@ -393,8 +393,8 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         switch (consistency) {
             case COMPARE:
                 final List<RelDataType> nonCharacterTypes = types.stream()
-                    .filter(type -> type.getFamily() != SqlTypeFamily.CHARACTER)
-                    .collect(Collectors.toList());
+                        .filter(type -> type.getFamily() != SqlTypeFamily.CHARACTER)
+                        .collect(Collectors.toList());
 
                 if (!nonCharacterTypes.isEmpty()) {
                     types = enlargeNumericTypes(bb, types.size(), nonCharacterTypes);
@@ -428,11 +428,11 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
     }
 
     private static QueryException literalConversionException(
-        SqlValidator validator,
-        SqlCall call,
-        Literal literal,
-        QueryDataType toType,
-        Exception e
+            SqlValidator validator,
+            SqlCall call,
+            Literal literal,
+            QueryDataType toType,
+            Exception e
     ) {
         String literalValue = literal.getStringValue();
 
@@ -441,9 +441,9 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         }
 
         Resources.ExInst<SqlValidatorException> contextError = HazelcastResources.RESOURCES.cannotCastLiteralValue(
-            literalValue,
-            toType.getTypeFamily().getPublicType().toString(),
-            e.getMessage()
+                literalValue,
+                toType.getTypeFamily().getPublicType().toString(),
+                e.getMessage()
         );
 
         CalciteContextException calciteContextError = validator.newValidationError(call, contextError);
@@ -453,10 +453,10 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
     // Copied from SqlToRelConverter.
     private RexNode convertInToOr(
-        final Blackboard bb,
-        final List<RexNode> leftKeys,
-        SqlNodeList valuesList,
-        SqlInOperator op
+            final Blackboard bb,
+            final List<RexNode> leftKeys,
+            SqlNodeList valuesList,
+            SqlInOperator op
     ) {
         final List<RexNode> comparisons = constructComparisons(bb, leftKeys, valuesList);
 
@@ -465,7 +465,7 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
                 return RexUtil.composeConjunction(rexBuilder, comparisons, true);
             case NOT_IN:
                 return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-                    RexUtil.composeDisjunction(rexBuilder, comparisons, true));
+                        RexUtil.composeDisjunction(rexBuilder, comparisons, true));
             case IN:
             case SOME:
                 return RexUtil.composeDisjunction(rexBuilder, comparisons, true);
@@ -479,9 +479,9 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
      * left-hand operand (as a rule, SqlIdentifier) and right-hand list.
      */
     private List<RexNode> constructComparisons(
-        Blackboard bb,
-        List<RexNode> leftKeys,
-        SqlNodeList valuesList
+            Blackboard bb,
+            List<RexNode> leftKeys,
+            SqlNodeList valuesList
     ) {
         final List<RexNode> comparisons = new ArrayList<>();
 
@@ -490,26 +490,26 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
             final SqlOperator comparisonOp = SqlStdOperatorTable.EQUALS;
             if (leftKeys.size() == 1) {
                 rexComparison = rexBuilder.makeCall(
-                    comparisonOp,
-                    leftKeys.get(0),
-                    ensureSqlType(
-                        leftKeys.get(0).getType(),
-                        bb.convertExpression(rightValues)
-                    )
+                        comparisonOp,
+                        leftKeys.get(0),
+                        ensureSqlType(
+                                leftKeys.get(0).getType(),
+                                bb.convertExpression(rightValues)
+                        )
                 );
             } else {
                 assert rightValues instanceof SqlCall;
                 final SqlBasicCall basicCall = (SqlBasicCall) rightValues;
                 assert basicCall.getOperator() instanceof SqlRowOperator && basicCall.operandCount() == leftKeys.size();
                 rexComparison = RexUtil.composeConjunction(rexBuilder,
-                    Pair.zip(leftKeys, basicCall.getOperandList()).stream().map(pair ->
-                        rexBuilder.makeCall(
-                            comparisonOp, pair.left, ensureSqlType(
-                                pair.left.getType(),
-                                bb.convertExpression(pair.right)
-                            )
-                        )
-                    ).collect(Collectors.toList()));
+                        Pair.zip(leftKeys, basicCall.getOperandList()).stream().map(pair ->
+                                rexBuilder.makeCall(
+                                        comparisonOp, pair.left, ensureSqlType(
+                                                pair.left.getType(),
+                                                bb.convertExpression(pair.right)
+                                        )
+                                )
+                        ).collect(Collectors.toList()));
             }
             comparisons.add(rexComparison);
         }
@@ -518,8 +518,8 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
     private RexNode ensureSqlType(RelDataType type, RexNode node) {
         if (type.getSqlTypeName() == node.getType().getSqlTypeName()
-            || (type.getSqlTypeName() == SqlTypeName.VARCHAR
-            && node.getType().getSqlTypeName() == SqlTypeName.CHAR)) {
+                || (type.getSqlTypeName() == SqlTypeName.VARCHAR
+                && node.getType().getSqlTypeName() == SqlTypeName.CHAR)) {
             return node;
         }
         return rexBuilder.ensureType(type, node, true);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
@@ -92,7 +92,9 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
     private static final SqlIntervalQualifier INTERVAL_YEAR_MONTH = new SqlIntervalQualifier(YEAR, MONTH, SqlParserPos.ZERO);
     private static final SqlIntervalQualifier INTERVAL_DAY_SECOND = new SqlIntervalQualifier(DAY, SECOND, SqlParserPos.ZERO);
 
-    /** See {@link #convertCall(SqlNode, Blackboard)} for more information. */
+    /**
+     * See {@link #convertCall(SqlNode, Blackboard)} for more information.
+     */
     private final Set<SqlNode> callSet = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public HazelcastSqlToRelConverter(
@@ -252,14 +254,14 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         if (rhs instanceof SqlNodeList) {
             SqlNodeList valueList = (SqlNodeList) rhs;
             return convertInToOr(
-                blackboard,
-                leftKeys,
-                valueList,
-                (SqlInOperator) call.getOperator()
+                    blackboard,
+                    leftKeys,
+                    valueList,
+                    (SqlInOperator) call.getOperator()
             );
         }
-        throw QueryException.error(SqlErrorCode.GENERIC,
-                "Hazelcast SQL engine doesn't support subqueries for IN operator.");
+        throw QueryException.error(SqlErrorCode.PARSING,
+                "Sub-queries are not supported for IN operator.");
     }
 
     /**
@@ -451,10 +453,10 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
     // Copied from SqlToRelConverter.
     private RexNode convertInToOr(
-        final Blackboard bb,
-        final List<RexNode> leftKeys,
-        SqlNodeList valuesList,
-        SqlInOperator op
+            final Blackboard bb,
+            final List<RexNode> leftKeys,
+            SqlNodeList valuesList,
+            SqlInOperator op
     ) {
         final List<RexNode> comparisons = constructComparisons(bb, leftKeys, valuesList);
 
@@ -463,7 +465,7 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
                 return RexUtil.composeConjunction(rexBuilder, comparisons, true);
             case NOT_IN:
                 return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-                    RexUtil.composeDisjunction(rexBuilder, comparisons, true));
+                        RexUtil.composeDisjunction(rexBuilder, comparisons, true));
             case IN:
             case SOME:
                 return RexUtil.composeDisjunction(rexBuilder, comparisons, true);
@@ -477,9 +479,9 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
      * left-hand operand (as a rule, SqlIdentifier) and right-hand list.
      */
     private List<RexNode> constructComparisons(
-        Blackboard bb,
-        List<RexNode> leftKeys,
-        SqlNodeList valuesList
+            Blackboard bb,
+            List<RexNode> leftKeys,
+            SqlNodeList valuesList
     ) {
         final List<RexNode> comparisons = new ArrayList<>();
 
@@ -488,26 +490,26 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
             final SqlOperator comparisonOp = SqlStdOperatorTable.EQUALS;
             if (leftKeys.size() == 1) {
                 rexComparison = rexBuilder.makeCall(
-                    comparisonOp,
-                    leftKeys.get(0),
-                    ensureSqlType(
-                        leftKeys.get(0).getType(),
-                        bb.convertExpression(rightValues)
-                    )
+                        comparisonOp,
+                        leftKeys.get(0),
+                        ensureSqlType(
+                                leftKeys.get(0).getType(),
+                                bb.convertExpression(rightValues)
+                        )
                 );
             } else {
                 assert rightValues instanceof SqlCall;
                 final SqlBasicCall basicCall = (SqlBasicCall) rightValues;
                 assert basicCall.getOperator() instanceof SqlRowOperator && basicCall.operandCount() == leftKeys.size();
                 rexComparison = RexUtil.composeConjunction(rexBuilder,
-                    Pair.zip(leftKeys, basicCall.getOperandList()).stream().map(pair ->
-                        rexBuilder.makeCall(
-                            comparisonOp, pair.left, ensureSqlType(
-                                pair.left.getType(),
-                                bb.convertExpression(pair.right)
-                            )
-                        )
-                    ).collect(Collectors.toList()));
+                        Pair.zip(leftKeys, basicCall.getOperandList()).stream().map(pair ->
+                                rexBuilder.makeCall(
+                                        comparisonOp, pair.left, ensureSqlType(
+                                                pair.left.getType(),
+                                                bb.convertExpression(pair.right)
+                                        )
+                                )
+                        ).collect(Collectors.toList()));
             }
             comparisons.add(rexComparison);
         }
@@ -516,8 +518,8 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
     private RexNode ensureSqlType(RelDataType type, RexNode node) {
         if (type.getSqlTypeName() == node.getType().getSqlTypeName()
-            || (type.getSqlTypeName() == SqlTypeName.VARCHAR
-            && node.getType().getSqlTypeName() == SqlTypeName.CHAR)) {
+                || (type.getSqlTypeName() == SqlTypeName.VARCHAR
+                && node.getType().getSqlTypeName() == SqlTypeName.CHAR)) {
             return node;
         }
         return rexBuilder.ensureType(type, node, true);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/HazelcastSqlToRelConverter.java
@@ -98,12 +98,12 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
     private final Set<SqlNode> callSet = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public HazelcastSqlToRelConverter(
-            RelOptTable.ViewExpander viewExpander,
-            SqlValidator validator,
-            Prepare.CatalogReader catalogReader,
-            RelOptCluster cluster,
-            SqlRexConvertletTable convertletTable,
-            Config config
+        RelOptTable.ViewExpander viewExpander,
+        SqlValidator validator,
+        Prepare.CatalogReader catalogReader,
+        RelOptCluster cluster,
+        SqlRexConvertletTable convertletTable,
+        Config config
     ) {
         super(viewExpander, validator, catalogReader, cluster, convertletTable, config);
     }
@@ -254,14 +254,14 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         if (rhs instanceof SqlNodeList) {
             SqlNodeList valueList = (SqlNodeList) rhs;
             return convertInToOr(
-                    blackboard,
-                    leftKeys,
-                    valueList,
-                    (SqlInOperator) call.getOperator()
+                blackboard,
+                leftKeys,
+                valueList,
+                (SqlInOperator) call.getOperator()
             );
         }
-        throw QueryException.error(SqlErrorCode.PARSING,
-                "Sub-queries are not supported for IN operator.");
+        throw QueryException.error(SqlErrorCode.GENERIC,
+            "Sub-queries are not supported for IN operator.");
     }
 
     /**
@@ -277,7 +277,7 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         final RexBuilder rexBuilder = getRexBuilder();
         final HazelcastBetweenOperator betweenOp = (HazelcastBetweenOperator) currentOperator;
         final List<RexNode> list = convertExpressionList(
-                rexBuilder, blackboard, call.getOperandList(), betweenOp.getOperandTypeChecker().getConsistency()
+            rexBuilder, blackboard, call.getOperandList(), betweenOp.getOperandTypeChecker().getConsistency()
         );
         final RexNode valueOperand = list.get(SqlBetweenOperator.VALUE_OPERAND);
         final RexNode lowerOperand = list.get(SqlBetweenOperator.LOWER_OPERAND);
@@ -393,8 +393,8 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         switch (consistency) {
             case COMPARE:
                 final List<RelDataType> nonCharacterTypes = types.stream()
-                        .filter(type -> type.getFamily() != SqlTypeFamily.CHARACTER)
-                        .collect(Collectors.toList());
+                    .filter(type -> type.getFamily() != SqlTypeFamily.CHARACTER)
+                    .collect(Collectors.toList());
 
                 if (!nonCharacterTypes.isEmpty()) {
                     types = enlargeNumericTypes(bb, types.size(), nonCharacterTypes);
@@ -428,11 +428,11 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
     }
 
     private static QueryException literalConversionException(
-            SqlValidator validator,
-            SqlCall call,
-            Literal literal,
-            QueryDataType toType,
-            Exception e
+        SqlValidator validator,
+        SqlCall call,
+        Literal literal,
+        QueryDataType toType,
+        Exception e
     ) {
         String literalValue = literal.getStringValue();
 
@@ -441,9 +441,9 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
         }
 
         Resources.ExInst<SqlValidatorException> contextError = HazelcastResources.RESOURCES.cannotCastLiteralValue(
-                literalValue,
-                toType.getTypeFamily().getPublicType().toString(),
-                e.getMessage()
+            literalValue,
+            toType.getTypeFamily().getPublicType().toString(),
+            e.getMessage()
         );
 
         CalciteContextException calciteContextError = validator.newValidationError(call, contextError);
@@ -453,10 +453,10 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
     // Copied from SqlToRelConverter.
     private RexNode convertInToOr(
-            final Blackboard bb,
-            final List<RexNode> leftKeys,
-            SqlNodeList valuesList,
-            SqlInOperator op
+        final Blackboard bb,
+        final List<RexNode> leftKeys,
+        SqlNodeList valuesList,
+        SqlInOperator op
     ) {
         final List<RexNode> comparisons = constructComparisons(bb, leftKeys, valuesList);
 
@@ -465,7 +465,7 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
                 return RexUtil.composeConjunction(rexBuilder, comparisons, true);
             case NOT_IN:
                 return rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-                        RexUtil.composeDisjunction(rexBuilder, comparisons, true));
+                    RexUtil.composeDisjunction(rexBuilder, comparisons, true));
             case IN:
             case SOME:
                 return RexUtil.composeDisjunction(rexBuilder, comparisons, true);
@@ -479,9 +479,9 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
      * left-hand operand (as a rule, SqlIdentifier) and right-hand list.
      */
     private List<RexNode> constructComparisons(
-            Blackboard bb,
-            List<RexNode> leftKeys,
-            SqlNodeList valuesList
+        Blackboard bb,
+        List<RexNode> leftKeys,
+        SqlNodeList valuesList
     ) {
         final List<RexNode> comparisons = new ArrayList<>();
 
@@ -490,26 +490,26 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
             final SqlOperator comparisonOp = SqlStdOperatorTable.EQUALS;
             if (leftKeys.size() == 1) {
                 rexComparison = rexBuilder.makeCall(
-                        comparisonOp,
-                        leftKeys.get(0),
-                        ensureSqlType(
-                                leftKeys.get(0).getType(),
-                                bb.convertExpression(rightValues)
-                        )
+                    comparisonOp,
+                    leftKeys.get(0),
+                    ensureSqlType(
+                        leftKeys.get(0).getType(),
+                        bb.convertExpression(rightValues)
+                    )
                 );
             } else {
                 assert rightValues instanceof SqlCall;
                 final SqlBasicCall basicCall = (SqlBasicCall) rightValues;
                 assert basicCall.getOperator() instanceof SqlRowOperator && basicCall.operandCount() == leftKeys.size();
                 rexComparison = RexUtil.composeConjunction(rexBuilder,
-                        Pair.zip(leftKeys, basicCall.getOperandList()).stream().map(pair ->
-                                rexBuilder.makeCall(
-                                        comparisonOp, pair.left, ensureSqlType(
-                                                pair.left.getType(),
-                                                bb.convertExpression(pair.right)
-                                        )
-                                )
-                        ).collect(Collectors.toList()));
+                    Pair.zip(leftKeys, basicCall.getOperandList()).stream().map(pair ->
+                        rexBuilder.makeCall(
+                            comparisonOp, pair.left, ensureSqlType(
+                                pair.left.getType(),
+                                bb.convertExpression(pair.right)
+                            )
+                        )
+                    ).collect(Collectors.toList()));
             }
             comparisons.add(rexComparison);
         }
@@ -518,8 +518,8 @@ public class HazelcastSqlToRelConverter extends SqlToRelConverter {
 
     private RexNode ensureSqlType(RelDataType type, RexNode node) {
         if (type.getSqlTypeName() == node.getType().getSqlTypeName()
-                || (type.getSqlTypeName() == SqlTypeName.VARCHAR
-                && node.getType().getSqlTypeName() == SqlTypeName.CHAR)) {
+            || (type.getSqlTypeName() == SqlTypeName.VARCHAR
+            && node.getType().getSqlTypeName() == SqlTypeName.CHAR)) {
             return node;
         }
         return rexBuilder.ensureType(type, node, true);

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/HazelcastSqlOperatorTable.java
@@ -277,17 +277,6 @@ public final class HazelcastSqlOperatorTable extends ReflectiveSqlOperatorTable 
                 SqlBasicCall basicCall = (SqlBasicCall) call;
                 SqlOperator operator = basicCall.getOperator();
 
-                // Remove raw NULL from the right-hand operand if it's a list. We ignore raw NULL.
-                if (operator.getKind() == SqlKind.IN || operator.getKind() == SqlKind.NOT_IN) {
-                    List<SqlNode> operandList = call.getOperandList();
-
-                    assert operandList.size() == 2;
-                    SqlNode rhs = operandList.get(1);
-                    if (rhs instanceof SqlNodeList) {
-                        call.setOperand(1, removeNullWithinInStatement((SqlNodeList) rhs));
-                    }
-                }
-
                 List<SqlOperator> resolvedOperators = new ArrayList<>(1);
 
                 validator.getOperatorTable().lookupOperatorOverloads(

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastInOperator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastInOperator.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.ExplicitOperatorBinding;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.fun.SqlInOperator;
@@ -77,27 +78,32 @@ public class HazelcastInOperator extends SqlInOperator implements HazelcastOpera
             SqlNodeList nodeList = (SqlNodeList) right;
             for (int i = 0; i < nodeList.size(); i++) {
                 SqlNode node = nodeList.get(i);
+                if (node instanceof SqlLiteral) {
+                    SqlLiteral lit = (SqlLiteral) node;
+                    // We are not supporting raw NULL literals within IN right-hand side list.
+                    if (lit.getValue() == null) {
+                        throw validator.newValidationError(right, HZRESOURCE.noRawNullsAllowed());
+                    }
+                }
                 RelDataType nodeType = validator.deriveType(scope, node);
                 rightTypeList.add(nodeType);
             }
             rightType = typeFactory.leastRestrictive(rightTypeList);
 
-            // First check that the expressions in the IN list are compatible
-            // with each other. Same rules as the VALUES operator (per
-            // SQL:2003 Part 2 Section 8.4, <in predicate>).
+            // First check that the expressions in the IN list are compatible with each other.
+            // Same rules as the VALUES operator (per SQL:2003 Part 2 Section 8.4, <in predicate>).
             if (null == rightType && validator.config().typeCoercionEnabled()) {
                 // Do implicit type cast if it is allowed to.
                 rightType = validator.getTypeCoercion().getWiderTypeFor(rightTypeList, false);
             }
             if (null == rightType) {
-                throw validator.newValidationError(right,
-                        RESOURCE.incompatibleTypesInList());
+                throw validator.newValidationError(right, RESOURCE.incompatibleTypesInList());
             }
 
             // Record the RHS type for use by SqlToRelConverter.
             ((SqlValidatorImpl) validator).setValidatedNodeType(nodeList, rightType);
         } else {
-            // We do not support subquerying for IN operator.
+            // We do not support sub-querying for IN operator.
             throw validator.newValidationError(call, HZRESOURCE.noSubQueryAllowed());
         }
         HazelcastCallBinding hazelcastCallBinding = prepareBinding(new SqlCallBinding(validator, scope, call));
@@ -126,8 +132,7 @@ public class HazelcastInOperator extends SqlInOperator implements HazelcastOpera
                 new ExplicitOperatorBinding(
                         hazelcastCallBinding,
                         ImmutableList.of(leftRowType, rightRowType)), hazelcastCallBinding)) {
-            throw validator.newValidationError(call,
-                    RESOURCE.incompatibleValueType(SqlStdOperatorTable.IN.getName()));
+            throw validator.newValidationError(call, RESOURCE.incompatibleValueType(SqlStdOperatorTable.IN.getName()));
         }
 
         return typeFactory.createTypeWithNullability(
@@ -149,5 +154,8 @@ public class HazelcastInOperator extends SqlInOperator implements HazelcastOpera
     interface HazelcastInOperatorResource extends CalciteResource {
         @Resources.BaseMessage("Sub-queries are not allowed for IN operator.")
         Resources.ExInst<SqlValidatorException> noSubQueryAllowed();
+
+        @Resources.BaseMessage("Raw nulls are not supported for IN operator.")
+        Resources.ExInst<SqlValidatorException> noRawNullsAllowed();
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastInOperator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/calcite/validate/operators/predicate/HazelcastInOperator.java
@@ -152,7 +152,7 @@ public class HazelcastInOperator extends SqlInOperator implements HazelcastOpera
     }
 
     interface HazelcastInOperatorResource extends CalciteResource {
-        @Resources.BaseMessage("Sub-queries are not allowed for IN operator.")
+        @Resources.BaseMessage("Sub-queries are not supported for IN operator.")
         Resources.ExInst<SqlValidatorException> noSubQueryAllowed();
 
         @Resources.BaseMessage("Raw nulls are not supported for IN operator.")

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/InOperatorIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/expression/predicate/InOperatorIntegrationTest.java
@@ -80,7 +80,7 @@ public class InOperatorIntegrationTest extends ExpressionTestSupport {
 
     @Test
     public void inPredicateWithSubQueryTest() {
-        String expectedExMessage = "Sub-queries are not allowed for IN operator.";
+        String expectedExMessage = "Sub-queries are not supported for IN operator.";
 
         putAll(1, 2);
         checkFailure0(sqlQuery("IN (SELECT __key FROM map)"), PARSING, expectedExMessage);


### PR DESCRIPTION
Long story short : if query havs raw `NULL` in the IN clause, Calcite want it to be transformed to inner table with JOIN then.
We currently doesn't support needed `JOIN` type, and we have two opportunities : or we produce wrong results on some kind of queries, or we deprecate raw `NULL`-s. 
Since raw `NULL` is used very seldom (if ever used), makes sense to deprecate its usage.  

Fixes #18592.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
