### PR TITLE
API-870 Add a proxy cleanup mechanism to client to avoid memory leak

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -154,6 +154,27 @@ public final class ProxyManager {
         }
 
         readProxyDescriptors();
+
+        this.addDistributedObjectListener(new CleanupDistObjListener(this));
+    }
+
+    public static class CleanupDistObjListener implements DistributedObjectListener {
+
+        private final ProxyManager proxyManager;
+
+        public CleanupDistObjListener(ProxyManager proxyManager){
+            this.proxyManager = proxyManager;
+        }
+
+        @Override
+        public void distributedObjectCreated(DistributedObjectEvent event) {
+            // no op
+        }
+
+        @Override
+        public void distributedObjectDestroyed(DistributedObjectEvent event) {
+            proxyManager.destroyProxyLocally(event.getServiceName(), (String) event.getObjectName());
+        }
     }
 
     private void readProxyDescriptors() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ProxyManager.java
@@ -158,11 +158,17 @@ public final class ProxyManager {
         this.addDistributedObjectListener(new CleanupDistObjListener(this));
     }
 
+    /**
+     * This listener is to destroy local distributed objects when they are destroyed in the cluster.
+     * This helps to avoid memory leak. Note that member-side code uses a similar event based mechanism to
+     * create/destroy local proxies when a destroy/create occurs in the cluster. We don't create proxies in
+     * this listener because the client does not need the proxies it does not use.
+     */
     public static class CleanupDistObjListener implements DistributedObjectListener {
 
         private final ProxyManager proxyManager;
 
-        public CleanupDistObjListener(ProxyManager proxyManager){
+        public CleanupDistObjListener(ProxyManager proxyManager) {
             this.proxyManager = proxyManager;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
@@ -16,21 +16,26 @@
 
 package com.hazelcast.client.impl.spi;
 
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,6 +47,7 @@ public class ClientProxyDestroyTest {
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     private HazelcastInstance client;
+    private HazelcastInstance client2;
 
     @After
     public void tearDown() {
@@ -52,6 +58,7 @@ public class ClientProxyDestroyTest {
     public void setup() {
         hazelcastFactory.newHazelcastInstance();
         client = hazelcastFactory.newHazelcastClient();
+        client2 = hazelcastFactory.newHazelcastClient();
     }
 
 
@@ -81,5 +88,18 @@ public class ClientProxyDestroyTest {
         assertFalse(client.getDistributedObjects().contains(clientMap));
         clientMap.put(1, 1);
         assertEquals(1, clientMap.get(1));
+    }
+
+    @Test
+    @Category(SlowTest.class)
+    public void testRemoteProxyDeletionDelegatesToClientEventually() {
+        final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        client.getMap("map");
+        assertEquals(1, clientInstanceImpl.getProxyManager().getDistributedObjects().size());
+
+        client2.getMap("map").destroy();
+        assertEquals(0, client2.getDistributedObjects().size());
+
+        assertTrueEventually(() -> assertEquals(0, clientInstanceImpl.getProxyManager().getDistributedObjects().size()));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
@@ -90,7 +90,6 @@ public class ClientProxyDestroyTest {
     }
 
     @Test
-    @Category(SlowTest.class)
     public void testRemoteProxyDeletionDelegatesToClientEventually() {
         final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         client.getMap("map");

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientProxyDestroyTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.collection.ISet;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;


### PR DESCRIPTION
Adds a poll based distributed objects synchronization to avoid memory leak

Improves https://github.com/hazelcast/hazelcast/pull/13569 that is reverted in https://github.com/hazelcast/hazelcast/pull/13912 and tries to fix the issue the fix created(which caused the revert): https://github.com/hazelcast/hazelcast-enterprise/issues/2470

The issue was the following:

1. Client gets distributed objects in sync distributed objects task
2. Before it can process it, client creates a proxy
3. Then the client process it. The newly created proxy object won't be in the proxies. It will be removed from the local proxies.

Cache proxies requires a local proxy to exist, therefore the test in https://github.com/hazelcast/hazelcast-enterprise/issues/2470
 was failing.

As a solution, I introduced a reader writer lock. The reader lock is locked in proxy creation, whereas the write lock is locked in getDistributedObjects and SyncDistributedObjectsTask. So when we are going to ask for remote distributed objects we are locking the write lock so that client can't create a local proxy until a response is received and processed.


EDIT: 

We decided to use event based approach because:

1. Members use event+operation based approach
2. Poll based approach needs locks, separate executor so performance penalty
3. Poll based approach has races that are complicated.

fixes #12470
