### PR TITLE
Silence MissingPartitionException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
@@ -33,6 +33,7 @@ import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.OrderedIndexStore;
 import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.sql.impl.QueryException;
@@ -406,7 +407,7 @@ public class MapFetchIndexOperation extends MapOperation implements ReadonlyOper
         }
     }
 
-    public static final class MissingPartitionException extends HazelcastException {
+    public static final class MissingPartitionException extends HazelcastException implements SilentException {
         public MissingPartitionException(String message) {
             super(message);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
@@ -33,7 +33,6 @@ import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.OrderedIndexStore;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.sql.impl.QueryException;
@@ -321,6 +320,13 @@ public class MapFetchIndexOperation extends MapOperation implements ReadonlyOper
     }
 
     @Override
+    public void logError(Throwable e) {
+        if (!(e instanceof MissingPartitionException)) {
+            super.logError(e);
+        }
+    }
+
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         indexName = in.readString();
@@ -407,7 +413,7 @@ public class MapFetchIndexOperation extends MapOperation implements ReadonlyOper
         }
     }
 
-    public static final class MissingPartitionException extends HazelcastException implements SilentException {
+    public static final class MissingPartitionException extends HazelcastException {
         public MissingPartitionException(String message) {
             super(message);
         }


### PR DESCRIPTION
`MissingPartitionException` could be considered as part of the flow (recoverable), hence maybe it should not be logged by `Operation.logError()` - moreover, it floods SQL split brain tests logs.