### PR TITLE
[4.2.z FORWARD-PORT] Cache byte array used to calculate partition stamps

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStamp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStamp.java
@@ -19,6 +19,9 @@ package com.hazelcast.internal.partition;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.util.HashUtil;
 
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
 /**
  * PartitionStamp is a utility class to generate stamp for the partition table.
  */
@@ -35,8 +38,28 @@ public final class PartitionStamp {
      * @param partitions partition table
      * @return stamp value
      */
-    public static long calculateStamp(InternalPartition[] partitions) {
-        byte[] bb = new byte[Integer.BYTES * partitions.length];
+    public static long calculateStamp(@Nonnull InternalPartition[] partitions) {
+        return calculateStamp(partitions, () -> new byte[Integer.BYTES * partitions.length]);
+    }
+
+
+    /**
+     * Calculates 64-bit stamp value for the given partitions.
+     * Stamp is calculated by hashing the individual partition versions
+     * using MurmurHash3.
+     *
+     * @param partitions     partition table
+     * @param bufferSupplier supplier for the buffer to use when calculating the stamp. The buffer
+     *                       returned from this supplier should have a size equal to
+     *                       {@code partitions.length} ints.
+     * @return stamp value
+     */
+    public static long calculateStamp(@Nonnull InternalPartition[] partitions,
+                                      @Nonnull Supplier<byte[]> bufferSupplier) {
+        byte[] bb = bufferSupplier.get();
+        assert bb.length == Integer.BYTES * partitions.length
+                : "The supplied buffer should have a size of partitions.length bytes";
+
         for (InternalPartition partition : partitions) {
             Bits.writeIntB(bb, partition.getPartitionId() * Integer.BYTES, partition.version());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -49,6 +49,7 @@ import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.Timer;
 import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
+import com.hazelcast.internal.util.collection.IntHashSet;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.internal.util.scheduler.CoalescingDelayedTrigger;
 import com.hazelcast.logging.ILogger;
@@ -1081,7 +1082,8 @@ public class MigrationManager {
          * Set of currently migrating partition IDs.
          * It's illegal to have concurrent migrations on the same partition.
          */
-        private final Set<Integer> migratingPartitions = new HashSet<>();
+        private final IntHashSet migratingPartitions;
+
         /**
          * Map of endpoint -> migration-count.
          * Only {@link #maxParallelMigrations} number of migrations are allowed on a single member.
@@ -1094,6 +1096,8 @@ public class MigrationManager {
         MigrationPlanTask(List<Queue<MigrationInfo>> migrationQs) {
             this.migrationQs = migrationQs;
             this.completed = new ArrayBlockingQueue<>(migrationQs.size());
+            this.migratingPartitions
+                    = new IntHashSet(migrationQs.stream().mapToInt(Collection::size).sum(), -1);
         }
 
         @Override


### PR DESCRIPTION
During repartitioning, the PartitionStamp#calculateStamp method may be
called many times and each invocation creates a byte array buffer with
enough size to contain partitionCount integers.

By running `WanCounterMigrationTest#testCountersReachZeroAfterMigrateToNewAndBack`
and setting the partition count to 2053, this is how many times it was
called from three different methods:
- com.hazelcast.internal.partition.impl.PartitionStateManager.updateStamp
16428
- com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl.createPartitionStateInternal
13
- com.hazelcast.internal.partition.PartitionTableView.stamp
16

As Zoltan says- if my calculation is right, with ~7k partitions a
migration allocated ~436MB only in this method with 2053 partitions it's
 ~38MB

That places considerable GC pressure. We will then create a dedicated
buffer in PartitionStateManager and reuse it every time we need to
calculate the stamp, this way avoiding most of the allocations.

We also use a IntHashSet in MigrationManager to consume less space.

Forward-port of: https://github.com/hazelcast/hazelcast/pull/19295