### PR TITLE
Improve default implementation of Replace All

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -245,6 +245,7 @@ import com.hazelcast.client.impl.protocol.codec.MapRemoveEntryListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveIfSameCodec;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveInterceptorCodec;
 import com.hazelcast.client.impl.protocol.codec.MapRemovePartitionLostListenerCodec;
+import com.hazelcast.client.impl.protocol.codec.MapReplaceAllCodec;
 import com.hazelcast.client.impl.protocol.codec.MapReplaceCodec;
 import com.hazelcast.client.impl.protocol.codec.MapReplaceIfSameCodec;
 import com.hazelcast.client.impl.protocol.codec.MapSetCodec;
@@ -621,6 +622,7 @@ import com.hazelcast.client.impl.protocol.task.map.MapRemoveIfSameMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapRemoveInterceptorMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapRemoveMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapRemovePartitionLostListenerMessageTask;
+import com.hazelcast.client.impl.protocol.task.map.MapReplaceAllMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapReplaceIfSameMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapReplaceMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapSetMessageTask;
@@ -1394,6 +1396,8 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 (cm, con) -> new MapEvictMessageTask(cm, node, con));
         factories.put(MapGetAllCodec.REQUEST_MESSAGE_TYPE,
                 (cm, con) -> new MapGetAllMessageTask(cm, node, con));
+        factories.put(MapReplaceAllCodec.REQUEST_MESSAGE_TYPE,
+                (cm, con) -> new MapReplaceAllMessageTask(cm, node, con));
         factories.put(MapForceUnlockCodec.REQUEST_MESSAGE_TYPE,
                 (cm, con) -> new MapForceUnlockMessageTask(cm, node, con));
         factories.put(MapLoadAllCodec.REQUEST_MESSAGE_TYPE,

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapReplaceAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapReplaceAllMessageTask.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapReplaceAllCodec;
+import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.ReplaceAllOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.security.Permission;
+import java.util.function.BiFunction;
+
+public class MapReplaceAllMessageTask
+        extends AbstractPartitionMessageTask<MapReplaceAllCodec.RequestParameters> {
+
+    private BiFunction function;
+    private String name;
+
+    public MapReplaceAllMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        return new ReplaceAllOperation(name, function);
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    protected MapReplaceAllCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        MapReplaceAllCodec.RequestParameters parameters =  MapReplaceAllCodec.decodeRequest(clientMessage);
+        function = serializationService.toObject(parameters.function);
+        name = parameters.name;
+        return parameters;
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return MapReplaceAllCodec.encodeResponse();
+    } //we had get all response method
+
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "replaceAll";
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -85,6 +85,7 @@ import com.hazelcast.client.impl.protocol.codec.MapTryPutCodec;
 import com.hazelcast.client.impl.protocol.codec.MapTryRemoveCodec;
 import com.hazelcast.client.impl.protocol.codec.MapUnlockCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesCodec;
+import com.hazelcast.client.impl.protocol.codec.MapReplaceAllCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPagingPredicateCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
 import com.hazelcast.client.impl.protocol.codec.holder.PagingPredicateHolder;
@@ -114,6 +115,7 @@ import com.hazelcast.internal.journal.EventJournalReader;
 import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.internal.util.IterationType;
 import com.hazelcast.map.EntryProcessor;
@@ -2188,6 +2190,25 @@ public class ClientMapProxy<K, V> extends ClientProxy
                     return value;
                 }
             }
+        }
+    }
+
+    @Override
+    public void replaceAll(@Nonnull BiFunction<? super K, ? super V, ? extends V> function) {
+        checkNotNull(function, NULL_BIFUNCTION_IS_NOT_ALLOWED);
+        replaceAllInternal(function);
+    }
+
+    protected void replaceAllInternal(BiFunction<? super K, ? super V, ? extends V> function) {
+        if (SerializationUtil.isClassStaticAndSerializable(function)) {
+            int partitionCount = getContext().getPartitionService().getPartitionCount();
+            Data functionAsData = toData(function);
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                ClientMessage request = MapReplaceAllCodec.encodeRequest(name, functionAsData);
+                new ClientInvocation(getClient(), request, getName(), partitionId).invoke();
+            }
+        } else {
+            IMap.super.replaceAll(function);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -115,6 +115,7 @@ import com.hazelcast.map.impl.operation.RemoveFromLoadAllOperation;
 import com.hazelcast.map.impl.operation.RemoveIfSameOperation;
 import com.hazelcast.map.impl.operation.RemoveInterceptorOperation;
 import com.hazelcast.map.impl.operation.RemoveOperation;
+import com.hazelcast.map.impl.operation.ReplaceAllOperation;
 import com.hazelcast.map.impl.operation.ReplaceIfSameOperation;
 import com.hazelcast.map.impl.operation.ReplaceOperation;
 import com.hazelcast.map.impl.operation.SetOperation;
@@ -322,8 +323,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int MAP_FETCH_INDEX_OPERATION = 155;
     public static final int INDEX_ITERATION_POINTER = 156;
     public static final int MAP_FETCH_INDEX_OPERATION_RESULT = 157;
+    public static final int REPLACE_ALL = 158;
 
-    private static final int LEN = MAP_FETCH_INDEX_OPERATION_RESULT + 1;
+    private static final int LEN = REPLACE_ALL + 1;
 
     @Override
     public int getFactoryId() {
@@ -488,6 +490,7 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[MAP_FETCH_INDEX_OPERATION] = arg -> new MapFetchIndexOperation();
         constructors[INDEX_ITERATION_POINTER] = arg -> new IndexIterationPointer();
         constructors[MAP_FETCH_INDEX_OPERATION_RESULT] = arg -> new MapFetchIndexOperationResult();
+        constructors[REPLACE_ALL] = arg -> new ReplaceAllOperation();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceAllOperation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
+
+import java.util.function.BiFunction;
+
+public class ReplaceAllOperation<K, V, R> extends MapOperation implements MutatingOperation {
+
+    private BiFunction<K, V, R> function;
+
+    public ReplaceAllOperation() {
+    }
+
+    public ReplaceAllOperation(String name, BiFunction function) {
+        super(name);
+        this.function = function;
+    }
+
+    @Override
+    protected void runInternal() {
+        recordStore.replaceAll(function);
+    }
+
+
+    @Override
+    public Object getResponse() {
+        return null;
+    }
+
+    @Override
+    public int getClassId() {
+        return MapDataSerializerHook.REPLACE_ALL;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 /**
  * Defines a record-store.
@@ -673,4 +674,13 @@ public interface RecordStore<R extends Record> {
     LocalRecordStoreStatsImpl getStats();
 
     void setStats(LocalRecordStoreStats stats);
+
+    /**
+     * Replaces each entry's value with the result of invoking the given
+     * function on that entry until all entries have been processed or the
+     * function throws an exception.
+     *
+     * @param function the function to apply to each entry
+     */
+    void replaceAll(BiFunction function);
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import testsubjects.StaticSerializableBiFunction;
 
 import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
@@ -871,6 +872,26 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
 
         assertEquals(value, result.get());
         assertNull(map.get(key));
+    }
+
+    @Test
+    public void testReplaceAllWithStaticSerializableFunction() {
+        IMap<String, String> map = client.getMap(randomString());
+        map.put("k1", "v1");
+        map.put("k2", "v2");
+        map.replaceAll(new StaticSerializableBiFunction("v_new"));
+        assertEquals(map.get("k1"), "v_new");
+        assertEquals(map.get("k2"), "v_new");
+    }
+
+    @Test
+    public void testReplaceAllWithLambdaFunction() {
+        IMap<String, Integer>  map = client.getMap(randomString());
+        map.put("k1", 1);
+        map.put("k2", 2);
+        map.replaceAll((k, v) -> v * 10);
+        assertEquals((int) map.get("k1"), 10);
+        assertEquals((int) map.get("k2"), 20);
     }
 
     @Test


### PR DESCRIPTION
Issue Description: "In some cases, the default implementations are very inefficient (e.g. Map.replaceAll and forEach fetching all entries and iterating over them locally). This was improved on member-side as the cluster version is available and in some cases we opted for using entry processors instead.

On the client-side, the cluster version is not available which meant it ends up still using the default version. This should be improved by adding full client support for some of the default methods (some are acceptable as-is), which means changing the client protocol, adding codecs, tasks, the works."

Fixes https://github.com/hazelcast/hazelcast/issues/17624

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
