### PR TITLE
MC-971 trimming classpath in phonehome data

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.util.phonehome;
 
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.impl.Node;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.util.phonehome;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.impl.Node;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -37,11 +38,11 @@ class BuildInfoCollector implements MetricsCollector {
     static final int CLASSPATH_MAX_LENGTH = 100_000;
 
     static String formatClassPath(String classpath) {
-        String[] classPathEntries = classpath.split(System.getProperty("path.separator"));
+        String[] classPathEntries = classpath.split(File.pathSeparator);
         String shortenedEntries = Arrays.stream(classPathEntries)
                 .filter(cpEntry -> cpEntry.endsWith(".jar"))
-                .map(cpEntry -> cpEntry.substring(cpEntry.lastIndexOf(System.getProperty("file.separator")) + 1))
-                .collect(Collectors.joining(":"));
+                .map(cpEntry -> cpEntry.substring(cpEntry.lastIndexOf(File.separator) + 1))
+                .collect(Collectors.joining(","));
         return shortenedEntries.substring(0, min(CLASSPATH_MAX_LENGTH, shortenedEntries.length()));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.util.phonehome;
 
 import org.junit.Test;
 
+import java.io.File;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -26,17 +27,13 @@ import static org.junit.Assert.assertEquals;
 
 public class ClassPathFormattingTest {
 
-    public static final String PATH_SEPARATOR = System.getProperty("path.separator");
-
-    public static final String FILE_SEPARATOR = System.getProperty("file.separator");
-
     private static String path(String ...fileNames) {
-        return FILE_SEPARATOR + join(FILE_SEPARATOR, fileNames);
+        return File.separator + join(File.separator, fileNames);
     }
 
     @Test
     public void testJarPathRemovals() {
-        String classpath = join(PATH_SEPARATOR,
+        String classpath = join(File.pathSeparator,
                 path("home", "log4j.jar"),
                 path("home", "user", "target"),
                 path("home", "user", "targetjar"),
@@ -44,7 +41,7 @@ public class ClassPathFormattingTest {
                 path("var", "lib", "jackson-databind.jar")
         );
         String actual = BuildInfoCollector.formatClassPath(classpath);
-        assertEquals("log4j.jar:hibernate-validator.jar:jackson-databind.jar", actual);
+        assertEquals("log4j.jar,hibernate-validator.jar,jackson-databind.jar", actual);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.util.phonehome;
 
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
@@ -1,0 +1,43 @@
+package com.hazelcast.internal.util.phonehome;
+
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.lang.String.join;
+import static org.junit.Assert.assertEquals;
+
+public class ClassPathFormattingTest {
+
+    public static final String PATH_SEPARATOR = System.getProperty("path.separator");
+
+    public static final String FILE_SEPARATOR = System.getProperty("file.separator");
+
+    private static String path(String ...fileNames) {
+        return FILE_SEPARATOR + join(FILE_SEPARATOR, fileNames);
+    }
+
+    @Test
+    public void testJarPathRemovals() {
+        String classpath = join(PATH_SEPARATOR,
+                path("home", "log4j.jar"),
+                path("home", "user", "target"),
+                path("home", "user", "targetjar"),
+                path("hibernate-validator.jar"),
+                path("var", "lib", "jackson-databind.jar")
+        );
+        String actual = BuildInfoCollector.formatClassPath(classpath);
+        assertEquals("log4j.jar:hibernate-validator.jar:jackson-databind.jar", actual);
+    }
+
+    @Test
+    public void maxSizeLimit() {
+        String longClassPath = IntStream.range(0, 30_000)
+                .mapToObj(i -> ".jar") // longClassPath.length() will be 120_000
+                .collect(Collectors.joining());
+        String actual = BuildInfoCollector.formatClassPath(longClassPath);
+        assertEquals(100_000, actual.length());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -58,6 +58,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -80,11 +81,7 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
         assertEquals(parameters.get(PhoneHomeMetrics.BUILD_VERSION.getRequestParameterName()), BuildInfoProvider.getBuildInfo().getVersion());
-        String expectedCP = System.getProperty("java.class.path");
-        assertEquals(
-                parameters.get(PhoneHomeMetrics.JAVA_CLASSPATH.getRequestParameterName()),
-                expectedCP.substring(0, min(expectedCP.length(), BuildInfoCollector.CLASSPATH_MAX_LENGTH))
-        );
+        assertTrue(parameters.get(PhoneHomeMetrics.JAVA_CLASSPATH.getRequestParameterName()).endsWith(".jar"));
         assertEquals(UUID.fromString(parameters.get(PhoneHomeMetrics.UUID_OF_CLUSTER.getRequestParameterName())), node.getLocalMember().getUuid());
         assertNull(parameters.get("e"));
         assertNull(parameters.get("oem"));

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -53,7 +53,6 @@ import java.util.function.Function;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.test.Accessors.getNode;
-import static java.lang.Math.min;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;


### PR DESCRIPTION
Changes the classpath sent to the phonehome server so that: 
 * any entry not ending with .jar should be omitted
 * the .jar entries should be filenames only, without path