### PR TITLE
Facilitate JetSqlSlowIndexTest and MapIndexScanPMigrationStressTest

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/JetSqlIndexAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/JetSqlIndexAbstractTest.java
@@ -496,13 +496,16 @@ public abstract class JetSqlIndexAbstractTest extends JetSqlIndexTestSupport {
         return res;
     }
 
+    /**
+     * It tests all non-base types. They were tested by quick test suite.
+     */
     protected static Collection<Object[]> parametersSlow() {
         List<Object[]> res = new ArrayList<>();
 
         for (IndexType indexType : Arrays.asList(IndexType.SORTED, IndexType.HASH)) {
             for (boolean composite : Arrays.asList(true, false)) {
-                for (ExpressionType<?> firstType : allTypes()) {
-                    for (ExpressionType<?> secondType : allTypes()) {
+                for (ExpressionType<?> firstType : nonBaseTypes()) {
+                    for (ExpressionType<?> secondType : nonBaseTypes()) {
                         res.add(new Object[]{indexType, composite, firstType, secondType});
                     }
                 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/JetSqlIndexAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/JetSqlIndexAbstractTest.java
@@ -497,7 +497,7 @@ public abstract class JetSqlIndexAbstractTest extends JetSqlIndexTestSupport {
     }
 
     /**
-     * It tests all non-base types. They were tested by quick test suite.
+     * It tests all non-base types. Base type interactions were tested by quick test suite.
      */
     protected static Collection<Object[]> parametersSlow() {
         List<Object[]> res = new ArrayList<>();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/JetSqlIndexTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/JetSqlIndexTestSupport.java
@@ -73,6 +73,19 @@ abstract class JetSqlIndexTestSupport extends OptimizerTestSupport {
         );
     }
 
+    protected static List<ExpressionType<?>> nonBaseTypes() {
+        return Arrays.asList(
+                BYTE,
+                SHORT,
+                LONG,
+                BIG_DECIMAL,
+                BIG_INTEGER,
+                FLOAT,
+                DOUBLE,
+                CHARACTER
+        );
+    }
+
     protected static List<ExpressionType<?>> allTypes() {
         return Arrays.asList(
                 BOOLEAN,

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/MapIndexScanPMigrationStressTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql_slow/MapIndexScanPMigrationStressTest.java
@@ -70,7 +70,7 @@ public class MapIndexScanPMigrationStressTest extends JetTestSupport {
     @Test
     public void stressTest_hash() throws InterruptedException {
         List<Row> expected = new ArrayList<>();
-        for (int i = 0; i <= ITEM_COUNT / 4; i++) {
+        for (int i = 0; i <= ITEM_COUNT / 5; i++) {
             map.put(i, 1);
             expected.add(new Row(i, 1));
         }


### PR DESCRIPTION
- Reduced tests count in `JetSqlSlowIndexTest`. 
Previosly, it tested all possible pairs of types, but the basic types (`BOOLEAN`, `INTEGER` and `STRING`) are included in the same quick test (`JetSqlIndexTest`).  Removal of repeatable test variants facilitates the test a lot and removes timeout exception.
- Unrelated to test report, but still useful change : reduced items count in `MapIndexScanPMigrationStressTest`. 
It consumed too much time during to `test_hash()` execution.
According to #19342: it isn't reproducible locally with referenced JVM.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

Closes #19341.
Closes #19342.
