### PR TITLE
Fix NPE thrown in MasterJobContext#onStartExecutionComplete

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -600,7 +600,7 @@ public class MasterJobContext {
                 if (requestedTerminationMode != null) {
                     // This cancellation can be because the master cancelled it. If that's the case, convert the exception
                     // to JobTerminateRequestedException.
-                    error = new JobTerminateRequestedException(requestedTerminationMode);
+                    error = new JobTerminateRequestedException(requestedTerminationMode).initCause(error);
                 }
                 // The cancellation can also happen if some participant left and
                 // the target cancelled the execution locally in JobExecutionService.onMemberRemoved().

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -598,15 +598,14 @@ public class MasterJobContext {
             if (error instanceof ExecutionNotFoundException) {
                 // If the StartExecutionOperation didn't find the execution, it means that it was cancelled.
                 if (requestedTerminationMode != null) {
-                    // This cancellation can be because the master cancelled it upon to a user
-                    // request. Let's pretend that case as the StartExecutionOperation returned
-                    // JobTerminateRequestedException.
+                    // This cancellation can be because the master cancelled it. If that's the case, convert the exception
+                    // to JobTerminateRequestedException.
                     error = new JobTerminateRequestedException(requestedTerminationMode);
                 }
-                // The cancellation can also happen that some participants left and
+                // The cancellation can also happen if some participant left and
                 // the target cancelled the execution locally in JobExecutionService.onMemberRemoved().
-                // Since this is an unexpected cancellation, we don't turn it into a post-handled
-                // exception type and let the execution complete with failure.
+                // We keep this (and possibly other) exceptions as they are
+                // and let the execution complete with failure.
             }
             finalizeJob(error);
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -595,7 +595,7 @@ public class MasterJobContext {
                     // have to use Async version, the future is completed inside a synchronized block
                     .whenCompleteAsync(withTryCatch(logger, (r, e) -> finalizeJob(finalError)));
         } else {
-            if (error instanceof ExecutionNotFoundException && requestedTerminationMode != null) {
+            if (error instanceof ExecutionNotFoundException) {
                 // If the StartExecutionOperation didn't find the execution, it means that it was cancelled.
                 if (requestedTerminationMode != null) {
                     // This cancellation can be because the master cancelled it upon to a user


### PR DESCRIPTION
This PR fixes the NPE that is thrown in the callback of
`StartExecutionOperation`.

See the stack trace:
```
Aug 27, 2021 9:41:57 AM com.hazelcast.jet.impl.EnterpriseMasterContext
SEVERE: [10.0.0.91]:5701 [HZ] [5.0-SNAPSHOT] Exception during callback
java.lang.NullPointerException
	at com.hazelcast.jet.impl.exception.JobTerminateRequestedException.<init>(JobTerminateRequestedException.java:28)
	at com.hazelcast.jet.impl.MasterJobContext.onStartExecutionComplete(MasterJobContext.java:602)
	at com.hazelcast.jet.impl.MasterJobContext.lambda$invokeStartExecution$6(MasterJobContext.java:473)
	at com.hazelcast.jet.impl.MasterContext.lambda$invokeOnParticipant$3(MasterContext.java:312)
	at com.hazelcast.jet.impl.util.ExceptionUtil.lambda$withTryCatch$0(ExceptionUtil.java:172)
	...
```

Consider this scenario that this NPE occurs:

- InitExecutionOperation's are performed on all of the members
- Split brain is occurred and master sends some member removed
events (MembershipEvents) to the members and simultaneously
 invokes StartExecutionOperations on members 
- On some of the members, the member removal handling took place
before the start execution operation and cancelled the local execution
there. Then, it throws `ExecutionNotFoundException` after it couldn't
find a running execution in `StartExecutionOperation`.

In this case, requestedTerminationMode becomes null and we get NPE
while handling this `ExecutionNotFoundException`. I made this
 `onStartCallback` to handle this case as if it had unexpected failure.

Partly fixes #19428


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
