### PR TITLE
do merge persistence configs for in-place mutations - DynamicConfigurationAwareConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -85,6 +85,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.internal.config.PersistenceAndHotRestartPersistenceMerger.merge;
 import static com.hazelcast.internal.dynamicconfig.AggregatingMap.aggregate;
 import static com.hazelcast.internal.dynamicconfig.search.ConfigSearch.supplierFor;
 import static com.hazelcast.spi.properties.ClusterProperty.SEARCH_DYNAMIC_CONFIG_FIRST;
@@ -123,6 +124,8 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     public DynamicConfigurationAwareConfig(Config staticConfig, HazelcastProperties properties) {
         assert !(staticConfig instanceof DynamicConfigurationAwareConfig) : "A static Config object is required";
+        merge(staticConfig.getHotRestartPersistenceConfig(), staticConfig.getPersistenceConfig());
+
         this.staticConfig = staticConfig;
         this.configPatternMatcher = staticConfig.getConfigPatternMatcher();
         this.isStaticFirst = !properties.getBoolean(SEARCH_DYNAMIC_CONFIG_FIRST);


### PR DESCRIPTION
Currently, we have two configs related to persistence and we should keep them in sync. So far, with set methods/XML config reads, (de)serialization merges happen, except when user mutates config in place without using any setters such as

```java
  Config config = new Config();
  config.getHotRestartPersistenceConfig()
    .setEnabled(true)
    .setParallelism(10)
    .setValidationTimeoutSeconds(74);
  var instance = Hazelcast.newHazelcastInstance(config);

  PersistenceConfig cfg = instance.getConfig().getPersistenceConfig();
  assertEquals(true, cfg.isEnabled());
  assertEquals(10, cfg.getParallelism());
  assertEquals(74, cfg.getValidationTimeoutSeconds());
```

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4281

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4287