### PR TITLE
Test portable array mapped as OBJECT in SQL

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolver.java
@@ -107,7 +107,7 @@ final class MetadataPortableResolver implements KvMetadataResolver {
                     .peek(mappingField -> {
                         QueryDataType type = mappingField.type();
                         if (type == QueryDataType.OBJECT) {
-                            throw QueryException.error("Cannot derive Portable type for '" + type + "'");
+                            throw QueryException.error("Cannot derive Portable type for '" + type.getTypeFamily() + "'");
                         }
                     });
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/PortableUpsertTarget.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/PortableUpsertTarget.java
@@ -194,7 +194,7 @@ class PortableUpsertTarget implements UpsertTarget {
                 }
             } catch (Exception e) {
                 throw QueryException.error("Cannot set value " +
-                        (value == null ? "null" : " of type " + value.getClass().getName())
+                        (value == null ? "null" : "of type " + value.getClass().getName())
                         + " to field \"" + name + "\" of type " + type + ": " + e.getMessage(), e);
             }
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/param/AnyToVarcharParameterConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/param/AnyToVarcharParameterConverter.java
@@ -30,7 +30,7 @@ public class AnyToVarcharParameterConverter extends AbstractParameterConverter {
 
     @Override
     protected boolean isValid(Object value, Converter valueConverter) {
-        // No validation, since everything could be converted to a string.
+        // No validation, since everything can be converted to a string.
         return true;
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolverTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.map.MapTableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
@@ -183,7 +184,7 @@ public class MetadataPortableResolverTest {
         //noinspection ResultOfMethodCallIgnored
         assertThatThrownBy(() -> INSTANCE.resolveAndValidateFields(key, fields, options, ss).collect(toList()))
                 .isInstanceOf(QueryException.class)
-                .hasMessageContaining("Cannot derive Portable type for '" + QueryDataType.OBJECT + "'");
+                .hasMessageContaining("Cannot derive Portable type for '" + QueryDataTypeFamily.OBJECT + "'");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolverTest.java
@@ -279,6 +279,42 @@ public class MetadataPortableResolverTest {
             "true, __key",
             "false, this"
     })
+    public void when_objectUsedForCurrentlyUnknownType_then_allowed(boolean key, String prefix) {
+        InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+        ClassDefinition nestedClassDef =
+                new ClassDefinitionBuilder(1, 3, 4)
+                        .addIntField("intField")
+                        .build();
+        ClassDefinition classDefinition =
+                new ClassDefinitionBuilder(1, 2, 3)
+                        .addIntArrayField("intArrayField")
+                        .addPortableField("nestedPortableField", nestedClassDef)
+                        .build();
+        ss.getPortableContext().registerClassDefinition(nestedClassDef);
+        ss.getPortableContext().registerClassDefinition(classDefinition);
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FACTORY_ID : OPTION_VALUE_FACTORY_ID), String.valueOf(classDefinition.getFactoryId()),
+                (key ? OPTION_KEY_CLASS_ID : OPTION_VALUE_CLASS_ID), String.valueOf(classDefinition.getClassId()),
+                (key ? OPTION_KEY_CLASS_VERSION : OPTION_VALUE_CLASS_VERSION), String.valueOf(classDefinition.getVersion())
+        );
+
+        // We normally don't allow mapping e.g. INT field as OBJECT. But we need to allow it for arrays and nested objects
+        // due to backwards-compatibility.
+        INSTANCE.resolveAndValidateFields(
+                key,
+                asList(
+                        field("intArrayField", QueryDataType.OBJECT, prefix + ".intArrayField"),
+                        field("nestedPortableField", QueryDataType.OBJECT, prefix + ".nestedPortableField")),
+                options,
+                ss
+        );
+    }
+
+    @Test
+    @Parameters({
+            "true, __key",
+            "false, this"
+    })
     public void when_duplicateExternalName_then_throws(boolean key, String prefix) {
         InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
         ClassDefinition classDefinition =


### PR DESCRIPTION
The portable resolver currently checks that the resolved and assigned
type are same. For arrays we resolve OBJECT, so we check that the user
actually used OBJECT.

However, in a future release we plan to introduce support for arrays and
for nested objects. We also want to preserve backwards compatibility.
Therefore this PR adds a test that checks that mapping ARRAY as OBJECT
still works.
