### PR TITLE
Rename InstanceConfig to JetEngineConfig

### DIFF
--- a/docs/jet/design-docs/019-memory-management.md
+++ b/docs/jet/design-docs/019-memory-management.md
@@ -70,7 +70,7 @@ Allow configuring `maxProcessorAccumulatedRecords` for the member:
 <!--Java-->
 
 ```java
-public class InstanceConfig {
+public class JetEngineConfig {
 
       public void setMaxProcessorAccumulatedRecords(long maxProcessorAccumulatedRecords) {
         checkPositive(maxProcessorAccumulatedRecords, "maxProcessorAccumulatedRecords must be a positive number");
@@ -83,7 +83,7 @@ public class InstanceConfig {
 
 ```yaml
   jet:
-    instance:
+    jet-engine:
       max-processor-accumulated-records: 1000000000
 ```
 
@@ -91,9 +91,9 @@ public class InstanceConfig {
 
 ```xml
   <jet>
-    <instance>
+    <jet-engine>
       <max-processor-accumulated-records>1000000000</max-processor-accumulated-records>
-    </instance>
+    </jet-engine>
   </jet>
 ```
 
@@ -115,8 +115,8 @@ public class JobConfig implements IdentifiedDataSerializable {
 
 To not break backward compatibility the default value of
 `maxProcessorAccumulatedRecords` for `JobConfig` is `-1` and for
-`InstanceConfig` it is `Long.MAX_VALUE`. `JobConfig`'s value, if set,
-has precedence over `InstanceConfig`'s one.
+`JetEngineConfig` it is `Long.MAX_VALUE`. `JobConfig`'s value, if set,
+has precedence over `JetEngineConfig`'s one.
 
 `maxProcessorAccumulatedRecords` is accessible for `Processor`s via
 `ProcessorMetaSupplier.Context.maxProcessorAccumulatedRecords()`.

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -130,7 +130,7 @@ import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.config.EdgeConfig;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapStore;
@@ -1518,12 +1518,12 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertTrue(jetConfig.isEnabled());
         assertTrue(jetConfig.isResourceUploadEnabled());
 
-        InstanceConfig instanceConfig = jetConfig.getInstanceConfig();
-        assertEquals(4, instanceConfig.getCooperativeThreadCount());
-        assertEquals(2, instanceConfig.getBackupCount());
-        assertEquals(200, instanceConfig.getFlowControlPeriodMs());
-        assertEquals(20000, instanceConfig.getScaleUpDelayMillis());
-        assertFalse(instanceConfig.isLosslessRestartEnabled());
+        JetEngineConfig jetEngineConfig = jetConfig.getJetEngineConfig();
+        assertEquals(4, jetEngineConfig.getCooperativeThreadCount());
+        assertEquals(2, jetEngineConfig.getBackupCount());
+        assertEquals(200, jetEngineConfig.getFlowControlPeriodMs());
+        assertEquals(20000, jetEngineConfig.getScaleUpDelayMillis());
+        assertFalse(jetEngineConfig.isLosslessRestartEnabled());
 
         EdgeConfig edgeConfig = jetConfig.getDefaultEdgeConfig();
         assertEquals(2048, edgeConfig.getQueueSize());

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -1032,14 +1032,14 @@
             </hz:sql>
 
             <hz:jet enabled="true" resource-upload-enabled="true">
-                <hz:instance>
+                <hz:jet-engine>
                     <hz:cooperative-thread-count>4</hz:cooperative-thread-count>
                     <hz:backup-count>2</hz:backup-count>
                     <hz:flow-control-period>200</hz:flow-control-period>
                     <hz:scale-up-delay-millis>20000</hz:scale-up-delay-millis>
                     <hz:lossless-restart-enabled>false</hz:lossless-restart-enabled>
                     <hz:max-processor-accumulated-records>1000000</hz:max-processor-accumulated-records>
-                </hz:instance>
+                </hz:jet-engine>
                 <hz:edge-defaults>
                     <hz:queue-size>2048</hz:queue-size>
                     <hz:packet-size-limit>15000</hz:packet-size-limit>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -131,7 +131,7 @@ import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.jet.config.EdgeConfig;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.spring.config.ConfigFactory;
@@ -2193,11 +2193,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             fillAttributeValues(node, jetConfigBuilder);
             for (Node child : childElements(node)) {
                 String nodeName = cleanNodeName(child);
-                if ("instance".equals(nodeName)) {
-                    BeanDefinitionBuilder instanceConfigBuilder = createBeanBuilder(InstanceConfig.class);
-                    fillValues(child, instanceConfigBuilder);
-                    jetConfigBuilder.addPropertyValue("instanceConfig",
-                            instanceConfigBuilder.getBeanDefinition());
+                if ("jet-engine".equals(nodeName)) {
+                    BeanDefinitionBuilder jetEngineConfigBuilder = createBeanBuilder(JetEngineConfig.class);
+                    fillValues(child, jetEngineConfigBuilder);
+                    jetConfigBuilder.addPropertyValue("jetEngineConfig",
+                            jetEngineConfigBuilder.getBeanDefinition());
                 } else if ("edge-defaults".equals(nodeName)) {
                     BeanDefinitionBuilder edgeConfigBuilder = createBeanBuilder(EdgeConfig.class);
                     fillValues(child, edgeConfigBuilder);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.0.xsd
@@ -5412,7 +5412,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="instance" minOccurs="0">
+            <xs:element name="jet-engine" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         General configuration options pertaining to a Jet instance.
@@ -5555,7 +5555,7 @@
                                     the data one `receive window` further than the last acknowledged byte and
                                     the receive window is sized in proportion to the rate of processing at
                                     the receiver.
-                                    Ack packets are sent in regular intervals (InstanceConfig#setFlowControlPeriodMs)
+                                    Ack packets are sent in regular intervals (JetEngineConfig#setFlowControlPeriodMs)
                                     and the `receive window multiplier` sets the factor of the linear
                                     relationship between the amount of data processed within one such
                                     interval and the size of the receive window.

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
@@ -386,7 +386,7 @@ public class CreateDagVisitor {
 
         if (preserveCollation) {
             int cooperativeThreadCount = nodeEngine.getConfig().getJetConfig()
-                    .getInstanceConfig().getCooperativeThreadCount();
+                    .getJetEngineConfig().getCooperativeThreadCount();
             int explicitLP = inputVertex.determineLocalParallelism(cooperativeThreadCount);
             // It's not strictly necessary to set the LP to the input, but we do it to ensure that the two
             // vertices indeed have the same LP

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlMemoryManagement.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlMemoryManagement.java
@@ -36,7 +36,7 @@ public class SqlMemoryManagement extends SqlTestSupport {
     @BeforeClass
     public static void setUpClass() {
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig()
+        config.getJetConfig().getJetEngineConfig()
                 .setCooperativeThreadCount(1)
                 .setMaxProcessorAccumulatedRecords(MAX_PROCESSOR_ACCUMULATED_RECORDS);
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -38,7 +38,7 @@ import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.jet.config.EdgeConfig;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -1662,16 +1662,16 @@ public class ConfigXmlGenerator {
 
     private static void jetConfig(XmlGenerator gen, Config config) {
         JetConfig jetConfig = config.getJetConfig();
-        InstanceConfig instanceConfig = jetConfig.getInstanceConfig();
+        JetEngineConfig jetEngineConfig = jetConfig.getJetEngineConfig();
         EdgeConfig edgeConfig = jetConfig.getDefaultEdgeConfig();
         gen.open("jet", "enabled", jetConfig.isEnabled(), "resource-upload-enabled", jetConfig.isResourceUploadEnabled())
-                .open("instance")
-                    .node("cooperative-thread-count", instanceConfig.getCooperativeThreadCount())
-                    .node("flow-control-period", instanceConfig.getFlowControlPeriodMs())
-                    .node("backup-count", instanceConfig.getBackupCount())
-                    .node("scale-up-delay-millis", instanceConfig.getScaleUpDelayMillis())
-                    .node("lossless-restart-enabled", instanceConfig.isLosslessRestartEnabled())
-                    .node("max-processor-accumulated-records", instanceConfig.getMaxProcessorAccumulatedRecords())
+                .open("jet-engine")
+                    .node("cooperative-thread-count", jetEngineConfig.getCooperativeThreadCount())
+                    .node("flow-control-period", jetEngineConfig.getFlowControlPeriodMs())
+                    .node("backup-count", jetEngineConfig.getBackupCount())
+                    .node("scale-up-delay-millis", jetEngineConfig.getScaleUpDelayMillis())
+                    .node("lossless-restart-enabled", jetEngineConfig.isLosslessRestartEnabled())
+                    .node("max-processor-accumulated-records", jetEngineConfig.getMaxProcessorAccumulatedRecords())
                 .close()
                 .open("edge-defaults")
                     .node("queue-size", edgeConfig.getQueueSize())

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/JetExtension.java
@@ -56,7 +56,7 @@ public class JetExtension {
     private void checkLosslessRestartAllowed() {
         Config config = node.config.getStaticConfig();
         JetConfig jetConfig = config.getJetConfig();
-        if (jetConfig.getInstanceConfig().isLosslessRestartEnabled()) {
+        if (jetConfig.getJetEngineConfig().isLosslessRestartEnabled()) {
             if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
                 throw new IllegalStateException("Lossless Restart requires Hazelcast Enterprise Edition");
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -138,7 +138,7 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.jet.config.EdgeConfig;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -2992,34 +2992,34 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
-            if (matches("instance", nodeName)) {
-                handleInstance(jetConfig, child);
+            if (matches("jet-engine", nodeName)) {
+                handleJetEngine(jetConfig, child);
             } else if (matches("edge-defaults", nodeName)) {
                 handleEdgeDefaults(jetConfig, child);
             }
         }
     }
 
-    private void handleInstance(JetConfig jetConfig, Node node) {
-        InstanceConfig instanceConfig = jetConfig.getInstanceConfig();
+    private void handleJetEngine(JetConfig jetConfig, Node node) {
+        JetEngineConfig jetEngineConfig = jetConfig.getJetEngineConfig();
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             if (matches("cooperative-thread-count", nodeName)) {
-                instanceConfig.setCooperativeThreadCount(
+                jetEngineConfig.setCooperativeThreadCount(
                         getIntegerValue("cooperative-thread-count", getTextContent(child)));
             } else if (matches("flow-control-period", nodeName)) {
-                instanceConfig.setFlowControlPeriodMs(
+                jetEngineConfig.setFlowControlPeriodMs(
                         getIntegerValue("flow-control-period", getTextContent(child)));
             } else if (matches("backup-count", nodeName)) {
-                instanceConfig.setBackupCount(
+                jetEngineConfig.setBackupCount(
                         getIntegerValue("backup-count", getTextContent(child)));
             } else if (matches("scale-up-delay-millis", nodeName)) {
-                instanceConfig.setScaleUpDelayMillis(
+                jetEngineConfig.setScaleUpDelayMillis(
                         getLongValue("scale-up-delay-millis", getTextContent(child)));
             } else if (matches("lossless-restart-enabled", nodeName)) {
-                instanceConfig.setLosslessRestartEnabled(getBooleanValue(getTextContent(child)));
+                jetEngineConfig.setLosslessRestartEnabled(getBooleanValue(getTextContent(child)));
             } else if (matches("max-processor-accumulated-records", nodeName)) {
-                instanceConfig.setMaxProcessorAccumulatedRecords(
+                jetEngineConfig.setMaxProcessorAccumulatedRecords(
                         getLongValue("max-processor-accumulated-records", getTextContent(child)));
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/EdgeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/EdgeConfig.java
@@ -95,7 +95,7 @@ public class EdgeConfig implements IdentifiedDataSerializable {
      * byte and the receive window is sized in proportion to the rate of
      * processing at the receiver.
      * <p>
-     * Ack packets are sent in {@link InstanceConfig#setFlowControlPeriodMs(int)
+     * Ack packets are sent in {@link JetEngineConfig#setFlowControlPeriodMs(int)
      * regular intervals} and the <em>receive window multiplier</em> sets the
      * factor of the linear relationship between the amount of data processed
      * within one such interval and the size of the receive window.

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JetConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JetConfig.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class JetConfig {
 
-    private InstanceConfig instanceConfig = new InstanceConfig();
+    private JetEngineConfig jetEngineConfig = new JetEngineConfig();
     private EdgeConfig defaultEdgeConfig = new EdgeConfig();
     private boolean enabled;
     private boolean resourceUploadEnabled;
@@ -73,17 +73,17 @@ public class JetConfig {
      * Returns the Jet instance config.
      */
     @Nonnull
-    public InstanceConfig getInstanceConfig() {
-        return instanceConfig;
+    public JetEngineConfig getJetEngineConfig() {
+        return jetEngineConfig;
     }
 
     /**
      * Sets the Jet instance config.
      */
     @Nonnull
-    public JetConfig setInstanceConfig(@Nonnull InstanceConfig instanceConfig) {
-        Preconditions.checkNotNull(instanceConfig, "instanceConfig");
-        this.instanceConfig = instanceConfig;
+    public JetConfig setJetEngineConfig(@Nonnull JetEngineConfig jetEngineConfig) {
+        Preconditions.checkNotNull(jetEngineConfig, "jetEngineConfig");
+        this.jetEngineConfig = jetEngineConfig;
         return this;
     }
 
@@ -123,7 +123,7 @@ public class JetConfig {
         if (resourceUploadEnabled != jetConfig.resourceUploadEnabled) {
             return false;
         }
-        if (!instanceConfig.equals(jetConfig.instanceConfig)) {
+        if (!jetEngineConfig.equals(jetConfig.jetEngineConfig)) {
             return false;
         }
         return defaultEdgeConfig.equals(jetConfig.defaultEdgeConfig);
@@ -131,7 +131,7 @@ public class JetConfig {
 
     @Override
     public int hashCode() {
-        int result = instanceConfig.hashCode();
+        int result = jetEngineConfig.hashCode();
         result = 31 * result + defaultEdgeConfig.hashCode();
         result = 31 * result + (enabled ? 1 : 0);
         result = 31 * result + (resourceUploadEnabled ? 1 : 0);

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JetEngineConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JetEngineConfig.java
@@ -30,10 +30,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * General configuration options pertaining to a Jet instance.
- *
- * @since Jet 3.0
  */
-public class InstanceConfig {
+public class JetEngineConfig {
 
     /**
      * The default value of the {@link #setFlowControlPeriodMs(int) flow-control period}.
@@ -68,7 +66,7 @@ public class InstanceConfig {
      * processors; each <em>blocking</em> processor is assigned its own thread.
      */
     @Nonnull
-    public InstanceConfig setCooperativeThreadCount(int size) {
+    public JetEngineConfig setCooperativeThreadCount(int size) {
         checkPositive(size, "cooperativeThreadCount should be a positive number");
         this.cooperativeThreadCount = size;
         return this;
@@ -89,7 +87,7 @@ public class InstanceConfig {
      * (in milliseconds) of the interval between flow-control ("ack") packets.
      */
     @Nonnull
-    public InstanceConfig setFlowControlPeriodMs(int flowControlPeriodMs) {
+    public JetEngineConfig setFlowControlPeriodMs(int flowControlPeriodMs) {
         checkPositive(flowControlPeriodMs, "flowControlPeriodMs should be a positive number");
         this.flowControlPeriodMs = flowControlPeriodMs;
         return this;
@@ -116,7 +114,7 @@ public class InstanceConfig {
      * and continue executing the job on the remaining members without loss.
      */
     @Nonnull
-    public InstanceConfig setBackupCount(int newBackupCount) {
+    public JetEngineConfig setBackupCount(int newBackupCount) {
         checkBackupCount(newBackupCount, 0);
         this.backupCount = newBackupCount;
         return this;
@@ -139,7 +137,7 @@ public class InstanceConfig {
      * @param millis the delay, in milliseconds
      * @return this instance for fluent API
      */
-    public InstanceConfig setScaleUpDelayMillis(long millis) {
+    public JetEngineConfig setScaleUpDelayMillis(long millis) {
         checkNotNegative(millis, "The delay must be >=0");
         this.scaleUpDelayMillis = millis;
         return this;
@@ -169,7 +167,7 @@ public class InstanceConfig {
      * If enabled, you have to also configure Hot Restart:
      * <pre>{@code
      *    JetConfig jetConfig = new JetConfig();
-     *    jetConfig.getInstanceConfig().setLosslessRestartEnabled(true);
+     *    jetConfig.getJetEngineConfig().setLosslessRestartEnabled(true);
      *    jetConfig.getHazelcastConfig().getHotRestartPersistenceConfig()
      *        .setEnabled(true)
      *        .setBaseDir(new File("/mnt/hot-restart"))
@@ -183,7 +181,7 @@ public class InstanceConfig {
      * Hazelcast Jet, the member will fail to start, you need Jet Enterprise to
      * run it and obtain a license from Hazelcast.
      */
-    public InstanceConfig setLosslessRestartEnabled(boolean enabled) {
+    public JetEngineConfig setLosslessRestartEnabled(boolean enabled) {
         this.losslessRestartEnabled = enabled;
         return this;
     }
@@ -243,7 +241,7 @@ public class InstanceConfig {
             return false;
         }
 
-        InstanceConfig that = (InstanceConfig) o;
+        JetEngineConfig that = (JetEngineConfig) o;
 
         if (cooperativeThreadCount != that.cooperativeThreadCount) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -173,7 +173,7 @@ public class JobConfig implements IdentifiedDataSerializable {
      * </pre>
      *
      * @return {@code this} instance for fluent API
-     * @see InstanceConfig#setScaleUpDelayMillis Configuring the scale-up delay
+     * @see JetEngineConfig#setScaleUpDelayMillis Configuring the scale-up delay
      * @see #setProcessingGuarantee Enabling/disabling snapshots
      */
     public JobConfig setAutoScaling(boolean enabled) {
@@ -1322,11 +1322,11 @@ public class JobConfig implements IdentifiedDataSerializable {
      * Sets the maximum number of records that can be accumulated by any single
      * {@link Processor} instance in the context of the job.
      * <p>
-     * For more info see {@link InstanceConfig#setMaxProcessorAccumulatedRecords(long)}.
+     * For more info see {@link JetEngineConfig#setMaxProcessorAccumulatedRecords(long)}.
      * <p>
-     * If set, it has precedence over {@link InstanceConfig}'s one.
+     * If set, it has precedence over {@link JetEngineConfig}'s one.
      * <p>
-     * The default value is {@code -1} - in that case {@link InstanceConfig}'s value
+     * The default value is {@code -1} - in that case {@link JetEngineConfig}'s value
      * is used.
      *
      * @since 5.0

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -121,7 +121,7 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         this.hazelcastInstance = engine.getHazelcastInstance();
         this.jet = new JetInstanceImpl(nodeEngine.getNode().hazelcastInstance, jetConfig);
         taskletExecutionService = new TaskletExecutionService(
-                nodeEngine, jetConfig.getInstanceConfig().getCooperativeThreadCount(), nodeEngine.getProperties()
+                nodeEngine, jetConfig.getJetEngineConfig().getCooperativeThreadCount(), nodeEngine.getProperties()
         );
         jobRepository = new JobRepository(hazelcastInstance);
 
@@ -132,7 +132,7 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         metricsService.registerPublisher(nodeEngine -> new JobMetricsPublisher(jobExecutionService,
                 nodeEngine.getLocalMember()));
         nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(jobExecutionService);
-        networking = new Networking(engine, jobExecutionService, jetConfig.getInstanceConfig().getFlowControlPeriodMs());
+        networking = new Networking(engine, jobExecutionService, jetConfig.getJetEngineConfig().getFlowControlPeriodMs());
 
         ClientEngine clientEngine = engine.getService(ClientEngineImpl.SERVICE_NAME);
         ClientExceptionFactory clientExceptionFactory = clientEngine.getExceptionFactory();
@@ -143,7 +143,7 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
                     " since the ClientExceptionFactory is not accessible.");
         }
         logger.info("Setting number of cooperative threads and default parallelism to "
-                + jetConfig.getInstanceConfig().getCooperativeThreadCount());
+                + jetConfig.getJetEngineConfig().getCooperativeThreadCount());
         if (sqlCoreBackend != null) {
             try {
                 Method initJetInstanceMethod = sqlCoreBackend.getClass().getMethod("init", HazelcastInstance.class);
@@ -157,7 +157,7 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
     public void configureJetInternalObjects(Config config, HazelcastProperties properties) {
         JetConfig jetConfig = config.getJetConfig();
         MapConfig internalMapConfig = new MapConfig(INTERNAL_JET_OBJECTS_PREFIX + '*')
-                .setBackupCount(jetConfig.getInstanceConfig().getBackupCount())
+                .setBackupCount(jetConfig.getJetEngineConfig().getBackupCount())
                 // we query creationTime of resources maps
                 .setStatisticsEnabled(true);
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -239,7 +239,7 @@ public class JobCoordinationService {
                 DAG dag;
                 Data serializedDag;
                 if (jobDefinition instanceof PipelineImpl) {
-                    int coopThreadCount = config.getInstanceConfig().getCooperativeThreadCount();
+                    int coopThreadCount = config.getJetEngineConfig().getCooperativeThreadCount();
                     dag = ((PipelineImpl) jobDefinition).toDag(new Context() {
                         @Override public int defaultLocalParallelism() {
                             return coopThreadCount;
@@ -311,7 +311,7 @@ public class JobCoordinationService {
         if (jobDefinition instanceof DAG) {
             dag = (DAG) jobDefinition;
         } else {
-            int coopThreadCount = config.getInstanceConfig().getCooperativeThreadCount();
+            int coopThreadCount = config.getJetEngineConfig().getCooperativeThreadCount();
             dag = ((PipelineImpl) jobDefinition).toDag(new Context() {
                 @Override public int defaultLocalParallelism() {
                     return coopThreadCount;
@@ -874,7 +874,7 @@ public class JobCoordinationService {
         }
 
         updateQuorumValues();
-        scheduleScaleUp(config.getInstanceConfig().getScaleUpDelayMillis());
+        scheduleScaleUp(config.getJetEngineConfig().getScaleUpDelayMillis());
     }
 
     void onMemberRemoved(UUID uuid) {
@@ -1055,7 +1055,7 @@ public class JobCoordinationService {
     }
 
     private String dagToJson(DAG dag) {
-        int coopThreadCount = config.getInstanceConfig().getCooperativeThreadCount();
+        int coopThreadCount = config.getJetEngineConfig().getCooperativeThreadCount();
         return dag.toJson(coopThreadCount).toString();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -165,7 +165,7 @@ public class MasterJobContext {
         this.mc = masterContext;
         this.logger = logger;
         this.defaultParallelism = mc.getJetServiceBackend().getJetConfig()
-              .getInstanceConfig().getCooperativeThreadCount();
+              .getJetEngineConfig().getCooperativeThreadCount();
         this.defaultQueueSize = mc.getJetServiceBackend().getJetConfig()
                 .getDefaultEdgeConfig().getQueueSize();
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
@@ -27,7 +27,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.jet.RestartableException;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.core.metrics.MetricNames;
 import com.hazelcast.jet.core.metrics.MetricTags;
 import com.hazelcast.jet.impl.util.ObjectWithPartitionId;
@@ -199,7 +199,7 @@ public class ReceiverTasklet implements Tasklet {
      *         measured in compressed seq units (see {@link #COMPRESSED_SEQ_UNIT_LOG2})
      *     </li><li>
      *         {@code seqsPerAckPeriod = (seqDelta / timeDelta) * }
-     *         {@link InstanceConfig#setFlowControlPeriodMs(int)
+     *         {@link JetEngineConfig#setFlowControlPeriodMs(int)
      *         flowControlPeriodMs}, projected amount of data processed by the receiver
      *         in one standard flow control period (called "ack period" for short)
      *     </li></ol>

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -184,7 +184,7 @@ public final class Contexts {
             long jobMaxProcessorAccumulatedRecords = jobConfig.getMaxProcessorAccumulatedRecords();
             return jobMaxProcessorAccumulatedRecords > -1
                     ? jobMaxProcessorAccumulatedRecords
-                    : hazelcastInstance().getConfig().getJetConfig().getInstanceConfig()
+                    : hazelcastInstance().getConfig().getJetConfig().getJetEngineConfig()
                     .getMaxProcessorAccumulatedRecords();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -646,7 +646,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                            ReceiverTasklet receiverTasklet = new ReceiverTasklet(
                                    collector, jobSerializationService,
                                    edge.getConfig().getReceiveWindowMultiplier(),
-                                   getJetConfig().getInstanceConfig().getFlowControlPeriodMs(),
+                                   getJetConfig().getJetEngineConfig().getFlowControlPeriodMs(),
                                    nodeEngine.getLoggingService(), addr, edge.destOrdinal(), edge.destVertex().name(),
                                    memberConnections.get(addr), jobPrefix);
                            addrToTasklet.put(addr, receiverTasklet);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -65,7 +65,7 @@ public final class ExecutionPlanBuilder {
             NodeEngineImpl nodeEngine, List<MemberInfo> memberInfos, DAG dag, long jobId, long executionId,
             JobConfig jobConfig, long lastSnapshotId, boolean isLightJob, Subject subject
     ) {
-        final int defaultParallelism = nodeEngine.getConfig().getJetConfig().getInstanceConfig().getCooperativeThreadCount();
+        final int defaultParallelism = nodeEngine.getConfig().getJetConfig().getJetEngineConfig().getCooperativeThreadCount();
         final Map<MemberInfo, int[]> partitionsByMember = getPartitionAssignment(nodeEngine, memberInfos);
         final Map<Address, int[]> partitionsByAddress =
                 partitionsByMember.entrySet().stream().collect(toMap(en -> en.getKey().getAddress(), Entry::getValue));

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/memory/AccumulationLimitExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/memory/AccumulationLimitExceededException.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.jet.impl.memory;
 
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 
 /**
  * This exception is thrown when a job exceeds a configurable processor accumulation limit.
  *
- * @see InstanceConfig#setMaxProcessorAccumulatedRecords
+ * @see JetEngineConfig#setMaxProcessorAccumulatedRecords
  */
 public class AccumulationLimitExceededException extends RuntimeException {
 
@@ -29,6 +29,6 @@ public class AccumulationLimitExceededException extends RuntimeException {
         super("Exception thrown to prevent an OutOfMemoryError on this Hazelcast instance."
                 + " An OOME might occur when a job accumulates large data sets in one of the processors,"
                 + " e.g. grouping, sorting, hash join."
-                + "See InstanceConfig.setMaxProcessorAccumulatedRecords() for further details.");
+                + "See JetEngineConfig.setMaxProcessorAccumulatedRecords() for further details.");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -28,7 +28,7 @@ import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.aggregate.AggregateOperation2;
 import com.hazelcast.jet.aggregate.AggregateOperation3;
 import com.hazelcast.jet.aggregate.AggregateOperations;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -78,7 +78,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @return the newly attached stage
@@ -100,7 +100,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param comparator the user-provided comparator that will be used for
@@ -225,7 +225,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * There is no guarantee which one of equal items it will emit.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @return the newly attached stage

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -23,7 +23,7 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.aggregate.AggregateOperation2;
 import com.hazelcast.jet.aggregate.AggregateOperation3;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -62,7 +62,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * key it will emit.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @return the newly attached stage
@@ -174,7 +174,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
@@ -212,7 +212,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * the input streams into the same accumulator.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
@@ -248,7 +248,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
@@ -302,7 +302,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * operation must combine the input streams into the same accumulator.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
@@ -344,7 +344,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
@@ -414,7 +414,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      *}</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      */
     @Nonnull
@@ -475,7 +475,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -25,7 +25,7 @@ import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -767,7 +767,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param stage1        the stage to hash-join with this one
@@ -814,7 +814,7 @@ public interface GeneralStage<T> extends Stage {
      * before reaching {@code #mapToOutputFn}.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param stage1        the stage to hash-join with this one
@@ -860,7 +860,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param stage1        the first stage to join
@@ -911,7 +911,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * <p>
@@ -972,7 +972,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @return the newly attached stage

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -23,7 +23,7 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetEngineConfig;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -89,7 +89,7 @@ public interface GeneralStageWithKey<T, K> {
      * latencies.groupingKey(Entry::getKey).rollingAggregate(summing())}.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param createFn function that returns the state object
@@ -131,7 +131,7 @@ public interface GeneralStageWithKey<T, K> {
      * Processor#isCooperative() cooperative}.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param createFn function that returns the state object
@@ -174,7 +174,7 @@ public interface GeneralStageWithKey<T, K> {
      * Processor#isCooperative() cooperative}.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param createFn  function that returns the state object
@@ -210,7 +210,7 @@ public interface GeneralStageWithKey<T, K> {
      * This stage is fault-tolerant and saves its state to the snapshot.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetEngineConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param aggrOp the aggregate operation to perform

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.json
@@ -4093,7 +4093,7 @@
           "type": "boolean",
           "default": false
         },
-        "instance": {
+        "jet-engine": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4128,7 +4128,7 @@
               "description": "Specifies the maximum number of records that can be accumulated by any single processor instance. Operations like grouping, sorting or joining require certain amount of records to be accumulated before they can proceed. You can set this option to reduce the probability of `OutOfMemoryError`. It applies to each processor instance separately, hence the effective limit of records accumulated by each cluster member is influenced by the vertex's `localParallelism` and the number of jobs in the cluster. Currently, this option limits: number of items sorted by the sort operation, number of distinct keys accumulated by aggregation operations, number of entries in each hash-join lookup table, number of entries in stateful transforms and number of distinct items in distinct operation. The limit does not apply to streaming aggregations."
             }
           },
-          "description": "General configuration options pertaining to a Jet instance."
+          "description": "General configuration options pertaining to a Jet Engine."
         },
         "edge-defaults": {
           "type": "object",
@@ -4147,7 +4147,7 @@
             "receive-window-multiplier": {
               "type": "integer",
               "default": 3,
-              "description": "Sets the scaling factor used by the adaptive receive window sizing function. For each distributed edge the receiving member regularly sends flow-control (\"ack\") packets to its sender which prevent it from sending too much data and overflowing the buffers. The sender is allowed to send the data one `receive window` further than the last acknowledged byte and the receive window is sized in proportion to the rate of processing at the receiver. Ack packets are sent in regular intervals (InstanceConfig#setFlowControlPeriodMs) and the `receive window multiplier` sets the factor of the linear relationship between the amount of data processed within one such interval and the size of the receive window. To put it another way, let us define an `ackworth` as the amount of data processed between two consecutive ack packets. The receive window multiplier determines the number of ackworths the sender can be ahead of the last acked byte. This setting has no effect on a non-distributed edge."
+              "description": "Sets the scaling factor used by the adaptive receive window sizing function. For each distributed edge the receiving member regularly sends flow-control (\"ack\") packets to its sender which prevent it from sending too much data and overflowing the buffers. The sender is allowed to send the data one `receive window` further than the last acknowledged byte and the receive window is sized in proportion to the rate of processing at the receiver. Ack packets are sent in regular intervals (JetEngineConfig#setFlowControlPeriodMs) and the `receive window multiplier` sets the factor of the linear relationship between the amount of data processed within one such interval and the size of the receive window. To put it another way, let us define an `ackworth` as the amount of data processed between two consecutive ack packets. The receive window multiplier determines the number of ackworths the sender can be ahead of the last acked byte. This setting has no effect on a non-distributed edge."
             }
           }
         }

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
@@ -5245,10 +5245,10 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="instance" minOccurs="0">
+            <xs:element name="jet-engine" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
-                        General configuration options pertaining to a Jet instance.
+                        General configuration options pertaining to a Jet Engine.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -5388,7 +5388,7 @@
                                     the data one `receive window` further than the last acknowledged byte and
                                     the receive window is sized in proportion to the rate of processing at
                                     the receiver.
-                                    Ack packets are sent in regular intervals (InstanceConfig#setFlowControlPeriodMs)
+                                    Ack packets are sent in regular intervals (JetEngineConfig#setFlowControlPeriodMs)
                                     and the `receive window multiplier` sets the factor of the linear
                                     relationship between the amount of data processed within one such
                                     interval and the size of the receive window.

--- a/hazelcast/src/main/resources/hazelcast-default-assembly.xml
+++ b/hazelcast/src/main/resources/hazelcast-default-assembly.xml
@@ -489,7 +489,7 @@
     </sql>
 
     <jet enabled="true" resource-upload-enabled="false">
-        <instance>
+        <jet-engine>
             <!-- time spacing of flow-control (ack) packets -->
             <flow-control-period>100</flow-control-period>
             <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
@@ -527,7 +527,7 @@
                  Note: the limit does not apply to streaming aggregations.
              -->
             <max-processor-accumulated-records>9223372036854775807</max-processor-accumulated-records>
-        </instance>
+        </jet-engine>
         <edge-defaults>
             <!-- capacity of the concurrent SPSC queue between each two processors -->
             <queue-size>1024</queue-size>

--- a/hazelcast/src/main/resources/hazelcast-default-assembly.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default-assembly.yaml
@@ -800,7 +800,7 @@ hazelcast:
     enabled: true
     # Specifies whether uploading resources when submitting the job is enabled or not
     resource-upload-enabled: false
-    instance:
+    jet-engine:
       # period between flow control packets in milliseconds
       flow-control-period: 100
       # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -487,7 +487,7 @@
     </sql>
 
     <jet enabled="false" resource-upload-enabled="false">
-        <instance>
+        <jet-engine>
             <!-- time spacing of flow-control (ack) packets -->
             <flow-control-period>100</flow-control-period>
             <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
@@ -525,7 +525,7 @@
                  Note: the limit does not apply to streaming aggregations.
              -->
             <max-processor-accumulated-records>9223372036854775807</max-processor-accumulated-records>
-        </instance>
+        </jet-engine>
         <edge-defaults>
             <!-- capacity of the concurrent SPSC queue between each two processors -->
             <queue-size>1024</queue-size>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -801,7 +801,7 @@ hazelcast:
     enabled: false
     # Specifies whether uploading resources when submitting the job is enabled or not
     resource-upload-enabled: false
-    instance:
+    jet-engine:
       # period between flow control packets in milliseconds
       flow-control-period: 100
       # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3622,7 +3622,7 @@
 
         It has the following sub-elements:
 
-        * <instance>:
+        * <jet-engine>:
             General configuration options pertaining to a Jet instance.
 
             It has the following sub-elements:
@@ -3713,7 +3713,7 @@
                 the data one `receive window` further than the last acknowledged byte and
                 the receive window is sized in proportion to the rate of processing at
                 the receiver.
-                Ack packets are sent in regular intervals (InstanceConfig#setFlowControlPeriodMs)
+                Ack packets are sent in regular intervals (JetEngineConfig#setFlowControlPeriodMs)
                 and the `receive window multiplier` sets the factor of the linear
                 relationship between the amount of data processed within one such
                 interval and the size of the receive window.
@@ -3724,7 +3724,7 @@
                 This setting has no effect on a non-distributed edge.
     -->
     <jet enabled="true" resource-upload-enabled="true">
-        <instance>
+        <jet-engine>
             <!-- number of threads in the cooperative thread pool -->
             <cooperative-thread-count>8</cooperative-thread-count>
             <!-- period between flow control packets in milliseconds -->
@@ -3740,7 +3740,7 @@
                  Restart feature of Hazelcast IMDG which persists the data to disk. -->
             <lossless-restart-enabled>false</lossless-restart-enabled>
             <max-processor-accumulated-records>1000000000</max-processor-accumulated-records>
-        </instance>
+        </jet-engine>
         <edge-defaults>
             <!-- capacity of the concurrent SPSC queue between each two processors -->
             <queue-size>1024</queue-size>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3518,7 +3518,7 @@ hazelcast:
   #
   #    It has the following sub-elements:
   #
-  #  * "instance":
+  #  * "jet-engine":
   #      General configuration options pertaining to the Jet Service.
   #
   #        It has the following sub-elements:
@@ -3621,7 +3621,7 @@ hazelcast:
   jet:
     enabled: true
     resource-upload-enabled: true
-    instance:
+    jet-engine:
       # number of threads in the cooperative thread pool
       cooperative-thread-count: 8
       # period between flow control packets in milliseconds

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -2153,7 +2153,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         Config config = new Config();
         JetConfig jetConfig = config.getJetConfig();
         jetConfig.setEnabled(false).setResourceUploadEnabled(true);
-        jetConfig.getInstanceConfig()
+        jetConfig.getJetEngineConfig()
                 .setLosslessRestartEnabled(true)
                 .setScaleUpDelayMillis(123)
                 .setBackupCount(2)

--- a/hazelcast/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
@@ -82,7 +82,7 @@ public abstract class TestInClusterSupport extends JetTestSupport {
         Config config = smallInstanceConfig();
 
         JetConfig jetConfig = config.getJetConfig().setResourceUploadEnabled(true);
-        jetConfig.getInstanceConfig().setCooperativeThreadCount(max(2, parallelism));
+        jetConfig.getJetEngineConfig().setCooperativeThreadCount(max(2, parallelism));
         config.getMetricsConfig().setCollectionFrequencySeconds(1);
         // Set partition count to match the parallelism of IMap sources.
         // Their preferred local parallelism is 2, therefore partition count

--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -70,7 +70,7 @@ public class BackpressureTest extends JetTestSupport {
     @Before
     public void setUp() {
         Config config = defaultInstanceConfigWithJetEnabled();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM_PER_MEMBER);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(PARALLELISM_PER_MEMBER);
         hz1 = createHazelcastInstance(config);
         hz2 = createHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
@@ -94,7 +94,7 @@ public class WordCountTest extends JetTestSupport implements Serializable {
     @Before
     public void before() {
         Config config = defaultInstanceConfigWithJetEnabled();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(PARALLELISM);
         config.setClusterName(randomName());
         final JoinConfig join = config.getNetworkConfig().getJoin();
         join.getMulticastConfig().setEnabled(false);

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JetConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JetConfigTest.java
@@ -37,14 +37,14 @@ public class JetConfigTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void when_setInstanceConfig_thenReturnsInstanceConfig() {
+    public void when_setJetEngineConfig_thenReturnsJetEngineConfig() {
         // When
         JetConfig config = new JetConfig();
-        InstanceConfig instanceConfig = new InstanceConfig();
-        config.setInstanceConfig(instanceConfig);
+        JetEngineConfig jetEngineConfig = new JetEngineConfig();
+        config.setJetEngineConfig(jetEngineConfig);
 
         // Then
-        assertEquals(instanceConfig, config.getInstanceConfig());
+        assertEquals(jetEngineConfig, config.getJetEngineConfig());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JetEngineConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JetEngineConfigTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class InstanceConfigTest {
+public class JetEngineConfigTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -38,56 +38,56 @@ public class InstanceConfigTest {
     @Test
     public void when_NegativeBackupCount_thenThrowsException() {
         // When
-        InstanceConfig instanceConfig = new InstanceConfig();
+        JetEngineConfig jetEngineConfig = new JetEngineConfig();
 
         // Then
         expectedException.expect(IllegalArgumentException.class);
-        instanceConfig.setBackupCount(-1);
+        jetEngineConfig.setBackupCount(-1);
     }
 
     @Test
     public void when_TooBigBackupCount_thenThrowsException() {
         // When
-        InstanceConfig instanceConfig = new InstanceConfig();
+        JetEngineConfig jetEngineConfig = new JetEngineConfig();
 
         // Then
         expectedException.expect(IllegalArgumentException.class);
-        instanceConfig.setBackupCount(10);
+        jetEngineConfig.setBackupCount(10);
     }
 
     @Test
     public void when_setBackupCount_thenReturnsBackupCount() {
         // When
-        InstanceConfig instanceConfig = new InstanceConfig();
-        instanceConfig.setBackupCount(3);
+        JetEngineConfig jetEngineConfig = new JetEngineConfig();
+        jetEngineConfig.setBackupCount(3);
 
         // Then
-        assertEquals(3, instanceConfig.getBackupCount());
+        assertEquals(3, jetEngineConfig.getBackupCount());
     }
 
     @Test
     public void when_setThreadCount_thenReturnsThreadCount() {
         // When
-        InstanceConfig instanceConfig = new InstanceConfig();
-        instanceConfig.setCooperativeThreadCount(5);
+        JetEngineConfig jetEngineConfig = new JetEngineConfig();
+        jetEngineConfig.setCooperativeThreadCount(5);
 
         // Then
-        assertEquals(5, instanceConfig.getCooperativeThreadCount());
+        assertEquals(5, jetEngineConfig.getCooperativeThreadCount());
     }
     @Test
     public void when_setFlowControlMs_thenReturnsFlowControlMs() {
         // When
-        InstanceConfig instanceConfig = new InstanceConfig();
-        instanceConfig.setFlowControlPeriodMs(500);
+        JetEngineConfig jetEngineConfig = new JetEngineConfig();
+        jetEngineConfig.setFlowControlPeriodMs(500);
 
         // Then
-        assertEquals(500, instanceConfig.getFlowControlPeriodMs());
+        assertEquals(500, jetEngineConfig.getFlowControlPeriodMs());
     }
 
     @Test
     public void when_scaleUpDelay_then_returnsDelay() {
         // When
-        InstanceConfig config = new InstanceConfig();
+        JetEngineConfig config = new JetEngineConfig();
         config.setScaleUpDelayMillis(123);
 
         // Then
@@ -97,7 +97,7 @@ public class InstanceConfigTest {
     @Test
     public void when_losslessRestartEnabled_then_returnsEnabled() {
         // When
-        InstanceConfig config = new InstanceConfig();
+        JetEngineConfig config = new JetEngineConfig();
         config.setLosslessRestartEnabled(true);
 
         // Then

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
@@ -106,7 +106,7 @@ public class JobConfigTest extends JetTestSupport {
     public void when_losslessRestartEnabled_then_openSourceMemberDoesNotStart() {
         // When
         Config config = new Config();
-        config.getJetConfig().setEnabled(true).getInstanceConfig().setLosslessRestartEnabled(true);
+        config.getJetConfig().setEnabled(true).getJetEngineConfig().setLosslessRestartEnabled(true);
 
         // Then
         exception.expect(IllegalStateException.class);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
@@ -59,7 +59,7 @@ public class ClusterStateChangeTest extends JetTestSupport {
     public void before() {
         TestProcessors.reset(TOTAL_PARALLELISM);
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
         members = createHazelcastInstances(config, NODE_COUNT);
 
         assertTrueEventually(() -> {

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -128,7 +128,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
     @Before
     public void before() {
-        parallelism = instance().getConfig().getJetConfig().getInstanceConfig().getCooperativeThreadCount();
+        parallelism = instance().getConfig().getJetConfig().getJetEngineConfig().getCooperativeThreadCount();
         TestProcessors.reset(MEMBER_COUNT * parallelism);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
@@ -85,7 +85,7 @@ public class ExecutionLifecycle_RestartableExceptionTest extends SimpleTestInClu
     @BeforeClass
     public static void beforeClass() {
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(2);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(2);
         initialize(MEMBER_COUNT, config);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -83,7 +83,7 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
 
     protected Config createConfig() {
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(PARALLELISM);
         config.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         config.setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
         onConfigCreated(config);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartStressTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartStressTestBase.java
@@ -42,7 +42,7 @@ public class JobRestartStressTestBase extends JetTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(4);
+        config.getJetConfig().setEnabled(true).getJetEngineConfig().setCooperativeThreadCount(4);
 
         instance1 = createHazelcastInstance(config);
         createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -92,7 +92,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
     @Before
     public void setup() {
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
 
         instance1 = createHazelcastInstance(config);
         instance2 = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -89,7 +89,7 @@ public class JobTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void beforeClass() {
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
         initializeWithClient(NODE_COUNT, config, null);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/Job_SeparateClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/Job_SeparateClusterTest.java
@@ -73,8 +73,8 @@ public class Job_SeparateClusterTest extends JetTestSupport {
         TestProcessors.reset(NODE_COUNT * LOCAL_PARALLELISM);
 
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
-        config.getJetConfig().getInstanceConfig().setScaleUpDelayMillis(10);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setScaleUpDelayMillis(10);
         instance1 = createHazelcastInstance(config);
         instance2 = createHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
@@ -50,7 +50,7 @@ public class ScaleUpTest extends JetTestSupport {
 
         dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
         config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setScaleUpDelayMillis(scaleUpDelay);
+        config.getJetConfig().getJetEngineConfig().setScaleUpDelayMillis(scaleUpDelay);
         instances = createHazelcastInstances(config, NODE_COUNT);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
@@ -63,7 +63,7 @@ public class SnapshotFailureTest extends JetTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getJetConfig().setEnabled(true).getJetEngineConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
 
         // force snapshots to fail by adding a failing map store configuration for snapshot data maps
         MapConfig mapConfig = new MapConfig(JobRepository.SNAPSHOT_DATA_MAP_PREFIX + '*');

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -66,8 +66,8 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
 
     @Override
     protected void onConfigCreated(Config config) {
-        config.getJetConfig().getInstanceConfig().setBackupCount(MAX_BACKUP_COUNT);
-        config.getJetConfig().getInstanceConfig().setScaleUpDelayMillis(3000);
+        config.getJetConfig().getJetEngineConfig().setBackupCount(MAX_BACKUP_COUNT);
+        config.getJetConfig().getJetEngineConfig().setScaleUpDelayMillis(3000);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendResumeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendResumeTest.java
@@ -66,7 +66,7 @@ public class SuspendResumeTest extends JetTestSupport {
         TestProcessors.reset(NODE_COUNT * PARALLELISM);
         instances = new HazelcastInstance[NODE_COUNT];
         config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(PARALLELISM);
         for (int i = 0; i < NODE_COUNT; i++) {
             instances[i] = createHazelcastInstance(config);
         }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -122,14 +122,14 @@ public class TopologyChangeTest extends JetTestSupport {
         TestProcessors.reset(nodeCount * PARALLELISM);
 
         config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
+        config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(PARALLELISM);
 
         instances = new HazelcastInstance[NODE_COUNT];
 
         for (int i = 0; i < NODE_COUNT; i++) {
             Config config = smallInstanceConfig();
             config.setLiteMember(liteMemberFlags[i]);
-            config.getJetConfig().getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
+            config.getJetConfig().getJetEngineConfig().setCooperativeThreadCount(PARALLELISM);
 
             instances[i] = createHazelcastInstance(config);
         }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
@@ -416,7 +416,7 @@ public class MetricsTest extends JetTestSupport {
 
         String instanceName = instance.getName();
         long sum = 0;
-        int availableProcessors = config.getJetConfig().getInstanceConfig().getCooperativeThreadCount();
+        int availableProcessors = config.getJetConfig().getJetEngineConfig().getCooperativeThreadCount();
         for (int i = 0; i < availableProcessors; i++) {
             JmxMetricsChecker jmxMetricsChecker = new JmxMetricsChecker(instanceName, job,
                     "vertex=fused(filter, map)", "procType=TransformP", "proc=" + i, "user=true");

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.jet.config.InstanceConfig.DEFAULT_FLOW_CONTROL_PERIOD_MS;
+import static com.hazelcast.jet.config.JetEngineConfig.DEFAULT_FLOW_CONTROL_PERIOD_MS;
 import static com.hazelcast.jet.impl.execution.ReceiverTasklet.COMPRESSED_SEQ_UNIT_LOG2;
 import static com.hazelcast.jet.impl.execution.ReceiverTasklet.INITIAL_RECEIVE_WINDOW_COMPRESSED;
 import static java.lang.Math.abs;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
@@ -48,7 +48,7 @@ public class DetermineLocalParallelismTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void before() {
         Config config = new Config();
-        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(DEFAULT_PARALLELISM);
+        config.getJetConfig().setEnabled(true).getJetEngineConfig().setCooperativeThreadCount(DEFAULT_PARALLELISM);
         initialize(1, config);
         nodeEngine = getNode(instance()).getNodeEngine();
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/memory/MemoryManagementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/memory/MemoryManagementTest.java
@@ -49,7 +49,7 @@ public class MemoryManagementTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void setUpClass() {
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig()
+        config.getJetConfig().getJetEngineConfig()
                 .setCooperativeThreadCount(1)
                 .setMaxProcessorAccumulatedRecords(MAX_PROCESSOR_ACCUMULATED_RECORDS);
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourceBuilder_TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourceBuilder_TopologyChangeTest.java
@@ -96,7 +96,7 @@ public class SourceBuilder_TopologyChangeTest extends JetTestSupport {
                 .build();
 
         Config config = smallInstanceConfig();
-        config.getJetConfig().getInstanceConfig().setScaleUpDelayMillis(1000); // restart sooner after member add
+        config.getJetConfig().getJetEngineConfig().setScaleUpDelayMillis(1000); // restart sooner after member add
         HazelcastInstance hz = createHazelcastInstance(config);
         HazelcastInstance possibleSecondNode = secondMemberSupplier.get();
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -194,7 +194,7 @@ public abstract class HazelcastTestSupport {
                 .setProperty(ClusterProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.EVENT_THREAD_COUNT.getName(), "1");
-        config.getJetConfig().setEnabled(true).getInstanceConfig().setCooperativeThreadCount(2);
+        config.getJetConfig().setEnabled(true).getJetEngineConfig().setCooperativeThreadCount(2);
 
         config.getSqlConfig().setExecutorPoolSize(2);
 

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/jet/multiple-failures.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/jet/multiple-failures.json
@@ -3,7 +3,7 @@
     "hazelcast": {
       "jet": {
         "unknown": true,
-        "instance": {
+        "jet-engine": {
           "unknown": true,
           "cooperative-thread-count": "2",
           "flow-control-period": "3",
@@ -67,47 +67,47 @@
         "message": "4 schema violations found"
       },
       {
-        "schemaLocation": "#/definitions/Jet/properties/instance",
-        "pointerToViolation": "#/hazelcast/jet/instance",
+        "schemaLocation": "#/definitions/Jet/properties/jet-engine",
+        "pointerToViolation": "#/hazelcast/jet/jet-engine",
         "causingExceptions": [
           {
-            "schemaLocation": "#/definitions/Jet/properties/instance",
-            "pointerToViolation": "#/hazelcast/jet/instance",
+            "schemaLocation": "#/definitions/Jet/properties/jet-engine",
+            "pointerToViolation": "#/hazelcast/jet/jet-engine",
             "causingExceptions": [],
             "keyword": "additionalProperties",
             "message": "extraneous key [unknown] is not permitted"
           },
           {
-            "schemaLocation": "#/definitions/Jet/properties/instance/properties/lossless-restart-enabled",
-            "pointerToViolation": "#/hazelcast/jet/instance/lossless-restart-enabled",
+            "schemaLocation": "#/definitions/Jet/properties/jet-engine/properties/lossless-restart-enabled",
+            "pointerToViolation": "#/hazelcast/jet/jet-engine/lossless-restart-enabled",
             "causingExceptions": [],
             "keyword": "type",
             "message": "expected type: Boolean, found: String"
           },
           {
-            "schemaLocation": "#/definitions/Jet/properties/instance/properties/cooperative-thread-count",
-            "pointerToViolation": "#/hazelcast/jet/instance/cooperative-thread-count",
+            "schemaLocation": "#/definitions/Jet/properties/jet-engine/properties/cooperative-thread-count",
+            "pointerToViolation": "#/hazelcast/jet/jet-engine/cooperative-thread-count",
             "causingExceptions": [],
             "keyword": "type",
             "message": "expected type: Integer, found: String"
           },
           {
-            "schemaLocation": "#/definitions/Jet/properties/instance/properties/flow-control-period",
-            "pointerToViolation": "#/hazelcast/jet/instance/flow-control-period",
+            "schemaLocation": "#/definitions/Jet/properties/jet-engine/properties/flow-control-period",
+            "pointerToViolation": "#/hazelcast/jet/jet-engine/flow-control-period",
             "causingExceptions": [],
             "keyword": "type",
             "message": "expected type: Integer, found: String"
           },
           {
-            "schemaLocation": "#/definitions/Jet/properties/instance/properties/backup-count",
-            "pointerToViolation": "#/hazelcast/jet/instance/backup-count",
+            "schemaLocation": "#/definitions/Jet/properties/jet-engine/properties/backup-count",
+            "pointerToViolation": "#/hazelcast/jet/jet-engine/backup-count",
             "causingExceptions": [],
             "keyword": "type",
             "message": "expected type: Integer, found: String"
           },
           {
-            "schemaLocation": "#/definitions/Jet/properties/instance/properties/scale-up-delay-millis",
-            "pointerToViolation": "#/hazelcast/jet/instance/scale-up-delay-millis",
+            "schemaLocation": "#/definitions/Jet/properties/jet-engine/properties/scale-up-delay-millis",
+            "pointerToViolation": "#/hazelcast/jet/jet-engine/scale-up-delay-millis",
             "causingExceptions": [],
             "keyword": "type",
             "message": "expected type: Integer, found: String"

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/jet/success.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/jet/success.json
@@ -2,7 +2,7 @@
   "instance": {
     "hazelcast": {
       "jet": {
-        "instance": {
+        "jet-engine": {
           "cooperative-thread-count": 2,
           "flow-control-period": 3,
           "backup-count": 4,


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/18774

Breaking changes (list specific methods/types/messages):
* API: `InstanceConfig` -> `JetEngineConfig`, for config files `instance` -> `jet-engine`

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
