### PR TITLE
Consolidate UUID in MC WAN events

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanConfigurationEventBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanConfigurationEventBase.java
@@ -20,36 +20,17 @@ import com.hazelcast.internal.json.JsonObject;
 
 import java.util.UUID;
 
-public abstract class AbstractWanAntiEntropyEventBase extends AbstractWanEvent {
-    protected final String wanReplicationName;
-    protected final String wanPublisherId;
-    protected final String mapName;
+public abstract class AbstractWanConfigurationEventBase extends AbstractWanEvent {
+    private final String wanConfigName;
 
-    AbstractWanAntiEntropyEventBase(UUID uuid, String wanReplicationName, String wanPublisherId, String mapName) {
+    protected AbstractWanConfigurationEventBase(UUID uuid, String wanConfigName) {
         super(uuid);
-        this.wanReplicationName = wanReplicationName;
-        this.wanPublisherId = wanPublisherId;
-        this.mapName = mapName;
+        this.wanConfigName = wanConfigName;
     }
 
-    public String getWanReplicationName() {
-        return wanReplicationName;
-    }
-
-    public String getWanPublisherId() {
-        return wanPublisherId;
-    }
-
-    public String getMapName() {
-        return mapName;
-    }
-
-    @Override
     public JsonObject toJson() {
         JsonObject json = super.toJson();
-        json.add("wanReplicationName", wanReplicationName);
-        json.add("wanPublisherId", wanPublisherId);
-        json.add("mapName", mapName);
+        json.add("wanConfigName", wanConfigName);
         return json;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEvent.java
@@ -24,6 +24,7 @@ abstract class AbstractWanEvent extends AbstractEventBase {
     private final UUID uuid;
 
     protected AbstractWanEvent(UUID uuid) {
+        assert uuid != null : "UUID must not be null";
         this.uuid = uuid;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AbstractWanEvent.java
@@ -18,35 +18,23 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
 
-abstract class AbstractWanEventBase extends AbstractEventBase {
-    protected final String wanReplicationName;
-    protected final String wanPublisherId;
-    protected final String mapName;
+import java.util.UUID;
 
-    AbstractWanEventBase(String wanReplicationName, String wanPublisherId, String mapName) {
-        this.wanReplicationName = wanReplicationName;
-        this.wanPublisherId = wanPublisherId;
-        this.mapName = mapName;
+abstract class AbstractWanEvent extends AbstractEventBase {
+    private final UUID uuid;
+
+    protected AbstractWanEvent(UUID uuid) {
+        this.uuid = uuid;
     }
 
-    public String getWanReplicationName() {
-        return wanReplicationName;
-    }
-
-    public String getWanPublisherId() {
-        return wanPublisherId;
-    }
-
-    public String getMapName() {
-        return mapName;
+    public UUID getUuid() {
+        return uuid;
     }
 
     @Override
     public JsonObject toJson() {
         JsonObject json = new JsonObject();
-        json.add("wanReplicationName", wanReplicationName);
-        json.add("wanPublisherId", wanPublisherId);
-        json.add("mapName", mapName);
+        json.add("uuid", uuid != null ? uuid.toString() : "null");
         return json;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanAddConfigurationIgnoredEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanAddConfigurationIgnoredEvent.java
@@ -18,25 +18,25 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
+import com.hazelcast.internal.util.UuidUtil;
 
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.ADD_WAN_CONFIGURATION_IGNORED;
 
-public final class AddWanConfigIgnoredEvent extends AbstractEventBase {
-    private final String wanConfigName;
+public final class WanAddConfigurationIgnoredEvent extends AbstractWanConfigurationEventBase {
     private final String reason;
 
-    private AddWanConfigIgnoredEvent(String wanConfigName, String reason) {
-        this.wanConfigName = wanConfigName;
+    private WanAddConfigurationIgnoredEvent(String wanConfigName, String reason) {
+        super(UuidUtil.newUnsecureUUID(), wanConfigName);
         this.reason = reason;
     }
 
-    public static AddWanConfigIgnoredEvent alreadyExists(String wanConfigName) {
-        return new AddWanConfigIgnoredEvent(wanConfigName,
+    public static WanAddConfigurationIgnoredEvent alreadyExists(String wanConfigName) {
+        return new WanAddConfigurationIgnoredEvent(wanConfigName,
                 "A WAN replication config already exists with the given name.");
     }
 
-    public static AddWanConfigIgnoredEvent enterpriseOnly(String wanConfigName) {
-        return new AddWanConfigIgnoredEvent(wanConfigName,
+    public static WanAddConfigurationIgnoredEvent enterpriseOnly(String wanConfigName) {
+        return new WanAddConfigurationIgnoredEvent(wanConfigName,
                 "Adding new WAN replication config is supported for enterprise clusters only.");
     }
 
@@ -47,8 +47,7 @@ public final class AddWanConfigIgnoredEvent extends AbstractEventBase {
 
     @Override
     public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.add("wanConfigName", wanConfigName);
+        JsonObject json = super.toJson();
         json.add("reason", reason);
         return json;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConfigurationAddedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConfigurationAddedEvent.java
@@ -16,27 +16,19 @@
 
 package com.hazelcast.internal.management.events;
 
-import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
+import com.hazelcast.internal.util.UuidUtil;
 
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONFIGURATION_ADDED;
 
-public class WanConfigurationAddedEvent extends AbstractEventBase {
-    private final String wanConfigName;
+public class WanConfigurationAddedEvent extends AbstractWanConfigurationEventBase {
 
     public WanConfigurationAddedEvent(String wanConfigName) {
-        this.wanConfigName = wanConfigName;
+        super(UuidUtil.newUnsecureUUID(), wanConfigName);
     }
 
     @Override
     public EventType getType() {
         return WAN_CONFIGURATION_ADDED;
-    }
-
-    @Override
-    public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.add("wanConfigName", wanConfigName);
-        return json;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConfigurationExtendedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConfigurationExtendedEvent.java
@@ -19,17 +19,17 @@ package com.hazelcast.internal.management.events;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
+import com.hazelcast.internal.util.UuidUtil;
 
 import java.util.Collection;
 
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONFIGURATION_EXTENDED;
 
-public class WanConfigurationExtendedEvent extends AbstractEventBase {
-    private final String wanConfigName;
+public class WanConfigurationExtendedEvent extends AbstractWanConfigurationEventBase {
     private final Collection<String> wanPublisherIds;
 
     public WanConfigurationExtendedEvent(String wanConfigName, Collection<String> wanPublisherIds) {
-        this.wanConfigName = wanConfigName;
+        super(UuidUtil.newUnsecureUUID(), wanConfigName);
         this.wanPublisherIds = wanPublisherIds;
     }
 
@@ -40,8 +40,7 @@ public class WanConfigurationExtendedEvent extends AbstractEventBase {
 
     @Override
     public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.add("wanConfigName", wanConfigName);
+        JsonObject json = super.toJson();
         JsonArray publisherIds = new JsonArray();
         for (String publisherId : wanPublisherIds) {
             publisherIds.add(publisherId);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckIgnoredEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConsistencyCheckIgnoredEvent.java
@@ -17,16 +17,29 @@
 package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.util.UuidUtil;
+
+import java.util.UUID;
 
 import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONSISTENCY_CHECK_IGNORED;
 
 public class WanConsistencyCheckIgnoredEvent extends AbstractWanAntiEntropyEventBase {
     private final String reason;
 
-    public WanConsistencyCheckIgnoredEvent(String wanReplicationName, String wanPublisherId, String mapName,
+    public WanConsistencyCheckIgnoredEvent(String wanReplicationName, String wanPublisherId, String mapName, String reason) {
+        this(UuidUtil.newUnsecureUUID(), wanReplicationName, wanPublisherId, mapName, reason);
+    }
+
+    public WanConsistencyCheckIgnoredEvent(UUID uuid, String wanReplicationName, String wanPublisherId, String mapName,
                                            String reason) {
-        super(null, wanReplicationName, wanPublisherId, mapName);
+        super(uuid, wanReplicationName, wanPublisherId, mapName);
         this.reason = reason;
+    }
+
+    public static WanConsistencyCheckIgnoredEvent enterpriseOnly(String wanReplicationName, String wanPublisherId,
+                                                                 String mapName) {
+        return new WanConsistencyCheckIgnoredEvent(UuidUtil.newUnsecureUUID(), wanReplicationName, wanPublisherId, mapName,
+                "Consistency check is supported for enterprise clusters only.");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanSyncIgnoredEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanSyncIgnoredEvent.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.management.events;
 
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
+import com.hazelcast.internal.util.UuidUtil;
 
 import java.util.UUID;
 
@@ -26,11 +27,11 @@ import static com.hazelcast.internal.management.events.EventMetadata.EventType.W
 public final class WanSyncIgnoredEvent extends AbstractWanAntiEntropyEventBase {
     private final String reason;
 
-    private WanSyncIgnoredEvent(UUID uuid,
-                                String wanReplicationName,
-                                String wanPublisherId,
-                                String mapName,
-                                String reason) {
+    public WanSyncIgnoredEvent(UUID uuid,
+                               String wanReplicationName,
+                               String wanPublisherId,
+                               String mapName,
+                               String reason) {
         super(uuid, wanReplicationName, wanPublisherId, mapName);
         this.reason = reason;
     }
@@ -38,7 +39,7 @@ public final class WanSyncIgnoredEvent extends AbstractWanAntiEntropyEventBase {
     public static WanSyncIgnoredEvent enterpriseOnly(String wanReplicationName,
                                                      String wanPublisherId,
                                                      String mapName) {
-        return new WanSyncIgnoredEvent(null, wanReplicationName, wanPublisherId, mapName,
+        return new WanSyncIgnoredEvent(UuidUtil.newUnsecureUUID(), wanReplicationName, wanPublisherId, mapName,
                 "WAN sync is supported for enterprise clusters only.");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.WanCustomPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.instance.impl.Node;
-import com.hazelcast.internal.management.events.AddWanConfigIgnoredEvent;
+import com.hazelcast.internal.management.events.WanAddConfigurationIgnoredEvent;
 import com.hazelcast.internal.management.events.WanConsistencyCheckIgnoredEvent;
 import com.hazelcast.internal.management.events.WanSyncIgnoredEvent;
 import com.hazelcast.internal.monitor.LocalWanStats;
@@ -236,8 +236,7 @@ public class WanReplicationServiceImpl implements WanReplicationService,
     @Override
     public UUID consistencyCheck(String wanReplicationName, String wanPublisherId, String mapName) {
         node.getManagementCenterService().log(
-                new WanConsistencyCheckIgnoredEvent(wanReplicationName, wanPublisherId, mapName,
-                        "Consistency check is supported for enterprise clusters only."));
+                WanConsistencyCheckIgnoredEvent.enterpriseOnly(wanReplicationName, wanPublisherId, mapName));
 
         throw new UnsupportedOperationException("Consistency check is not supported.");
     }
@@ -249,7 +248,7 @@ public class WanReplicationServiceImpl implements WanReplicationService,
 
     @Override
     public AddWanConfigResult addWanReplicationConfig(WanReplicationConfig wanReplicationConfig) {
-        node.getManagementCenterService().log(AddWanConfigIgnoredEvent.enterpriseOnly(wanReplicationConfig.getName()));
+        node.getManagementCenterService().log(WanAddConfigurationIgnoredEvent.enterpriseOnly(wanReplicationConfig.getName()));
 
         throw new UnsupportedOperationException("Adding new WAN config is not supported.");
     }

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanOpenSourceAntiEntropyMcEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanOpenSourceAntiEntropyMcEventsTest.java
@@ -97,7 +97,6 @@ public class WanOpenSourceAntiEntropyMcEventsTest extends HazelcastTestSupport {
         HTTPCommunicator communicator = new HTTPCommunicator(hz);
 
         NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
-        WanReplicationService wanService = nodeEngine.getWanReplicationService();
         ManagementCenterService mcService = nodeEngine.getManagementCenterService();
 
         List<Event> events = new LinkedList<>();
@@ -155,7 +154,6 @@ public class WanOpenSourceAntiEntropyMcEventsTest extends HazelcastTestSupport {
         HTTPCommunicator communicator = new HTTPCommunicator(hz);
 
         NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
-        WanReplicationService wanService = nodeEngine.getWanReplicationService();
         ManagementCenterService mcService = nodeEngine.getManagementCenterService();
 
         List<Event> events = new LinkedList<>();
@@ -213,7 +211,6 @@ public class WanOpenSourceAntiEntropyMcEventsTest extends HazelcastTestSupport {
         HTTPCommunicator communicator = new HTTPCommunicator(hz);
 
         NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
-        WanReplicationService wanService = nodeEngine.getWanReplicationService();
         ManagementCenterService mcService = nodeEngine.getManagementCenterService();
 
         List<Event> events = new LinkedList<>();

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanOpenSourceAntiEntropyMcEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanOpenSourceAntiEntropyMcEventsTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.config.RestEndpointGroup;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.ascii.HTTPCommunicator;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.internal.management.events.Event;
+import com.hazelcast.internal.management.events.WanConsistencyCheckIgnoredEvent;
+import com.hazelcast.internal.management.events.WanSyncIgnoredEvent;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONSISTENCY_CHECK_IGNORED;
+import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_SYNC_IGNORED;
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static com.hazelcast.test.TestEnvironment.HAZELCAST_TEST_USE_NETWORK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class WanOpenSourceAntiEntropyMcEventsTest extends HazelcastTestSupport {
+    private static final String MAP_NAME = "map";
+    private static final String WAN_REPLICATION_NAME = "wanRepName";
+    private static final String WAN_PUBLISHER_ID = "wanPubId";
+
+    private TestHazelcastInstanceFactory factory;
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+        System.clearProperty(HAZELCAST_TEST_USE_NETWORK);
+    }
+
+    @Test
+    public void testConsistencyCheckAPI() {
+        HazelcastInstance hz = createHazelcastInstance();
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
+        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
+
+        List<Event> events = new LinkedList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        mcService.setEventListener(event -> {
+            events.add(event);
+            latch.countDown();
+        });
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> wanService.consistencyCheck(WAN_REPLICATION_NAME, WAN_PUBLISHER_ID, MAP_NAME));
+        assertOpenEventually(latch);
+
+        Event event = events.get(0);
+        assertTrue(event instanceof WanConsistencyCheckIgnoredEvent);
+        WanConsistencyCheckIgnoredEvent checkIgnoredEvent = (WanConsistencyCheckIgnoredEvent) event;
+        assertNotNull(checkIgnoredEvent.getUuid());
+        assertEquals(MAP_NAME, checkIgnoredEvent.getMapName());
+    }
+
+    @Test
+    public void testConsistencyCheckREST() throws Exception {
+        System.setProperty(HAZELCAST_TEST_USE_NETWORK, "true");
+
+        HazelcastInstance hz = createHazelcastInstance(getConfigWithRest());
+        HTTPCommunicator communicator = new HTTPCommunicator(hz);
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
+        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
+
+        List<Event> events = new LinkedList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        mcService.setEventListener(event -> {
+            events.add(event);
+            latch.countDown();
+        });
+
+        String jsonResult = communicator.wanMapConsistencyCheck(hz.getConfig().getClusterName(), "", WAN_REPLICATION_NAME,
+                WAN_PUBLISHER_ID, MAP_NAME);
+        assertOpenEventually(latch);
+
+        JsonObject result = Json.parse(jsonResult).asObject();
+        Event event = events.get(0);
+        assertTrue(event instanceof WanConsistencyCheckIgnoredEvent);
+        WanConsistencyCheckIgnoredEvent checkIgnoredEvent = (WanConsistencyCheckIgnoredEvent) event;
+        assertNotNull(checkIgnoredEvent.getUuid());
+        assertNull(result.getString("uuid", null));
+        assertEquals(MAP_NAME, checkIgnoredEvent.getMapName());
+        assertEquals(WAN_CONSISTENCY_CHECK_IGNORED, checkIgnoredEvent.getType());
+    }
+
+    @Test
+    public void testSyncAPI() {
+        HazelcastInstance hz = createHazelcastInstance();
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
+        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
+
+        List<Event> events = new LinkedList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        mcService.setEventListener(event -> {
+            events.add(event);
+            latch.countDown();
+        });
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> wanService.syncMap(WAN_REPLICATION_NAME, WAN_PUBLISHER_ID, MAP_NAME));
+        assertOpenEventually(latch);
+
+        Event event = events.get(0);
+        assertTrue(event instanceof WanSyncIgnoredEvent);
+        WanSyncIgnoredEvent syncIgnoredEvent = (WanSyncIgnoredEvent) event;
+        assertNotNull(syncIgnoredEvent.getUuid());
+        assertEquals(MAP_NAME, syncIgnoredEvent.getMapName());
+    }
+
+    @Test
+    public void testSyncREST() throws Exception {
+        System.setProperty(HAZELCAST_TEST_USE_NETWORK, "true");
+
+        HazelcastInstance hz = createHazelcastInstance(getConfigWithRest());
+        HTTPCommunicator communicator = new HTTPCommunicator(hz);
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
+        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
+
+        List<Event> events = new LinkedList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        mcService.setEventListener(event -> {
+            events.add(event);
+            latch.countDown();
+        });
+
+        String jsonResult = communicator.syncMapOverWAN(hz.getConfig().getClusterName(), "", WAN_REPLICATION_NAME,
+                WAN_PUBLISHER_ID, MAP_NAME);
+        assertOpenEventually(latch);
+
+        JsonObject result = Json.parse(jsonResult).asObject();
+        Event event = events.get(0);
+        assertTrue(event instanceof WanSyncIgnoredEvent);
+        WanSyncIgnoredEvent syncIgnoredEvent = (WanSyncIgnoredEvent) event;
+        assertNotNull(syncIgnoredEvent.getUuid());
+        assertNull(result.getString("uuid", null));
+        assertEquals(MAP_NAME, syncIgnoredEvent.getMapName());
+        assertEquals(WAN_SYNC_IGNORED, syncIgnoredEvent.getType());
+    }
+
+    @Test
+    public void testAllMapsSyncAPI() {
+        HazelcastInstance hz = createHazelcastInstance();
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
+        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
+
+        List<Event> events = new LinkedList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        mcService.setEventListener(event -> {
+            events.add(event);
+            latch.countDown();
+        });
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> wanService.syncAllMaps(WAN_REPLICATION_NAME, WAN_PUBLISHER_ID));
+        assertOpenEventually(latch);
+
+        Event event = events.get(0);
+        assertTrue(event instanceof WanSyncIgnoredEvent);
+        WanSyncIgnoredEvent syncIgnoredEvent = (WanSyncIgnoredEvent) event;
+        assertNotNull(syncIgnoredEvent.getUuid());
+        assertNull(syncIgnoredEvent.getMapName());
+    }
+
+    @Test
+    public void testSyncAllREST() throws Exception {
+        System.setProperty(HAZELCAST_TEST_USE_NETWORK, "true");
+
+        HazelcastInstance hz = createHazelcastInstance(getConfigWithRest());
+        HTTPCommunicator communicator = new HTTPCommunicator(hz);
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
+        ManagementCenterService mcService = nodeEngine.getManagementCenterService();
+
+        List<Event> events = new LinkedList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        mcService.setEventListener(event -> {
+            events.add(event);
+            latch.countDown();
+        });
+
+        String jsonResult = communicator.syncMapsOverWAN(hz.getConfig().getClusterName(), "", WAN_REPLICATION_NAME,
+                WAN_PUBLISHER_ID);
+        assertOpenEventually(latch);
+
+        JsonObject result = Json.parse(jsonResult).asObject();
+        Event event = events.get(0);
+        assertTrue(event instanceof WanSyncIgnoredEvent);
+        WanSyncIgnoredEvent syncIgnoredEvent = (WanSyncIgnoredEvent) event;
+        assertNotNull(syncIgnoredEvent.getUuid());
+        assertNull(result.getString("uuid", null));
+        assertNull(syncIgnoredEvent.getMapName());
+        assertEquals(WAN_SYNC_IGNORED, syncIgnoredEvent.getType());
+    }
+
+    @Override
+    protected HazelcastInstance createHazelcastInstance() {
+        factory = new TestHazelcastInstanceFactory();
+        return factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance createHazelcastInstance(Config config) {
+        factory = new TestHazelcastInstanceFactory();
+        return factory.newHazelcastInstance(config);
+    }
+
+    private Config getConfigWithRest() {
+        Config config = smallInstanceConfig();
+        RestApiConfig restApiConfig = config.getNetworkConfig().getRestApiConfig();
+        restApiConfig.setEnabled(true);
+        restApiConfig.enableGroups(RestEndpointGroup.WAN);
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getMulticastConfig()
+                .setEnabled(false);
+        joinConfig.getTcpIpConfig()
+                .setEnabled(true)
+                .addMember("127.0.0.1");
+        return config;
+    }
+
+}


### PR DESCRIPTION
Set UUID consisteltly on all WAN MC events. The change sets the UUID in the WAN anti-entropy ignored events. Also, at some places we did not emit the ignored events: if there was no map found to be synchronized or the map was not configured for WAN replication, the ignored events were not sent to MC. 

Additionally, the configuration related events are extended with a UUID field to be consistent with the other WAN events. In these events the UUID doesn't correlate with any field on the response, MC needs it only for grouping.

Implements https://github.com/hazelcast/hazelcast-enterprise/issues/4154
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4255