### PR TITLE
Add WAN queue fill percent metric

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -612,6 +612,7 @@ public final class MetricDescriptorConstants {
     public static final String WAN_METRIC_ACK_DELAY_CURRENT_MILLIS = "ackDelayCurrentMillis";
     public static final String WAN_METRIC_ACK_DELAY_LAST_START = "ackDelayLastStart";
     public static final String WAN_METRIC_ACK_DELAY_LAST_END = "ackDelayLastEnd";
+    public static final String WAN_QUEUE_FILL_PERCENT = "queueFillPercent";
     // ===[/WAN]========================================================
 
     public static final String GENERAL_DISCRIMINATOR_NAME = "name";


### PR DESCRIPTION
Report new metric to show how filled an outbound queue is:
`outboundQueueSize / maxOutboundQueueSize (from config)`.

Implements https://github.com/hazelcast/hazelcast-enterprise/issues/4154

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4258
