### PR TITLE
[5.0 FORWARD-PORT] Enable instance tracking by default for NLC builds

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigAccessor.java
@@ -41,4 +41,8 @@ public final class ConfigAccessor {
     public static ServicesConfig getServicesConfig(Config config) {
         return config.getServicesConfig();
     }
+
+    public static boolean isInstanceTrackingEnabledSet(Config config) {
+        return config.getInstanceTrackingConfig().isEnabledSet;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
@@ -57,11 +57,12 @@ public class InstanceTrackingConfig {
      */
     public static final String PLACEHOLDER_NAMESPACE = "HZ_INSTANCE_TRACKING";
 
+    boolean isEnabledSet;
+
     private boolean enabled = DEFAULT_ENABLED;
     private String fileName;
     private String formatPattern;
 
-    boolean isEnabledSet;
 
     public InstanceTrackingConfig() {
         super();

--- a/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.util.EmptyStatement;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -53,6 +57,16 @@ public class InstanceTrackingConfig {
 
     public InstanceTrackingConfig() {
         super();
+        try {
+            Class<?> helper = Class.forName("com.hazelcast.license.util.LicenseHelper");
+            Method getLicense = helper.getMethod("getBuiltInLicense");
+            // enabled for NLC build
+            enabled = getLicense.invoke(null) != null;
+        } catch (ClassNotFoundException | NoSuchMethodException
+                | IllegalAccessException | InvocationTargetException e) {
+            // running OS, instance tracking is disabled by default
+            EmptyStatement.ignore(e);
+        }
     }
 
     public InstanceTrackingConfig(InstanceTrackingConfig other) {

--- a/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
@@ -46,27 +46,25 @@ public class InstanceTrackingConfig {
     public static final Path DEFAULT_FILE = Paths.get(System.getProperty("java.io.tmpdir"), "Hazelcast.process");
 
     /**
+     * Default setting whether instance tracking should be enabled or not.
+     * It depends on whether the instance is an OEM/NLC build or not.
+     */
+    public static final boolean DEFAULT_ENABLED = isOEMBuild();
+
+    /**
      * Namespace for the placeholders in the file name and format pattern to
      * distinguish between different types of placeholders.
      */
     public static final String PLACEHOLDER_NAMESPACE = "HZ_INSTANCE_TRACKING";
 
-    private boolean enabled;
+    private boolean enabled = DEFAULT_ENABLED;
     private String fileName;
     private String formatPattern;
 
+    boolean isEnabledSet;
+
     public InstanceTrackingConfig() {
         super();
-        try {
-            Class<?> helper = Class.forName("com.hazelcast.license.util.LicenseHelper");
-            Method getLicense = helper.getMethod("getBuiltInLicense");
-            // enabled for NLC build
-            enabled = getLicense.invoke(null) != null;
-        } catch (ClassNotFoundException | NoSuchMethodException
-                | IllegalAccessException | InvocationTargetException e) {
-            // running OS, instance tracking is disabled by default
-            EmptyStatement.ignore(e);
-        }
     }
 
     public InstanceTrackingConfig(InstanceTrackingConfig other) {
@@ -90,6 +88,7 @@ public class InstanceTrackingConfig {
      */
     public InstanceTrackingConfig setEnabled(boolean enabled) {
         this.enabled = enabled;
+        this.isEnabledSet = true;
         return this;
     }
 
@@ -324,5 +323,22 @@ public class InstanceTrackingConfig {
         public String getModeName() {
             return modeName;
         }
+    }
+
+    /**
+     * Returns whether this build is an OEM/NLC build or not.
+     */
+    private static boolean isOEMBuild() {
+        try {
+            Class<?> helper = Class.forName("com.hazelcast.license.util.LicenseHelper");
+            Method getLicense = helper.getMethod("getBuiltInLicense");
+            // enabled for OEM/NLC build
+            return getLicense.invoke(null) != null;
+        } catch (ClassNotFoundException | NoSuchMethodException
+                | IllegalAccessException | InvocationTargetException e) {
+            // running OS, instance tracking is disabled by default
+            EmptyStatement.ignore(e);
+        }
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -48,6 +48,7 @@ import static com.hazelcast.internal.config.DomConfigHelper.childElements;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
 import static com.hazelcast.internal.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.internal.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmptyAfterTrim;
 import static com.hazelcast.internal.util.StringUtil.upperCaseInternal;
 
 /**
@@ -404,8 +405,10 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
 
     protected void handleInstanceTracking(Node node, InstanceTrackingConfig trackingConfig) {
         Node attrEnabled = getNamedItemNode(node, "enabled");
-        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
-        trackingConfig.setEnabled(enabled);
+        String textContent = getTextContent(attrEnabled);
+        if (!isNullOrEmptyAfterTrim(textContent)) {
+            trackingConfig.setEnabled(getBooleanValue(textContent));
+        }
 
         for (Node n : childElements(node)) {
             final String name = cleanNodeName(n);

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -477,10 +477,6 @@
         <collection-frequency-seconds>5</collection-frequency-seconds>
     </metrics>
 
-    <instance-tracking enabled="false">
-
-    </instance-tracking>
-
     <sql>
         <executor-pool-size>-1</executor-pool-size>
         <statement-timeout-millis>0</statement-timeout-millis>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -775,9 +775,6 @@ hazelcast:
     # 'hazelcast.metrics.collection.frequency' system property.
     collection-frequency-seconds: 5
 
-  instance-tracking:
-    enabled: false
-
   sql:
     # Sets the number of threads responsible for execution of SQL statements.
     # The default value -1 sets the pool size equal to the number of CPU cores,


### PR DESCRIPTION
Instance tracking should be on by default, but only for NLC builds. The
field is set to true by the constructor but we need to introduce
additional changes to prevent instance tracking of being disabled even
though the user didn't add any configuration:
- we need to remove instances tracking config from both XML and YAML
default config files
- we need to prevent setting the enabled field unless there is content
found for the "enabled" field. Otherwise, even an empty instance
tracking config could be parsed by YAML parser, and it would disable
instance tracking
- also, NLC builds don't have a default file name and it should be
explicitly set. Non-NLC builds use the default file name.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/4166
Forward-port of: https://github.com/hazelcast/hazelcast/pull/19250
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/4197