### PR TITLE
Fix JetClassLoader not set as context classloader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -241,10 +241,9 @@ public class ExecutionContext implements DynamicMetricsProvider {
         if (!executionCompleted.compareAndSet(false, true)) {
             return;
         }
-        ClassLoader jobClassLoader = jetServiceBackend.getJobExecutionService().getClassLoader(jobConfig, jobId);
         for (Tasklet tasklet : tasklets) {
             try {
-                doWithClassLoader(jobClassLoader, tasklet::close);
+                tasklet.close();
             } catch (Throwable e) {
                 logger.severe(jobNameAndExecutionId()
                         + " encountered an exception in Processor.close(), ignoring it", e);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -240,10 +240,11 @@ public class ExecutionContext implements DynamicMetricsProvider {
         if (!executionCompleted.compareAndSet(false, true)) {
             return;
         }
-
+        JetServiceBackend service = nodeEngine.getService(JetServiceBackend.SERVICE_NAME);
+        ClassLoader jobClassLoader = service.getJobExecutionService().getClassLoader(jobConfig, jobId);
         for (Tasklet tasklet : tasklets) {
             try {
-                tasklet.close();
+                doWithClassLoader(jobClassLoader, tasklet::close);
             } catch (Throwable e) {
                 logger.severe(jobNameAndExecutionId()
                         + " encountered an exception in Processor.close(), ignoring it", e);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -402,7 +402,8 @@ public class ProcessorTasklet implements Tasklet {
             case CLOSE:
                 if (isCooperative() && !processor.closeIsCooperative()) {
                     if (closeFuture == null) {
-                        closeFuture = executionService.submit(this::closeProcessor);
+                        ClassLoader contextCl = Thread.currentThread().getContextClassLoader();
+                        closeFuture = executionService.submit(() -> doWithClassLoader(contextCl, this::closeProcessor));
                         progTracker.madeProgress();
                     }
                     if (!closeFuture.isDone()) {
@@ -618,7 +619,7 @@ public class ProcessorTasklet implements Tasklet {
 
     @Override
     public boolean isCooperative() {
-        return doWithClassLoader(processor.getClass().getClassLoader(), () -> processor.isCooperative());
+        return doWithClassLoader(context.classLoader(), () -> processor.isCooperative());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.function.ComparatorEx;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.partition.IPartitionService;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -174,7 +174,6 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         initDag(jobSerializationService);
 
         this.ptionArrgmt = new PartitionArrangement(partitionAssignment, nodeEngine.getThisAddress());
-        HazelcastInstance hazelcastInstance = nodeEngine.getHazelcastInstance();
         Set<Integer> higherPriorityVertices = VertexDef.getHigherPriorityVertices(vertices);
         for (Address destAddr : remoteMembers.get()) {
             memberConnections.put(destAddr, getMemberConnection(nodeEngine, destAddr));

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -493,24 +493,32 @@ public final class Util {
     public static void doWithClassLoader(ClassLoader cl, RunnableEx action) {
         Thread currentThread = Thread.currentThread();
         ClassLoader previousCl = currentThread.getContextClassLoader();
-        currentThread.setContextClassLoader(cl);
+        if (cl != null) {
+            currentThread.setContextClassLoader(cl);
+        }
         try {
             action.run();
         } finally {
-            currentThread.setContextClassLoader(previousCl);
+            if (cl != null) {
+                currentThread.setContextClassLoader(previousCl);
+            }
         }
     }
 
     public static <T> T doWithClassLoader(ClassLoader cl, Callable<T> callable) {
         Thread currentThread = Thread.currentThread();
         ClassLoader previousCl = currentThread.getContextClassLoader();
-        currentThread.setContextClassLoader(cl);
+        if (cl != null) {
+            currentThread.setContextClassLoader(cl);
+        }
         try {
             return callable.call();
         } catch (Exception e) {
             throw rethrow(e);
         } finally {
-            currentThread.setContextClassLoader(previousCl);
+            if (cl != null) {
+                currentThread.setContextClassLoader(previousCl);
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -82,15 +82,13 @@ public class JetClassLoaderTest extends JetTestSupport {
     }
 
     @Test
-    public void when_processorCalled_then_contextClassLoaderSet() throws InterruptedException {
+    public void when_processorCalled_then_contextClassLoaderSet() {
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v1", SourceP::new).localParallelism(1);
         Vertex v2 = dag.newVertex("v2", TargetP::new).localParallelism(1);
         dag.edge(Edge.between(v1, v2));
 
-        Config config = smallInstanceConfig();
-        config.getJetConfig().setResourceUploadEnabled(true);
-        HazelcastInstance instance = createHazelcastInstance(config);
+        HazelcastInstance instance = createHazelcastInstance(smallInstanceWithResourceUploadConfig());
 
         JobConfig jobConfig = new JobConfig()
                 .setProcessingGuarantee(ProcessingGuarantee.AT_LEAST_ONCE)

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -18,9 +18,18 @@ package com.hazelcast.jet.impl.deployment;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.core.Edge;
+import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -28,6 +37,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -61,5 +78,185 @@ public class JetClassLoaderTest extends JetTestSupport {
             classLoader = (JetClassLoader) Thread.currentThread().getContextClassLoader();
             return true;
         }
+
     }
+
+    @Test
+    public void when_processorCalled_then_contextClassLoaderSet() throws InterruptedException {
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", SourceP::new).localParallelism(1);
+        Vertex v2 = dag.newVertex("v2", TargetP::new).localParallelism(1);
+        dag.edge(Edge.between(v1, v2));
+
+        Config config = smallInstanceConfig();
+        config.getJetConfig().setResourceUploadEnabled(true);
+        HazelcastInstance instance = createHazelcastInstance(config);
+
+        JobConfig jobConfig = new JobConfig()
+                .setProcessingGuarantee(ProcessingGuarantee.AT_LEAST_ONCE)
+                .setSnapshotIntervalMillis(1);
+
+        Job job = instance.getJet().newJob(dag, jobConfig);
+
+        assertJobStatusEventually(job, JobStatus.RUNNING);
+        job.suspend();
+        assertJobStatusEventually(job, JobStatus.SUSPENDED);
+        job.resume();
+        job.join();
+
+        for (Map.Entry<String, List<ClassLoader>> entry : TargetP.classLoaders.entrySet()) {
+            List<ClassLoader> cls = entry.getValue();
+            for (ClassLoader cl : cls) {
+                assertThat(cl)
+                        .describedAs("expecting JetClassLoader for method " + entry.getKey())
+                        .isInstanceOf(JetClassLoader.class);
+            }
+        }
+
+        // Future-proof against Processor API additions
+        Method[] methods = Processor.class.getMethods();
+        for (Method method : methods) {
+            String name = method.getName();
+            assertThat(TargetP.classLoaders)
+                    .describedAs("method " + name + " not called")
+                    .containsKey(name);
+        }
+    }
+
+    /**
+     * Special source that emits one event and one watermark and completing only after a restore from a snapshot
+     * As a consequence on a downstream processor (see {@link TargetP}) all Processor methods will be called.
+     */
+    private static class SourceP extends AbstractProcessor {
+
+        private volatile boolean emitted = false;
+        private volatile boolean emittedWm = false;
+        private volatile boolean restored = false;
+
+        @Override
+        public boolean complete() {
+            if (!emitted) {
+                emitted = tryEmit(1);
+                return false;
+            } else if (!emittedWm) {
+                emittedWm = tryEmit(new Watermark(System.currentTimeMillis()));
+                return false;
+            } else {
+                // This source will complete only after restoring from snapshot (suspend -> resume)
+                return restored;
+            }
+        }
+
+        @Override
+        public boolean finishSnapshotRestore() {
+            restored = true;
+            return super.finishSnapshotRestore();
+        }
+
+    }
+
+    private static class TargetP extends AbstractProcessor {
+
+        private volatile boolean received = false;
+        private volatile boolean restored = false;
+
+        private static Map<String, List<ClassLoader>> classLoaders = new HashMap<>();
+
+        private void putClassLoader(String methodName) {
+            List<ClassLoader> cls = classLoaders.computeIfAbsent(methodName, (key) -> new ArrayList<>());
+            cls.add(Thread.currentThread().getContextClassLoader());
+        }
+
+        @Override
+        public boolean isCooperative() {
+            putClassLoader("isCooperative");
+            return super.isCooperative();
+        }
+
+        @Override
+        protected void init(@Nonnull Context context) throws Exception {
+            putClassLoader("init");
+            super.init(context);
+        }
+
+        @Override
+        public void process(int ordinal, @Nonnull Inbox inbox) {
+            putClassLoader("process");
+            super.process(ordinal, inbox);
+        }
+
+        @Override
+        public boolean tryProcessWatermark(@Nonnull Watermark watermark) {
+            putClassLoader("tryProcessWatermark");
+            return super.tryProcessWatermark(watermark);
+        }
+
+        @Override
+        public boolean tryProcess() {
+            putClassLoader("tryProcess");
+            return super.tryProcess();
+        }
+
+        @Override
+        public boolean completeEdge(int ordinal) {
+            putClassLoader("completeEdge");
+            return super.completeEdge(ordinal);
+        }
+
+        @Override
+        public boolean complete() {
+            putClassLoader("complete");
+            return restored && received;
+        }
+
+        @Override
+        public boolean saveToSnapshot() {
+            getOutbox().offerToSnapshot(1, 1);
+            putClassLoader("saveToSnapshot");
+            return super.saveToSnapshot();
+        }
+
+        @Override
+        public boolean snapshotCommitPrepare() {
+            putClassLoader("snapshotCommitPrepare");
+            return super.snapshotCommitPrepare();
+        }
+
+        @Override
+        public boolean snapshotCommitFinish(boolean success) {
+            putClassLoader("snapshotCommitFinish");
+            return super.snapshotCommitFinish(success);
+        }
+
+        @Override
+        protected void restoreFromSnapshot(@Nonnull Object key, @Nonnull Object value) {
+            putClassLoader("restoreFromSnapshot");
+        }
+
+        @Override
+        public boolean finishSnapshotRestore() {
+            restored = true;
+            putClassLoader("finishSnapshotRestore");
+            return super.finishSnapshotRestore();
+        }
+
+        @Override
+        public void close() throws Exception {
+            putClassLoader("close");
+            super.close();
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            putClassLoader("closeIsCooperative");
+            return super.closeIsCooperative();
+        }
+
+        @Override
+        protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
+            received = true;
+            return true;
+        }
+    }
+
 }


### PR DESCRIPTION
- when we introduced the processor classloader feature we introduced a
regression that set the context classloade to null, this is #19083

- discovered cases, where the job classloader wasn't set as the context
classloader for some methods - most importantly Processor#close, this
could cause issues when e.g. closing some resources needs to load a new
class and it uses the context classloader for that

- setting the context classloader for some methods, e.g.
Processor#isCooperative is likely unnecessary, but it is easy enough to
do to keep the consistency

Fixes #19083
