### PR TITLE
Fix the stats collection of multimap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
@@ -18,9 +18,11 @@ package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.util.Timer;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
@@ -36,6 +38,7 @@ public class PutOperation extends AbstractBackupAwareMultiMapOperation implement
     private Data value;
     private int index = -1;
     private long recordId;
+    private transient long startTimeNanos;
 
     public PutOperation() {
     }
@@ -44,6 +47,13 @@ public class PutOperation extends AbstractBackupAwareMultiMapOperation implement
         super(name, dataKey, threadId);
         this.value = value;
         this.index = index;
+    }
+
+    @Override
+    public void beforeRun() {
+        if (getOrCreateContainer().getConfig().isStatisticsEnabled()) {
+            startTimeNanos = Timer.nanos();
+        }
     }
 
     @Override
@@ -67,8 +77,13 @@ public class PutOperation extends AbstractBackupAwareMultiMapOperation implement
     @Override
     public void afterRun() throws Exception {
         if (Boolean.TRUE.equals(response)) {
-            getOrCreateContainer().update();
+            MultiMapContainer container = getOrCreateContainer();
+            container.update();
             publishEvent(EntryEventType.ADDED, dataKey, value, null);
+            if (container.getConfig().isStatisticsEnabled()) {
+                ((MultiMapService) getService()).getLocalMultiMapStatsImpl(name)
+                        .incrementPutLatencyNanos(Timer.nanosElapsed(startTimeNanos));
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -18,9 +18,11 @@ package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.util.Timer;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -34,6 +36,7 @@ import java.util.Collection;
 public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implements MutatingOperation {
 
     private Data value;
+    private transient long startTimeNanos;
 
     public RemoveOperation() {
     }
@@ -41,6 +44,13 @@ public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implem
     public RemoveOperation(String name, Data dataKey, long threadId, Data value) {
         super(name, dataKey, threadId);
         this.value = value;
+    }
+
+    @Override
+    public void beforeRun() {
+        if (getOrCreateContainer().getConfig().isStatisticsEnabled()) {
+            startTimeNanos = Timer.nanos();
+        }
     }
 
     @Override
@@ -63,8 +73,13 @@ public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implem
     @Override
     public void afterRun() throws Exception {
         if (Boolean.TRUE.equals(response)) {
-            getOrCreateContainer().update();
+            MultiMapContainer container = getOrCreateContainer();
+            container.update();
             publishEvent(EntryEventType.REMOVED, dataKey, null, value);
+            if (container.getConfig().isStatisticsEnabled()) {
+                ((MultiMapService) getService()).getLocalMultiMapStatsImpl(name)
+                        .incrementRemoveLatencyNanos(Timer.nanosElapsed(startTimeNanos));
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/multimap/ClientMultiMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/multimap/ClientMultiMapStatsTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -103,25 +102,21 @@ public class ClientMultiMapStatsTest extends LocalMultiMapStatsTest {
 
     @Override
     @Test
-    @Ignore("GH issue 15307")
     public void testDelete() {
     }
 
     @Override
     @Test
-    @Ignore("GH issue 15307")
     public void testGetAndHitsGenerated() {
     }
 
     @Override
     @Test
-    @Ignore("GH issue 15307")
     public void testPutAndHitsGenerated() {
     }
 
     @Override
     @Test
-    @Ignore("GH issue 15307")
     public void testRemove() {
     }
 }


### PR DESCRIPTION
This work in this PR is still WIP. 

When MultiMap operations are called from the client-side, these calls
don't reflect on the stats of MultiMap. This PR aims to fix these
issues.

Fixes #19282

Forward-port (backport) of: #NNNN (link to PR which is the basis for this PR, if applicable)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
