### PR TITLE
Create less garbage in TimedMemberStateFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -229,15 +229,15 @@ public class TimedMemberStateFactory {
         Config config = instance.getConfig();
         for (StatisticsAwareService service : services) {
             if (service instanceof MapService) {
-                handleMap(memberState, config, ((MapService) service).getStats());
+                handleMap(memberState, ((MapService) service).getStats());
             } else if (service instanceof MultiMapService) {
-                handleMultiMap(memberState, config, ((MultiMapService) service).getStats());
+                handleMultiMap(memberState, ((MultiMapService) service).getStats());
             } else if (service instanceof QueueService) {
-                handleQueue(memberState, config, ((QueueService) service).getStats());
+                handleQueue(memberState, ((QueueService) service).getStats());
             } else if (service instanceof TopicService) {
-                handleTopic(memberState, config, ((TopicService) service).getStats());
+                handleTopic(memberState, ((TopicService) service).getStats());
             } else if (service instanceof ReliableTopicService) {
-                handleReliableTopic(memberState, config, ((ReliableTopicService) service).getStats());
+                handleReliableTopic(memberState, ((ReliableTopicService) service).getStats());
             } else if (service instanceof DistributedExecutorService) {
                 handleExecutorService(memberState, config, ((DistributedExecutorService) service).getStats());
             } else if (service instanceof DistributedScheduledExecutorService) {
@@ -309,15 +309,9 @@ public class TimedMemberStateFactory {
         memberState.setDurableExecutorsWithStats(executorsWithStats);
     }
 
-    private void handleMultiMap(MemberStateImpl memberState, Config config,
+    private void handleMultiMap(MemberStateImpl memberState,
                                 Map<String, LocalMultiMapStats> multiMaps) {
-        Set<String> mapsWithStats = createHashSet(multiMaps.size());
-        for (String name : multiMaps.keySet()) {
-            if (config.findMultiMapConfig(name).isStatisticsEnabled()) {
-                mapsWithStats.add(name);
-            }
-        }
-        memberState.setMultiMapsWithStats(mapsWithStats);
+        memberState.setMultiMapsWithStats(multiMaps.keySet());
     }
 
     private void handleReplicatedMap(MemberStateImpl memberState, Config config,
@@ -342,45 +336,21 @@ public class TimedMemberStateFactory {
         memberState.setPNCountersWithStats(countersWithStats);
     }
 
-    private void handleReliableTopic(MemberStateImpl memberState, Config config,
+    private void handleReliableTopic(MemberStateImpl memberState,
                                      Map<String, LocalTopicStats> topics) {
-        Set<String> topicsWithStats = createHashSet(topics.size());
-        for (String name : topics.keySet()) {
-            if (config.findReliableTopicConfig(name).isStatisticsEnabled()) {
-                topicsWithStats.add(name);
-            }
-        }
-        memberState.setReliableTopicsWithStats(topicsWithStats);
+        memberState.setReliableTopicsWithStats(topics.keySet());
     }
 
-    private void handleTopic(MemberStateImpl memberState, Config config, Map<String, LocalTopicStats> topics) {
-        Set<String> topicsWithStats = createHashSet(topics.size());
-        for (String name : topics.keySet()) {
-            if (config.findTopicConfig(name).isStatisticsEnabled()) {
-                topicsWithStats.add(name);
-            }
-        }
-        memberState.setTopicsWithStats(topicsWithStats);
+    private void handleTopic(MemberStateImpl memberState, Map<String, LocalTopicStats> topics) {
+        memberState.setTopicsWithStats(topics.keySet());
     }
 
-    private void handleQueue(MemberStateImpl memberState, Config config, Map<String, LocalQueueStats> queues) {
-        Set<String> queuesWithStats = createHashSet(queues.size());
-        for (String name : queues.keySet()) {
-            if (config.findQueueConfig(name).isStatisticsEnabled()) {
-                queuesWithStats.add(name);
-            }
-        }
-        memberState.setQueuesWithStats(queuesWithStats);
+    private void handleQueue(MemberStateImpl memberState, Map<String, LocalQueueStats> queues) {
+        memberState.setQueuesWithStats(queues.keySet());
     }
 
-    private void handleMap(MemberStateImpl memberState, Config config, Map<String, LocalMapStats> maps) {
-        Set<String> mapsWithStats = createHashSet(maps.size());
-        for (String name : maps.keySet()) {
-            if (config.findMapConfig(name).isStatisticsEnabled()) {
-                mapsWithStats.add(name);
-            }
-        }
-        memberState.setMapsWithStats(mapsWithStats);
+    private void handleMap(MemberStateImpl memberState, Map<String, LocalMapStats> maps) {
+        memberState.setMapsWithStats(maps.keySet());
     }
 
     private void handleCache(MemberStateImpl memberState, CacheService cacheService) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -40,18 +40,20 @@ public enum MetricTarget {
     DIAGNOSTICS,
     JET_JOB;
 
-    public static final List<MetricTarget> ALL_TARGETS = unmodifiableList(asList(values()));
+    private static final MetricTarget[] VALUES = values();
+
+    public static final List<MetricTarget> ALL_TARGETS = unmodifiableList(asList(VALUES));
     public static final Collection<MetricTarget> NONE_OF = EnumSet.noneOf(MetricTarget.class);
     public static final Collection<MetricTarget> ALL_TARGETS_BUT_DIAGNOSTICS;
 
     static final Int2ObjectHashMap<Set<MetricTarget>> BITSET_TO_SET_CACHE = new Int2ObjectHashMap<>();
 
-    private static final int MASK_ALL_TARGETS = bitset(values());
+    private static final int MASK_ALL_TARGETS = bitset(VALUES);
 
     static {
         // building BITSET_TO_SET_CACHE using a recursive algorithm for generating all combinations
-        for (int i = 0; i <= values().length; i++) {
-            generateCombinations(new int[i], 0, values().length - 1, 0);
+        for (int i = 0; i <= VALUES.length; i++) {
+            generateCombinations(new int[i], 0, VALUES.length - 1, 0);
         }
 
         ALL_TARGETS_BUT_DIAGNOSTICS = asSetWithout(ALL_TARGETS, DIAGNOSTICS);
@@ -59,7 +61,7 @@ public enum MetricTarget {
 
     private static void generateCombinations(int[] ordinals, int start, int end, int index) {
         if (index == ordinals.length) {
-            MetricTarget[] allTargets = values();
+            MetricTarget[] allTargets = VALUES;
             MetricTarget[] combination = new MetricTarget[ordinals.length];
             for (int i = 0; i < ordinals.length; i++) {
                 combination[i] = allTargets[ordinals[i]];
@@ -76,8 +78,8 @@ public enum MetricTarget {
      * Returns set based on the given array of {@link MetricTarget}.
      * Set objects are returned from a preliminary warmed up cache, so this method has no memory overhead.
      *
-     * @param targets   input array
-     * @return          set containing all items from the input array
+     * @param targets input array
+     * @return set containing all items from the input array
      */
     public static Set<MetricTarget> asSet(MetricTarget... targets) {
         if (targets.length == 0) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -40,20 +40,18 @@ public enum MetricTarget {
     DIAGNOSTICS,
     JET_JOB;
 
-    private static final MetricTarget[] VALUES = values();
-
-    public static final List<MetricTarget> ALL_TARGETS = unmodifiableList(asList(VALUES));
+    public static final List<MetricTarget> ALL_TARGETS = unmodifiableList(asList(values()));
     public static final Collection<MetricTarget> NONE_OF = EnumSet.noneOf(MetricTarget.class);
     public static final Collection<MetricTarget> ALL_TARGETS_BUT_DIAGNOSTICS;
 
     static final Int2ObjectHashMap<Set<MetricTarget>> BITSET_TO_SET_CACHE = new Int2ObjectHashMap<>();
 
-    private static final int MASK_ALL_TARGETS = bitset(VALUES);
+    private static final int MASK_ALL_TARGETS = bitset(values());
 
     static {
         // building BITSET_TO_SET_CACHE using a recursive algorithm for generating all combinations
-        for (int i = 0; i <= VALUES.length; i++) {
-            generateCombinations(new int[i], 0, VALUES.length - 1, 0);
+        for (int i = 0; i <= values().length; i++) {
+            generateCombinations(new int[i], 0, values().length - 1, 0);
         }
 
         ALL_TARGETS_BUT_DIAGNOSTICS = asSetWithout(ALL_TARGETS, DIAGNOSTICS);
@@ -61,7 +59,7 @@ public enum MetricTarget {
 
     private static void generateCombinations(int[] ordinals, int start, int end, int index) {
         if (index == ordinals.length) {
-            MetricTarget[] allTargets = VALUES;
+            MetricTarget[] allTargets = values();
             MetricTarget[] combination = new MetricTarget[ordinals.length];
             for (int i = 0; i < ordinals.length; i++) {
                 combination[i] = allTargets[ordinals[i]];
@@ -78,8 +76,8 @@ public enum MetricTarget {
      * Returns set based on the given array of {@link MetricTarget}.
      * Set objects are returned from a preliminary warmed up cache, so this method has no memory overhead.
      *
-     * @param targets input array
-     * @return set containing all items from the input array
+     * @param targets   input array
+     * @return          set containing all items from the input array
      */
     public static Set<MetricTarget> asSet(MetricTarget... targets) {
         if (targets.length == 0) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/MetricsMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/MetricsMBean.java
@@ -117,6 +117,7 @@ public class MetricsMBean implements DynamicMBean {
     public enum Type {
         LONG("long"),
         DOUBLE("double");
+        private static final Type[] VALUES = values();
 
         private final String type;
 
@@ -125,7 +126,7 @@ public class MetricsMBean implements DynamicMBean {
         }
 
         static Type of(String strType) {
-            for (Type value : values()) {
+            for (Type value : VALUES) {
                 if (strType.equals(value.type)) {
                     return value;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/IterationType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/IterationType.java
@@ -34,6 +34,8 @@ public enum IterationType {
      */
     ENTRY((byte) 2);
 
+    private static final IterationType[] VALUES = values();
+
     private final byte id;
 
     IterationType(byte id) {
@@ -59,7 +61,7 @@ public enum IterationType {
      * @throws IllegalArgumentException if no IterationType was found
      */
     public static IterationType getById(byte id) {
-        for (IterationType type : values()) {
+        for (IterationType type : VALUES) {
             if (type.id == id) {
                 return type;
             }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/19242

There was a huge garbage created for only getting names of stats-enabled data-structures. For 100_000 maps, it was creating 100_000 read-only map-configs un-neededly.
Now, for appropriate ones, we only add returned set of names from related service.

