### PR TITLE
Change wording and log level of security recommendations.

### DIFF
--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -123,6 +123,11 @@
             <destName>hazelcast-security-hardened.yaml</destName>
             <outputDirectory>config/examples</outputDirectory>
         </file>
+        <file>
+            <source>${configs.from.jar}/hazelcast-security-hardened.xml</source>
+            <destName>hazelcast-security-hardened.xml</destName>
+            <outputDirectory>config/examples</outputDirectory>
+        </file>
     </files>
 
     <fileSets>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -140,6 +140,11 @@
             <destName>hazelcast-security-hardened.yaml</destName>
             <outputDirectory>config/examples</outputDirectory>
         </file>
+        <file>
+            <source>${configs.from.jar}/hazelcast-security-hardened.xml</source>
+            <destName>hazelcast-security-hardened.xml</destName>
+            <outputDirectory>config/examples</outputDirectory>
+        </file>
     </files>
 
     <fileSets>

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -969,7 +969,7 @@ public class Node {
                     trustedEnv);
             if (config.getJetConfig().isResourceUploadEnabled()) {
                 addSecurityFeatureInfo(sb, "Jet resource upload is enabled. Any uploaded code can be executed within "
-                        + "the Hazelcast. Use this in trusted environments only.");
+                        + "Hazelcast. Use this in trusted environments only.");
             }
         }
         if (config.getUserCodeDeploymentConfig().isEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -16,45 +16,6 @@
 
 package com.hazelcast.instance.impl;
 
-import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
-import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
-import static com.hazelcast.instance.EndpointQualifier.CLIENT;
-import static com.hazelcast.instance.EndpointQualifier.MEMBER;
-import static com.hazelcast.instance.impl.NodeShutdownHelper.shutdownNodeByFiringEvents;
-import static com.hazelcast.internal.cluster.impl.MulticastService.createMulticastService;
-import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.allUsePublicAddress;
-import static com.hazelcast.internal.config.ConfigValidator.checkAdvancedNetworkConfig;
-import static com.hazelcast.internal.config.ConfigValidator.warnForUsageOfDeprecatedSymmetricEncryption;
-import static com.hazelcast.internal.util.EmptyStatement.ignore;
-import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.FutureUtil.waitWithDeadline;
-import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
-import static com.hazelcast.spi.properties.ClusterProperty.DISCOVERY_SPI_ENABLED;
-import static com.hazelcast.spi.properties.ClusterProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED;
-import static com.hazelcast.spi.properties.ClusterProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
-import static com.hazelcast.spi.properties.ClusterProperty.LOGGING_ENABLE_DETAILS;
-import static com.hazelcast.spi.properties.ClusterProperty.LOGGING_TYPE;
-import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_ENABLED;
-import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_POLICY;
-import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SERVER_BIND_ANY;
-import static java.lang.Thread.currentThread;
-import static java.security.AccessController.doPrivileged;
-
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-
 import com.hazelcast.client.ClientListener;
 import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.client.impl.ClientEngineImpl;
@@ -64,21 +25,14 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MembershipListener;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.config.AdvancedNetworkConfig;
-import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
-import com.hazelcast.config.EncryptionAtRestConfig;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MemberAttributeConfig;
-import com.hazelcast.config.PersistenceConfig;
-import com.hazelcast.config.SSLConfig;
-import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.UserCodeDeploymentConfig;
-import com.hazelcast.config.security.RealmConfig;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
@@ -144,11 +98,46 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
 
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
+import static com.hazelcast.instance.EndpointQualifier.CLIENT;
+import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import static com.hazelcast.instance.impl.NodeShutdownHelper.shutdownNodeByFiringEvents;
+import static com.hazelcast.internal.cluster.impl.MulticastService.createMulticastService;
+import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.allUsePublicAddress;
+import static com.hazelcast.internal.config.ConfigValidator.checkAdvancedNetworkConfig;
+import static com.hazelcast.internal.config.ConfigValidator.warnForUsageOfDeprecatedSymmetricEncryption;
+import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.FutureUtil.waitWithDeadline;
+import static com.hazelcast.internal.util.ThreadUtil.createThreadName;
+import static com.hazelcast.spi.properties.ClusterProperty.DISCOVERY_SPI_ENABLED;
+import static com.hazelcast.spi.properties.ClusterProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED;
+import static com.hazelcast.spi.properties.ClusterProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
+import static com.hazelcast.spi.properties.ClusterProperty.LOGGING_ENABLE_DETAILS;
+import static com.hazelcast.spi.properties.ClusterProperty.LOGGING_TYPE;
+import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_ENABLED;
+import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_POLICY;
+import static java.lang.Thread.currentThread;
+import static java.security.AccessController.doPrivileged;
+
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:visibilitymodifier", "checkstyle:classdataabstractioncoupling",
         "checkstyle:classfanoutcomplexity"})
 public class Node {
-
-    protected static final String SECURITY_BANNER_CATEGORY = "com.hazelcast.system.security";
 
     private static final int THREAD_SLEEP_DURATION_MS = 500;
     private static final String GRACEFUL_SHUTDOWN_EXECUTOR_NAME = "hz:graceful-shutdown";
@@ -173,7 +162,6 @@ public class Node {
      */
     public final Address address;
     public final SecurityContext securityContext;
-    private final ILogger securityLogger;
     private final ILogger logger;
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
     private final NodeShutdownHookThread shutdownHookThread;
@@ -245,7 +233,6 @@ public class Node {
             loggingService.setThisMember(localMember);
             tmpLogger = loggingService.getLogger(Node.class.getName());
             logger = tmpLogger;
-            securityLogger = loggingService.getLogger(SECURITY_BANNER_CATEGORY);
 
             nodeExtension.printNodeInfo();
             nodeExtension.beforeStart();
@@ -272,7 +259,8 @@ public class Node {
             boolean isAutoDetectionEnabled = joinConfig.isAutoDetectionEnabled();
             discoveryService = createDiscoveryService(discoveryConfig, aliasedDiscoveryConfigs, isAutoDetectionEnabled,
                     localMember);
-            printSecurityInfo();
+            new NodeSecurityBanner(config, properties, shouldUseMulticastJoiner(joinConfig), loggingService)
+                    .printSecurityInfo();
             clusterService = new ClusterServiceImpl(this, localMember);
             partitionService = new InternalPartitionServiceImpl(this);
             textCommandService = nodeExtension.createTextCommandService();
@@ -925,101 +913,4 @@ public class Node {
         Address masterAddress = clusterService.getMasterAddress();
         return server.doAddressesMatch(masterAddress, address);
     }
-
-    public void printSecurityInfo() {
-        securityLogger.info(String.format(
-                "Enable DEBUG/FINE log level for log category %1$s "
-                        + " or use -D%1$s system property to see 🔒 security recommendations and the status of current config.",
-                SECURITY_BANNER_CATEGORY));
-        boolean showInfoSecurityBanner = System.getProperty(SECURITY_BANNER_CATEGORY) != null;
-        if ((showInfoSecurityBanner && securityLogger.isInfoEnabled()) || securityLogger.isFineEnabled()) {
-            printSecurityFeaturesInfo(getConfig(), showInfoSecurityBanner ? Level.INFO : Level.FINE);
-        }
-    }
-
-    @SuppressWarnings({ "checkstyle:CyclomaticComplexity", "checkstyle:MethodLength" })
-    private void printSecurityFeaturesInfo(Config config, Level logLevel) {
-        StringBuilder sb = new StringBuilder("\n🔒Security recommendations and their status:");
-        addSecurityFeatureCheck(sb, "Use a custom cluster name", !Config.DEFAULT_CLUSTER_NAME.equals(config.getClusterName()));
-        boolean isMulticastJoin = shouldUseMulticastJoiner(getActiveMemberNetworkConfig(config).getJoin());
-        addSecurityFeatureCheck(sb, "Disable member multicast discovery/join method", !isMulticastJoin);
-
-        AdvancedNetworkConfig advancedNetworkConfig = config.getAdvancedNetworkConfig();
-        addSecurityFeatureCheck(sb, "Use advanced networking, separate client and member sockets",
-                advancedNetworkConfig.isEnabled());
-        boolean bindAny = getProperties().getBoolean(SOCKET_SERVER_BIND_ANY);
-        addSecurityFeatureCheck(sb,
-                "Bind Server sockets to a single network interface (disable " + SOCKET_SERVER_BIND_ANY.getName() + ")",
-                !bindAny);
-        StringBuilder tlsSb = new StringBuilder();
-        boolean tlsUsed = true;
-        if (advancedNetworkConfig.isEnabled()) {
-            for (Map.Entry<EndpointQualifier, EndpointConfig> e : advancedNetworkConfig.getEndpointConfigs().entrySet()) {
-                tlsUsed = addAdvNetworkTlsInfo(tlsSb, e.getKey(), e.getValue().getSSLConfig()) && tlsUsed;
-            }
-        } else {
-            SSLConfig sslConfig = config.getNetworkConfig().getSSLConfig();
-            tlsUsed = addSecurityFeatureCheck(tlsSb, "Use TLS communication protection (Enterprise)",
-                    sslConfig != null && sslConfig.isEnabled());
-        }
-        boolean jetEnabled = config.getJetConfig().isEnabled();
-        if (jetEnabled) {
-            boolean trustedEnv = tlsUsed || !bindAny;
-            addSecurityFeatureCheck(sb, "Use Jet in trusted environments only (single network interface and/or TLS enabled)",
-                    trustedEnv);
-            if (config.getJetConfig().isResourceUploadEnabled()) {
-                addSecurityFeatureInfo(sb, "Jet resource upload is enabled. Any uploaded code can be executed within "
-                        + "Hazelcast. Use this in trusted environments only.");
-            }
-        }
-        if (config.getUserCodeDeploymentConfig().isEnabled()) {
-            addSecurityFeatureInfo(sb, "User code deployment is enabled. Any uploaded code can be executed within "
-                    + "Hazelcast. Use this in trusted environments only.");
-        }
-        addSecurityFeatureCheck(sb, "Disable scripting in the Management Center",
-                !config.getManagementCenterConfig().isScriptingEnabled());
-        SecurityConfig securityConfig = config.getSecurityConfig();
-        boolean securityEnabled = securityConfig != null && securityConfig.isEnabled();
-
-        addSecurityFeatureCheck(sb, "Enable Security (Enterprise)", securityEnabled);
-        if (securityEnabled) {
-            checkAuthnConfigured(sb, securityConfig, "member-authentication", securityConfig.getMemberRealm());
-            checkAuthnConfigured(sb, securityConfig, "client-authentication", securityConfig.getClientRealm());
-        }
-        // TLS here
-        sb.append(tlsSb.toString());
-        PersistenceConfig persistenceConfig = config.getPersistenceConfig();
-        if (persistenceConfig != null && persistenceConfig.isEnabled()) {
-            EncryptionAtRestConfig encryptionAtRestConfig = persistenceConfig.getEncryptionAtRestConfig();
-            addSecurityFeatureCheck(sb, "Enable encryption-at-rest in the Persistence config (Enterprise)",
-                    encryptionAtRestConfig != null && encryptionAtRestConfig.isEnabled());
-        }
-        AuditlogConfig auditlogConfig = config.getAuditlogConfig();
-        addSecurityFeatureCheck(sb, "Enable auditlog (Enterprise)", auditlogConfig != null && auditlogConfig.isEnabled());
-
-        sb.append("\nCheck the hazelcast-security-hardened.xml/yaml example config file to find why and how to configure"
-                + " these security related settings.\n");
-        securityLogger.log(logLevel, sb.toString());
-    }
-
-    private void checkAuthnConfigured(StringBuilder sb, SecurityConfig securityConfig, String authName, String realmName) {
-        RealmConfig rc = securityConfig.getRealmConfig(realmName);
-        addSecurityFeatureCheck(sb, "Configure " + authName + " explicitly (Enterprise)",
-                rc != null && rc.isAuthenticationConfigured());
-    }
-
-    private boolean addAdvNetworkTlsInfo(StringBuilder sb, EndpointQualifier endpoint, SSLConfig sslConfig) {
-        return addSecurityFeatureCheck(sb, "Use TLS in the " + endpoint.toMetricsPrefixString() + " endpoint (Enterprise)",
-                sslConfig != null && sslConfig.isEnabled());
-    }
-
-    private boolean addSecurityFeatureCheck(StringBuilder sb, String feature, boolean enabled) {
-        sb.append("\n  ").append(enabled ? "✅ " : "⚠️ ").append(feature);
-        return enabled;
-    }
-
-    private void addSecurityFeatureInfo(StringBuilder sb, String feature) {
-        sb.append("\n  ℹ️ ").append(feature);
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -974,7 +974,7 @@ public class Node {
         }
         if (config.getUserCodeDeploymentConfig().isEnabled()) {
             addSecurityFeatureInfo(sb, "User code deployment is enabled. Any uploaded code can be executed within "
-                    + "the Hazelcast. Use this in trusted environments only.");
+                    + "Hazelcast. Use this in trusted environments only.");
         }
         addSecurityFeatureCheck(sb, "Disable scripting in the Management Center",
                 !config.getManagementCenterConfig().isScriptingEnabled());

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -971,8 +971,6 @@ public class Node {
                 addSecurityFeatureInfo(sb, "Jet resource upload is enabled. Any uploaded code can be executed within "
                         + "the Hazelcast. Use this in trusted environments only.");
             }
-        } else {
-            addSecurityFeatureInfo(sb, "Jet is disabled");
         }
         if (config.getUserCodeDeploymentConfig().isEnabled()) {
             addSecurityFeatureInfo(sb, "User code deployment is enabled. Any uploaded code can be executed within "

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeSecurityBanner.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeSecurityBanner.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SERVER_BIND_ANY;
+
+import java.util.Map;
+import java.util.logging.Level;
+
+import com.hazelcast.config.AdvancedNetworkConfig;
+import com.hazelcast.config.AuditlogConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EncryptionAtRestConfig;
+import com.hazelcast.config.EndpointConfig;
+import com.hazelcast.config.PersistenceConfig;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.config.SecurityConfig;
+import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.spi.properties.HazelcastProperties;
+
+/**
+ * Class resposible for printing security recommendation to the log during the {@link Node} start.
+ */
+class NodeSecurityBanner {
+
+    protected static final String SECURITY_BANNER_CATEGORY = "com.hazelcast.system.security";
+    private final Config config;
+    private final HazelcastProperties properties;
+    private final boolean multicastUsed;
+    private final ILogger securityLogger;
+
+    NodeSecurityBanner(Config config, HazelcastProperties properties, boolean multicastUsed,
+            LoggingService loggingService) {
+        this.config = config;
+        this.properties = properties;
+        this.multicastUsed = multicastUsed;
+        this.securityLogger = loggingService.getLogger(SECURITY_BANNER_CATEGORY);
+    }
+
+    public void printSecurityInfo() {
+        securityLogger.info(String.format(
+                "Enable DEBUG/FINE log level for log category %1$s "
+                        + " or use -D%1$s system property to see 🔒 security recommendations and the status of current config.",
+                SECURITY_BANNER_CATEGORY));
+        boolean showInfoSecurityBanner = System.getProperty(SECURITY_BANNER_CATEGORY) != null;
+        if ((showInfoSecurityBanner && securityLogger.isInfoEnabled()) || securityLogger.isFineEnabled()) {
+            printSecurityFeaturesInfo(config, showInfoSecurityBanner ? Level.INFO : Level.FINE);
+        }
+    }
+
+    @SuppressWarnings({ "checkstyle:CyclomaticComplexity", "checkstyle:MethodLength" })
+    private void printSecurityFeaturesInfo(Config config, Level logLevel) {
+        StringBuilder sb = new StringBuilder("\n🔒Security recommendations and their status:");
+        addSecurityFeatureCheck(sb, "Use a custom cluster name", !Config.DEFAULT_CLUSTER_NAME.equals(config.getClusterName()));
+        addSecurityFeatureCheck(sb, "Disable member multicast discovery/join method", !multicastUsed);
+
+        AdvancedNetworkConfig advancedNetworkConfig = config.getAdvancedNetworkConfig();
+        addSecurityFeatureCheck(sb, "Use advanced networking, separate client and member sockets",
+                advancedNetworkConfig.isEnabled());
+        boolean bindAny = properties.getBoolean(SOCKET_SERVER_BIND_ANY);
+        addSecurityFeatureCheck(sb,
+                "Bind Server sockets to a single network interface (disable " + SOCKET_SERVER_BIND_ANY.getName() + ")",
+                !bindAny);
+        StringBuilder tlsSb = new StringBuilder();
+        boolean tlsUsed = true;
+        if (advancedNetworkConfig.isEnabled()) {
+            for (Map.Entry<EndpointQualifier, EndpointConfig> e : advancedNetworkConfig.getEndpointConfigs().entrySet()) {
+                tlsUsed = addAdvNetworkTlsInfo(tlsSb, e.getKey(), e.getValue().getSSLConfig()) && tlsUsed;
+            }
+        } else {
+            SSLConfig sslConfig = config.getNetworkConfig().getSSLConfig();
+            tlsUsed = addSecurityFeatureCheck(tlsSb, "Use TLS communication protection (Enterprise)",
+                    sslConfig != null && sslConfig.isEnabled());
+        }
+        boolean jetEnabled = config.getJetConfig().isEnabled();
+        if (jetEnabled) {
+            boolean trustedEnv = tlsUsed || !bindAny;
+            addSecurityFeatureCheck(sb, "Use Jet in trusted environments only (single network interface and/or TLS enabled)",
+                    trustedEnv);
+            if (config.getJetConfig().isResourceUploadEnabled()) {
+                addSecurityFeatureInfo(sb, "Jet resource upload is enabled. Any uploaded code can be executed within "
+                        + "Hazelcast. Use this in trusted environments only.");
+            }
+        }
+        if (config.getUserCodeDeploymentConfig().isEnabled()) {
+            addSecurityFeatureInfo(sb, "User code deployment is enabled. Any uploaded code can be executed within "
+                    + "Hazelcast. Use this in trusted environments only.");
+        }
+        addSecurityFeatureCheck(sb, "Disable scripting in the Management Center",
+                !config.getManagementCenterConfig().isScriptingEnabled());
+        SecurityConfig securityConfig = config.getSecurityConfig();
+        boolean securityEnabled = securityConfig != null && securityConfig.isEnabled();
+
+        addSecurityFeatureCheck(sb, "Enable Security (Enterprise)", securityEnabled);
+        if (securityEnabled) {
+            checkAuthnConfigured(sb, securityConfig, "member-authentication", securityConfig.getMemberRealm());
+            checkAuthnConfigured(sb, securityConfig, "client-authentication", securityConfig.getClientRealm());
+        }
+        // TLS here
+        sb.append(tlsSb.toString());
+        PersistenceConfig persistenceConfig = config.getPersistenceConfig();
+        if (persistenceConfig != null && persistenceConfig.isEnabled()) {
+            EncryptionAtRestConfig encryptionAtRestConfig = persistenceConfig.getEncryptionAtRestConfig();
+            addSecurityFeatureCheck(sb, "Enable encryption-at-rest in the Persistence config (Enterprise)",
+                    encryptionAtRestConfig != null && encryptionAtRestConfig.isEnabled());
+        }
+        AuditlogConfig auditlogConfig = config.getAuditlogConfig();
+        addSecurityFeatureCheck(sb, "Enable auditlog (Enterprise)", auditlogConfig != null && auditlogConfig.isEnabled());
+
+        sb.append("\nCheck the hazelcast-security-hardened.xml/yaml example config file to find why and how to configure"
+                + " these security related settings.\n");
+        securityLogger.log(logLevel, sb.toString());
+    }
+
+    private void checkAuthnConfigured(StringBuilder sb, SecurityConfig securityConfig, String authName, String realmName) {
+        RealmConfig rc = securityConfig.getRealmConfig(realmName);
+        addSecurityFeatureCheck(sb, "Configure " + authName + " explicitly (Enterprise)",
+                rc != null && rc.isAuthenticationConfigured());
+    }
+
+    private boolean addAdvNetworkTlsInfo(StringBuilder sb, EndpointQualifier endpoint, SSLConfig sslConfig) {
+        return addSecurityFeatureCheck(sb, "Use TLS in the " + endpoint.toMetricsPrefixString() + " endpoint (Enterprise)",
+                sslConfig != null && sslConfig.isEnabled());
+    }
+
+    private boolean addSecurityFeatureCheck(StringBuilder sb, String feature, boolean enabled) {
+        sb.append("\n  ").append(enabled ? "✅ " : "⚠️ ").append(feature);
+        return enabled;
+    }
+
+    private void addSecurityFeatureInfo(StringBuilder sb, String feature) {
+        sb.append("\n  ℹ️ ").append(feature);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1760,6 +1760,23 @@ public final class ClusterProperty {
     public static final HazelcastProperty PROCESSOR_CUSTOM_LIB_DIR
             = new HazelcastProperty("hazelcast.jet.custom.lib.dir", "custom-lib");
 
+    /**
+     * Controls whether cluster emojis can be used in log messages. This is a hint flag, implementation details on services
+     * calling the logging. The default value is {@code true}.
+     *
+     * @since 5.0
+     */
+    public static final HazelcastProperty LOG_EMOJI_ENABLED = new HazelcastProperty("hazelcast.logging.emoji.enabled", true);
+
+    /**
+     * When set to any not-{@code null} value, security recommendations are logged on INFO level during the node start. The
+     * default value is {@code null}.
+     *
+     * @since 5.0
+     */
+    public static final HazelcastProperty SECURITY_RECOMMENDATIONS = new HazelcastProperty(
+            "hazelcast.security.recommendations");
+
     private ClusterProperty() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1761,8 +1761,7 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.jet.custom.lib.dir", "custom-lib");
 
     /**
-     * Controls whether cluster emojis can be used in log messages. This is a hint flag, implementation details on services
-     * calling the logging. The default value is {@code true}.
+     * Controls whether cluster emojis can be used in log messages. This is just a hint for components calling the logging.
      *
      * @since 5.0
      */

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeExtensionSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeExtensionSecurityBannerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.test.ChangeLoggingRule;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Test that security banners are logged on proper levels.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelJVMTest.class })
+public class NodeExtensionSecurityBannerTest extends HazelcastTestSupport {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
+
+    @Test
+    public void testTwoMessagesPrinted() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = context.getConfiguration();
+        TestAppender appender = new TestAppender();
+        appender.start();
+        configuration.addAppender(appender);
+        configuration.getRootLogger().addAppender(appender, null, null);
+        createHazelcastInstance();
+        assertEquals(2, appender.events.size());
+        assertEquals(Level.INFO, appender.events.get(0).getLevel());
+        LogEvent secondLog = appender.events.get(1);
+        assertEquals(Level.DEBUG, secondLog.getLevel());
+        String secondMsg = secondLog.getMessage().getFormattedMessage();
+        assertTrue(secondMsg.contains("⚠️ Use a custom cluster name"));
+        assertTrue(secondMsg.contains("✅ Disable Jet resource upload"));
+    }
+
+    private static class TestAppender extends AbstractAppender {
+
+        final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+        TestAppender() {
+            super(TestAppender.class.getName(), null, null, true, null);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            if ("com.hazelcast.system.security".equals(event.getLoggerName())) {
+                events.add(event);
+            }
+        }
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeExtensionSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeExtensionSecurityBannerTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.instance.impl;
 
-import static com.hazelcast.instance.impl.DefaultNodeExtension.SECURITY_BANNER_CATEGORY;
+import static com.hazelcast.instance.impl.Node.SECURITY_BANNER_CATEGORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeExtensionSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeExtensionSecurityBannerTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.instance.impl;
 
+import static com.hazelcast.instance.impl.DefaultNodeExtension.SECURITY_BANNER_CATEGORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -28,43 +29,84 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.junit.ClassRule;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import com.hazelcast.test.ChangeLoggingRule;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 
 /**
  * Test that security banners are logged on proper levels.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({ QuickTest.class, ParallelJVMTest.class })
 public class NodeExtensionSecurityBannerTest extends HazelcastTestSupport {
 
-    @ClassRule
-    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
+    @Rule
+    public OverridePropertyRule sysPropSecurityBanner = OverridePropertyRule.set(SECURITY_BANNER_CATEGORY, null);
+
+    private LoggerContext context = (org.apache.logging.log4j.core.LoggerContext) LogManager.getContext(false);
+
+    @After
+    public void after() {
+        context.setConfigLocation(null);
+    }
 
     @Test
-    public void testTwoMessagesPrinted() {
-        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+    public void testDebugLevel() throws Exception {
+        context.setConfigLocation(getClass().getClassLoader().getResource("log4j2-debug.xml").toURI());
+        TestAppender appender = configureTestAppender();
+        createHazelcastInstance();
+        assertEquals(2, appender.events.size());
+        assertEquals(Level.INFO, appender.events.get(0).getLevel());
+        LogEvent secondLog = appender.events.get(1);
+        assertEquals(Level.DEBUG, secondLog.getLevel());
+        assertRecommendationContent(secondLog);
+    }
+
+    @Test
+    public void testSystemProperty() throws Exception {
+        sysPropSecurityBanner.setOrClearProperty("");
+        TestAppender appender = configureTestAppender();
+        createHazelcastInstance();
+        assertEquals(2, appender.events.size());
+        assertEquals(Level.INFO, appender.events.get(0).getLevel());
+        LogEvent secondLog = appender.events.get(1);
+        assertEquals(Level.INFO, secondLog.getLevel());
+        assertRecommendationContent(secondLog);
+    }
+
+    @Test
+    public void testDefault() throws Exception {
         Configuration configuration = context.getConfiguration();
         TestAppender appender = new TestAppender();
         appender.start();
         configuration.addAppender(appender);
         configuration.getRootLogger().addAppender(appender, null, null);
         createHazelcastInstance();
-        assertEquals(2, appender.events.size());
+        assertEquals(1, appender.events.size());
         assertEquals(Level.INFO, appender.events.get(0).getLevel());
-        LogEvent secondLog = appender.events.get(1);
-        assertEquals(Level.DEBUG, secondLog.getLevel());
-        String secondMsg = secondLog.getMessage().getFormattedMessage();
+    }
+
+    private void assertRecommendationContent(LogEvent logEvent) {
+        String secondMsg = logEvent.getMessage().getFormattedMessage();
         assertTrue(secondMsg.contains("⚠️ Use a custom cluster name"));
-        assertTrue(secondMsg.contains("✅ Disable Jet resource upload"));
+        assertTrue(secondMsg.contains("✅ Disable member multicast"));
+    }
+
+    private TestAppender configureTestAppender() {
+        Configuration configuration = context.getConfiguration();
+        TestAppender appender = new TestAppender();
+        appender.start();
+        configuration.addAppender(appender);
+        configuration.getRootLogger().addAppender(appender, null, null);
+        return appender;
     }
 
     private static class TestAppender extends AbstractAppender {
@@ -77,10 +119,9 @@ public class NodeExtensionSecurityBannerTest extends HazelcastTestSupport {
 
         @Override
         public void append(LogEvent event) {
-            if ("com.hazelcast.system.security".equals(event.getLoggerName())) {
+            if (SECURITY_BANNER_CATEGORY.equals(event.getLoggerName()) && events.size() < 10) {
                 events.add(event);
             }
         }
-
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.instance.impl;
 
-import static com.hazelcast.instance.impl.Node.SECURITY_BANNER_CATEGORY;
+import static com.hazelcast.instance.impl.NodeSecurityBanner.SECURITY_BANNER_CATEGORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
@@ -46,7 +46,7 @@ import com.hazelcast.test.annotation.QuickTest;
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({ QuickTest.class, ParallelJVMTest.class })
-public class NodeExtensionSecurityBannerTest extends HazelcastTestSupport {
+public class NodeSecurityBannerTest extends HazelcastTestSupport {
 
     @Rule
     public OverridePropertyRule sysPropSecurityBanner = OverridePropertyRule.set(SECURITY_BANNER_CATEGORY, null);

--- a/hazelcast/src/test/resources/log4j2-debug.xml
+++ b/hazelcast/src/test/resources/log4j2-debug.xml
@@ -31,5 +31,6 @@
         <Logger name="com.hazelcast.internal.partition" level="debug"/>
         <Logger name="com.hazelcast.internal.hotrestart.cluster" level="debug"/>
         <Logger name="com.hazelcast.test.mocknetwork" level="debug"/>
+        <Logger name="com.hazelcast.system" level="debug"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Follow up for #19513

This PR hides the node startup info about security-related settings to DEBUG log level.

To avoid scaring users too much it also replaces the red ❌ character with a warning triangle.