### PR TITLE
Exclude internal objects from DistributedObjectCounterCollector counts

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.services.RemoteService;
 import com.hazelcast.internal.services.TenantContextAwareService;
 import com.hazelcast.internal.util.EmptyStatement;
+import com.hazelcast.internal.util.SetUtil;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.spi.impl.AbstractDistributedObject;
@@ -34,6 +35,7 @@ import com.hazelcast.spi.tenantcontrol.TenantControl;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -43,11 +45,21 @@ import static com.hazelcast.core.DistributedObjectEvent.EventType.DESTROYED;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.jet.impl.JobRepository.INTERNAL_JET_OBJECTS_PREFIX;
 
 /**
  * A ProxyRegistry contains all proxies for a given service. For example, it contains all proxies for the IMap.
  */
 public final class ProxyRegistry {
+
+    public static final Set<String> INTERNAL_OBJECTS_PREFIXES;
+
+    static {
+        INTERNAL_OBJECTS_PREFIXES = SetUtil.createHashSet(3);
+        INTERNAL_OBJECTS_PREFIXES.add(INTERNAL_JET_OBJECTS_PREFIX);
+        INTERNAL_OBJECTS_PREFIXES.add("__mc.");
+        INTERNAL_OBJECTS_PREFIXES.add("__sql.");
+    }
 
     private final ProxyServiceImpl proxyService;
     private final String serviceName;
@@ -259,7 +271,9 @@ public final class ProxyRegistry {
                 }
             }
             proxyFuture.set(proxy, initialize);
-            createdCounter.inc();
+            if (INTERNAL_OBJECTS_PREFIXES.stream().noneMatch(name::startsWith)) {
+                createdCounter.inc();
+            }
         } catch (Throwable e) {
             // proxy creation or initialization failed
             // deregister future to avoid infinite hang on future.get()
@@ -393,10 +407,10 @@ public final class ProxyRegistry {
     }
 
     /**
-     * Returns the total number of created proxies, even if some have already
+     * Returns the total number of created non-internal proxies, even if some have already
      * been destroyed.
      *
-     * @return the total count of created proxies
+     * @return the total count of created non-internal proxies
      */
     public long getCreatedCount() {
         return createdCounter.get();

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -52,6 +52,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
+import static com.hazelcast.spi.impl.proxyservice.impl.ProxyRegistry.INTERNAL_OBJECTS_PREFIXES;
 import static com.hazelcast.test.Accessors.getNode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -528,6 +529,13 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         assertEquals(parameters.get(totalCountMetric.getRequestParameterName()), Integer.toString(initial + 1));
 
         DistributedObject obj2 = distributedObjectCreateFn.apply("phonehome");
+        parameters = phoneHome.phoneHome(true);
+        assertEquals(parameters.get(countMetric.getRequestParameterName()), Integer.toString(initial + 2));
+        assertEquals(parameters.get(totalCountMetric.getRequestParameterName()), Integer.toString(initial + 2));
+
+        INTERNAL_OBJECTS_PREFIXES.stream()
+                .map(prefix -> prefix + "phonehome")
+                .forEach(distributedObjectCreateFn::apply);
         parameters = phoneHome.phoneHome(true);
         assertEquals(parameters.get(countMetric.getRequestParameterName()), Integer.toString(initial + 2));
         assertEquals(parameters.get(totalCountMetric.getRequestParameterName()), Integer.toString(initial + 2));


### PR DESCRIPTION
Fixes #19058

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible