### PR TITLE
Throw unsupported operation exception if perEntryStatsEnabled is false

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -140,7 +140,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
 
     @Override
     public boolean isExpired(Data key, long now, boolean backup) {
-         return hasExpired(key, now, backup) != NOT_EXPIRED;
+        return hasExpired(key, now, backup) != NOT_EXPIRED;
     }
 
     @Override
@@ -168,7 +168,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     public void accessRecord(Data dataKey, Record record, long now) {
         record.onAccess(now);
         updateStatsOnGet(now);
-        expirySystem.extendExpiryTime(dataKey, now);
+        expirySystem.extendExpiryTime(dataKey, now, record.getLastUpdateTime());
     }
 
     protected void mergeRecordExpiration(Data key, Record record,
@@ -180,11 +180,11 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         Long maxIdle = mergingEntry.getMaxIdle();
         if (maxIdle != null) {
             getExpirySystem().addKeyIfExpirable(key, mergingEntry.getTtl(),
-                    maxIdle, mergingEntry.getExpirationTime(), now);
+                    maxIdle, mergingEntry.getExpirationTime(), now, record);
         } else {
             ExpiryMetadata expiredMetadata = getExpirySystem().getExpiredMetadata(key);
             getExpirySystem().addKeyIfExpirable(key, mergingEntry.getTtl(),
-                    expiredMetadata.getMaxIdle(), mergingEntry.getExpirationTime(), now);
+                    expiredMetadata.getMaxIdle(), mergingEntry.getExpirationTime(), now, record);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpirySystem.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpirySystem.java
@@ -217,9 +217,6 @@ public class ExpirySystem {
             return;
         }
 
-        checkIfTtlGreaterThanMaxIdle(recordStore.getName(),
-                lastUpdateTime, maxIdle, ttl);
-
         expiryMetadata.setExpirationTime(
                 nextExpirationTime(ttl, maxIdle, now, lastUpdateTime));
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
@@ -39,11 +39,13 @@ public abstract class AbstractClientMapTest extends HazelcastTestSupport {
     public final void startHazelcastInstances() {
         Config config = getConfig();
         MapConfig mapConfig = new MapConfig("mapWithTTL");
+        mapConfig.setPerEntryStatsEnabled(true);
         mapConfig.setTimeToLiveSeconds(1);
         config.addMapConfig(mapConfig);
 
         MapConfig mapConfig1 = new MapConfig("mapWithMaxIdle");
         mapConfig1.setMaxIdleSeconds(11);
+        mapConfig1.setPerEntryStatsEnabled(true);
         config.addMapConfig(mapConfig1);
         ClientConfig clientConfig = getClientConfig();
 

--- a/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
@@ -63,6 +63,7 @@ public class DynamicMapConfigTest extends HazelcastTestSupport {
         String mapName = randomMapName();
 
         Config config = getConfig();
+        config.getMapConfig(mapName).setPerEntryStatsEnabled(true);
         config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), "1");
 
         HazelcastInstance node = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1444,6 +1444,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
     private void testEntryProcessorWithPredicate_updatesLastAccessTime(boolean accessExpected) {
         Config config = withoutNetworkJoin(smallInstanceConfig());
         config.getMapConfig(MAP_NAME)
+                .setPerEntryStatsEnabled(true)
                 .setTimeToLiveSeconds(60)
                 .setMaxIdleSeconds(30);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordReaderWriter;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -33,23 +33,98 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ExpirationTimeTest extends HazelcastTestSupport {
 
     private static final long ONE_MINUTE_IN_MILLIS = MINUTES.toMillis(1);
+
+    @Parameterized.Parameter
+    public boolean statisticsEnabled;
+    @Parameterized.Parameter(1)
+    public boolean perEntryStatsEnabled;
+
+    @Parameterized.Parameters(name = "statisticsEnabled:{0}, perEntryStatsEnabled:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true, true},
+                {false, true},
+                {true, false},
+                {false, false},
+        });
+    }
+
+    @Test
+    public void expire_based_on_ttl_when_when_ttl_is_smaller_than_max_idle() {
+        IMap<Integer, Integer> map = createMap();
+        final long ttlSeconds = 5;
+        final long maxIdleSeconds = 10;
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        // access
+        for (int i = 0; i < 2; i++) {
+            sleepSeconds(2);
+            map.get(1);
+        }
+
+        long expirationTimeAfterGet = getExpirationTime(map, 1);
+
+        assertEquals(expirationTimeAfterGet, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void ttl_limits_expiration_time_increase_when_max_idle_is_smaller_than_ttl() {
+        assumeThat(perEntryStatsEnabled, is(true));
+        IMap<Integer, Integer> map = createMap();
+        final long ttlSeconds = 12;
+        final long maxIdleSeconds = 10;
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        // access
+        for (int i = 0; i < 2; i++) {
+            sleepSeconds(2);
+            map.get(1);
+        }
+
+        long expirationTimeAfterGet = getExpirationTime(map, 1);
+
+        long diff = expirationTimeAfterGet - expirationTimeAfterPut;
+        assertEquals(ttlSeconds - maxIdleSeconds, MILLISECONDS.toSeconds(diff));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void throw_exception_when_ttl_is_greater_than_maxIdleSeconds_and_perEntryStatsEnabled_is_false() {
+        assumeThat(perEntryStatsEnabled, is(false));
+        IMap<Integer, Integer> map = createMap();
+        final long ttlSeconds = 11;
+        final long maxIdleSeconds = 10;
+
+        map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);
+    }
 
     @Test
     public void put_without_ttl_after_put_with_ttl_cancels_previous_ttl() {
@@ -123,6 +198,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withTTL() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS);
@@ -169,6 +246,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withTTL_withShorterMaxIdle() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS, 10, SECONDS);
@@ -182,6 +261,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withShorterTTL_andMaxIdle() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, 10, SECONDS, 20, SECONDS);
@@ -249,6 +330,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
     @Test
     public void testExpirationTime_withTTL_afterMultipleUpdates() {
+        assumeThat(perEntryStatsEnabled, is(true));
+
         IMap<Integer, Integer> map = createMap();
 
         map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS);
@@ -502,7 +585,8 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
         config.getMetricsConfig().setEnabled(false);
         MapConfig mapConfig = config.getMapConfig(mapName);
         mapConfig.setInMemoryFormat(inMemoryFormat());
-        mapConfig.setPerEntryStatsEnabled(true);
+        mapConfig.setPerEntryStatsEnabled(perEntryStatsEnabled);
+        mapConfig.setStatisticsEnabled(statisticsEnabled);
         return createHazelcastInstance(config).getMap(mapName);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -75,7 +75,7 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
     @Test
     public void expire_based_on_ttl_when_when_ttl_is_smaller_than_max_idle() {
         IMap<Integer, Integer> map = createMap();
-        final long ttlSeconds = 5;
+        final long ttlSeconds = 8;
         final long maxIdleSeconds = 10;
 
         map.put(1, 1, ttlSeconds, SECONDS, maxIdleSeconds, SECONDS);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -104,6 +104,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true).setImplementation(testEntryLoader);
         config.getMapConfig("default")
+                .setPerEntryStatsEnabled(true)
                 .setMapStoreConfig(mapStoreConfig)
                 .setInMemoryFormat(inMemoryFormat);
         return config;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryStoreSimpleTest.java
@@ -86,6 +86,7 @@ public class EntryStoreSimpleTest extends HazelcastTestSupport {
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true).setImplementation(testEntryStore);
         config.getMapConfig("default")
+                .setPerEntryStatsEnabled(true)
                 .setMapStoreConfig(mapStoreConfig)
                 .setInMemoryFormat(inMemoryFormat);
         return config;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/EntryStoreWriteBehindTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/EntryStoreWriteBehindTest.java
@@ -35,7 +35,8 @@ public class EntryStoreWriteBehindTest extends EntryStoreSimpleTest {
     @Override
     protected Config getConfig() {
         Config config = super.getConfig();
-        config.getMapConfig("default").getMapStoreConfig().setWriteDelaySeconds(1);
+        config.getMapConfig("default").setPerEntryStatsEnabled(true)
+                .getMapStoreConfig().setWriteDelaySeconds(1);
         return config;
     }
 


### PR DESCRIPTION
fixes #19305 for 4.2 branch

**Issue:**
Issue happens if you configure both ttl and maxIdle for a key. In this case, we need to know last-update-time to calculate ttl expiry time which is needed to compare with maxIdle expiry time. 

**Modifications:**
For 4.2, this requirement can only be satisfied when `perEntryStatsEnabled` is enabled. So we will throw exception and warn user to set `perEntryStatsEnabled` to `true`.

**Note:**
We cannot add last-update-time to expiry metadata due to the backward compatibility issues.