### PR TITLE
[5.0 FORWARD-PORT] Cache byte array used to calculate partition stamps

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -50,6 +50,7 @@ import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.Timer;
 import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
+import com.hazelcast.internal.util.collection.IntHashSet;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.internal.util.scheduler.CoalescingDelayedTrigger;
 import com.hazelcast.logging.ILogger;
@@ -1151,7 +1152,8 @@ public class MigrationManager {
          * Set of currently migrating partition IDs.
          * It's illegal to have concurrent migrations on the same partition.
          */
-        private final Set<Integer> migratingPartitions = new HashSet<>();
+        private final IntHashSet migratingPartitions;
+
         /**
          * Map of endpoint -> migration-count.
          * Only {@link #maxParallelMigrations} number of migrations are allowed on a single member.
@@ -1164,6 +1166,8 @@ public class MigrationManager {
         MigrationPlanTask(List<Queue<MigrationInfo>> migrationQs) {
             this.migrationQs = migrationQs;
             this.completed = new ArrayBlockingQueue<>(migrationQs.size());
+            this.migratingPartitions
+                    = new IntHashSet(migrationQs.stream().mapToInt(Collection::size).sum(), -1);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -81,6 +81,11 @@ public class PartitionStateManager {
     // before partition rebalancing
     private final ConcurrentMap<UUID, PartitionTableView> snapshotOnRemove;
 
+    // we keep a cached buffer because stamp calculation can happen many times
+    // during repartitioning and this introduces GC pressure, especially at high
+    // partition counts
+    private final byte[] stampCalculationBuffer;
+
     // updates will be done under lock, but reads will be multithreaded.
     // set to true when the partitions are assigned for the first time. remains true until partition service has been reset.
     private volatile boolean initialized;
@@ -100,6 +105,7 @@ public class PartitionStateManager {
         this.partitionService = partitionService;
         this.partitionCount = partitionService.getPartitionCount();
         this.partitions = new InternalPartitionImpl[partitionCount];
+        this.stampCalculationBuffer = new byte[partitionCount * Integer.BYTES];
 
         PartitionReplicaInterceptor interceptor = new DefaultPartitionReplicaInterceptor(partitionService);
         PartitionReplica localReplica = PartitionReplica.from(node.getLocalMember());
@@ -377,7 +383,7 @@ public class PartitionStateManager {
     }
 
     public void updateStamp() {
-        stateStamp = calculateStamp(partitions);
+        stateStamp = calculateStamp(partitions, () -> stampCalculationBuffer);
         if (logger.isFinestEnabled()) {
             logger.finest("New calculated partition state stamp is: " + stateStamp);
         }


### PR DESCRIPTION
During repartitioning, the PartitionStamp#calculateStamp method may be
called many times and each invocation creates a byte array buffer with
enough size to contain partitionCount integers.

By running `WanCounterMigrationTest#testCountersReachZeroAfterMigrateToNewAndBack`
and setting the partition count to 2053, this is how many times it was
called from three different methods:
- com.hazelcast.internal.partition.impl.PartitionStateManager.updateStamp
16428
- com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl.createPartitionStateInternal
13
- com.hazelcast.internal.partition.PartitionTableView.stamp
16

As Zoltan says- if my calculation is right, with ~7k partitions a
migration allocated ~436MB only in this method with 2053 partitions it's
 ~38MB

That places considerable GC pressure. We will then create a dedicated
buffer in PartitionStateManager and reuse it every time we need to
calculate the stamp, this way avoiding most of the allocations.

We also use a IntHashSet in MigrationManager to consume less space.

Forward-port of: https://github.com/hazelcast/hazelcast/pull/19295