### PR TITLE
Increase invalidation sequence instead of resetting it

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -129,8 +129,8 @@ public class CacheEventHandler {
         }
     }
 
-    public void resetPartitionMetaData(String name, int partitionId) {
-        invalidator.resetPartitionMetaData(name, partitionId);
+    public void forceIncrementSequence(String name, int partitionId) {
+        invalidator.forceIncrementSequence(name, partitionId);
     }
 
     public void destroy(String name, UUID sourceUuid) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
@@ -21,12 +21,12 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
-import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
-import com.hazelcast.internal.services.ObjectNamespace;
-import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.internal.services.ServiceNamespaceAware;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.internal.services.ServiceNamespaceAware;
+import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import javax.cache.CacheException;
 
@@ -77,9 +77,9 @@ public class CacheClearOperation
         IPartitionService partitionService = getNodeEngine().getPartitionService();
         if (partitionService.getPartitionId(name) == partitionId) {
             cacheService.sendInvalidationEvent(name, null, SOURCE_NOT_AVAILABLE);
+        } else {
+            cacheService.getCacheEventHandler().forceIncrementSequence(name, partitionId);
         }
-
-        cacheService.getCacheEventHandler().resetPartitionMetaData(name, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
@@ -89,10 +89,9 @@ public abstract class Invalidator {
         return metaDataGenerator;
     }
 
-    public final void resetPartitionMetaData(String dataStructureName, int partitionId) {
+    public final void forceIncrementSequence(String dataStructureName, int partitionId) {
         MetaDataGenerator metaDataGenerator = getMetaDataGenerator();
-        metaDataGenerator.regenerateUuid(partitionId);
-        metaDataGenerator.resetSequence(dataStructureName, partitionId);
+        metaDataGenerator.nextSequence(dataStructureName, partitionId);
     }
 
     private Invalidation newKeyInvalidation(Data key, String dataStructureName, UUID sourceUuid) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -268,9 +268,9 @@ public abstract class MapOperation extends AbstractNamedOperation
 
             if (partitionId == getNodeEngine().getPartitionService().getPartitionId(name)) {
                 invalidator.invalidateAllKeys(name, getCallerUuid());
+            } else {
+                invalidator.forceIncrementSequence(name, getPartitionId());
             }
-
-            invalidator.resetPartitionMetaData(name, getPartitionId());
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapReconciliationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapReconciliationTest.java
@@ -150,7 +150,7 @@ public class MemberMapReconciliationTest extends HazelcastTestSupport {
         }
 
         NearCacheStats nearCacheStats = nearCachedMapFromNewServer.getLocalMapStats().getNearCacheStats();
-        assertStats(nearCacheStats, total, 0, total);
+        assertStats(MAP_NAME, nearCacheStats, total, 0, total);
 
         sleepSeconds(2 * RECONCILIATION_INTERVAL_SECS);
 
@@ -158,7 +158,7 @@ public class MemberMapReconciliationTest extends HazelcastTestSupport {
             nearCachedMapFromNewServer.get(i);
         }
 
-        assertStats(nearCacheStats, total, total, total);
+        assertStats(MAP_NAME, nearCacheStats, total, total, total);
     }
 
     @Override
@@ -176,7 +176,7 @@ public class MemberMapReconciliationTest extends HazelcastTestSupport {
     }
 
     private void waitForNearCacheInvalidationMetadata(final IMap<Integer, Integer> nearCachedMapFromNewServer,
-                                                             final HazelcastInstance server) {
+                                                      final HazelcastInstance server) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -208,10 +208,14 @@ public class MemberMapReconciliationTest extends HazelcastTestSupport {
         return (DefaultNearCache) nearCachedMapFromNewServer.getNearCache().unwrap(DefaultNearCache.class);
     }
 
-    public static void assertStats(NearCacheStats nearCacheStats, int ownedEntryCount, int expectedHits, int expectedMisses) {
-        String msg = "Wrong %s [%s]";
-        assertEquals(format(msg, "ownedEntryCount", nearCacheStats), ownedEntryCount, nearCacheStats.getOwnedEntryCount());
-        assertEquals(format(msg, "expectedHits", nearCacheStats), expectedHits, nearCacheStats.getHits());
-        assertEquals(format(msg, "expectedMisses", nearCacheStats), expectedMisses, nearCacheStats.getMisses());
+    public static void assertStats(String name, NearCacheStats nearCacheStats,
+                                   int ownedEntryCount, int expectedHits, int expectedMisses) {
+        String msg = "NearCache for map `%s`, got wrong %s [%s]";
+        assertEquals(format(msg, name, "ownedEntryCount", nearCacheStats),
+                ownedEntryCount, nearCacheStats.getOwnedEntryCount());
+        assertEquals(format(msg, name, "expectedHits", nearCacheStats),
+                expectedHits, nearCacheStats.getHits());
+        assertEquals(format(msg, name, "expectedMisses", nearCacheStats),
+                expectedMisses, nearCacheStats.getMisses());
     }
 }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/19501

**Issue:**
Calling `map.clear/cache.clear` evicts all entries in all near caches of all maps, not only the map/cache `clear` called on.

**Background:**
UUID is the identity of all invalidation-sequences of all near caches in a partition. We have only one UUID per partition. But each near-cache has its own invalidation-sequence in every partition. Upon `map.clear/cache.clear`, we were resetting UUID and this was causing unneeded eviction of all entries in all near caches, even the near caches belong another map/cache. This eviction was done by reconciliation task eventually.

**Fix:**
With this PR, we only increase associated invalidation-sequence of near cache and not doing uuid reset upon `map.clear/cache.clear`. So other near caches will not be affected.
