### PR TITLE
Convert the path to canonical path for file permissions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.util;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -149,5 +150,11 @@ public final class IOUtil {
         // URLs always use forward slash to separate directories
         int lastSlash = fnamePath.lastIndexOf('/');
         return lastSlash < 0 ? fnamePath : fnamePath.substring(lastSlash + 1);
+    }
+
+
+    @Nonnull
+    public static String canonicalName(String directory) {
+        return Util.uncheckCall(() -> new File(directory).getCanonicalPath());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ConnectorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ConnectorPermission.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.jet.impl.util.IOUtil;
+
 import javax.annotation.Nullable;
 
 public class ConnectorPermission extends InstancePermission {
@@ -33,8 +35,12 @@ public class ConnectorPermission extends InstancePermission {
         super(name, actions);
     }
 
+    /**
+     * converts the {@code directory} to canonical path.
+     */
     public static ConnectorPermission file(String directory, String action) {
-        return new ConnectorPermission(FILE_PREFIX + directory, action);
+        String canonicalPath = IOUtil.canonicalName(directory);
+        return new ConnectorPermission(FILE_PREFIX + canonicalPath, action);
     }
 
     public static ConnectorPermission socket(String host, int port, String action) {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4221

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
