### PR TITLE
Store snapshots for all members removed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -75,11 +75,11 @@ public interface InternalPartitionService extends IPartitionService, ManagedServ
     void memberAdded(Member member);
 
     /**
-     * Called when a member is removed from the cluster.
-     * Executes maintenance tasks, removes the member from partition table and triggers promotions.
-     * @param member removed member
+     * Called when some members are removed from the cluster.
+     * Executes maintenance tasks, removes the members from the partition table and triggers promotions.
+     * @param members removed members
      */
-    void memberRemoved(Member member);
+    void memberRemoved(Member... members);
 
     InternalPartition[] getInternalPartitions();
 


### PR DESCRIPTION
Before 5.0 persistence improvements when `autoRemoveStaleData = true`, a node would rejoin the cluster through force start skipping validation phase. Currently members are allowed to rejoin the `ACTIVE` cluster, and the failure is due to one member doing force start (because partition assignments table snapshot was not stored for it during its leave), but another doing smooth rejoin, which during validation phase detects a new member in the cluster with unknown UUID, and thus fails to start. 

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4216