### PR TITLE
Try to fix PhoneHomeIntegrationTest.testMapLatenciesWithMapStore

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/DelayMapStore.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/DelayMapStore.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastMillis;
 
 public class DelayMapStore implements MapStore<Object, Object> {
     Map<Object, Object> store = new ConcurrentHashMap<>();
@@ -49,7 +49,7 @@ public class DelayMapStore implements MapStore<Object, Object> {
 
     @Override
     public Object load(Object key) {
-        sleepMillis(200);
+        sleepAtLeastMillis(200);
         return store.get(key);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
@@ -114,7 +114,7 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         return condition ? aResponse().withStatus(200) : aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER);
     }
 
-    @Test()
+    @Test
     public void testMapMetrics() {
         node.hazelcastInstance.getMap("hazelcast");
         node.hazelcastInstance.getMap("phonehome");


### PR DESCRIPTION
If `PhoneHomeIntegrationTest.testMapLatenciesWithMapStore` failures were caused by clock drifts in `com.hazelcast.test.HazelcastTestSupport#sleepMillis`, changing it to `com.hazelcast.test.HazelcastTestSupport#sleepAtLeastMillis` should help.

Fixes #18724

Backport of: https://github.com/hazelcast/hazelcast/pull/19352

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
