### PR TITLE
[BACKPORT] Make InstanceTrackingConfig#enabled not effectively static (#19393)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InstanceTrackingConfig.java
@@ -46,22 +46,22 @@ public class InstanceTrackingConfig {
     public static final Path DEFAULT_FILE = Paths.get(System.getProperty("java.io.tmpdir"), "Hazelcast.process");
 
     /**
-     * Default setting whether instance tracking should be enabled or not.
-     * It depends on whether the instance is an OEM/NLC build or not.
-     */
-    public static final boolean DEFAULT_ENABLED = isOEMBuild();
-
-    /**
      * Namespace for the placeholders in the file name and format pattern to
      * distinguish between different types of placeholders.
      */
     public static final String PLACEHOLDER_NAMESPACE = "HZ_INSTANCE_TRACKING";
 
-    private boolean enabled = DEFAULT_ENABLED;
+    boolean isEnabledSet;
+
+    /**
+     * Setting whether instance tracking should be enabled or not.
+     * It depends on whether the instance is an OEM/NLC build or not.
+     */
+    private boolean enabled = isOEMBuild();
+
     private String fileName;
     private String formatPattern;
 
-    boolean isEnabledSet;
 
     public InstanceTrackingConfig() {
         super();


### PR DESCRIPTION
(cherry picked from commit 1a0589199561668beeadbdd28b514dfc2b4c3f25)

Description: hazelcast/hazelcast-enterprise#4217

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/4208

Backport of: https://github.com/hazelcast/hazelcast/pull/19393

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4240

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
