### PR TITLE
Return full page for batch SQL queries

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetPlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetPlanExecutor.java
@@ -211,7 +211,7 @@ public class JetPlanExecutor {
                 .setArgument(SQL_ARGUMENTS_KEY_NAME, args)
                 .setTimeoutMillis(timeout);
 
-        JetQueryResultProducer queryResultProducer = new JetQueryResultProducer();
+        JetQueryResultProducer queryResultProducer = new JetQueryResultProducer(!plan.isStreaming());
         AbstractJetInstance<?> jet = (AbstractJetInstance<?>) hazelcastInstance.getJet();
         long jobId = jet.newJobId();
         Object oldValue = resultRegistry.store(jobId, queryResultProducer);


### PR DESCRIPTION
The IMDG SQL engine used to always send a full page to the client when fetching results. Jet, on the other hand, waited only for the first available row and then returned immediately. This PR changes the behavior for Jet engine: for batch jobs, we also wait for a full page of results.

Fixes #19313