### PR TITLE
Refactor IMap replication stats

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/EmptyLocalReplicatedMapStats.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.map.LocalReplicationStats;
 import com.hazelcast.nearcache.NearCacheStats;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
@@ -195,23 +196,8 @@ public class EmptyLocalReplicatedMapStats implements LocalReplicatedMapStats {
     }
 
     @Override
-    public long getDifferentialPartitionReplicationCount() {
-        return 0;
-    }
-
-    @Override
-    public long getFullPartitionReplicationCount() {
-        return 0;
-    }
-
-    @Override
-    public long getDifferentialReplicationRecordCount() {
-        return 0;
-    }
-
-    @Override
-    public long getFullReplicationRecordCount() {
-        return 0;
+    public LocalReplicationStats getReplicationStats() {
+        throw new UnsupportedOperationException("Replication stats are not available for replicated maps.");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitor.impl;
 
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.map.LocalReplicationStats;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.replicatedmap.LocalReplicatedMapStats;
 
@@ -364,23 +365,8 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     @Override
-    public long getDifferentialPartitionReplicationCount() {
-        return 0;
-    }
-
-    @Override
-    public long getFullPartitionReplicationCount() {
-        return 0;
-    }
-
-    @Override
-    public long getDifferentialReplicationRecordCount() {
-        return 0;
-    }
-
-    @Override
-    public long getFullReplicationRecordCount() {
-        return 0;
+    public LocalReplicationStats getReplicationStats() {
+        throw new UnsupportedOperationException("Replication stats are not available for replicated maps.");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicationStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalReplicationStatsImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitor.impl;
+
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.map.LocalReplicationStats;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_DIFF_PARTITION_REPLICATION_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_DIFF_PARTITION_REPLICATION_RECORDS_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_FULL_PARTITION_REPLICATION_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_FULL_PARTITION_REPLICATION_RECORDS_COUNT;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+public class LocalReplicationStatsImpl implements LocalReplicationStats {
+
+    private static final AtomicLongFieldUpdater<LocalReplicationStatsImpl> FULL_PARTITION_REPLICATION_COUNT =
+            newUpdater(LocalReplicationStatsImpl.class, "fullPartitionReplicationCount");
+    private static final AtomicLongFieldUpdater<LocalReplicationStatsImpl> DIFF_PARTITION_REPLICATION_COUNT =
+            newUpdater(LocalReplicationStatsImpl.class, "diffPartitionReplicationCount");
+    private static final AtomicLongFieldUpdater<LocalReplicationStatsImpl> FULL_PARTITION_REPLICATION_RECORDS_COUNT =
+            newUpdater(LocalReplicationStatsImpl.class, "fullPartitionReplicationRecordsCount");
+    private static final AtomicLongFieldUpdater<LocalReplicationStatsImpl> DIFF_PARTITION_REPLICATION_RECORDS_COUNT =
+            newUpdater(LocalReplicationStatsImpl.class, "diffPartitionReplicationRecordsCount");
+
+    @Probe(name = MAP_METRIC_FULL_PARTITION_REPLICATION_COUNT)
+    private volatile long fullPartitionReplicationCount;
+    @Probe(name = MAP_METRIC_DIFF_PARTITION_REPLICATION_COUNT)
+    private volatile long diffPartitionReplicationCount;
+    @Probe(name = MAP_METRIC_FULL_PARTITION_REPLICATION_RECORDS_COUNT)
+    private volatile long fullPartitionReplicationRecordsCount;
+    @Probe(name = MAP_METRIC_DIFF_PARTITION_REPLICATION_RECORDS_COUNT)
+    private volatile long diffPartitionReplicationRecordsCount;
+
+    @Override
+    public long getDifferentialReplicationRecordCount() {
+        return diffPartitionReplicationRecordsCount;
+    }
+
+    @Override
+    public long getFullReplicationRecordCount() {
+        return fullPartitionReplicationRecordsCount;
+    }
+
+    @Override
+    public long getDifferentialPartitionReplicationCount() {
+        return diffPartitionReplicationCount;
+    }
+
+    @Override
+    public long getFullPartitionReplicationCount() {
+        return fullPartitionReplicationCount;
+    }
+
+    public void incrementFullPartitionReplicationRecordsCount(long delta) {
+        FULL_PARTITION_REPLICATION_COUNT.incrementAndGet(this);
+        FULL_PARTITION_REPLICATION_RECORDS_COUNT.addAndGet(this, delta);
+    }
+
+    public void incrementDiffPartitionReplicationRecordsCount(long delta) {
+        DIFF_PARTITION_REPLICATION_COUNT.incrementAndGet(this);
+        DIFF_PARTITION_REPLICATION_RECORDS_COUNT.addAndGet(this, delta);
+    }
+
+    @Override
+    public String toString() {
+        return "LocalReplicationStats{" + "fullPartitionReplicationCount=" + fullPartitionReplicationCount
+                + ", differentialPartitionReplicationCount=" + diffPartitionReplicationCount
+                + ", fullPartitionReplicationRecordsCount="
+                + fullPartitionReplicationRecordsCount
+                + ", differentialPartitionReplicationRecordsCount="
+                + diffPartitionReplicationRecordsCount + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/LocalMapStats.java
@@ -229,7 +229,7 @@ public interface LocalMapStats extends LocalInstanceStats {
     /**
      * Cost of map &amp; Near Cache &amp; backup &amp; Merkle trees in bytes
      * <p>
-     * When {@link com.hazelcast.config.InMemoryFormat#OBJECT} is used, the heapcost is zero.
+     * When {@link com.hazelcast.config.InMemoryFormat#OBJECT} is used, the heap cost is zero.
      *
      * @return heap cost
      */
@@ -274,11 +274,9 @@ public interface LocalMapStats extends LocalInstanceStats {
      */
     Map<String, LocalIndexStats> getIndexStats();
 
-    // todo reconsider exposure of replication stats, probably better encapsulated in separate "LocalReplicationStats"?
-    // these stats reflect full/diff partition replication stats with local map partitions as the migration source
-    long getDifferentialPartitionReplicationCount();
-    long getFullPartitionReplicationCount();
-    long getDifferentialReplicationRecordCount();
-    long getFullReplicationRecordCount();
-
+    /**
+     * @return replication statistics.
+     * @since 5.0
+     */
+    LocalReplicationStats getReplicationStats();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/LocalReplicationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/LocalReplicationStats.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+/**
+ * Local map statistics related to partition data replication.
+ * <p>
+ * Partition data are replicated across members either because
+ * a new member becomes owner of a partition replica (usually the
+ * term migration is used for this data replication action) or because
+ * the member that owns a backup replica determined it may be
+ * out of sync with the partition owner and requests partition data
+ * replication.
+ *
+ * @since 5.0
+ */
+public interface LocalReplicationStats {
+
+    /**
+     * @return count of differential partition replications
+     *         originating from this member.
+     */
+    long getDifferentialPartitionReplicationCount();
+
+    /**
+     * @return count of full partition replications
+     *         originating from this member.
+     */
+    long getFullPartitionReplicationCount();
+
+    /**
+     * @return count of records replicated due to differential
+     *         partition replications originating from this member.
+     */
+    long getDifferentialReplicationRecordCount();
+
+    /**
+     * @return count of records replicated due to full
+     *         partition replications originating from this member.
+     */
+    long getFullReplicationRecordCount();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -21,8 +21,8 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.monitor.LocalRecordStoreStats;
-import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.monitor.impl.LocalRecordStoreStatsImpl;
+import com.hazelcast.internal.monitor.impl.LocalReplicationStatsImpl;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
@@ -76,7 +76,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     // holds recordStore-references of this partitions' maps
     protected transient Map<String, RecordStore<Record>> storesByMapName;
 
-    protected transient Map<String, LocalMapStatsImpl> statsByMapName = new ConcurrentHashMap<>();
+    protected transient Map<String, LocalReplicationStatsImpl> statsByMapName = new ConcurrentHashMap<>();
 
     // data for each map
     protected transient Map<String, List> data;
@@ -136,7 +136,8 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
             loaded.put(mapName, recordStore.isLoaded());
             storesByMapName.put(mapName, recordStore);
             statsByMapName.put(mapName,
-                    mapContainer.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(mapName));
+                    mapContainer.getMapServiceContext().getLocalMapStatsProvider()
+                                .getLocalMapStatsImpl(mapName).getReplicationStats());
 
             Set<IndexConfig> indexConfigs = new HashSet<>();
             if (mapContainer.isGlobalIndexEnabled()) {


### PR DESCRIPTION
`IMap` partition replication stats
are now separately reported
by `LocalMapStats#getReplicationStats`
as discussed [here](https://github.com/hazelcast/hazelcast/pull/19013#discussion_r666782368).

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4190