### PR TITLE
Make serializable classes less fragile to small build and implementation changes

### DIFF
--- a/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSerializableTest.java
+++ b/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.avro;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class AvroSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = AvroSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ParsingException.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ParsingException.java
@@ -26,8 +26,11 @@ import com.hazelcast.jet.annotation.EvolvingApi;
 @EvolvingApi
 public class ParsingException extends Exception {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Constructs a new exception with the specified detail message.
+     *
      * @param message the detail message.
      */
     public ParsingException(String message) {

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcDebeziumSerializableTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcDebeziumSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.cdc;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class CdcDebeziumSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = DebeziumCdcSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/CdcMysqlSerializableTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/CdcMysqlSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.cdc.mysql;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class CdcMysqlSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = MySqlCdcSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <debezium.version>1.2.5.Final</debezium.version>
-        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
 
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/CdcPostgresSerializableTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/CdcPostgresSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.cdc.postgres;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class CdcPostgresSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = PostgresCdcSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -92,6 +92,12 @@
             <artifactId>jackson-dataformat-csv</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.slf4j.binding.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/csv/src/test/java/com/hazelcast/jet/csv/CsvSerializableTest.java
+++ b/extensions/csv/src/test/java/com/hazelcast/jet/csv/CsvSerializableTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.csv;
+
+import com.hazelcast.jet.csv.impl.CsvReadFileFnProvider;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class CsvSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = CsvReadFileFnProvider.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
@@ -62,6 +62,8 @@ import static java.util.Objects.requireNonNull;
  */
 public final class ElasticSinkBuilder<T> implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String DEFAULT_NAME = "elasticSink";
     private static final int DEFAULT_LOCAL_PARALLELISM = 2;
     private static final int DEFAULT_RETRIES = 5;

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePSupplier.java
@@ -33,6 +33,8 @@ import static java.util.stream.Collectors.toList;
 
 class ElasticSourcePSupplier<T> implements ProcessorSupplier {
 
+    private static final long serialVersionUID = 1L;
+
     private final ElasticSourceConfiguration<T> configuration;
 
     private final List<Shard> shards;

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/Elastic5SerializableTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/Elastic5SerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class Elastic5SerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = ElasticSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
@@ -63,6 +63,8 @@ import static java.util.Objects.requireNonNull;
  */
 public final class ElasticSinkBuilder<T> implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String DEFAULT_NAME = "elasticSink";
     private static final int DEFAULT_LOCAL_PARALLELISM = 2;
     private static final int DEFAULT_RETRIES = 5;

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePSupplier.java
@@ -33,6 +33,8 @@ import static java.util.stream.Collectors.toList;
 
 class ElasticSourcePSupplier<T> implements ProcessorSupplier {
 
+    private static final long serialVersionUID = 1L;
+
     private final ElasticSourceConfiguration<T> configuration;
 
     private final List<Shard> shards;

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/Elastic6SerializableTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/Elastic6SerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class Elastic6SerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = ElasticSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
@@ -63,6 +63,8 @@ import static java.util.Objects.requireNonNull;
  */
 public final class ElasticSinkBuilder<T> implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String DEFAULT_NAME = "elasticSink";
     private static final int DEFAULT_LOCAL_PARALLELISM = 2;
     private static final int DEFAULT_RETRIES = 5;

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePSupplier.java
@@ -33,6 +33,8 @@ import static java.util.stream.Collectors.toList;
 
 class ElasticSourcePSupplier<T> implements ProcessorSupplier {
 
+    private static final long serialVersionUID = 1L;
+
     private final ElasticSourceConfiguration<T> configuration;
 
     private final List<Shard> shards;

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/Elastic7SerializableTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/Elastic7SerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class Elastic7SerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = ElasticSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -97,5 +97,11 @@
             <artifactId>grpc-api</artifactId>
             <version>${grpc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.slf4j.binding.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/StatusExceptionJet.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/StatusExceptionJet.java
@@ -25,6 +25,9 @@ import io.grpc.StatusException;
  * Jet replaces it with a serializable one.
  */
 public class StatusExceptionJet extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
     StatusExceptionJet(StatusException brokenGrpcException) {
         super(brokenGrpcException.getMessage(), brokenGrpcException.getCause());
         setStackTrace(brokenGrpcException.getStackTrace());

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/StatusRuntimeExceptionJet.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/StatusRuntimeExceptionJet.java
@@ -25,6 +25,9 @@ import io.grpc.StatusRuntimeException;
  * Jet replaces it with a serializable one.
  */
 public class StatusRuntimeExceptionJet extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
     StatusRuntimeExceptionJet(StatusRuntimeException brokenGrpcException) {
         super(brokenGrpcException.getMessage(), brokenGrpcException.getCause());
         setStackTrace(brokenGrpcException.getStackTrace());

--- a/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcSerializableTest.java
+++ b/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.grpc;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class GrpcSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = GrpcService.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/HadoopFileSourceFactory.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/HadoopFileSourceFactory.java
@@ -194,6 +194,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
 
     private static class AvroFormatJobConfigurer implements JobConfigurer {
 
+        private static final long serialVersionUID = 1L;
+
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
             AvroFileFormat<T> avroFileFormat = (AvroFileFormat<T>) format;
@@ -225,6 +227,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
 
     private static class RawBytesFormatJobConfigurer implements JobConfigurer {
 
+        private static final long serialVersionUID = 1L;
+
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
             job.setInputFormatClass(WholeFileAsBytesInputFormat.class);
@@ -243,6 +247,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
     }
 
     private static class CsvFormatJobConfigurer implements JobConfigurer {
+
+        private static final long serialVersionUID = 1L;
 
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
@@ -272,6 +278,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
 
     private static class JsonFormatJobConfigurer implements JobConfigurer {
 
+        private static final long serialVersionUID = 1L;
+
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
             JsonFileFormat<T> jsonFileFormat = (JsonFileFormat<T>) format;
@@ -300,6 +308,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
 
     private static class LineTextJobConfigurer implements JobConfigurer {
 
+        private static final long serialVersionUID = 1L;
+
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
             job.setInputFormatClass(TextInputFormat.class);
@@ -318,6 +328,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
     }
 
     private static class ParquetFormatJobConfigurer implements JobConfigurer {
+
+        private static final long serialVersionUID = 1L;
 
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
@@ -346,6 +358,8 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
     }
 
     private static class TextJobConfigurer implements JobConfigurer {
+
+        private static final long serialVersionUID = 1L;
 
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/IndexedInputSplit.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/IndexedInputSplit.java
@@ -36,6 +36,8 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
  */
 class IndexedInputSplit implements Comparable<IndexedInputSplit>, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private int index;
     private org.apache.hadoop.mapred.InputSplit oldSplit;
     private org.apache.hadoop.mapreduce.InputSplit newSplit;

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/SerializableConfiguration.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/SerializableConfiguration.java
@@ -31,6 +31,8 @@ import java.io.Serializable;
  */
 public final class SerializableConfiguration extends Configuration implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     @SuppressWarnings("unused") // for deserialization
     SerializableConfiguration() {
     }

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/SerializableJobConf.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/SerializableJobConf.java
@@ -30,6 +30,8 @@ import java.io.Serializable;
  */
 public final class SerializableJobConf extends JobConf implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     SerializableJobConf() {
         //For deserialization
     }

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/HadoopSerializableTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/HadoopSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.hadoop;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class HadoopSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = HadoopSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
@@ -32,6 +32,20 @@
             <artifactId>hazelcast-3-connector-interface</artifactId>
             <version>5.0-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-archunit-rules</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.slf4j.binding.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SerializableTest.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.connector;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class Hz3SerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = Hz3Sources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/pom.xml
@@ -51,5 +51,17 @@
             <version>${hazelcast-3.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-archunit-rules</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.slf4j.binding.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/src/test/java/com/hazelcast/internal/serialization/impl/Hz3ImplSerializableTest.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/src/test/java/com/hazelcast/internal/serialization/impl/Hz3ImplSerializableTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.connector.map.impl.MapReader;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+public class Hz3ImplSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = MapReader.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java
@@ -287,6 +287,9 @@ public final class WriteKafkaP<T, K, V> implements Processor {
     }
 
     public static class KafkaTransactionId implements TwoPhaseSnapshotCommitUtility.TransactionId, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
         private final int processorIndex;
         private long producerId = -1;
         private short epoch = -1;

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaSerializableTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class KafkaSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = KafkaSources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -32,10 +32,6 @@
         <version>5.0-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -98,6 +98,13 @@
             <version>${log4j2.slf4j.binding.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-archunit-rules</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/AwsConfig.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/AwsConfig.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 public class AwsConfig implements Serializable {
+
     private static final long serialVersionUID = 1L;
 
     @Nullable

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/AwsConfig.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/AwsConfig.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 public class AwsConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @Nullable
     private String endpoint;

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/HashRange.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/HashRange.java
@@ -30,6 +30,7 @@ public class HashRange implements Serializable {
     public static final BigInteger MIN_VALUE = ZERO;
     public static final BigInteger MAX_VALUE = valueOf(2).pow(128);
     public static final HashRange DOMAIN = new HashRange(MIN_VALUE, MAX_VALUE);
+
     private static final long serialVersionUID = 1L;
 
     private final BigInteger minInclusive;

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/HashRange.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/HashRange.java
@@ -27,10 +27,10 @@ import static java.math.BigInteger.ZERO;
 import static java.math.BigInteger.valueOf;
 
 public class HashRange implements Serializable {
-
     public static final BigInteger MIN_VALUE = ZERO;
     public static final BigInteger MAX_VALUE = valueOf(2).pow(128);
     public static final HashRange DOMAIN = new HashRange(MIN_VALUE, MAX_VALUE);
+    private static final long serialVersionUID = 1L;
 
     private final BigInteger minInclusive;
     private final BigInteger maxExclusive;

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/InitialShardIterators.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/InitialShardIterators.java
@@ -101,6 +101,7 @@ public class InitialShardIterators implements IdentifiedDataSerializable, Serial
     }
 
     private static final class Specification implements Serializable {
+
         private static final long serialVersionUID = 1L;
 
         private final Pattern pattern;

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/InitialShardIterators.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/InitialShardIterators.java
@@ -101,6 +101,7 @@ public class InitialShardIterators implements IdentifiedDataSerializable, Serial
     }
 
     private static final class Specification implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         private final Pattern pattern;
 

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisSerializableTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisSerializableTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 
-public class SerializableTest {
+public class KinesisSerializableTest {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisSerializableTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisSerializableTest.java
@@ -16,14 +16,20 @@
 
 package com.hazelcast.jet.kinesis;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
 public class KinesisSerializableTest {
 
     @Test

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/SerializableTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/SerializableTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kinesis;
+
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+public class SerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = KinesisSinks.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -110,6 +110,12 @@
             <version>${project.version}</version>
             <classifier>tests</classifier>
         </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-archunit-rules</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -133,5 +133,11 @@
             <artifactId>hazelcast-jet-grpc</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.slf4j.binding.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/InvalidPythonServiceConfigException.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/InvalidPythonServiceConfigException.java
@@ -18,6 +18,9 @@ package com.hazelcast.jet.python;
 import com.hazelcast.jet.JetException;
 
 class InvalidPythonServiceConfigException extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
     InvalidPythonServiceConfigException(String message) {
         super(message);
     }

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceConfig.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceConfig.java
@@ -97,6 +97,9 @@ import java.util.StringJoiner;
  * @since Jet 4.0
  */
 public class PythonServiceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private static final String HANDLER_FUNCTION_DEFAULT = "transform_list";
 
     private File baseDir;

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonSerializableTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.python;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class PythonSerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = PythonServiceConfig.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SerializableTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.s3;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
+public class S3SerializableTest {
+
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = S3Sources.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+}

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <!-- needed for CheckStyle -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
     </properties>
 
     <dependencies>

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>hazelcast-archunit-rules</name>
+    <artifactId>hazelcast-archunit-rules</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-root</artifactId>
+        <version>5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <!-- needed for CheckStyle -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.slf4j.binding.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -49,4 +49,28 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+                            <excludes>
+                                <exclude>.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -44,7 +44,6 @@ public final class ArchUnitRules {
             .and().doNotHaveModifier(JavaModifier.ABSTRACT)
             .and().implement(Serializable.class)
             .and().doNotImplement("com.hazelcast.nio.serialization.DataSerializable")
-            .and().areNotAssignableTo(Exception.class)
             .and().areNotAnonymousClasses()
             .should(haveValidSerialVersionUid());
 

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.archunit;
+
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+import java.io.Serializable;
+
+import static com.hazelcast.test.archunit.ArchUnitRules.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beStatic;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.haveRawType;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+
+public final class ArchUnitRules {
+    /**
+     * ArchUnit rule checking that Serializable classes have a valid serialVersionUID
+     */
+    public static final ArchRule SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID = classes()
+            .that()
+            .areNotEnums()
+            .and().doNotHaveModifier(JavaModifier.ABSTRACT)
+            .and().implement(Serializable.class)
+            .and().doNotImplement("com.hazelcast.nio.serialization.DataSerializable")
+            .and().areNotAssignableTo(Exception.class)
+            .and().areNotAnonymousClasses()
+            .should(haveValidSerialVersionUid());
+
+    private ArchUnitRules() {
+    }
+
+    static class SerialVersionUidFieldCondition extends ArchCondition<JavaClass> {
+        private static final String FIELD_NAME = "serialVersionUID";
+
+        SerialVersionUidFieldCondition() {
+            super("have a valid " + FIELD_NAME);
+        }
+
+        @Override
+        public void check(JavaClass clazz, ConditionEvents events) {
+            Optional<JavaField> field = clazz.tryGetField(FIELD_NAME);
+            if (field.isPresent()) {
+                haveRawType("long").and(beFinal()).and(beStatic()).check(field.get(), events);
+            } else {
+                events.add(SimpleConditionEvent.violated(clazz, FIELD_NAME + " field is missing in class " + clazz.getName()));
+            }
+        }
+
+        static SerialVersionUidFieldCondition haveValidSerialVersionUid() {
+            return new SerialVersionUidFieldCondition();
+        }
+    }
+}

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/package-info.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ArchUnit rules for Hazelcast code
+ */
+package com.hazelcast.test.archunit;

--- a/hazelcast-archunit-rules/src/test/java/com/example/broken/BrokenSerializable.java
+++ b/hazelcast-archunit-rules/src/test/java/com/example/broken/BrokenSerializable.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.broken;
+
+import java.io.Serializable;
+
+public class BrokenSerializable implements Serializable {
+}

--- a/hazelcast-archunit-rules/src/test/java/com/example/valid/ValidSerializable.java
+++ b/hazelcast-archunit-rules/src/test/java/com/example/valid/ValidSerializable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.valid;
+
+import java.io.Serializable;
+
+public class ValidSerializable implements Serializable {
+    private static final long serialVersionUID = 1L;
+}

--- a/hazelcast-archunit-rules/src/test/java/com/example/valid/ValidSerializable.java
+++ b/hazelcast-archunit-rules/src/test/java/com/example/valid/ValidSerializable.java
@@ -19,5 +19,6 @@ package com.example.valid;
 import java.io.Serializable;
 
 public class ValidSerializable implements Serializable {
+
     private static final long serialVersionUID = 1L;
 }

--- a/hazelcast-archunit-rules/src/test/java/com/hazelcast/test/archunit/ArchUnitRulesTest.java
+++ b/hazelcast-archunit-rules/src/test/java/com/hazelcast/test/archunit/ArchUnitRulesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.ONLY_INCLUDE_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ArchUnitRulesTest {
+    @Test
+    public void should_fail_with_non_compliant_class() {
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(ONLY_INCLUDE_TESTS)
+                .importPackages("com.example.broken");
+        assertThat(classes).isNotEmpty();
+
+        assertThatThrownBy(() -> ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("was violated (1 times)");
+    }
+
+    @Test
+    public void should_NOT_fail_with_non_compliant_class() {
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(ONLY_INCLUDE_TESTS)
+                .importPackages("com.example.valid");
+        assertThat(classes).isNotEmpty();
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+}

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -779,5 +779,12 @@
             <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-archunit-rules</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/jet/JetException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/JetException.java
@@ -25,6 +25,8 @@ import com.hazelcast.core.HazelcastException;
  */
 public class JetException extends HazelcastException {
 
+    private static final long serialVersionUID = 1L;
+
     public JetException() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/JobAlreadyExistsException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/JobAlreadyExistsException.java
@@ -25,6 +25,8 @@ package com.hazelcast.jet;
  */
 public class JobAlreadyExistsException extends JetException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates the exception
      */

--- a/hazelcast/src/main/java/com/hazelcast/jet/RestartableException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/RestartableException.java
@@ -42,6 +42,8 @@ import com.hazelcast.jet.core.ProcessorSupplier;
  */
 public class RestartableException extends JetException {
 
+    private static final long serialVersionUID = 1L;
+
     public RestartableException() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/EventTimePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/EventTimePolicy.java
@@ -70,11 +70,14 @@ public final class EventTimePolicy<T> implements Serializable {
      */
     public static final long DEFAULT_IDLE_TIMEOUT = 60_000L;
 
+    private static final long serialVersionUID = 1L;
+
     private static final ObjLongBiFunction<?, ?> NO_WRAPPING = (event, timestamp) -> event;
 
     private static final SupplierEx<WatermarkPolicy> NO_WATERMARKS = () -> new WatermarkPolicy() {
         @Override
-        public void reportEvent(long timestamp) { }
+        public void reportEvent(long timestamp) {
+        }
 
         @Override
         public long getCurrentWatermark() {

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/JobNotFoundException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/JobNotFoundException.java
@@ -26,8 +26,10 @@ import com.hazelcast.jet.Util;
  */
 public class JobNotFoundException extends JetException {
 
+    private static final long serialVersionUID = 1L;
+
     public JobNotFoundException(long jobId) {
-       super("Job with id " + Util.idToString(jobId) + " not found");
+        super("Job with id " + Util.idToString(jobId) + " not found");
     }
 
     public JobNotFoundException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/TopologyChangedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/TopologyChangedException.java
@@ -28,6 +28,8 @@ import com.hazelcast.jet.JetException;
  */
 public class TopologyChangedException extends JetException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates the exception
      */

--- a/hazelcast/src/main/java/com/hazelcast/jet/datamodel/Tag.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/datamodel/Tag.java
@@ -35,6 +35,9 @@ import java.io.Serializable;
  */
 @SerializableByConvention
 public final class Tag<T> implements Comparable<Tag<?>>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private static final Tag TAG_0 = new Tag(0);
     private static final Tag TAG_1 = new Tag(1);
     private static final Tag TAG_2 = new Tag(2);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -144,6 +144,8 @@ public final class ReadFilesP<T> extends AbstractProcessor {
 
     private static final class MetaSupplier<T> implements FileProcessorMetaSupplier<T> {
 
+        private static final long serialVersionUID = 1L;
+
         private static final ILogger LOGGER = Logger.getLogger(MetaSupplier.class);
 
         private final int localParallelism;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteObservableP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteObservableP.java
@@ -86,6 +86,8 @@ public final class WriteObservableP<T> extends AsyncHazelcastWriterP {
 
     public static final class Supplier extends AbstractHazelcastConnectorSupplier {
 
+        private static final long serialVersionUID = 1L;
+
         private final String observableName;
 
         public Supplier(String observableName) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/XaSinkProcessorBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/XaSinkProcessorBase.java
@@ -338,6 +338,9 @@ public abstract class XaSinkProcessorBase implements Processor {
     }
 
     private static final class BetterXAException extends XAException {
+
+        private static final long serialVersionUID = 1L;
+
         private BetterXAException(String message, int errorCode, Throwable cause) {
             super(message);
             initCause(cause);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/EnteringPassiveClusterStateException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/EnteringPassiveClusterStateException.java
@@ -26,4 +26,7 @@ import com.hazelcast.jet.impl.operation.StartExecutionOperation;
  * passive state.
  */
 public class EnteringPassiveClusterStateException extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/ExecutionNotFoundException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/ExecutionNotFoundException.java
@@ -25,6 +25,9 @@ import static com.hazelcast.jet.Util.idToString;
  * target doesn't know the execution.
  */
 public class ExecutionNotFoundException extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
     public ExecutionNotFoundException() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/JetDisabledException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/JetDisabledException.java
@@ -24,6 +24,8 @@ import com.hazelcast.jet.JetException;
  */
 public class JetDisabledException extends JetException {
 
+    private static final long serialVersionUID = 1L;
+
     public JetDisabledException(String message) {
         super(message);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/JobTerminateRequestedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/JobTerminateRequestedException.java
@@ -22,6 +22,9 @@ import com.hazelcast.jet.impl.TerminationMode;
 import javax.annotation.Nonnull;
 
 public class JobTerminateRequestedException extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
     private final TerminationMode mode;
 
     public JobTerminateRequestedException(@Nonnull TerminationMode mode) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/TerminatedWithSnapshotException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/TerminatedWithSnapshotException.java
@@ -23,4 +23,7 @@ import com.hazelcast.jet.JetException;
  * result of a terminal snapshot.
  */
 public class TerminatedWithSnapshotException extends JetException {
+
+    private static final long serialVersionUID = 1L;
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/BroadcastEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/BroadcastEntry.java
@@ -26,6 +26,9 @@ import java.util.Map.Entry;
  * @param <V> type of value
  */
 public final class BroadcastEntry<K, V> extends SimpleImmutableEntry<K, V> implements BroadcastItem {
+
+    private static final long serialVersionUID = 1L;
+
     public BroadcastEntry(K key, V value) {
         super(key, value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/memory/AccumulationLimitExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/memory/AccumulationLimitExceededException.java
@@ -25,6 +25,8 @@ import com.hazelcast.jet.config.InstanceConfig;
  */
 public class AccumulationLimitExceededException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     public AccumulationLimitExceededException() {
         super("Exception thrown to prevent an OutOfMemoryError on this Hazelcast instance."
                 + " An OOME might occur when a job accumulates large data sets in one of the processors,"

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/PipelineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/PipelineImpl.java
@@ -53,11 +53,14 @@ import static java.util.stream.Collectors.toList;
 
 public class PipelineImpl implements Pipeline {
 
+    private static final long serialVersionUID = 1L;
+
     private final Map<Transform, List<Transform>> adjacencyMap = new LinkedHashMap<>();
     private final Map<String, File> attachedFiles = new HashMap<>();
     private boolean preserveOrder;
 
-    @Nonnull @Override
+    @Nonnull
+    @Override
     @SuppressWarnings("unchecked")
     public <T> BatchStage<T> readFrom(@Nonnull BatchSource<? extends T> source) {
         BatchSourceTransform<? extends T> xform = (BatchSourceTransform<? extends T>) source;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/SinkImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/SinkImpl.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
 
 public class SinkImpl<T> implements Sink<T> {
 
+    private static final long serialVersionUID = 1L;
+
     private final String name;
     private final ProcessorMetaSupplier metaSupplier;
     private boolean assignedToStage;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
@@ -36,6 +36,7 @@ import static com.hazelcast.jet.core.processor.Processors.combineP;
 
 public class AggregateTransform<A, R> extends AbstractTransform {
     public static final String FIRST_STAGE_VERTEX_NAME_SUFFIX = "-prepare";
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
@@ -21,10 +21,9 @@ import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
-
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -37,6 +36,7 @@ import static com.hazelcast.jet.core.processor.Processors.combineP;
 
 public class AggregateTransform<A, R> extends AbstractTransform {
     public static final String FIRST_STAGE_VERTEX_NAME_SUFFIX = "-prepare";
+    private static final long serialVersionUID = 1L;
 
     @Nonnull
     private final AggregateOperation<A, ? extends R> aggrOp;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/BatchSourceTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/BatchSourceTransform.java
@@ -31,6 +31,7 @@ import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static java.util.Collections.emptyList;
 
 public class BatchSourceTransform<T> extends AbstractTransform implements BatchSource<T> {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/BatchSourceTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/BatchSourceTransform.java
@@ -31,6 +31,7 @@ import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static java.util.Collections.emptyList;
 
 public class BatchSourceTransform<T> extends AbstractTransform implements BatchSource<T> {
+    private static final long serialVersionUID = 1L;
 
     @Nonnull
     public ProcessorMetaSupplier metaSupplier;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
@@ -35,6 +35,7 @@ import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST
 import static com.hazelcast.jet.pipeline.ServiceFactories.nonSharedService;
 
 public class DistinctTransform<T, K> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
 
     private final FunctionEx<? super T, ? extends K> keyFn;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
@@ -35,6 +35,7 @@ import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST
 import static com.hazelcast.jet.pipeline.ServiceFactories.nonSharedService;
 
 public class DistinctTransform<T, K> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     private final FunctionEx<? super T, ? extends K> keyFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapStatefulTransform.java
@@ -32,6 +32,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.flatMapStatefulP;
 
 public class FlatMapStatefulTransform<T, K, S, R> extends StatefulKeyedTransformBase<T, K, S> {
+
     private static final long serialVersionUID = 1L;
 
     private final TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> statefulFlatMapFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapStatefulTransform.java
@@ -20,9 +20,9 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,6 +32,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.flatMapStatefulP;
 
 public class FlatMapStatefulTransform<T, K, S, R> extends StatefulKeyedTransformBase<T, K, S> {
+    private static final long serialVersionUID = 1L;
 
     private final TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> statefulFlatMapFn;
     private final TriFunction<? super S, ? super K, ? super Long, ? extends Traverser<R>> onEvictFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapTransform.java
@@ -29,6 +29,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.flatMapP;
 
 public class FlatMapTransform<T, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapTransform.java
@@ -19,9 +19,9 @@ package com.hazelcast.jet.impl.pipeline.transform;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.core.Edge;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +29,8 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.flatMapP;
 
 public class FlatMapTransform<T, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     private FunctionEx<? super T, ? extends Traverser<? extends R>> flatMapFn;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalFlatMapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalFlatMapStatefulTransform.java
@@ -20,16 +20,17 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.util.ConstantFunctionEx;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
 import static com.hazelcast.jet.core.processor.Processors.flatMapStatefulP;
 
 public class GlobalFlatMapStatefulTransform<T, S, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
 
     private final ToLongFunctionEx<? super T> timestampFn;
     private final SupplierEx<? extends S> createFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalFlatMapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalFlatMapStatefulTransform.java
@@ -30,6 +30,7 @@ import javax.annotation.Nonnull;
 import static com.hazelcast.jet.core.processor.Processors.flatMapStatefulP;
 
 public class GlobalFlatMapStatefulTransform<T, S, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     private final ToLongFunctionEx<? super T> timestampFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalMapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalMapStatefulTransform.java
@@ -29,6 +29,7 @@ import javax.annotation.Nonnull;
 import static com.hazelcast.jet.core.processor.Processors.mapStatefulP;
 
 public class GlobalMapStatefulTransform<T, S, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     private final ToLongFunctionEx<? super T> timestampFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalMapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalMapStatefulTransform.java
@@ -19,16 +19,17 @@ package com.hazelcast.jet.impl.pipeline.transform;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.util.ConstantFunctionEx;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
 import static com.hazelcast.jet.core.processor.Processors.mapStatefulP;
 
 public class GlobalMapStatefulTransform<T, S, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
 
     private final ToLongFunctionEx<? super T> timestampFn;
     private final SupplierEx<? extends S> createFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GroupTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GroupTransform.java
@@ -20,9 +20,9 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.aggregate.AggregateOperation;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -37,6 +37,8 @@ import static com.hazelcast.jet.core.processor.Processors.combineByKeyP;
 import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST_STAGE_VERTEX_NAME_SUFFIX;
 
 public class GroupTransform<K, A, R, OUT> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     private final List<FunctionEx<?, ? extends K>> groupKeyFns;
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GroupTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GroupTransform.java
@@ -37,6 +37,7 @@ import static com.hazelcast.jet.core.processor.Processors.combineByKeyP;
 import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST_STAGE_VERTEX_NAME_SUFFIX;
 
 public class GroupTransform<K, A, R, OUT> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -23,12 +23,12 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.processor.HashJoinCollectP;
 import com.hazelcast.jet.impl.processor.HashJoinP;
 import com.hazelcast.jet.pipeline.JoinClause;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -42,6 +42,8 @@ import static com.hazelcast.jet.impl.util.Util.toList;
 
 @SuppressWarnings("rawtypes")
 public class HashJoinTransform<T0, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     private final List<JoinClause<?, ? super T0, ?, ?>> clauses;
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -42,6 +42,7 @@ import static com.hazelcast.jet.impl.util.Util.toList;
 
 @SuppressWarnings("rawtypes")
 public class HashJoinTransform<T0, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapStatefulTransform.java
@@ -31,6 +31,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.mapStatefulP;
 
 public class MapStatefulTransform<T, K, S, R> extends StatefulKeyedTransformBase<T, K, S> {
+
     private static final long serialVersionUID = 1L;
 
     private final TriFunction<? super S, ? super K, ? super T, ? extends R> statefulMapFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapStatefulTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapStatefulTransform.java
@@ -19,10 +19,9 @@ package com.hazelcast.jet.impl.pipeline.transform;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
-
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,6 +31,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.mapStatefulP;
 
 public class MapStatefulTransform<T, K, S, R> extends StatefulKeyedTransformBase<T, K, S> {
+    private static final long serialVersionUID = 1L;
 
     private final TriFunction<? super S, ? super K, ? super T, ? extends R> statefulMapFn;
     @Nullable private TriFunction<? super S, ? super K, ? super Long, ? extends R> onEvictFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapTransform.java
@@ -18,9 +18,9 @@ package com.hazelcast.jet.impl.pipeline.transform;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.Edge;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
@@ -28,6 +28,8 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 
 public class MapTransform<T, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     private FunctionEx<? super T, ? extends R> mapFn;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapTransform.java
@@ -28,6 +28,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 
 public class MapTransform<T, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MergeTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MergeTransform.java
@@ -17,9 +17,9 @@
 package com.hazelcast.jet.impl.pipeline.transform;
 
 import com.hazelcast.jet.core.Edge;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +29,7 @@ import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static java.util.Arrays.asList;
 
 public class MergeTransform<T> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
 
     public MergeTransform(@Nonnull Transform upstream1, @Nonnull Transform upstream2) {
         super("merge", asList(upstream1, upstream2));

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MergeTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MergeTransform.java
@@ -29,6 +29,7 @@ import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static java.util.Arrays.asList;
 
 public class MergeTransform<T> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     public MergeTransform(@Nonnull Transform upstream1, @Nonnull Transform upstream2) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -36,6 +36,7 @@ import static com.hazelcast.jet.core.processor.Processors.filterUsingServiceP;
 import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceP;
 
 public final class PartitionedProcessorTransform<T, K> extends ProcessorTransform {
+
     private static final long serialVersionUID = 1L;
 
     private final FunctionEx<? super T, ? extends K> partitionKeyFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -23,9 +23,9 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.processor.Processors;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 
 import javax.annotation.Nonnull;
@@ -36,6 +36,7 @@ import static com.hazelcast.jet.core.processor.Processors.filterUsingServiceP;
 import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceP;
 
 public final class PartitionedProcessorTransform<T, K> extends ProcessorTransform {
+    private static final long serialVersionUID = 1L;
 
     private final FunctionEx<? super T, ? extends K> partitionKeyFn;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
@@ -18,9 +18,9 @@ package com.hazelcast.jet.impl.pipeline.transform;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
@@ -28,6 +28,8 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekOutputP;
 
 public class PeekTransform<T> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     public final PredicateEx<? super T> shouldLogFn;
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
@@ -28,6 +28,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekOutputP;
 
 public class PeekTransform<T> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
@@ -42,6 +42,7 @@ import static com.hazelcast.jet.core.processor.Processors.mapUsingServiceP;
 
 public class ProcessorTransform extends AbstractTransform {
     public static final int NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM = 2;
+
     private static final long serialVersionUID = 1L;
 
     final ProcessorMetaSupplier processorSupplier;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
@@ -23,12 +23,12 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.processor.AsyncTransformUsingServiceBatchedP;
 import com.hazelcast.jet.impl.processor.AsyncTransformUsingServiceOrderedP;
 import com.hazelcast.jet.impl.processor.AsyncTransformUsingServiceUnorderedP;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 
 import javax.annotation.Nonnull;
@@ -42,6 +42,7 @@ import static com.hazelcast.jet.core.processor.Processors.mapUsingServiceP;
 
 public class ProcessorTransform extends AbstractTransform {
     public static final int NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM = 2;
+    private static final long serialVersionUID = 1L;
 
     final ProcessorMetaSupplier processorSupplier;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SinkTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SinkTransform.java
@@ -18,10 +18,10 @@ package com.hazelcast.jet.impl.pipeline.transform;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.Partitioner;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.pipeline.SinkImpl;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -32,6 +32,8 @@ import static com.hazelcast.jet.impl.pipeline.SinkImpl.Type.TOTAL_PARALLELISM_ON
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
 
 public class SinkTransform<T> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     private static final int[] EMPTY_ORDINALS = new int[0];
 
     private final SinkImpl<T> sink;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SinkTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SinkTransform.java
@@ -32,6 +32,7 @@ import static com.hazelcast.jet.impl.pipeline.SinkImpl.Type.TOTAL_PARALLELISM_ON
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
 
 public class SinkTransform<T> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     private static final int[] EMPTY_ORDINALS = new int[0];

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
@@ -36,6 +36,7 @@ import static com.hazelcast.jet.core.processor.Processors.sortP;
 
 
 public class SortTransform<T> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     private static final String COLLECT_STAGE_SUFFIX = "-collect";

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
@@ -36,6 +36,7 @@ import static com.hazelcast.jet.core.processor.Processors.sortP;
 
 
 public class SortTransform<T> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
 
     private static final String COLLECT_STAGE_SUFFIX = "-collect";
     private final ComparatorEx<? super T> comparator;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/StreamSourceTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/StreamSourceTransform.java
@@ -41,6 +41,7 @@ import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static java.util.Collections.emptyList;
 
 public class StreamSourceTransform<T> extends AbstractTransform implements StreamSource<T> {
+
     private static final long serialVersionUID = 1L;
 
     public FunctionEx<? super EventTimePolicy<? super T>, ? extends ProcessorMetaSupplier> metaSupplierFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/StreamSourceTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/StreamSourceTransform.java
@@ -21,14 +21,13 @@ import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.impl.ProcessorClassLoaderTLHolder;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.StreamSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -42,6 +41,7 @@ import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static java.util.Collections.emptyList;
 
 public class StreamSourceTransform<T> extends AbstractTransform implements StreamSource<T> {
+    private static final long serialVersionUID = 1L;
 
     public FunctionEx<? super EventTimePolicy<? super T>, ? extends ProcessorMetaSupplier> metaSupplierFn;
     private boolean isAssignedToStage;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/TimestampTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/TimestampTransform.java
@@ -29,6 +29,7 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.insertWatermarksP;
 
 public class TimestampTransform<T> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/TimestampTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/TimestampTransform.java
@@ -18,9 +18,9 @@ package com.hazelcast.jet.impl.pipeline.transform;
 
 import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.EventTimePolicy;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +29,8 @@ import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.Processors.insertWatermarksP;
 
 public class TimestampTransform<T> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     private EventTimePolicy<? super T> eventTimePolicy;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowAggregateTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowAggregateTransform.java
@@ -48,7 +48,9 @@ import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST
 import static java.util.Collections.nCopies;
 
 public class WindowAggregateTransform<A, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
+
     private static final int MAX_WATERMARK_STRIDE = 100;
     private static final int MIN_WMS_PER_SESSION = 100;
     @SuppressWarnings("rawtypes")

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowAggregateTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowAggregateTransform.java
@@ -25,10 +25,10 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.function.KeyedWindowResultFunction;
 import com.hazelcast.jet.datamodel.WindowResult;
 import com.hazelcast.jet.impl.JetEvent;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.util.ConstantFunctionEx;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.SessionWindowDefinition;
 import com.hazelcast.jet.pipeline.SlidingWindowDefinition;
 import com.hazelcast.jet.pipeline.WindowDefinition;
@@ -48,6 +48,7 @@ import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST
 import static java.util.Collections.nCopies;
 
 public class WindowAggregateTransform<A, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
     private static final int MAX_WATERMARK_STRIDE = 100;
     private static final int MIN_WMS_PER_SESSION = 100;
     @SuppressWarnings("rawtypes")

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowGroupTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowGroupTransform.java
@@ -49,6 +49,7 @@ import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST
 import static java.util.Collections.nCopies;
 
 public class WindowGroupTransform<K, R> extends AbstractTransform {
+
     private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("rawtypes")

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowGroupTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowGroupTransform.java
@@ -25,9 +25,9 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.function.KeyedWindowResultFunction;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.jet.impl.JetEvent;
+import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.impl.pipeline.Planner;
 import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
-import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 import com.hazelcast.jet.pipeline.SessionWindowDefinition;
 import com.hazelcast.jet.pipeline.SlidingWindowDefinition;
 import com.hazelcast.jet.pipeline.WindowDefinition;
@@ -49,6 +49,7 @@ import static com.hazelcast.jet.impl.pipeline.transform.AggregateTransform.FIRST
 import static java.util.Collections.nCopies;
 
 public class WindowGroupTransform<K, R> extends AbstractTransform {
+    private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("rawtypes")
     private static final KeyedWindowResultFunction JET_EVENT_KEYED_WINDOW_RESULT_FN =

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinCollectP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinCollectP.java
@@ -88,6 +88,9 @@ public class HashJoinCollectP<K, T, V> extends AbstractProcessor {
     // We need a custom ArrayList subclass because the user's V type could be
     // ArrayList and then the logic that relies on instanceof would break
     static final class HashJoinArrayList extends ArrayList<Object> {
+
+        private static final long serialVersionUID = 1L;
+
         HashJoinArrayList() {
             super(2);
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ConstantFunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ConstantFunctionEx.java
@@ -25,6 +25,9 @@ import com.hazelcast.function.FunctionEx;
  * it to be able to do some optimizations.
  */
 public class ConstantFunctionEx<T, R> implements FunctionEx<T, R> {
+
+    private static final long serialVersionUID = 1L;
+
     private final R key;
 
     public ConstantFunctionEx(R key) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
@@ -191,6 +191,9 @@ public final class ImdgUtil {
     }
 
     private static final class ImdgPredicateWrapper<T> implements PredicateEx<T> {
+
+        private static final long serialVersionUID = 1L;
+
         private final Predicate<T> wrapped;
 
         ImdgPredicateWrapper(Predicate<T> wrapped) {
@@ -204,6 +207,9 @@ public final class ImdgUtil {
     }
 
     private static final class ImdgFunctionWrapper<T, R> implements FunctionEx<T, R> {
+
+        private static final long serialVersionUID = 1L;
+
         private final Function<T, R> wrapped;
 
         ImdgFunctionWrapper(Function<T, R> wrapped) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
@@ -34,6 +34,9 @@ import java.util.function.Function;
  * {@code wrapperSupplier}.
  */
 public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplier {
+
+    private static final long serialVersionUID = 1L;
+
     private ProcessorMetaSupplier wrapped;
     private FunctionEx<Processor, Processor> wrapperSupplier;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
@@ -30,6 +30,9 @@ import static com.hazelcast.jet.impl.util.Util.toList;
  * with one that will wrap its processors using {@code wrapperSupplier}.
  */
 public final class WrappingProcessorSupplier implements ProcessorSupplier {
+
+    private static final long serialVersionUID = 1L;
+
     private ProcessorSupplier wrapped;
     private FunctionEx<Processor, Processor> wrapperSupplier;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/JoinClause.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/JoinClause.java
@@ -56,6 +56,9 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.checkS
  */
 @SerializableByConvention
 public final class JoinClause<K, T0, T1, T1_OUT> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private final FunctionEx<? super T0, ? extends K> leftKeyFn;
     private final FunctionEx<? super T1, ? extends K> rightKeyFn;
     private final FunctionEx<? super T1, ? extends T1_OUT> rightProjectFn;

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
@@ -96,6 +96,8 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
      */
     public static final boolean COOPERATIVE_DEFAULT = true;
 
+    private static final long serialVersionUID = 1L;
+
     private boolean isCooperative = COOPERATIVE_DEFAULT;
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/SessionWindowDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/SessionWindowDefinition.java
@@ -25,6 +25,9 @@ import com.hazelcast.internal.serialization.SerializableByConvention;
  */
 @SerializableByConvention
 public class SessionWindowDefinition extends WindowDefinition {
+
+    private static final long serialVersionUID = 1L;
+
     private final long sessionTimeout;
 
     SessionWindowDefinition(long sessionTimeout) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/SlidingWindowDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/SlidingWindowDefinition.java
@@ -28,6 +28,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
  */
 @SerializableByConvention
 public class SlidingWindowDefinition extends WindowDefinition {
+
+    private static final long serialVersionUID = 1L;
+
     private final long windowSize;
     private final long slideBy;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/AvroFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/AvroFileFormat.java
@@ -34,6 +34,8 @@ public class AvroFileFormat<T> implements FileFormat<T> {
      */
     public static final String FORMAT_AVRO = "avro";
 
+    private static final long serialVersionUID = 1L;
+
     private Class<T> reflectClass;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/CsvFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/CsvFileFormat.java
@@ -35,6 +35,8 @@ public class CsvFileFormat<T> implements FileFormat<T> {
      */
     public static final String FORMAT_CSV = "csv";
 
+    private static final long serialVersionUID = 1L;
+
     private final Class<T> clazz;
     private final List<String> fieldNames;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/JsonFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/JsonFileFormat.java
@@ -34,6 +34,8 @@ public class JsonFileFormat<T> implements FileFormat<T> {
      */
     public static final String FORMAT_JSON = "json";
 
+    private static final long serialVersionUID = 1L;
+
     private Class<T> clazz;
     private boolean multiline = true;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/LinesTextFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/LinesTextFileFormat.java
@@ -36,6 +36,8 @@ public class LinesTextFileFormat implements FileFormat<String> {
      */
     public static final String FORMAT_LINES = "lines";
 
+    private static final long serialVersionUID = 1L;
+
     private final String charset;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/ParquetFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/ParquetFileFormat.java
@@ -32,6 +32,8 @@ public class ParquetFileFormat<T> implements FileFormat<T> {
      */
     public static final String FORMAT_PARQUET = "parquet";
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates {@link ParquetFileFormat}. See {@link FileFormat#parquet()}
      * for more details.
@@ -39,7 +41,8 @@ public class ParquetFileFormat<T> implements FileFormat<T> {
     ParquetFileFormat() {
     }
 
-    @Nonnull @Override
+    @Nonnull
+    @Override
     public String format() {
         return FORMAT_PARQUET;
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/RawBytesFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/RawBytesFileFormat.java
@@ -31,6 +31,8 @@ public class RawBytesFileFormat implements FileFormat<byte[]> {
      */
     public static final String FORMAT_BIN = "bin";
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Create {@link RawBytesFileFormat}. See {@link FileFormat#bytes()} for more
      * details.
@@ -38,7 +40,8 @@ public class RawBytesFileFormat implements FileFormat<byte[]> {
     RawBytesFileFormat() {
     }
 
-    @Nonnull @Override
+    @Nonnull
+    @Override
     public String format() {
         return FORMAT_BIN;
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/TextFileFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/TextFileFormat.java
@@ -36,6 +36,8 @@ public class TextFileFormat implements FileFormat<String> {
      */
     public static final String FORMAT_TXT = "txt";
 
+    private static final long serialVersionUID = 1L;
+
     private final String charset;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/impl/FileSourceConfiguration.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/file/impl/FileSourceConfiguration.java
@@ -34,6 +34,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class FileSourceConfiguration<T> implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final String path;
     private final String glob;
     private final FileFormat<T> format;

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/test/AssertionCompletedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/test/AssertionCompletedException.java
@@ -29,6 +29,8 @@ import com.hazelcast.jet.annotation.EvolvingApi;
 @EvolvingApi
 public final class AssertionCompletedException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates the exception
      */

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/test/SimpleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/test/SimpleEvent.java
@@ -28,6 +28,8 @@ import java.util.Objects;
  */
 public class SimpleEvent implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final long timestamp;
     private final long sequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/retry/impl/IntervalFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/retry/impl/IntervalFunctions.java
@@ -67,6 +67,8 @@ public final class IntervalFunctions {
 
     private static class IntervalFunctionImpl implements IntervalFunction {
 
+        private static final long serialVersionUID = 1L;
+
         private final FunctionEx<Integer, Long> fn;
         private final String description;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/retry/impl/RetryStrategyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/retry/impl/RetryStrategyImpl.java
@@ -21,6 +21,8 @@ import com.hazelcast.jet.retry.RetryStrategy;
 
 public class RetryStrategyImpl implements RetryStrategy {
 
+    private static final long serialVersionUID = 1L;
+
     private final int maxAttempts;
     private final IntervalFunction intervalFunction;
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/JetSerializableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/JetSerializableTest.java
@@ -16,14 +16,20 @@
 
 package com.hazelcast.jet;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(ParallelJVMTest.class)
 public class JetSerializableTest {
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/hazelcast/src/test/java/com/hazelcast/jet/JetSerializableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/JetSerializableTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet;
+
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+
+public class JetSerializableTest {
+    @Test
+    public void serializable_classes_should_have_valid_serialVersionUID() {
+        String basePackage = JetService.class.getPackage().getName();
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(DO_NOT_INCLUDE_JARS)
+                .withImportOption(DO_NOT_INCLUDE_TESTS)
+                .importPackages(basePackage);
+
+        ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -159,7 +159,7 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
     }
 
     protected boolean isMatching(String urlString) {
-        return urlString.contains("target");
+        return urlString.contains("hazelcast/target");
     }
 
     protected String getMajorVersion() {

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <modules>
         <module>hazelcast</module>
+        <module>hazelcast-archunit-rules</module>
         <module>hazelcast-spring</module>
         <module>hazelcast-spring-tests</module>
         <module>hazelcast-build-utils</module>
@@ -140,6 +141,7 @@
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.15.3</testcontainers.version>
         <zookeeper.version>3.5.8</zookeeper.version>
+        <archunit.version>0.21.0</archunit.version>
 
         <sonar.jacoco.jar>${basedir}/lib/jacocoagent.jar</sonar.jacoco.jar>
         <!--<sonar.phase>post-integration-test</sonar.phase>-->
@@ -1506,6 +1508,11 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.tngtech.archunit</groupId>
+                <artifactId>archunit</artifactId>
+                <version>${archunit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <kafka.version>2.2.2</kafka.version>
         <kotlin.version>1.3.61</kotlin.version>
         <log4j.version>1.2.17</log4j.version>
+        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
         <log4j2.version>2.14.0</log4j2.version>
         <mysql.connector.version>8.0.20</mysql.connector.version>
         <netty.version>4.1.63.Final</netty.version>


### PR DESCRIPTION
Related to https://github.com/hazelcast/hazelcast/issues/19320

- Added `serialVersionUID` fields to `Transform` implementation in Jet and in serializable classes in `hazelcast-jet-kinesis` extension
- Added `hazelcast-archunit-rules` module with a shareable ArchUnit rule for Serializable classes
- A [test](https://github.com/hazelcast/hazelcast/pull/19534/files#diff-8723ab58d30463912f118b197f6d873a11321470e207b8e404d14844b9323f18R27) against the ArchUnit rule was added only for `hazelcast-jet-kinesis` since other modules need to be fixed first.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
