### PR TITLE
Check cluster name of connecting client when security is enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -127,6 +127,11 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
     }
 
     private AuthenticationStatus authenticate(SecurityContext securityContext) {
+        String nodeClusterName = nodeEngine.getConfig().getClusterName();
+        if (! nodeClusterName.equals(clusterName)) {
+            return CREDENTIALS_FAILED;
+        }
+
         Connection connection = endpoint.getConnection();
         Boolean passed = Boolean.FALSE;
         try {


### PR DESCRIPTION
Fixes hazelcast/hazelcast-enterprise#4214