### PR TITLE
make gracefulShutdown test more robust

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
@@ -117,36 +117,38 @@ public abstract class AbstractGracefulShutdownCorrectnessTest extends PartitionC
     public void testPartitionData_whenNodesStartedShutdown_whileOperationsOngoing() throws InterruptedException {
         final Config config = getConfig(true, false);
 
-        Future future = spawn(new Runnable() {
-            @Override
-            public void run() {
-                LinkedList<HazelcastInstance> instances
-                        = new LinkedList<HazelcastInstance>(Arrays.asList(factory.newInstances(config, nodeCount)));
-                try {
-                    for (int i = 0; i < 3; i++) {
-                        shutdownNodes(instances, shutdownNodeCount);
-                        Collection<HazelcastInstance> startedInstances = startNodes(config, shutdownNodeCount);
-                        instances.addAll(startedInstances);
-                    }
+        Future future = spawn(() -> {
+            LinkedList<HazelcastInstance> instances
+                    = new LinkedList<>(Arrays.asList(factory.newInstances(config, nodeCount)));
+            try {
+                for (int i = 0; i < 3; i++) {
                     shutdownNodes(instances, shutdownNodeCount);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Collection<HazelcastInstance> startedInstances = startNodes(config, shutdownNodeCount);
+                    instances.addAll(startedInstances);
                 }
+                shutdownNodes(instances, shutdownNodeCount);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
         });
 
         HazelcastInstance hz = factory.newHazelcastInstance(config);
         NodeEngine nodeEngine = getNodeEngineImpl(hz);
+
+        while (!nodeEngine.getClusterService().isJoined()) {
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
         OperationService operationService = nodeEngine.getOperationService();
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
 
         int value = 0;
-        while (!future.isDone()) {
+        do {
             value++;
             for (int p = 0; p < partitionCount; p++) {
                 operationService.invokeOnPartition(null, new TestPutOperation(value), p).join();
             }
-        }
+        } while (!future.isDone());
 
         for (int p = 0; p < partitionCount; p++) {
             Integer actual = (Integer) operationService.invokeOnPartition(null, new TestGetOperation(), p).join();


### PR DESCRIPTION
The test failure is due to invoking get without having issued put operations. From the logs we have that:
```
5702 started
5703 started

5702 shutdown
5704 started

5703 shutdown
5705 started

5704 shutdown
5706 started

5705 shutdown

5701 : Resetting master address because join address timeout
5701 started

```
And put operations are issued through `5701`. Basically, the following part from `AbstractGracefulShutdownCorrectnessTest#testPartitionData_whenNodesStartedShutdown_whileOperationsOngoing` is not executed
```java
while (!future.isDone()) {
    value++;
    for (int p = 0; p < partitionCount; p++) {
        operationService.invokeOnPartition(null, new TestPutOperation(value), p).join();
    }
}
```
And, afterwards when get operations are issued, there is no data to read.

Fixes https://github.com/hazelcast/hazelcast/issues/8065
