### PR TITLE
[CN-164] Add explicit configuration for Kubernetes Expose Externally configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -59,8 +59,8 @@ final class HazelcastKubernetesDiscoveryStrategy
 
     private static KubernetesClient buildKubernetesClient(KubernetesConfig config) {
         return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getKubernetesApiToken(),
-                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.isUseNodeNameAsExternalAddress(),
-                config.getServicePerPodLabelName(), config.getServicePerPodLabelValue());
+                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.getExposeExternallyMode(),
+                config.isUseNodeNameAsExternalAddress(), config.getServicePerPodLabelName(), config.getServicePerPodLabelValue());
     }
 
     public void start() {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -51,6 +51,7 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
                 KubernetesProperties.POD_LABEL_VALUE,
                 KubernetesProperties.RESOLVE_NOT_READY_ADDRESSES,
                 KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS,
+                KubernetesProperties.EXPOSE_EXTERNALLY,
                 KubernetesProperties.SERVICE_PER_POD_LABEL_NAME,
                 KubernetesProperties.SERVICE_PER_POD_LABEL_VALUE,
                 KubernetesProperties.KUBERNETES_API_RETIRES,

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -427,7 +427,8 @@ class KubernetesClient {
         }
         if (!left.isEmpty()) {
             // At least one Hazelcast Member POD does not have a corresponding service.
-            throw new KubernetesClientException(String.format("Cannot fetch services dedicated to the following PODs: %s", left));
+            throw new KubernetesClientException(String.format("Cannot expose externally, the following Hazelcast"
+                    + " member pods do not have corresponding Kubernetes services: %s", left));
         }
         return result;
     }
@@ -458,7 +459,8 @@ class KubernetesClient {
         }
         if (!left.isEmpty()) {
             // At least one Hazelcast Member POD does not have 'nodeName' assigned.
-            throw new KubernetesClientException(String.format("Cannot fetch nodeName from the following PODs: %s", left));
+            throw new KubernetesClientException(String.format("Cannot expose externally, the following Hazelcast"
+                    + " member pods do not have corresponding Endpoint.nodeName value assigned: %s", left));
         }
         return result;
     }
@@ -491,7 +493,8 @@ class KubernetesClient {
         JsonArray ports = toJsonArray(serviceJson.get("spec").asObject().get("ports"));
         // Service must have one and only one Node Port assigned.
         if (ports.size() != 1) {
-            throw new KubernetesClientException("Cannot fetch nodePort from the service");
+            throw new KubernetesClientException(String.format("Cannot expose externally, service %s needs to have "
+                    + "exactly one port defined", serviceJson.get("metadata").asObject().get("name")));
         }
         return ports.get(0).asObject().get("port").asInt();
     }
@@ -500,7 +503,8 @@ class KubernetesClient {
         JsonArray ports = toJsonArray(serviceJson.get("spec").asObject().get("ports"));
         // Service must have one and only one Node Port assigned.
         if (ports.size() != 1) {
-            throw new KubernetesClientException("Cannot fetch nodePort from the service");
+            throw new KubernetesClientException(String.format("Cannot expose externally, service %s needs to have "
+                    + "exactly one nodePort defined", serviceJson.get("metadata").asObject().get("name")));
         }
         return ports.get(0).asObject().get("nodePort").asInt();
     }
@@ -523,7 +527,8 @@ class KubernetesClient {
                 return address.asObject().get("address").asString();
             }
         }
-        throw new KubernetesClientException("Node does not have ExternalIP assigned");
+        throw new KubernetesClientException(String.format("Cannot expose externally, node %s does not have ExternalIP"
+                + " assigned", nodeJson.get("metadata").asObject().get("name")));
     }
 
     private static List<Endpoint> createEndpoints(List<Endpoint> endpoints, Map<EndpointAddress, String> publicIps,

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import static com.hazelcast.kubernetes.KubernetesProperties.EXPOSE_EXTERNALLY;
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_RETIRES;
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_TOKEN;
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_CA_CERTIFICATE;
@@ -69,6 +70,7 @@ final class KubernetesConfig {
     private final String podLabelName;
     private final String podLabelValue;
     private final boolean resolveNotReadyAddresses;
+    private final ExposeExternallyMode exposeExternallyMode;
     private final boolean useNodeNameAsExternalAddress;
     private final String servicePerPodLabelName;
     private final String servicePerPodLabelValue;
@@ -92,6 +94,7 @@ final class KubernetesConfig {
         this.resolveNotReadyAddresses = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, RESOLVE_NOT_READY_ADDRESSES, true);
         this.useNodeNameAsExternalAddress
                 = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, USE_NODE_NAME_AS_EXTERNAL_ADDRESS, false);
+        this.exposeExternallyMode = getExposeExternallyMode(properties);
         this.servicePerPodLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_PER_POD_LABEL_NAME);
         this.servicePerPodLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_PER_POD_LABEL_VALUE);
         this.kubernetesApiRetries
@@ -103,6 +106,17 @@ final class KubernetesConfig {
         this.namespace = getNamespaceWithFallbacks(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE);
 
         validateConfig();
+    }
+
+    private ExposeExternallyMode getExposeExternallyMode(Map<String, Comparable> properties) {
+        Boolean exposeExternally = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, EXPOSE_EXTERNALLY);
+        if (exposeExternally == null) {
+            return ExposeExternallyMode.AUTO;
+        } else if (exposeExternally) {
+            return ExposeExternallyMode.ENABLED;
+        } else {
+            return ExposeExternallyMode.DISABLED;
+        }
     }
 
     private String getNamespaceWithFallbacks(Map<String, Comparable> properties,
@@ -301,6 +315,10 @@ final class KubernetesConfig {
         return podLabelValue;
     }
 
+    public ExposeExternallyMode getExposeExternallyMode() {
+        return exposeExternallyMode;
+    }
+
     public String getServicePerPodLabelName() {
         return servicePerPodLabelName;
     }
@@ -350,6 +368,7 @@ final class KubernetesConfig {
                 + "pod-label: " + podLabelName + ", "
                 + "pod-label-value: " + podLabelValue + ", "
                 + "resolve-not-ready-addresses: " + resolveNotReadyAddresses + ", "
+                + "expose-externally-mode: " + exposeExternallyMode.name() + ", "
                 + "use-node-name-as-external-address: " + useNodeNameAsExternalAddress + ", "
                 + "service-per-pod-label: " + servicePerPodLabelName + ", "
                 + "service-per-pod-label-value: " + servicePerPodLabelValue + ", "
@@ -360,5 +379,11 @@ final class KubernetesConfig {
     enum DiscoveryMode {
         DNS_LOOKUP,
         KUBERNETES_API
+    }
+
+    enum ExposeExternallyMode {
+        AUTO,
+        ENABLED,
+        DISABLED
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -97,6 +97,15 @@ public final class KubernetesProperties {
     public static final PropertyDefinition POD_LABEL_VALUE = property("pod-label-value", STRING);
 
     /**
+     * <p>Configuration key: <code>expose-externally</code></p>
+     * Specifies if Hazelcast should try to find its public addresses exposed with a single service.
+     * If not set, Hazelcast tries to automatically find public addresses, but fails silently.
+     * If <code>true</code>false, Hazelcast crashes if it can't find its public address.
+     * If <code>false</code>, Hazelcast does not even try to find its public address.
+     */
+    public static final PropertyDefinition EXPOSE_EXTERNALLY = property("expose-externally", BOOLEAN);
+
+    /**
      * <p>Configuration key: <code>service-per-pod-label-name</code></p>
      * Defines the label name of the service used to expose one Hazelcast pod (for the external smart client use case).
      */

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.kubernetes;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.hazelcast.kubernetes.KubernetesClient.Endpoint;
+import com.hazelcast.kubernetes.KubernetesConfig.ExposeExternallyMode;
 import com.hazelcast.spi.exception.RestClientException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -918,7 +919,7 @@ public class KubernetesClientTest {
 
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress, String servicePerPodLabelName, String servicePerPodLabelValue) {
         String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
-        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, TOKEN, CA_CERTIFICATE, RETRIES, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue);
+        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, TOKEN, CA_CERTIFICATE, RETRIES, ExposeExternallyMode.AUTO, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue);
     }
 
     private static List<String> format(List<Endpoint> addresses) {

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -61,7 +61,7 @@ public class KubernetesClientTest {
 
     @Before
     public void setUp() {
-        kubernetesClient = newKubernetesClient(false);
+        kubernetesClient = newKubernetesClient();
         stubFor(get(urlMatching("/api/.*")).atPriority(5)
                 .willReturn(aResponse().withStatus(401).withBody("\"reason\":\"Forbidden\"")));
     }
@@ -634,6 +634,46 @@ public class KubernetesClientTest {
         assertThat(formatPublic(result), containsInAnyOrder(ready("node-name-1", 31916), ready("node-name-2", 31917)));
     }
 
+    @Test
+    public void endpointsIgnoreNoPublicAccess() {
+        // given
+        stub(String.format("/api/v1/namespaces/%s/pods", NAMESPACE), podsListResponse());
+        stub(String.format("/api/v1/namespaces/%s/endpoints", NAMESPACE), endpointsListResponse());
+
+        stub(String.format("/api/v1/namespaces/%s/services/service-0", NAMESPACE), nodePortServiceIncorrectResponseException());
+        stub(String.format("/api/v1/namespaces/%s/services/hazelcast-0", NAMESPACE), nodePortServiceIncorrectResponseException());
+        stub(String.format("/api/v1/namespaces/%s/services/service-1", NAMESPACE), nodePortServiceIncorrectResponseException());
+        stub("/api/v1/nodes/node-name-1", node1Response());
+        stub("/api/v1/nodes/node-name-2", node2Response());
+
+        // when
+        List<Endpoint> result = kubernetesClient.endpoints();
+
+        // then
+        assertThat(format(result), containsInAnyOrder(ready("192.168.0.25", 5701), ready("172.17.0.5", 5702)));
+    }
+
+    @Test(expected = KubernetesClientException.class)
+    public void endpointsFailFastWhenNoPublicAccess() {
+        // given
+        kubernetesClient = newKubernetesClient(ExposeExternallyMode.ENABLED, false, null, null);
+
+        stub(String.format("/api/v1/namespaces/%s/pods", NAMESPACE), podsListResponse());
+        stub(String.format("/api/v1/namespaces/%s/endpoints", NAMESPACE), endpointsListResponse());
+
+        stub(String.format("/api/v1/namespaces/%s/services/service-0", NAMESPACE), nodePortServiceIncorrectResponseException());
+        stub(String.format("/api/v1/namespaces/%s/services/hazelcast-0", NAMESPACE), nodePortServiceIncorrectResponseException());
+        stub(String.format("/api/v1/namespaces/%s/services/service-1", NAMESPACE), nodePortServiceIncorrectResponseException());
+        stub("/api/v1/nodes/node-name-1", node1Response());
+        stub("/api/v1/nodes/node-name-2", node2Response());
+
+        // when
+        List<Endpoint> result = kubernetesClient.endpoints();
+
+        // then
+        // exception
+    }
+
     private static String podsListResponse() {
         //language=JSON
         return "{\n"
@@ -837,6 +877,31 @@ public class KubernetesClientTest {
                 + "}";
     }
 
+    private String nodePortServiceIncorrectResponseException() {
+        //language=JSON
+        return "{\n"
+                + "  \"kind\": \"Service\",\n" +
+                "  \"metadata\": {\n" +
+                "    \"name\": \"incorrect-service\"\n" +
+                "  " +
+                "},\n" +
+                "  \"spec\": {\n"
+                + "    \"ports\": [\n"
+                + "      {\n"
+                + "        \"port\": 0,\n"
+                + "        \"targetPort\": 0,\n"
+                + "        \"nodePort\": 0\n"
+                + "      },\n" +
+                "      {\n" +
+                "        \"port\": 1,\n" +
+                "        \"targetPort\": 1,\n" +
+                "        \"nodePort\": 2\n" +
+                "      }\n"
+                + "    ]\n"
+                + "  }\n"
+                + "}";
+    }
+
     private String node1Response() {
         //language=JSON
         return "{\n"
@@ -913,13 +978,22 @@ public class KubernetesClientTest {
                 .hasMessageContaining("Message: \"reason\":\"Forbidden\". HTTP Error Code: 501");
     }
 
+    private KubernetesClient newKubernetesClient() {
+        return newKubernetesClient(false);
+    }
+
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress) {
         return newKubernetesClient(useNodeNameAsExternalAddress, null, null);
     }
 
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress, String servicePerPodLabelName, String servicePerPodLabelValue) {
         String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
-        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, TOKEN, CA_CERTIFICATE, RETRIES, ExposeExternallyMode.AUTO, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue);
+        return newKubernetesClient(ExposeExternallyMode.AUTO, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue);
+    }
+
+    private KubernetesClient newKubernetesClient(ExposeExternallyMode exposeExternally, boolean useNodeNameAsExternalAddress, String servicePerPodLabelName, String servicePerPodLabelValue) {
+        String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
+        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, TOKEN, CA_CERTIFICATE, RETRIES, exposeExternally, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue);
     }
 
     private static List<String> format(List<Endpoint> addresses) {

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -880,23 +880,23 @@ public class KubernetesClientTest {
     private String nodePortServiceIncorrectResponseException() {
         //language=JSON
         return "{\n"
-                + "  \"kind\": \"Service\",\n" +
-                "  \"metadata\": {\n" +
-                "    \"name\": \"incorrect-service\"\n" +
-                "  " +
-                "},\n" +
-                "  \"spec\": {\n"
+                + "  \"kind\": \"Service\",\n"
+                + "  \"metadata\": {\n"
+                + "    \"name\": \"incorrect-service\"\n"
+                + "  "
+                + "},\n"
+                + "  \"spec\": {\n"
                 + "    \"ports\": [\n"
                 + "      {\n"
                 + "        \"port\": 0,\n"
                 + "        \"targetPort\": 0,\n"
                 + "        \"nodePort\": 0\n"
-                + "      },\n" +
-                "      {\n" +
-                "        \"port\": 1,\n" +
-                "        \"targetPort\": 1,\n" +
-                "        \"nodePort\": 2\n" +
-                "      }\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"port\": 1,\n"
+                + "        \"targetPort\": 1,\n"
+                + "        \"nodePort\": 2\n"
+                + "      }\n"
                 + "    ]\n"
                 + "  }\n"
                 + "}";

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.kubernetes;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.kubernetes.KubernetesConfig.ExposeExternallyMode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -116,6 +117,7 @@ public class KubernetesConfigTest {
         assertEquals(false, config.isUseNodeNameAsExternalAddress());
         assertEquals(TEST_API_TOKEN, config.getKubernetesApiToken());
         assertEquals(TEST_CA_CERTIFICATE, config.getKubernetesCaCertificate());
+        assertEquals(ExposeExternallyMode.AUTO, config.getExposeExternallyMode());
     }
 
     @Test
@@ -162,6 +164,19 @@ public class KubernetesConfigTest {
 
         // then
         assertEquals(true, config.isUseNodeNameAsExternalAddress());
+    }
+
+    @Test
+    public void kubernetesApiExposeExternally() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(KubernetesProperties.EXPOSE_EXTERNALLY.key(), true);
+
+        // when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        // then
+        assertEquals(ExposeExternallyMode.ENABLED, config.getExposeExternallyMode());
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Add Kubernetes parameter `expose-externally` for explicit configuration
- Improve error messages

Currently, Kubernetes plugin always tries to resolve public addresses of Hazelcast member pods which causes the following issues:
- It's hard to debug what's wrong if someone wants to use external configuration (because errors are silently ignored)
- If someone does not want to use an external client, there are some not needed Kubernetes API calls

This PR is backwards-compatible, so by default Kubernetes plugin tries to resolve public member addresses and errors are silently ignored. However, the user can set the property `expose-externally` to:
- `true` - then if Kubernetes cannot find public addresses, it fails fast
- `false` - then, Kubernetes does not even try to find public addresses

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
