### PR TITLE
Use the proper client config file in the hz-cli

### DIFF
--- a/distribution/src/bin-filemode-755/hz-cli
+++ b/distribution/src/bin-filemode-755/hz-cli
@@ -24,10 +24,16 @@ function findScriptDir() {
 findScriptDir
 . "$SCRIPT_DIR/common.sh"
 
+# HAZELCAST_CLIENT_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
+if [ -z "$HAZELCAST_CLIENT_CONFIG" ]; then
+    HAZELCAST_CLIENT_CONFIG="config/hazelcast-client.xml"
+fi
+
 readJvmOptionsFile "jvm-client.options"
 
 JAVA_OPTS_ARRAY=(\
 $JDK_OPTS \
+"-Dhazelcast.client.config=$HAZELCAST_HOME/$HAZELCAST_CLIENT_CONFIG" \
 $JVM_OPTIONS \
 $JAVA_OPTS \
 )


### PR DESCRIPTION
This PR fixes the `hz-cli` shell script and adds a path to the client configuration file in the `config` directory.

This was incorrectly removed in #19053.

Fixes #19102