### PR TITLE
Simplify protocol signaling routines

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberChannelInitializer.java
@@ -39,8 +39,8 @@ public class MemberChannelInitializer
         InboundHandler[] inboundHandlers = serverContext.createInboundHandlers(EndpointQualifier.MEMBER, connection);
 
         SingleProtocolEncoder protocolEncoder = new SingleProtocolEncoder(new MemberProtocolEncoder(outboundHandlers));
-        SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(ProtocolType.MEMBER,
-                inboundHandlers, protocolEncoder, true);
+        SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(ProtocolType.MEMBER, inboundHandlers,
+                protocolEncoder);
 
         channel.outboundPipeline().addLast(protocolEncoder);
         channel.inboundPipeline().addLast(protocolDecoder);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
@@ -45,10 +45,9 @@ public class SingleProtocolDecoder
     protected final ProtocolType supportedProtocol;
 
     private final SingleProtocolEncoder encoder;
-    private final boolean shouldSignalMemberProtocolEncoder;
 
     public SingleProtocolDecoder(ProtocolType supportedProtocol, InboundHandler next, SingleProtocolEncoder encoder) {
-        this(supportedProtocol, new InboundHandler[]{next}, encoder, false);
+        this(supportedProtocol, new InboundHandler[]{next}, encoder);
     }
 
     /**
@@ -67,19 +66,13 @@ public class SingleProtocolDecoder
      *                                          that will be notified when
      *                                          non-matching protocol bytes have
      *                                          been received
-     * @param shouldSignalMemberProtocolEncoder a boolean used to notify the
-     *                                          next encoder in the pipeline
-     *                                          after the {@link SingleProtocolEncoder}
-     *                                          when matching protocol bytes
-     *                                          have been received
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public SingleProtocolDecoder(ProtocolType supportedProtocol, InboundHandler[] next,
-                                 SingleProtocolEncoder encoder, boolean shouldSignalMemberProtocolEncoder) {
+                                 SingleProtocolEncoder encoder) {
         this.supportedProtocol = supportedProtocol;
         this.inboundHandlers = next;
         this.encoder = encoder;
-        this.shouldSignalMemberProtocolEncoder = shouldSignalMemberProtocolEncoder;
     }
 
     @Override
@@ -102,10 +95,6 @@ public class SingleProtocolDecoder
             // initialize the connection
             initConnection();
             setupNextDecoder();
-
-            if (shouldSignalProtocolLoaded()) {
-                ((MemberProtocolEncoder) encoder.getFirstOutboundHandler()).signalProtocolLoaded();
-            }
 
             return CLEAN;
         } finally {
@@ -144,9 +133,5 @@ public class SingleProtocolDecoder
             TcpServerConnection connection = (TcpServerConnection) channel.attributeMap().get(ServerConnection.class);
             connection.setConnectionType(ConnectionType.MEMBER);
         }
-    }
-
-    private boolean shouldSignalProtocolLoaded() {
-        return !channel.isClientMode() && shouldSignalMemberProtocolEncoder;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/SingleEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/SingleEncoderDecoderTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.server.tcp;
 
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.networking.OutboundPipeline;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
@@ -73,7 +74,7 @@ public class SingleEncoderDecoderTest extends HazelcastTestSupport {
     public void testIncompatibleProtocolSentToClient() {
         // Set up encoder and decoder
         SingleProtocolEncoder protocolEncoder = new SingleProtocolEncoder((OutboundHandler) null);
-        SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(supportedProtocol, null, protocolEncoder);
+        SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(supportedProtocol, (InboundHandler) null, protocolEncoder);
 
         // Set up buffers
         ByteBuffer encoderDst = ByteBuffer.allocate(1000);


### PR DESCRIPTION
Fixes hazelcast/hazelcast-enterprise#4059

This change should prevent NPE in the `MemberProtocolEncoder`
```
java.lang.NullPointerException: null
	at com.hazelcast.internal.server.tcp.MemberProtocolEncoder.signalProtocolLoaded(MemberProtocolEncoder.java:101) ~[hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.server.tcp.SingleProtocolDecoder.onRead(SingleProtocolDecoder.java:107) ~[hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.networking.nio.NioInboundPipeline.process(NioInboundPipeline.java:136) ~[hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.networking.nio.NioThread.processSelectionKey(NioThread.java:383) [hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.networking.nio.NioThread.processSelectionKeys(NioThread.java:368) [hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.networking.nio.NioThread.selectLoop(NioThread.java:294) [hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.networking.nio.NioThread.executeRun(NioThread.java:249) [hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
	at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102) [hazelcast-5.0-SNAPSHOT.jar:5.0-SNAPSHOT]
```
