### PR TITLE
Filter non-hazelcast classes for DataSerializableConventionsTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -59,6 +59,7 @@ import java.util.TreeSet;
 
 import static com.hazelcast.test.ReflectionsHelper.REFLECTIONS;
 import static com.hazelcast.test.ReflectionsHelper.filterNonConcreteClasses;
+import static com.hazelcast.test.ReflectionsHelper.filterNonHazelcastClasses;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -148,6 +149,9 @@ public class DataSerializableConventionsTest {
                 = REFLECTIONS.getSubTypesOf(IdentifiedDataSerializable.class);
 
         serializableClasses.removeAll(allIdDataSerializableClasses);
+
+        // do not check non hazelcast classes & interfaces
+        filterNonHazelcastClasses(serializableClasses);
         // do not check abstract classes & interfaces
         filterNonConcreteClasses(serializableClasses);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
@@ -72,13 +72,16 @@ public final class ReflectionsHelper {
      * Removes abstract and anonymous classes and interfaces from the given set.
      */
     public static void filterNonConcreteClasses(Set<? extends Class> classes) {
-        Iterator<? extends Class> iterator = classes.iterator();
-        while (iterator.hasNext()) {
-            Class<?> klass = iterator.next();
-            if (klass.isAnonymousClass() || klass.isInterface() || Modifier.isAbstract(klass.getModifiers())) {
-                iterator.remove();
-            }
-        }
+        classes.removeIf(klass -> klass.isAnonymousClass()
+                || klass.isInterface() || Modifier.isAbstract(klass.getModifiers())
+        );
+    }
+
+    /**
+     * Removes the classes that does not belong to `com.hazelcast` package.
+     */
+    public static void filterNonHazelcastClasses(Set<? extends Class> classes) {
+        classes.removeIf(klass -> !klass.getName().startsWith("com.hazelcast"));
     }
 
     /**


### PR DESCRIPTION
reasoning: On the EE side, I've added a jet extension (jar-with-dependencies) as a dependency with test scope. DataSerializableConventionsTest picked all of the classes in the dependency. We shouldn't check the non-hazelcast classes for conventions. 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
