### PR TITLE
MC-577: sending cluster size to phonehome server as exact number

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/ClusterInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/ClusterInfoCollector.java
@@ -37,7 +37,7 @@ class ClusterInfoCollector implements MetricsCollector {
 
         metricsConsumer.accept(PhoneHomeMetrics.UUID_OF_CLUSTER, node.getThisUuid().toString());
         metricsConsumer.accept(PhoneHomeMetrics.CLUSTER_ID, clusterService.getClusterId().toString());
-        metricsConsumer.accept(PhoneHomeMetrics.CLUSTER_SIZE, MetricsCollector.convertToLetter(clusterSize));
+        metricsConsumer.accept(PhoneHomeMetrics.CLUSTER_SIZE, String.valueOf(clusterSize));
         metricsConsumer.accept(PhoneHomeMetrics.TIME_TAKEN_TO_CLUSTER_UP, Long.toString(clusterUpTime));
         metricsConsumer.accept(PhoneHomeMetrics.UPTIME_OF_RUNTIME_MXBEAN, Long.toString(rt.getUptime()));
         metricsConsumer.accept(PhoneHomeMetrics.RUNTIME_MXBEAN_VM_NAME, rt.getVmName());

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/ClusterInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/ClusterInfoCollector.java
@@ -37,7 +37,8 @@ class ClusterInfoCollector implements MetricsCollector {
 
         metricsConsumer.accept(PhoneHomeMetrics.UUID_OF_CLUSTER, node.getThisUuid().toString());
         metricsConsumer.accept(PhoneHomeMetrics.CLUSTER_ID, clusterService.getClusterId().toString());
-        metricsConsumer.accept(PhoneHomeMetrics.CLUSTER_SIZE, String.valueOf(clusterSize));
+        metricsConsumer.accept(PhoneHomeMetrics.CLUSTER_SIZE, MetricsCollector.convertToLetter(clusterSize));
+        metricsConsumer.accept(PhoneHomeMetrics.EXACT_CLUSTER_SIZE, String.valueOf(clusterSize));
         metricsConsumer.accept(PhoneHomeMetrics.TIME_TAKEN_TO_CLUSTER_UP, Long.toString(clusterUpTime));
         metricsConsumer.accept(PhoneHomeMetrics.UPTIME_OF_RUNTIME_MXBEAN, Long.toString(rt.getUptime()));
         metricsConsumer.accept(PhoneHomeMetrics.RUNTIME_MXBEAN_VM_NAME, rt.getVmName());

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -62,7 +62,13 @@ public enum PhoneHomeMetrics {
     //CLUSTER INFO METRICS
     UUID_OF_CLUSTER("m"),
     CLUSTER_ID("c"),
+    /**
+     * Maintained for backward-compatibility (in PhoneHome reports), but otherwise deprecated, please use
+     * {@link #EXACT_CLUSTER_SIZE} instead.
+     */
+    @Deprecated
     CLUSTER_SIZE("crsz"),
+    EXACT_CLUSTER_SIZE("ecrsz"),
     TIME_TAKEN_TO_CLUSTER_UP("cuptm"),
     UPTIME_OF_RUNTIME_MXBEAN("nuptm"),
     RUNTIME_MXBEAN_VM_NAME("jvmn"),

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -91,7 +91,7 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         assertNull(parameters.get("l"));
         assertNull(parameters.get("hdgb"));
         assertEquals(parameters.get(PhoneHomeMetrics.HAZELCAST_DOWNLOAD_ID.getRequestParameterName()), "source");
-        assertEquals(parameters.get(PhoneHomeMetrics.CLUSTER_SIZE.getRequestParameterName()), "A");
+        assertEquals(parameters.get(PhoneHomeMetrics.CLUSTER_SIZE.getRequestParameterName()), "1");
         assertEquals(parameters.get(PhoneHomeMetrics.CLIENT_ENDPOINT_COUNT.getRequestParameterName()), "A");
 
         assertEquals(parameters.get(PhoneHomeMetrics.ACTIVE_CPP_CLIENTS_COUNT.getRequestParameterName()), "0");

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -91,7 +91,8 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         assertNull(parameters.get("l"));
         assertNull(parameters.get("hdgb"));
         assertEquals(parameters.get(PhoneHomeMetrics.HAZELCAST_DOWNLOAD_ID.getRequestParameterName()), "source");
-        assertEquals(parameters.get(PhoneHomeMetrics.CLUSTER_SIZE.getRequestParameterName()), "1");
+        assertEquals(parameters.get(PhoneHomeMetrics.CLUSTER_SIZE.getRequestParameterName()), "A");
+        assertEquals(parameters.get(PhoneHomeMetrics.EXACT_CLUSTER_SIZE.getRequestParameterName()), "1");
         assertEquals(parameters.get(PhoneHomeMetrics.CLIENT_ENDPOINT_COUNT.getRequestParameterName()), "A");
 
         assertEquals(parameters.get(PhoneHomeMetrics.ACTIVE_CPP_CLIENTS_COUNT.getRequestParameterName()), "0");


### PR DESCRIPTION
Reporting the cluster size as an integer instead of a letter-encoded range value.

Fixes [MC-577](https://hazelcast.atlassian.net/browse/MC-577)
