### PR TITLE
MC-957: add isLightJob flag to JobSummary

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -241,8 +241,7 @@ public class JobCoordinationService {
                 if (jobDefinition instanceof PipelineImpl) {
                     int coopThreadCount = config.getInstanceConfig().getCooperativeThreadCount();
                     dag = ((PipelineImpl) jobDefinition).toDag(new Context() {
-                        @Override
-                        public int defaultLocalParallelism() {
+                        @Override public int defaultLocalParallelism() {
                             return coopThreadCount;
                         }
                     });
@@ -314,8 +313,7 @@ public class JobCoordinationService {
         } else {
             int coopThreadCount = config.getInstanceConfig().getCooperativeThreadCount();
             dag = ((PipelineImpl) jobDefinition).toDag(new Context() {
-                @Override
-                public int defaultLocalParallelism() {
+                @Override public int defaultLocalParallelism() {
                     return coopThreadCount;
                 }
             });
@@ -366,8 +364,7 @@ public class JobCoordinationService {
                 .collect(Collectors.toSet());
     }
 
-    @SuppressWarnings("WeakerAccess")
-        // used by jet-enterprise
+    @SuppressWarnings("WeakerAccess") // used by jet-enterprise
     MasterContext createMasterContext(JobRecord jobRecord, JobExecutionRecord jobExecutionRecord) {
         return new MasterContext(nodeEngine, this, jobRecord, jobExecutionRecord);
     }
@@ -382,8 +379,8 @@ public class JobCoordinationService {
         }
 
         return masterContexts.values()
-                .stream()
-                .anyMatch(ctx -> jobName.equals(ctx.jobConfig().getName()));
+                             .stream()
+                             .anyMatch(ctx -> jobName.equals(ctx.jobConfig().getName()));
     }
 
     public CompletableFuture<Void> prepareForPassiveClusterState() {
@@ -725,11 +722,11 @@ public class JobCoordinationService {
         }
         logFine(logger, "Added a shutting-down member: %s", uuid);
         CompletableFuture[] futures = masterContexts.values().stream()
-                .map(mc -> mc.jobContext().onParticipantGracefulShutdown(uuid))
-                .toArray(CompletableFuture[]::new);
+                                                    .map(mc -> mc.jobContext().onParticipantGracefulShutdown(uuid))
+                                                    .toArray(CompletableFuture[]::new);
         // Need to do this even if futures.length == 0, we need to perform the action in whenComplete
         CompletableFuture.allOf(futures)
-                .whenComplete(withTryCatch(logger, (r, e) -> future.complete(null)));
+                         .whenComplete(withTryCatch(logger, (r, e) -> future.complete(null)));
         return future;
     }
 
@@ -1155,7 +1152,7 @@ public class JobCoordinationService {
         } else {
             status = ctx.jobStatus();
         }
-        return new JobSummary(record.getJobId(), execId, record.getJobNameOrId(), status, record.getCreationTime());
+        return new JobSummary(false, record.getJobId(), execId, record.getJobNameOrId(), status, record.getCreationTime());
     }
 
     private InternalPartitionServiceImpl getInternalPartitionService() {
@@ -1205,8 +1202,7 @@ public class JobCoordinationService {
         return record != null ? record : new JobExecutionRecord(jobId, getQuorumSize());
     }
 
-    @SuppressWarnings("WeakerAccess")
-        // used by jet-enterprise
+    @SuppressWarnings("WeakerAccess") // used by jet-enterprise
     void assertIsMaster(String error) {
         if (!isMaster()) {
             throw new JetException(error + ". Master address: " + nodeEngine.getClusterService().getMasterAddress());
@@ -1217,8 +1213,7 @@ public class JobCoordinationService {
         return nodeEngine.getClusterService().isMaster();
     }
 
-    @SuppressWarnings("unused")
-        // used in jet-enterprise
+    @SuppressWarnings("unused") // used in jet-enterprise
     NodeEngineImpl nodeEngine() {
         return nodeEngine;
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobSummary.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobSummary.java
@@ -31,6 +31,7 @@ import static com.hazelcast.jet.impl.util.Util.toLocalTime;
 
 public class JobSummary implements IdentifiedDataSerializable {
 
+    private boolean isLightJob;
     private long jobId;
     private long executionId;
     private String nameOrId;
@@ -52,6 +53,21 @@ public class JobSummary implements IdentifiedDataSerializable {
             @Nonnull JobStatus status,
             long submissionTime
     ) {
+        this(false, jobId, executionId, nameOrId, status, submissionTime);
+    }
+
+    /**
+     * Constructor for a light job
+     */
+    public JobSummary(
+            boolean isLightJob,
+            long jobId,
+            long executionId,
+            @Nonnull String nameOrId,
+            @Nonnull JobStatus status,
+            long submissionTime
+    ) {
+        this.isLightJob = isLightJob;
         this.jobId = jobId;
         this.executionId = executionId;
         this.nameOrId = nameOrId;
@@ -102,6 +118,7 @@ public class JobSummary implements IdentifiedDataSerializable {
      * @deprecated use {@link #getNameOrId()}, semantics is the same
      */
     @Nonnull
+    @Deprecated
     public String getName() {
         return nameOrId;
     }
@@ -130,6 +147,10 @@ public class JobSummary implements IdentifiedDataSerializable {
         return failureText;
     }
 
+    public boolean isLightJob() {
+        return isLightJob;
+    }
+
     @Override
     public int getFactoryId() {
         return JetInitDataSerializerHook.FACTORY_ID;
@@ -142,6 +163,7 @@ public class JobSummary implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeBoolean(isLightJob);
         out.writeLong(jobId);
         out.writeLong(executionId);
         out.writeString(nameOrId);
@@ -153,6 +175,7 @@ public class JobSummary implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+        isLightJob = in.readBoolean();
         jobId = in.readLong();
         executionId = in.readLong();
         nameOrId = in.readString();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobSummary.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobSummary.java
@@ -47,19 +47,6 @@ public class JobSummary implements IdentifiedDataSerializable {
      * Constructor for a running job
      */
     public JobSummary(
-            long jobId,
-            long executionId,
-            @Nonnull String nameOrId,
-            @Nonnull JobStatus status,
-            long submissionTime
-    ) {
-        this(false, jobId, executionId, nameOrId, status, submissionTime);
-    }
-
-    /**
-     * Constructor for a light job
-     */
-    public JobSummary(
             boolean isLightJob,
             long jobId,
             long executionId,

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobSummary.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobSummary.java
@@ -81,6 +81,10 @@ public class JobSummary implements IdentifiedDataSerializable {
         this.failureText = failureText;
     }
 
+    public boolean isLightJob() {
+        return isLightJob;
+    }
+
     public long getJobId() {
         return jobId;
     }
@@ -132,10 +136,6 @@ public class JobSummary implements IdentifiedDataSerializable {
     @Nullable
     public String getFailureText() {
         return failureText;
-    }
-
-    public boolean isLightJob() {
-        return isLightJob;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
@@ -42,8 +42,10 @@ import java.util.List;
 
 import static com.hazelcast.jet.Util.idToString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -79,6 +81,7 @@ public class JobSummaryTest extends JetTestSupport {
         assertEquals(1, list.size());
         JobSummary jobSummary = list.get(0);
 
+        assertFalse(jobSummary.isLightJob());
         assertEquals("jobA", jobSummary.getNameOrId());
         assertEquals(job.getId(), jobSummary.getJobId());
         assertEquals(JobStatus.COMPLETED, jobSummary.getStatus());
@@ -92,6 +95,7 @@ public class JobSummaryTest extends JetTestSupport {
         assertEquals(1, list.size());
         JobSummary jobSummary = list.get(0);
 
+        assertFalse(jobSummary.isLightJob());
         assertEquals("jobA", jobSummary.getNameOrId());
         assertEquals(job.getId(), jobSummary.getJobId());
 
@@ -121,6 +125,19 @@ public class JobSummaryTest extends JetTestSupport {
             assertEquals(JobStatus.FAILED, summary.getStatus());
             assertEquals(0, summary.getExecutionId());
         }, 20);
+    }
+
+    @Test
+    public void when_lightJob() {
+        Job job = instance.getJet().newLightJob(newStreamPipeline());
+
+        List<JobSummary> list = getJetClientInstanceImpl(client).getJobSummaryList();
+        assertEquals(1, list.size());
+        JobSummary jobSummary = list.get(0);
+
+        assertTrue(jobSummary.isLightJob());
+        assertEquals(idToString(job.getId()), jobSummary.getNameOrId());
+        assertEquals(job.getId(), jobSummary.getJobId());
     }
 
     @Test


### PR DESCRIPTION
This change allows MC to filter out light jobs and hide them or show them in a different way on dashboards

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
