### PR TITLE
Remove listeners sync with the calling thread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
@@ -339,7 +339,7 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
                             + " has failed for address " + subscriber.getRemoteAddress(), throwable);
                 }
                 return null;
-            });
+            }).joinInternal();
         }
         return true;
     }


### PR DESCRIPTION
It turns out that there are some services relying on the removal
of a listener on the member when listener is removed from the client.
Example:
Cache listener count is kept per proxy. When listener is removed,
we decrease the listener count from the cache context.
Since listener removal is async, it could be the case that the cache
is destroyed from the calling thread before we decrement the value.
In such cases, we decrement but the incremented value is lost. Therefore,
we can end up with negative values.

The listener derregistration invoctions are not waited. It was
sync but we have changed the behavior as a side affect during
this fix https://github.com/hazelcast/hazelcast/pull/17646

We may solve this only for CacheListener but there could be more
services relying on sync listener removal. Therefore, as a fix,
we wait for invocation answer from the remote.

fixes https://github.com/hazelcast/hazelcast/issues/19269
