### PR TITLE
Add last-update-time to expiry metadata

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
@@ -28,17 +28,23 @@ public final class ExpirationTimeSetter {
     private ExpirationTimeSetter() {
     }
 
-    public static long calculateExpirationTime(long ttlMillis, long maxIdleMillis, long now) {
-        // select most nearest expiration time
-        long expiryTime = Math.min(ttlMillis, maxIdleMillis);
-        if (expiryTime == Long.MAX_VALUE) {
-            return expiryTime;
-        } else {
-            long nextExpiryTime = expiryTime + now;
-            // Due to the overflow possibility, we
-            // check nextExpiryTime against zero.
-            return nextExpiryTime <= 0 ? Long.MAX_VALUE : nextExpiryTime;
-        }
+    public static long nextExpirationTime(long ttlMillis, long maxIdleMillis,
+                                          long now, long lastUpdateTime) {
+        long nextTtlExpirationTime = nextTtlExpirationTime(ttlMillis, lastUpdateTime);
+        long nextMaxIdleExpirationTime = nextMaxIdleExpirationTime(maxIdleMillis, now);
+        return Math.min(nextTtlExpirationTime, nextMaxIdleExpirationTime);
+    }
+
+    private static long nextTtlExpirationTime(long ttlMillis, long lastUpdateTime) {
+        return handleOverflow(ttlMillis + lastUpdateTime);
+    }
+
+    private static long nextMaxIdleExpirationTime(long maxIdleMillis, long now) {
+        return handleOverflow(maxIdleMillis + now);
+    }
+
+    private static long handleOverflow(long time) {
+        return time <= 0 ? Long.MAX_VALUE : time;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.impl.MapDataSerializerHook;
@@ -27,6 +28,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.BackupOperation;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 
@@ -87,14 +89,27 @@ public class PutBackupOperation
 
         IOUtil.writeData(out, dataKey);
         Records.writeRecord(out, record, dataValue, expiryMetadata);
+        // RU_COMPAT_4_2
+        Version version = out.getVersion();
+        if (version.isGreaterOrEqual(Versions.V5_0)) {
+            Records.writeExpiry(out, expiryMetadata);
+        }
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
+        // RU_COMPAT_4_2
+        Version version = in.getVersion();
+        boolean isV5 = version.isGreaterOrEqual(Versions.V5_0);
 
         dataKey = IOUtil.readData(in);
-        expiryMetadata = new ExpiryMetadataImpl();
+        if (!isV5) {
+            expiryMetadata = new ExpiryMetadataImpl();
+        }
         record = Records.readRecord(in, expiryMetadata);
+        if (isV5) {
+            expiryMetadata = Records.readExpiry(in);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.record;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.recordstore.expiry.ExpiryMetadata;
+import com.hazelcast.map.impl.recordstore.expiry.ExpiryMetadataImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -47,6 +48,24 @@ public final class Records {
                                     ExpiryMetadata expiryMetadata) throws IOException {
         byte matchingDataRecordId = in.readByte();
         return getById(matchingDataRecordId).readRecord(in, expiryMetadata);
+    }
+
+    public static void writeExpiry(ObjectDataOutput out, ExpiryMetadata expiryMetadata) throws IOException {
+        boolean hasExpiry = expiryMetadata.hasExpiry();
+        out.writeBoolean(hasExpiry);
+        if (hasExpiry) {
+            expiryMetadata.write(out);
+        }
+    }
+
+    public static ExpiryMetadata readExpiry(ObjectDataInput in) throws IOException {
+        ExpiryMetadata expiryMetadata = ExpiryMetadata.NULL;
+        boolean hasExpiry = in.readBoolean();
+        if (hasExpiry) {
+            expiryMetadata = new ExpiryMetadataImpl();
+            expiryMetadata.read(in);
+        }
+        return expiryMetadata;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -140,7 +140,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
 
     @Override
     public boolean isExpired(Data key, long now, boolean backup) {
-         return hasExpired(key, now, backup) != NOT_EXPIRED;
+        return hasExpired(key, now, backup) != NOT_EXPIRED;
     }
 
     @Override
@@ -180,11 +180,12 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         Long maxIdle = mergingEntry.getMaxIdle();
         if (maxIdle != null) {
             getExpirySystem().addKeyIfExpirable(key, mergingEntry.getTtl(),
-                    maxIdle, mergingEntry.getExpirationTime(), now);
+                    maxIdle, mergingEntry.getExpirationTime(), now, mergingEntry.getLastUpdateTime());
         } else {
             ExpiryMetadata expiredMetadata = getExpirySystem().getExpiredMetadata(key);
             getExpirySystem().addKeyIfExpirable(key, mergingEntry.getTtl(),
-                    expiredMetadata.getMaxIdle(), mergingEntry.getExpirationTime(), now);
+                    expiredMetadata.getMaxIdle(), mergingEntry.getExpirationTime(),
+                    now, mergingEntry.getLastUpdateTime());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -192,13 +192,14 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public Record putReplicatedRecord(Data dataKey, Record replicatedRecord,
                                       ExpiryMetadata expiryMetadata,
-                                      boolean populateIndexes, long nowInMillis) {
-        Record newRecord = createRecord(replicatedRecord, nowInMillis);
+                                      boolean populateIndexes, long now) {
+        Record newRecord = createRecord(replicatedRecord, now);
         storage.put(dataKey, newRecord);
         expirySystem.addKeyIfExpirable(dataKey, expiryMetadata.getTtl(),
-                expiryMetadata.getMaxIdle(), expiryMetadata.getExpirationTime(), getNow());
+                expiryMetadata.getMaxIdle(), expiryMetadata.getExpirationTime(),
+                now, expiryMetadata.getLastUpdateTime());
         mutationObserver.onReplicationPutRecord(dataKey, newRecord, populateIndexes);
-        updateStatsOnPut(replicatedRecord.getHits(), nowInMillis);
+        updateStatsOnPut(replicatedRecord.getHits(), now);
 
         return newRecord;
     }
@@ -922,7 +923,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             putIntoMapStore(record, key, newValue, ttl, maxIdle, now, transactionId);
         }
         storage.put(key, record);
-        expirySystem.addKeyIfExpirable(key, ttl, maxIdle, expiryTime, now);
+        expirySystem.addKeyIfExpirable(key, ttl, maxIdle, expiryTime, now, now);
 
         if (entryEventType == EntryEventType.LOADED) {
             mutationObserver.onLoadRecord(key, record, backup);
@@ -949,7 +950,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
 
         storage.updateRecordValue(key, record, newValue);
-        expirySystem.addKeyIfExpirable(key, ttl, maxIdle, expiryTime, now);
+        expirySystem.addKeyIfExpirable(key, ttl, maxIdle, expiryTime, now, now);
         mutationObserver.onUpdateRecord(key, record, oldValue, newValue, backup);
     }
 
@@ -966,7 +967,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     protected Object putIntoMapStore(Record record, Data key, Object newValue,
                                      long ttlMillis, long maxIdleMillis,
                                      long now, UUID transactionId) {
-        long expirationTime = expirySystem.calculateExpirationTime(ttlMillis, maxIdleMillis, now);
+        long expirationTime = expirySystem.calculateExpirationTime(ttlMillis, maxIdleMillis, now, now);
         newValue = mapDataStore.add(key, newValue, expirationTime, now, transactionId);
         if (mapDataStore.isPostProcessingMapStore()) {
             storage.updateRecordValue(key, record, newValue);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
@@ -16,6 +16,13 @@
 
 package com.hazelcast.map.impl.recordstore.expiry;
 
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.version.Version;
+
+import java.io.IOException;
+
 import static com.hazelcast.map.impl.record.Record.EPOCH_TIME;
 import static com.hazelcast.map.impl.record.Record.UNSET;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -25,6 +32,11 @@ public interface ExpiryMetadata {
 
     @SuppressWarnings("checkstyle:anoninnerlength")
     ExpiryMetadata NULL = new ExpiryMetadata() {
+        @Override
+        public boolean hasExpiry() {
+            return false;
+        }
+
         @Override
         public long getTtl() {
             return Long.MAX_VALUE;
@@ -84,8 +96,31 @@ public interface ExpiryMetadata {
         public ExpiryMetadata setRawExpirationTime(int expirationTime) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public long getLastUpdateTime() {
+            return 0;
+        }
+
+        @Override
+        public int getRawLastUpdateTime() {
+            return 0;
+        }
+
+        @Override
+        public ExpiryMetadata setLastUpdateTime(long lastUpdateTime) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExpiryMetadata setRawLastUpdateTime(int lastUpdateTime) {
+            throw new UnsupportedOperationException();
+        }
     };
 
+    default boolean hasExpiry() {
+        return true;
+    }
 
     long getTtl();
 
@@ -110,6 +145,36 @@ public interface ExpiryMetadata {
     ExpiryMetadata setExpirationTime(long expirationTime);
 
     ExpiryMetadata setRawExpirationTime(int expirationTime);
+
+    long getLastUpdateTime();
+
+    int getRawLastUpdateTime();
+
+    ExpiryMetadata setLastUpdateTime(long lastUpdateTime);
+
+    ExpiryMetadata setRawLastUpdateTime(int lastUpdateTime);
+
+    default void write(ObjectDataOutput out) throws IOException {
+        out.writeInt(getRawTtl());
+        out.writeInt(getRawMaxIdle());
+        out.writeInt(getRawExpirationTime());
+        // RU_COMPAT_4_2
+        Version version = out.getVersion();
+        if (version.isGreaterOrEqual(Versions.V5_0)) {
+            out.writeInt(getRawLastUpdateTime());
+        }
+    }
+
+    default void read(ObjectDataInput in) throws IOException {
+        setRawTtl(in.readInt());
+        setRawMaxIdle(in.readInt());
+        setRawExpirationTime(in.readInt());
+        // RU_COMPAT_4_2
+        Version version = in.getVersion();
+        if (version.isGreaterOrEqual(Versions.V5_0)) {
+            setRawLastUpdateTime(in.readInt());
+        }
+    }
 
     default int stripBaseTime(long value) {
         int diff = UNSET;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadataImpl.java
@@ -24,23 +24,24 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     private int ttl;
     private int maxIdle;
-    // RU_COMPAT_4_1
-    // No need to set default value of
-    // expirationTime to UNSET after version 4.2
-    private volatile int expirationTime = UNSET;
+    private int lastUpdateTime;
+    private volatile int expirationTime;
 
     public ExpiryMetadataImpl() {
     }
 
-    public ExpiryMetadataImpl(long ttl, long maxIdle, long expirationTime) {
+    public ExpiryMetadataImpl(long ttl, long maxIdle,
+                              long expirationTime, long lastUpdateTime) {
         setTtl(ttl);
         setMaxIdle(maxIdle);
         setExpirationTime(expirationTime);
+        setLastUpdateTime(lastUpdateTime);
     }
 
     @Override
     public long getTtl() {
-        return ttl == Integer.MAX_VALUE ? Long.MAX_VALUE : SECONDS.toMillis(ttl);
+        return ttl == Integer.MAX_VALUE
+                ? Long.MAX_VALUE : SECONDS.toMillis(ttl);
     }
 
     @Override
@@ -55,7 +56,8 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
             ttlSeconds = 1;
         }
 
-        this.ttl = ttlSeconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) ttlSeconds;
+        this.ttl = ttlSeconds > Integer.MAX_VALUE
+                ? Integer.MAX_VALUE : (int) ttlSeconds;
         return this;
     }
 
@@ -67,7 +69,8 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public long getMaxIdle() {
-        return maxIdle == Integer.MAX_VALUE ? Long.MAX_VALUE : SECONDS.toMillis(maxIdle);
+        return maxIdle == Integer.MAX_VALUE
+                ? Long.MAX_VALUE : SECONDS.toMillis(maxIdle);
     }
 
     @Override
@@ -81,7 +84,8 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
         if (maxIdleSeconds == 0 && maxIdle != 0) {
             maxIdleSeconds = 1;
         }
-        this.maxIdle = maxIdleSeconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) maxIdleSeconds;
+        this.maxIdle = maxIdleSeconds > Integer.MAX_VALUE
+                ? Integer.MAX_VALUE : (int) maxIdleSeconds;
         return this;
     }
 
@@ -124,11 +128,44 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
     }
 
     @Override
+    public long getLastUpdateTime() {
+        if (lastUpdateTime == UNSET) {
+            return 0L;
+        }
+
+        if (lastUpdateTime == Integer.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+
+        return recomputeWithBaseTime(lastUpdateTime);
+    }
+
+    @Override
+    public int getRawLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    @Override
+    public ExpiryMetadata setLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime == Long.MAX_VALUE
+                ? Integer.MAX_VALUE
+                : stripBaseTime(lastUpdateTime);
+        return this;
+    }
+
+    @Override
+    public ExpiryMetadata setRawLastUpdateTime(int lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+        return this;
+    }
+
+    @Override
     public String toString() {
         return "ExpiryMetadataImpl{"
                 + "ttl=" + getTtl()
                 + ", maxIdle=" + getMaxIdle()
                 + ", expirationTime=" + getExpirationTime()
+                + ", lastUpdateTime=" + getLastUpdateTime()
                 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -25,7 +25,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordReaderWriter;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -33,23 +34,104 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ExpirationTimeTest extends HazelcastTestSupport {
 
     private static final long ONE_MINUTE_IN_MILLIS = MINUTES.toMillis(1);
+
+    @Parameterized.Parameter
+    public boolean statisticsEnabled;
+    @Parameterized.Parameter(1)
+    public boolean perEntryStatsEnabled;
+
+    @Parameterized.Parameters(name = "statisticsEnabled:{0}, perEntryStatsEnabled:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true, true},
+                {false, true},
+                {true, false},
+                {false, false},
+        });
+    }
+
+    @Test
+    public void expire_based_on_ttl_when_when_ttl_is_smaller_than_max_idle() {
+        IMap<Integer, Integer> map = createMap();
+        final long ttlSeconds = 5;
+        final long maxIdleSeconds = 10;
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        // access
+        for (int i = 0; i < 2; i++) {
+            sleepSeconds(2);
+            map.get(1);
+        }
+
+        long expirationTimeAfterGet = getExpirationTime(map, 1);
+
+        assertEquals(expirationTimeAfterGet, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void ttl_limits_expiration_time_increase_when_max_idle_is_smaller_than_ttl() {
+        IMap<Integer, Integer> map = createMap();
+        final long ttlSeconds = 12;
+        final long maxIdleSeconds = 10;
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        // access
+        for (int i = 0; i < 2; i++) {
+            sleepSeconds(2);
+            map.get(1);
+        }
+
+        long expirationTimeAfterGet = getExpirationTime(map, 1);
+
+        long diff = expirationTimeAfterGet - expirationTimeAfterPut;
+        assertEquals(ttlSeconds - maxIdleSeconds, MILLISECONDS.toSeconds(diff));
+    }
+
+    @Test
+    public void last_update_time_as_version_when_both_ttl_and_max_idle_defined() {
+        assumeThat(perEntryStatsEnabled, is(false));
+
+        final long ttlSeconds = 12;
+        final long maxIdleSeconds = 10;
+        IMap<Integer, Integer> map = createMap();
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+        long version1 = map.getEntryView(1).getVersion();
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+        long version2 = map.getEntryView(1).getVersion();
+
+        assertTrue(version2 > version1);
+    }
 
     @Test
     public void put_without_ttl_after_put_with_ttl_cancels_previous_ttl() {
@@ -123,6 +205,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withTTL() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS);
@@ -169,6 +253,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withTTL_withShorterMaxIdle() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS, 10, SECONDS);
@@ -182,6 +268,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withShorterTTL_andMaxIdle() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, 10, SECONDS, 20, SECONDS);
@@ -249,6 +337,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withTTL_afterMultipleUpdates() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS);
@@ -502,7 +592,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
         config.getMetricsConfig().setEnabled(false);
         MapConfig mapConfig = config.getMapConfig(mapName);
         mapConfig.setInMemoryFormat(inMemoryFormat());
-        mapConfig.setPerEntryStatsEnabled(true);
+        mapConfig.setPerEntryStatsEnabled(perEntryStatsEnabled);
+        mapConfig.setStatisticsEnabled(statisticsEnabled);
         return createHazelcastInstance(config).getMap(mapName);
     }
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/19305

**Issue:**
Issue happens if you configure both ttl and maxIdle for a key. In this case, we need to know last-update-time to calculate ttl expiry time which is needed to compare with maxIdle expiry time. 

**Modifications:**
- Added last-update-time to expiry metadata in a backward compatible manner.
- Removed extra serialization for un-needed expiry metadata.

Forward-port of: https://github.com/hazelcast/hazelcast/pull/19483
