### PR TITLE
Fix race condition related problem with SingleProtocolEncoder/Decoder

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
@@ -104,7 +104,7 @@ public class SingleProtocolDecoder
             initConnection();
             setupNextDecoder();
             if (!channel.isClientMode()) {
-                // Set up the next encoder in the pipeline if  in client mode
+                // Set up the next encoder in the pipeline if in server mode
                 // This replaces SignalProtocolEncoder with next one in the pipeline
                 encoder.setupNextEncoder();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -74,8 +74,10 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
                 }
             }
 
-            // Set up the next encoder in the pipeline
-            setupNextEncoder();
+            if (channel.isClientMode()) {
+                // Set up the next encoder in the pipeline if  in client mode
+                setupNextEncoder();
+            }
 
             return CLEAN;
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -75,7 +75,7 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
             }
 
             if (channel.isClientMode()) {
-                // Set up the next encoder in the pipeline if  in client mode
+                // Set up the next encoder in the pipeline if in client mode
                 setupNextEncoder();
             }
 


### PR DESCRIPTION
There was a race condition prone problem introduced in the https://github.com/hazelcast/hazelcast/pull/19304. The problem is `MemberProtocolEncoder#signalProtocolLoaded` (called from `SingleProtocolDecoder`) is sometimes called before `SingleProtocolEncoder#setupNextEncoder()` (called from only `SingleProtocolEncoder` before this PR). This causes `NullPointerException` because `SingleProtocolEncoder` is not replaced with `MemberProtocolEncoder` yet, hence `MemberProtocolEncoder`'s channel is null. 

This PR solves this problem by calling `SingleProtocolEncoder#setupNextEncoder()` from `SingleProtocolDecoder` if in server mode. Note that `SingleProtocolEncoder#setupNextEncoder()` is still called from `SingleProtocolEncoder` in client mode.


Fixes #19463
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4059#issuecomment-913416932

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
