### PR TITLE
Wait decoder signal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
@@ -107,11 +107,11 @@ public class SingleProtocolDecoder
                 // Set up the next encoder in the pipeline if in server mode
                 // This replaces SignalProtocolEncoder with next one in the pipeline
                 encoder.setupNextEncoder();
+            }
 
-                // Signal the member protocol encoder only if it's needed
-                if (shouldSignalMemberProtocolEncoder) {
-                    ((MemberProtocolEncoder) encoder.getFirstOutboundHandler()).signalProtocolLoaded();
-                }
+            // Signal the member protocol encoder only if it's needed
+            if (shouldSignalMemberProtocolEncoder) {
+                ((MemberProtocolEncoder) encoder.getFirstOutboundHandler()).signalEncoderCanReplace();
             }
 
             return CLEAN;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
@@ -151,6 +151,7 @@ public class UnifiedProtocolDecoder
     }
 
     private void initChannelForCluster() {
+        protocolEncoder.signalEncoderCanReplace();
         channel.options()
                 .setOption(SO_SNDBUF, props.getInteger(SOCKET_RECEIVE_BUFFER_SIZE) * KILO_BYTE);
 
@@ -160,6 +161,7 @@ public class UnifiedProtocolDecoder
     }
 
     private void initChannelForClient() {
+        protocolEncoder.signalEncoderCanReplace();
         channel.options()
                 .setOption(SO_RCVBUF, clientRcvBuf())
                 // clients dont support direct buffers
@@ -170,6 +172,8 @@ public class UnifiedProtocolDecoder
     }
 
     private void initChannelForText(String protocol, boolean restApi) {
+        protocolEncoder.signalEncoderCanReplace();
+
         ChannelOptions config = channel.options();
 
         config.setOption(SO_RCVBUF, clientRcvBuf());


### PR DESCRIPTION
Protocols are not encrypted. Also protocol encoders does not wait a reply from decoders and immediately sends a package after the protocol is sent by replacing themselves with the next encoder in the pipeline. SymmetricEncryptionSmokeTest fails because client sends a packet after a protocol, which throws exception in the server side. This makes server close the connection. Since client doesn't receive a reply from server sometimes it registers itself as master and creates another cluster. This PR aims to fix this issue.

This PR supersedes https://github.com/hazelcast/hazelcast/pull/19467 and https://github.com/hazelcast/hazelcast-enterprise/pull/4274. If this PR is merged, mentioned PRs must be closed without merging.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4059

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
