### PR TITLE
Delete duplicate build() of member builder in create snapshot of client's cluster service

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -285,7 +285,7 @@ public class ClientClusterServiceImpl
                     .uuid(memberInfo.getUuid())
                     .attributes(memberInfo.getAttributes())
                     .liteMember(memberInfo.isLiteMember())
-                    .memberListJoinVersion(memberInfo.getMemberListJoinVersion()).build();
+                    .memberListJoinVersion(memberInfo.getMemberListJoinVersion());
             newMembers.put(memberInfo.getUuid(), memberBuilder.build());
         }
         return new MemberListSnapshot(memberListVersion, newMembers);


### PR DESCRIPTION
Small easy fix for leftover logic. We built member builder twice in client cluster service. Building twice did not cause problems about correctness, but it does unnecessary extra job. 

resolves #19500