### PR TITLE
Fix TestSources to support extremely high rates

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/test/TestSources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/test/TestSources.java
@@ -229,7 +229,7 @@ public final class TestSources {
         private long sequence;
 
         private ItemStreamSource(int itemsPerSecond, GeneratorFunction<? extends T> generator) {
-            this.periodNanos = TimeUnit.SECONDS.toNanos(1) / itemsPerSecond;
+            this.periodNanos = Math.max(TimeUnit.SECONDS.toNanos(1) / itemsPerSecond, 1);
             this.generator = generator;
         }
 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/19353

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
