### PR TITLE
assert after the event is procesed - AdvancedNetworkClientIntegration…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/io/AdvancedNetworkClientIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/io/AdvancedNetworkClientIntegrationTest.java
@@ -67,7 +67,7 @@ public class AdvancedNetworkClientIntegrationTest {
     private static final int CLUSTER_SIZE = 3;
     private static final int BASE_CLIENT_PORT = 9090;
 
-    private HazelcastInstance[] instances = new HazelcastInstance[CLUSTER_SIZE];
+    private final HazelcastInstance[] instances = new HazelcastInstance[CLUSTER_SIZE];
     private HazelcastInstance client;
 
     @Before
@@ -152,6 +152,7 @@ public class AdvancedNetworkClientIntegrationTest {
         instances[2] = Hazelcast.newHazelcastInstance(getConfig());
         assertClusterSizeEventually(3, instances);
 
+        assertTrueEventually(() -> assertNotNull(memberAdded.get()));
         assertEquals(memberAdded.get().getAddress(), instances[2].getCluster().getLocalMember().getAddressMap().get(CLIENT));
     }
 


### PR DESCRIPTION
The reason for test failure is that we assert before the event is processed, which implies there was an assumption that `event fired and processed` happens before `cluster membership state change`, whereas it is actually the opposite.

Fixes https://github.com/hazelcast/hazelcast/issues/15104
