### PR TITLE
Cache byte array used to calculate partition stamps

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -39,7 +39,6 @@ public final class NearCacheConfigAccessor {
             return nearCacheConfig;
         }
 
-
         // create copy of eviction config
         EvictionConfig copyEvictionConfig = new EvictionConfig(evictionConfig)
                 .setSize(MapConfig.DEFAULT_MAX_SIZE);

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -39,6 +39,7 @@ public final class NearCacheConfigAccessor {
             return nearCacheConfig;
         }
 
+
         // create copy of eviction config
         EvictionConfig copyEvictionConfig = new EvictionConfig(evictionConfig)
                 .setSize(MapConfig.DEFAULT_MAX_SIZE);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStamp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStamp.java
@@ -24,6 +24,8 @@ import com.hazelcast.internal.util.HashUtil;
  */
 public final class PartitionStamp {
 
+    private static ThreadLocal<byte[]> BYTE_ARRAY = new ThreadLocal<>();
+
     private PartitionStamp() {
     }
 
@@ -36,7 +38,12 @@ public final class PartitionStamp {
      * @return stamp value
      */
     public static long calculateStamp(InternalPartition[] partitions) {
-        byte[] bb = new byte[Integer.BYTES * partitions.length];
+        byte[] bb = BYTE_ARRAY.get();
+        if (bb == null) {
+            bb = new byte[Integer.BYTES * partitions.length];
+            BYTE_ARRAY.set(bb);
+        }
+
         for (InternalPartition partition : partitions) {
             Bits.writeIntB(bb, partition.getPartitionId() * Integer.BYTES, partition.version());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1487,9 +1487,7 @@ public class MigrationManager {
             }
         }
 
-        /**
-         * Waits for some time and rerun the {@link ControlTask}.
-         */
+        /** Waits for some time and rerun the {@link ControlTask}. */
         private void triggerRepartitioningAfterMigrationFailure() {
             // Migration failed.
             // Pause migration process for a small amount of time, if a migration attempt is failed.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1087,8 +1087,8 @@ public class MigrationManager {
          * Set of currently migrating partition IDs.
          * It's illegal to have concurrent migrations on the same partition.
          */
-        private final IntHashSet migratingPartitions
-                = new IntHashSet(partitionService.getPartitionCount(), -1);
+        private final IntHashSet migratingPartitions;
+
         /**
          * Map of endpoint -> migration-count.
          * Only {@link #maxParallelMigrations} number of migrations are allowed on a single member.
@@ -1101,6 +1101,8 @@ public class MigrationManager {
         MigrationPlanTask(List<Queue<MigrationInfo>> migrationQs) {
             this.migrationQs = migrationQs;
             this.completed = new ArrayBlockingQueue<>(migrationQs.size());
+            this.migratingPartitions
+                    = new IntHashSet(migrationQs.stream().mapToInt(Collection::size).sum(), -1);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -49,6 +49,7 @@ import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.Timer;
 import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
+import com.hazelcast.internal.util.collection.IntHashSet;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.internal.util.scheduler.CoalescingDelayedTrigger;
 import com.hazelcast.logging.ILogger;
@@ -1086,7 +1087,8 @@ public class MigrationManager {
          * Set of currently migrating partition IDs.
          * It's illegal to have concurrent migrations on the same partition.
          */
-        private final Set<Integer> migratingPartitions = new HashSet<>();
+        private final IntHashSet migratingPartitions
+                = new IntHashSet(partitionService.getPartitionCount(), -1);
         /**
          * Map of endpoint -> migration-count.
          * Only {@link #maxParallelMigrations} number of migrations are allowed on a single member.
@@ -1485,7 +1487,9 @@ public class MigrationManager {
             }
         }
 
-        /** Waits for some time and rerun the {@link ControlTask}. */
+        /**
+         * Waits for some time and rerun the {@link ControlTask}.
+         */
         private void triggerRepartitioningAfterMigrationFailure() {
             // Migration failed.
             // Pause migration process for a small amount of time, if a migration attempt is failed.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -84,6 +84,11 @@ public class PartitionStateManager implements ClusterVersionListener {
     private final PartitionStateGenerator partitionStateGenerator;
     private final MemberGroupFactory memberGroupFactory;
 
+    // we keep a cached buffer because stamp calculation can happen many times
+    // during repartitioning and this introduces GC pressure, especially at high
+    // partition counts
+    private final byte[] stampCalculationBuffer;
+
     // updates will be done under lock, but reads will be multithreaded.
     // set to true when the partitions are assigned for the first time. remains true until partition service has been reset.
     private volatile boolean initialized;
@@ -103,6 +108,7 @@ public class PartitionStateManager implements ClusterVersionListener {
         this.partitionService = partitionService;
         this.partitionCount = partitionService.getPartitionCount();
         this.partitions = new InternalPartitionImpl[partitionCount];
+        this.stampCalculationBuffer = new byte[partitionCount * Integer.BYTES];
 
         PartitionReplicaInterceptor interceptor = new DefaultPartitionReplicaInterceptor(partitionService);
         PartitionReplica localReplica = PartitionReplica.from(node.getLocalMember());
@@ -381,7 +387,7 @@ public class PartitionStateManager implements ClusterVersionListener {
     }
 
     public void updateStamp() {
-        stateStamp = calculateStamp(partitions);
+        stateStamp = calculateStamp(partitions, () -> stampCalculationBuffer);
         if (logger.isFinestEnabled()) {
             logger.finest("New calculated partition state stamp is: " + stateStamp);
         }


### PR DESCRIPTION
During repartitioning, the `PartitionStamp#calculateStamp` method may be called many times and each invocation creates a byte array buffer with enough size to contain `partitionCount` integers. 

And to give you an idea of how many times the method may be called, @blazember ran `WanCounterMigrationTest#testCountersReachZeroAfterMigrateToNewAndBack` and set partition count to 2053, this is how many times it was called from three different methods:
```shell
$ grep -cF "CALLER com.hazelcast.internal.partition.impl.PartitionStateManager.updateStamp" intellij.log 
16428
$ grep -cF "CALLER com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl.createPartitionStateInternal" intellij.log 
13
$ grep -cF "CALLER com.hazelcast.internal.partition.PartitionTableView.stamp" intellij.log 
16
```

As he says:
> if my calculation is right, with ~7k partitions a migration allocated ~436MB only in this method
> with 2053 partitions it's ~38MB

That places considerable GC pressure. We will then create a dedicated buffer in `PartitionStateManager` and reuse it every time we need to calculate the stamp, this way avoiding most of the allocations.