### PR TITLE
Add support for declarative compact serialization configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfigAccessor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.util.TriTuple;
+import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+import java.util.Map;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+
+/**
+ * An accessor for the package-private fields of the {@link CompactSerializationConfig}.
+ *
+ * This is intended to be used while registering explicit and reflective serializers
+ * via declarative configuration. This kind of accessor is necessary as the register
+ * methods on the {@link CompactSerializationConfig} accepts concrete {@link Class}
+ * or {@link com.hazelcast.nio.serialization.compact.CompactSerializer} instances
+ * rather than the string representation of the fully qualified class names.
+ */
+@Beta
+@PrivateApi
+public final class CompactSerializationConfigAccessor {
+
+    private CompactSerializationConfigAccessor() {
+    }
+
+    /**
+     * Registers an explicit compact serializer for the given class and type name.
+     */
+     public static void registerExplicitSerializer(CompactSerializationConfig compactSerializationConfig,
+                                                   String className, String typeName,
+                                                   String serializerClassName) {
+         checkNotNull(className, "Class name cannot be null");
+         checkNotNull(typeName, "Type name cannot be null");
+         checkNotNull(serializerClassName, "Explicit serializer class name cannot be null");
+         register(compactSerializationConfig, className, typeName, serializerClassName);
+     }
+
+    /**
+     * Registers a reflective compact serializer for the given class name.
+     * The type name will be the same with the class name.
+     */
+     public static void registerReflectiveSerializer(CompactSerializationConfig compactSerializationConfig,
+                                                     String className) {
+         checkNotNull(className, "Class name cannot be null");
+         register(compactSerializationConfig, className, className, null);
+     }
+
+    /**
+     * Returns the map of type names to config registrations.
+     */
+     public static Map<String, TriTuple<String, String, String>> getNamedRegistries(
+             CompactSerializationConfig compactSerializationConfig) {
+         return compactSerializationConfig.typeNameToNamedRegistryMap;
+     }
+
+
+    private static void register(CompactSerializationConfig compactSerializationConfig,
+                                  String className, String typeName, String explicitSerializerClassName) {
+         TriTuple<String, String, String> registry = TriTuple.of(className, typeName, explicitSerializerClassName);
+         TriTuple<String, String, String> oldRegistry = compactSerializationConfig
+                 .typeNameToNamedRegistryMap
+                 .putIfAbsent(typeName, registry);
+         if (oldRegistry != null) {
+             throw new InvalidConfigurationException("Already have a registry for the type name " + typeName);
+         }
+
+         oldRegistry = compactSerializationConfig
+                 .classNameToNamedRegistryMap
+                 .putIfAbsent(className, registry);
+         if (oldRegistry != null) {
+             throw new InvalidConfigurationException("Already have a registry for class name " + className);
+         }
+     }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -18,6 +18,8 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.AbstractFactoryWithPropertiesConfig;
 import com.hazelcast.config.ClassFilter;
+import com.hazelcast.config.CompactSerializationConfig;
+import com.hazelcast.config.CompactSerializationConfigAccessor;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InvalidConfigurationException;
@@ -178,9 +180,57 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
                 fillSerializers(child, serializationConfig);
             } else if (matches("java-serialization-filter", name)) {
                 fillJavaSerializationFilter(child, serializationConfig);
+            } else if (matches("compact-serialization", name)) {
+                handleCompactSerialization(child, serializationConfig);
             }
         }
         return serializationConfig;
+    }
+
+    protected void handleCompactSerialization(Node node, SerializationConfig serializationConfig) {
+        CompactSerializationConfig compactSerializationConfig = serializationConfig.getCompactSerializationConfig();
+        Node enabledNode = getNamedItemNode(node, "enabled");
+        if (enabledNode != null) {
+            boolean enabled = getBooleanValue(getTextContent(enabledNode));
+            compactSerializationConfig.setEnabled(enabled);
+        }
+
+        for (Node child : childElements(node)) {
+            String name = cleanNodeName(child);
+            if (matches("registered-classes", name)) {
+                fillCompactSerializableClasses(child, compactSerializationConfig);
+            }
+        }
+    }
+
+    protected void fillCompactSerializableClasses(Node node, CompactSerializationConfig compactSerializationConfig) {
+        for (Node child : childElements(node)) {
+            String name = cleanNodeName(child);
+            if (matches("class", name)) {
+                String className = getTextContent(child);
+                Node typeNameNode = getNamedItemNode(child, "type-name");
+                String typeName = typeNameNode != null ? getTextContent(typeNameNode) : null;
+                Node serializerClassNameNode = getNamedItemNode(child, "serializer");
+                String serializerClassName = serializerClassNameNode != null
+                        ? getTextContent(serializerClassNameNode) : null;
+                registerCompactSerializableClass(compactSerializationConfig, className, typeName, serializerClassName);
+            }
+        }
+    }
+
+    protected void registerCompactSerializableClass(CompactSerializationConfig compactSerializationConfig,
+                                                    String className, String typeName, String serializerClassName) {
+        if (typeName != null && serializerClassName != null) {
+            CompactSerializationConfigAccessor.registerExplicitSerializer(compactSerializationConfig, className,
+                    typeName, serializerClassName);
+        } else if (typeName == null && serializerClassName == null) {
+            CompactSerializationConfigAccessor.registerReflectiveSerializer(compactSerializationConfig, className);
+        } else {
+            throw new InvalidConfigurationException("Either both 'type-name' and 'serializer' attributes "
+                    + "must be defined to register a class with an explicit serializer, "
+                    + "or no attributes should be defined to register a class to be used with "
+                    + "reflective compact serializer.");
+        }
     }
 
     protected void fillDataSerializableFactories(Node node, SerializationConfig serializationConfig) {
@@ -330,7 +380,7 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
 
     private void handlePersistentMemoryConfig(PersistentMemoryConfig persistentMemoryConfig, Node node) {
         Node enabledNode = getNamedItemNode(node, "enabled");
-            if (enabledNode != null) {
+        if (enabledNode != null) {
             boolean enabled = getBooleanValue(getTextContent(enabledNode));
             persistentMemoryConfig.setEnabled(enabled);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.ClassFilter;
+import com.hazelcast.config.CompactSerializationConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -619,9 +620,35 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
                 fillGlobalSerializer(child, serializationConfig);
             } else if (matches("java-serialization-filter", name)) {
                 fillJavaSerializationFilter(child, serializationConfig);
+            } else if (matches("compact-serialization", name)) {
+                handleCompactSerialization(child, serializationConfig);
             }
         }
         return serializationConfig;
+    }
+
+    @Override
+    protected void handleCompactSerialization(Node node, SerializationConfig serializationConfig) {
+        CompactSerializationConfig compactSerializationConfig = serializationConfig.getCompactSerializationConfig();
+        for (Node child : childElements(node)) {
+            String name = cleanNodeName(child);
+            if (matches("enabled", name)) {
+                boolean enabled = getBooleanValue(getTextContent(child));
+                compactSerializationConfig.setEnabled(enabled);
+            } else if (matches("registered-classes", name)) {
+                fillCompactSerializableClasses(child, compactSerializationConfig);
+            }
+        }
+    }
+
+    @Override
+    protected void fillCompactSerializableClasses(Node node, CompactSerializationConfig compactSerializationConfig) {
+        for (Node child : childElements(node)) {
+            String className = getAttribute(child, "class");
+            String typeName = getAttribute(child, "type-name");
+            String serializerClassName = getAttribute(child, "serializer");
+            registerCompactSerializableClass(compactSerializationConfig, className, typeName, serializerClassName);
+        }
     }
 
     private void fillGlobalSerializer(Node child, SerializationConfig serializationConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.serialization.impl.compact;
 
 import com.hazelcast.config.CompactSerializationConfig;
+import com.hazelcast.config.CompactSerializationConfigAccessor;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
@@ -77,15 +78,8 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
         this.bufferObjectDataOutputSupplier = bufferObjectDataOutputSupplier;
         this.classLoader = classLoader;
         this.isEnabled = compactSerializationConfig.isEnabled();
-        Map<String, TriTuple<Class, String, CompactSerializer>> registries = compactSerializationConfig.getRegistries();
-        for (Map.Entry<String, TriTuple<Class, String, CompactSerializer>> entry : registries.entrySet()) {
-            String typeName = entry.getKey();
-            CompactSerializer serializer = entry.getValue().element3;
-            serializer = serializer == null ? reflectiveSerializer : serializer;
-            Class clazz = entry.getValue().element1;
-            classToRegistrationMap.put(clazz, new CompactSerializableRegistration(clazz, typeName, serializer));
-            classNameToRegistrationMap.put(typeName, new CompactSerializableRegistration(clazz, typeName, serializer));
-        }
+        registerConfiguredSerializers(compactSerializationConfig);
+        registerConfiguredNamedSerializers(compactSerializationConfig);
     }
 
     /**
@@ -281,5 +275,47 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     //Should be deleted with removing Beta tags
     public boolean isEnabled() {
         return isEnabled;
+    }
+
+    private void registerConfiguredSerializers(CompactSerializationConfig compactSerializationConfig) {
+        Map<String, TriTuple<Class, String, CompactSerializer>> registries = compactSerializationConfig.getRegistries();
+        for (TriTuple<Class, String, CompactSerializer> registry : registries.values()) {
+            Class clazz = registry.element1;
+            String typeName = registry.element2;
+            CompactSerializer serializer = registry.element3;
+            serializer = serializer == null ? reflectiveSerializer : serializer;
+            CompactSerializableRegistration registration = new CompactSerializableRegistration(clazz, typeName, serializer);
+            classToRegistrationMap.put(clazz, registration);
+            classNameToRegistrationMap.put(typeName, registration);
+        }
+    }
+
+    private void registerConfiguredNamedSerializers(CompactSerializationConfig compactSerializationConfig) {
+        Map<String, TriTuple<String, String, String>> namedRegistries
+                = CompactSerializationConfigAccessor.getNamedRegistries(compactSerializationConfig);
+        for (TriTuple<String, String, String> registry : namedRegistries.values()) {
+            String className = registry.element1;
+            String typeName = registry.element2;
+            String serializerClassName = registry.element3;
+            CompactSerializer serializer;
+            if (serializerClassName != null) {
+                try {
+                    serializer = ClassLoaderUtil.newInstance(classLoader, serializerClassName);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Cannot create an instance of " + serializerClassName);
+                }
+            } else {
+                serializer = reflectiveSerializer;
+            }
+            Class clazz;
+            try {
+                clazz = ClassLoaderUtil.loadClass(classLoader, className);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException("Cannot load the class " + className);
+            }
+            CompactSerializableRegistration registration = new CompactSerializableRegistration(clazz, typeName, serializer);
+            classToRegistrationMap.put(clazz, registration);
+            classNameToRegistrationMap.put(typeName, registration);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -75,7 +75,8 @@ import static java.util.stream.Collectors.toList;
  * Reflective serializer works for Compact format in zero-config case.
  * Specifically when explicit serializer is not given via
  * {@link com.hazelcast.config.CompactSerializationConfig#register(Class, String, CompactSerializer)}
- * {@link com.hazelcast.config.CompactSerializationConfig#register(Class, CompactSerializer)}
+ * or when a class is registered as reflectively serializable with
+ * {@link com.hazelcast.config.CompactSerializationConfig#register(Class)}.
  * <p>
  * ReflectiveCompactSerializer can de/serialize classes having an accessible empty constructor only.
  * Only types in {@link CompactWriter}/{@link CompactReader} interface are supported as fields.

--- a/hazelcast/src/test/java/com/hazelcast/config/CompactSerializationConfigConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CompactSerializationConfigConfigBuilderTest.java
@@ -53,6 +53,9 @@ import static org.junit.Assert.assertTrue;
  * schema validation. The tests should be run serially to not
  * interfere with the other tests, as the schema validation
  * is disabled through a system property.
+ *
+ * TODO: Move these tests to appropriate classes once the
+ *  compact serialization is promoted to the stable status.
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -384,7 +387,6 @@ public class CompactSerializationConfigConfigBuilderTest extends HazelcastTestSu
         EmployeeDTO deserializedObject = serializationService.toObject(data);
         assertEquals(object, deserializedObject);
     }
-
 
     private ClientConfig buildXmlClientConfig(String xml) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());

--- a/hazelcast/src/test/java/com/hazelcast/config/CompactSerializationConfigConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CompactSerializationConfigConfigBuilderTest.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.config.YamlClientConfigBuilder;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.compact.CompactTestUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import example.serialization.EmployeeDTO;
+import example.serialization.ExternalizableEmployeeDTO;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+
+import static com.hazelcast.config.ConfigRecognizerTest.HAZELCAST_CLIENT_END_TAG;
+import static com.hazelcast.config.ConfigRecognizerTest.HAZELCAST_CLIENT_START_TAG;
+import static com.hazelcast.config.ConfigRecognizerTest.HAZELCAST_END_TAG;
+import static com.hazelcast.config.ConfigRecognizerTest.HAZELCAST_START_TAG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that we are able to parse and use the declarative
+ * configuration for the CompactSerializationConfig. Since this
+ * feature is in BETA, there is no XSD definition. That's why,
+ * to parse declarative configuration for it, we have to disable
+ * schema validation. The tests should be run serially to not
+ * interfere with the other tests, as the schema validation
+ * is disabled through a system property.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CompactSerializationConfigConfigBuilderTest extends HazelcastTestSupport {
+
+    @Rule
+    public OverridePropertyRule disableSchemaValidationRule
+            = OverridePropertyRule.set("hazelcast.config.schema.validation.enabled", "false");
+
+    @Test
+    public void testCompactSerializationEnabledWithXmlClientConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\" />\n"
+                + "    </serialization>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        ClientConfig clientConfig = buildXmlClientConfig(xml);
+        assertTrue(clientConfig.getSerializationConfig().getCompactSerializationConfig().isEnabled());
+    }
+
+    @Test
+    public void testCompactSerializationEnabledWithXmlConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\" />\n"
+                + "    </serialization>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildXmlConfig(xml);
+        assertTrue(config.getSerializationConfig().getCompactSerializationConfig().isEnabled());
+    }
+
+    @Test
+    public void testCompactSerializationEnabledWithYamlClientConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n";
+
+        ClientConfig clientConfig = buildYamlClientConfig(yaml);
+        assertTrue(clientConfig.getSerializationConfig().getCompactSerializationConfig().isEnabled());
+    }
+
+    @Test
+    public void testCompactSerializationEnabledWithYamlConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n";
+
+        Config config = buildYamlConfig(yaml);
+        assertTrue(config.getSerializationConfig().getCompactSerializationConfig().isEnabled());
+    }
+
+    @Test
+    public void testRegisterClassWithExplicitSerializerWithXmlClientConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class type-name=\"obj\" serializer=\"example.serialization.EmployeeDTOSerializer\">"
+                + "                    example.serialization.EmployeeDTO\n"
+                + "                </class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        ClientConfig clientConfig = buildXmlClientConfig(xml);
+        verifyExplicitSerializerIsUsed(clientConfig.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithExplicitSerializerWithXmlConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class type-name=\"obj\" serializer=\"example.serialization.EmployeeDTOSerializer\">"
+                + "                    example.serialization.EmployeeDTO\n"
+                + "                </class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildXmlConfig(xml);
+        verifyExplicitSerializerIsUsed(config.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithExplicitSerializerWithYamlClientConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.EmployeeDTO\n"
+                + "                  type-name: obj\n"
+                + "                  serializer: example.serialization.EmployeeDTOSerializer\n";
+
+        ClientConfig clientConfig = buildYamlClientConfig(yaml);
+        verifyExplicitSerializerIsUsed(clientConfig.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithExplicitSerializerWithYamlConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.EmployeeDTO\n"
+                + "                  type-name: obj\n"
+                + "                  serializer: example.serialization.EmployeeDTOSerializer\n";
+
+        Config config = buildYamlConfig(yaml);
+        verifyExplicitSerializerIsUsed(config.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithReflectiveSerializerWithXmlClientConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class>example.serialization.ExternalizableEmployeeDTO</class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        ClientConfig clientConfig = buildXmlClientConfig(xml);
+        verifyReflectiveSerializerIsUsed(clientConfig.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithReflectiveSerializerWithXmlConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class>example.serialization.ExternalizableEmployeeDTO</class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildXmlConfig(xml);
+        verifyReflectiveSerializerIsUsed(config.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithReflectiveSerializerWithYamlClientConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.ExternalizableEmployeeDTO\n";
+
+        ClientConfig clientConfig = buildYamlClientConfig(yaml);
+        verifyReflectiveSerializerIsUsed(clientConfig.getSerializationConfig());
+    }
+
+    @Test
+    public void testRegisterClassWithReflectiveSerializerWithYamlConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.ExternalizableEmployeeDTO\n";
+
+        Config config = buildYamlConfig(yaml);
+        verifyReflectiveSerializerIsUsed(config.getSerializationConfig());
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustTypeNameWithXmlClientConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class type-name=\"employee\">example.serialization.EmployeeDTO</class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        buildXmlClientConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustTypeNameWithXmlConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class type-name=\"employee\">example.serialization.EmployeeDTO</class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_END_TAG;
+
+        buildXmlConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustTypeNameWithYamlClientConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.EmployeeDTO\n"
+                + "                  type-name: employee\n";
+
+        buildYamlClientConfig(yaml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustTypeNameWithYamlConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.EmployeeDTO\n"
+                + "                  type-name: employee\n";
+
+        buildYamlConfig(yaml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustSerializerNameWithXmlClientConfig() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class serializer=\"example.serialization.EmployeeDTOSerializer\">\n"
+                + "                    example.serialization.EmployeeDTO\n"
+                + "                </class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        buildXmlClientConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustSerializerNameWithXmlConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <serialization>\n"
+                + "        <compact-serialization enabled=\"true\">\n"
+                + "            <registered-classes>\n"
+                + "                <class serializer=\"example.serialization.EmployeeDTOSerializer\">\n"
+                + "                    example.serialization.EmployeeDTO\n"
+                + "                </class>\n"
+                + "            </registered-classes>\n"
+                + "        </compact-serialization>\n"
+                + "    </serialization>\n"
+                + HAZELCAST_END_TAG;
+
+        buildXmlConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustSerializerNameWithYamlClientConfig() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.EmployeeDTO\n"
+                + "                  serializer: example.serialization.EmployeeDTOSerializer\n";
+
+        buildYamlClientConfig(yaml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testRegisterClassWithJustSerializerNameWithYamlConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "    serialization:\n"
+                + "        compact-serialization:\n"
+                + "            enabled: true\n"
+                + "            registered-classes:\n"
+                + "                - class: example.serialization.EmployeeDTO\n"
+                + "                  serializer: example.serialization.EmployeeDTOSerializer\n";
+
+        buildYamlConfig(yaml);
+    }
+
+    private void verifyReflectiveSerializerIsUsed(SerializationConfig serializationConfig) {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder()
+                .setSchemaService(CompactTestUtil.createInMemorySchemaService())
+                .setConfig(serializationConfig)
+                .build();
+
+        ExternalizableEmployeeDTO object = new ExternalizableEmployeeDTO();
+        Data data = serializationService.toData(object);
+        assertFalse(object.usedExternalizableSerialization());
+
+        ExternalizableEmployeeDTO deserializedObject = serializationService.toObject(data);
+        assertFalse(deserializedObject.usedExternalizableSerialization());
+    }
+
+    private void verifyExplicitSerializerIsUsed(SerializationConfig serializationConfig) {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder()
+                .setSchemaService(CompactTestUtil.createInMemorySchemaService())
+                .setConfig(serializationConfig)
+                .build();
+
+        EmployeeDTO object = new EmployeeDTO(1, 1);
+        Data data = serializationService.toData(object);
+
+        EmployeeDTO deserializedObject = serializationService.toObject(data);
+        assertEquals(object, deserializedObject);
+    }
+
+
+    private ClientConfig buildXmlClientConfig(String xml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
+    private Config buildXmlConfig(String xml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
+    private ClientConfig buildYamlClientConfig(String yaml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        YamlClientConfigBuilder configBuilder = new YamlClientConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
+    private Config buildYamlConfig(String yaml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1555,7 +1555,8 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.isEnableSharedObject(), c2.isEnableSharedObject())
                     && nullSafeEqual(c1.isAllowUnsafe(), c2.isAllowUnsafe())
                     && nullSafeEqual(c1.isAllowOverrideDefaultSerializers(), c2.isAllowOverrideDefaultSerializers())
-                    && nullSafeEqual(c1.getJavaSerializationFilterConfig(), c2.getJavaSerializationFilterConfig());
+                    && nullSafeEqual(c1.getJavaSerializationFilterConfig(), c2.getJavaSerializationFilterConfig())
+                    && nullSafeEqual(c1.getCompactSerializationConfig(), c2.getCompactSerializationConfig());
         }
 
         private static boolean isCompatible(GlobalSerializerConfig c1, GlobalSerializerConfig c2) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -34,8 +34,10 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import example.serialization.BitsDTO;
 import example.serialization.EmployeeDTO;
+import example.serialization.EmployeeDTOSerializer;
 import example.serialization.EmployeeWithSerializerDTO;
 import example.serialization.EmployerDTO;
+import example.serialization.ExternalizableEmployeeDTO;
 import example.serialization.NodeDTO;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -250,20 +252,7 @@ public class CompactStreamSerializerTest {
     public void testWithExplicitSerializer() {
         SerializationConfig serializationConfig = new SerializationConfig();
         serializationConfig.getCompactSerializationConfig().setEnabled(true)
-                .register(EmployeeDTO.class, "employee",
-                        new CompactSerializer<EmployeeDTO>() {
-                            @Nonnull
-                            @Override
-                            public EmployeeDTO read(@Nonnull CompactReader in) {
-                                return new EmployeeDTO(in.readInt("a"), in.readLong("i"));
-                            }
-
-                            @Override
-                            public void write(@Nonnull CompactWriter out, @Nonnull EmployeeDTO object) {
-                                out.writeInt("a", object.getAge());
-                                out.writeLong("i", object.getId());
-                            }
-                        });
+                .register(EmployeeDTO.class, "employee", new EmployeeDTOSerializer());
 
         SerializationService serializationService = new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService).setConfig(serializationConfig).build();
@@ -341,19 +330,21 @@ public class CompactStreamSerializerTest {
     }
 
     @Test
-    public void testOverridenClassNameWithAlias() {
+    public void testOverridesJavaSerializationWhenRegisteredAsReflectivelySerializable() {
         SerializationConfig serializationConfig = new SerializationConfig();
         serializationConfig.getCompactSerializationConfig().setEnabled(true)
-                .register(EmployeeDTO.class, "employee");
+                .register(ExternalizableEmployeeDTO.class);
 
         SerializationService serializationService = new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService).setConfig(serializationConfig).build();
 
-        EmployeeDTO employeeDTO = new EmployeeDTO(30, 102310312);
+        ExternalizableEmployeeDTO employeeDTO = new ExternalizableEmployeeDTO(30, "John Doe");
         Data data = serializationService.toData(employeeDTO);
+        assertFalse(employeeDTO.usedExternalizableSerialization());
 
         Object object = serializationService.toObject(data);
-        EmployeeDTO actual = (EmployeeDTO) object;
+        ExternalizableEmployeeDTO actual = (ExternalizableEmployeeDTO) object;
+        assertFalse(employeeDTO.usedExternalizableSerialization());
 
         assertEquals(employeeDTO, actual);
     }
@@ -362,7 +353,7 @@ public class CompactStreamSerializerTest {
     public void testDeserializedToGenericRecordWhenClassNotFoundOnClassPath() {
         SerializationConfig serializationConfig = new SerializationConfig();
         serializationConfig.getCompactSerializationConfig().setEnabled(true)
-                .register(EmployeeDTO.class, "employee");
+                .register(EmployeeDTO.class, "employee", new EmployeeDTOSerializer());
 
         SerializationService serializationService = new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService)
@@ -482,7 +473,7 @@ public class CompactStreamSerializerTest {
         SerializationConfig serializationConfig = new SerializationConfig();
         //Using this registration to mimic schema evolution. This is usage is not advised.
         serializationConfig.getCompactSerializationConfig().setEnabled(true)
-                .register(EmployeeDTO.class, new CompactSerializer<EmployeeDTO>() {
+                .register(EmployeeDTO.class, "employee", new CompactSerializer<EmployeeDTO>() {
                     @Nonnull
                     @Override
                     public EmployeeDTO read(@Nonnull CompactReader in) throws IOException {
@@ -520,7 +511,7 @@ public class CompactStreamSerializerTest {
         SerializationConfig serializationConfig = new SerializationConfig();
         //Using this registration to mimic schema evolution. This is usage is not advised.
         serializationConfig.getCompactSerializationConfig().setEnabled(true)
-                .register(EmployeeDTO.class, new CompactSerializer<EmployeeDTO>() {
+                .register(EmployeeDTO.class, EmployeeDTO.class.getName(), new CompactSerializer<EmployeeDTO>() {
                     @Nonnull
                     @Override
                     public EmployeeDTO read(@Nonnull CompactReader in) throws IOException {

--- a/hazelcast/src/test/java/example/serialization/EmployeeDTOSerializer.java
+++ b/hazelcast/src/test/java/example/serialization/EmployeeDTOSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactSerializer;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+public class EmployeeDTOSerializer implements CompactSerializer<EmployeeDTO> {
+    @Nonnull
+    @Override
+    public EmployeeDTO read(@Nonnull CompactReader in) throws IOException {
+        return new EmployeeDTO(in.readInt("age"), in.readLong("id"));
+    }
+
+    @Override
+    public void write(@Nonnull CompactWriter out, @Nonnull EmployeeDTO object) throws IOException {
+        out.writeInt("age", object.getAge());
+        out.writeLong("id", object.getId());
+    }
+}

--- a/hazelcast/src/test/java/example/serialization/ExternalizableEmployeeDTO.java
+++ b/hazelcast/src/test/java/example/serialization/ExternalizableEmployeeDTO.java
@@ -66,6 +66,6 @@ public class ExternalizableEmployeeDTO implements Externalizable {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        usedExternalizableSerialization = false;
+        usedExternalizableSerialization = true;
     }
 }

--- a/hazelcast/src/test/java/example/serialization/ExternalizableEmployeeDTO.java
+++ b/hazelcast/src/test/java/example/serialization/ExternalizableEmployeeDTO.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Objects;
+
+public class ExternalizableEmployeeDTO implements Externalizable {
+
+    private int id;
+    private String name;
+
+    // This is set to true on writeExternal and readExternal methods.
+    private boolean usedExternalizableSerialization = false;
+
+    public ExternalizableEmployeeDTO() {
+    }
+
+    public ExternalizableEmployeeDTO(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public boolean usedExternalizableSerialization() {
+        return usedExternalizableSerialization;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExternalizableEmployeeDTO that = (ExternalizableEmployeeDTO) o;
+        return id == that.id && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        usedExternalizableSerialization = true;
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        usedExternalizableSerialization = false;
+    }
+}


### PR DESCRIPTION
This PR adds support for declarative configuration for the compact
serialization format.

For the XML configuration, the structure will look like

```xml
<serialization>
	<compact-serialization enabled="true">
		<registered-classes>
			<class>com.foo.Bar</class>
			<class type-name="baz" serializer="com.foo.BazSerializer">com.foo.Baz</class>
		</registered-classes>
	</compact-serialization>
</serialization>
```

For YAML, the structure is as follows

```yaml
serialization:
	compact-serialization:
		enabled: true
		registered-classes:
			- class: com.foo.Bar
			- class: com.foo.Baz
			  type-name: baz
			  serializer: com.foo.BazSerializer
```

After an internal discussion, we decided to remove support for
registering reflective serialization with a custom type name and
registering explicit serializer without a type name, and that
changes are reflected in the declarative configuration as well.

Since this is a BETA feature, I didn't make any changes to the
XSDs. That's why one has to disable schema validation to be
able to use declarative configuration. This limitation will be
documented in the reference manual.

