### PR TITLE
add logging on processing state of migrations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -49,6 +49,7 @@ import com.hazelcast.internal.partition.operation.ShutdownRequestOperation;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.HashUtil;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.internal.util.scheduler.CoalescingDelayedTrigger;
 import com.hazelcast.internal.util.scheduler.ScheduledEntry;
 import com.hazelcast.logging.ILogger;
@@ -1496,6 +1497,20 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                     applyNewPartitionTable(latestPartitions, allCompletedMigrations, thisAddress);
                 }
                 shouldFetchPartitionTables = false;
+            } catch (Throwable rethrowed) {
+                String lineSeparator = System.lineSeparator();
+
+                StringBuilder sb = new StringBuilder()
+                        .append("latestPartitions:").append(lineSeparator)
+                        .append(StringUtil.toString(latestPartitions)).append(lineSeparator)
+                        .append("allCompletedMigrations:").append(lineSeparator)
+                        .append(StringUtil.toString(allCompletedMigrations)).append(lineSeparator)
+                        .append("allActiveMigrations:").append(lineSeparator)
+                        .append(StringUtil.toString((allActiveMigrations))).append(lineSeparator)
+                        .append(rethrowed);
+
+                logger.warning(sb.toString());
+                throw rethrowed;
             } finally {
                 lock.unlock();
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -22,12 +22,15 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.lang.Character.isLetter;
 import static java.lang.Character.isLowerCase;
@@ -467,6 +470,28 @@ public final class StringUtil {
             startIndex = sb.indexOf(placeholderPrefix, endIndex);
         }
         return sb.toString();
+    }
+
+    /**
+     * Converts the provided collection to string, joined by LINE_SEPARATOR
+     * @param collection collection to convert to string
+     * @return string
+     */
+    public static <T> String toString(Collection<T> collection) {
+        return collection.stream()
+                .map(Objects::toString)
+                .collect(Collectors.joining(LINE_SEPARATOR));
+    }
+
+    /**
+     * Converts the provided array to string, joined by LINE_SEPARATOR
+     * @param arr array to convert to string
+     * @return string
+     */
+    public static <T> String toString(T[] arr) {
+        return Arrays.stream(arr)
+                .map(Objects::toString)
+                .collect(Collectors.joining(LINE_SEPARATOR));
     }
 
     /**


### PR DESCRIPTION
Added logging to capture context when the failure happens. Hard to reproduce, even with logging in this PR (i.e., little logging) it did not reproduce despite 2k+ iterations.

Fixes https://github.com/hazelcast/hazelcast/issues/18799
