### PR TITLE
Unwrap InvocationTargetException for Hz 3 init

### DIFF
--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/Hz3Sinks.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/Hz3Sinks.java
@@ -84,8 +84,8 @@ public final class Hz3Sinks {
      */
     @Beta
     @Nonnull
-    public static <K, V> Sink<Map.Entry<K, V>> map(@Nonnull String mapName, @Nonnull String clientXml) {
-        return map(mapName, Map.Entry::getKey, Map.Entry::getValue, clientXml);
+    public static <K, V> Sink<Map.Entry<K, V>> remoteMap(@Nonnull String mapName, @Nonnull String clientXml) {
+        return remoteMap(mapName, Map.Entry::getKey, Map.Entry::getValue, clientXml);
     }
 
     /**
@@ -105,13 +105,13 @@ public final class Hz3Sinks {
      */
     @Beta
     @Nonnull
-    public static <T, K, V> Sink<T> map(
+    public static <T, K, V> Sink<T> remoteMap(
             @Nonnull String mapName,
             @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
             @Nonnull FunctionEx<? super T, ? extends V> toValueFn,
             @Nonnull String clientXml) {
         return new SinkImpl<>("mapSink(" + mapName + ')',
-                writeMapP(mapName, toKeyFn, toValueFn, clientXml), toKeyFn);
+                writeRemoteMapP(mapName, toKeyFn, toValueFn, clientXml), toKeyFn);
     }
 
     /**
@@ -119,7 +119,7 @@ public final class Hz3Sinks {
      * {@link Sinks#map(String, FunctionEx, FunctionEx)}.
      */
     @Nonnull
-    static <T, K, V> ProcessorMetaSupplier writeMapP(
+    static <T, K, V> ProcessorMetaSupplier writeRemoteMapP(
             @Nonnull String mapName,
             @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
             @Nonnull FunctionEx<? super T, ? extends V> toValueFn,

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/Hz3Util.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/Hz3Util.java
@@ -18,6 +18,7 @@ package com.hazelcast.connector;
 
 import com.hazelcast.connector.map.Hz3MapAdapter;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.jet.JetException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -30,10 +31,12 @@ final class Hz3Util {
     static Hz3MapAdapter createMapAdapter(String clientXml) {
         try {
             Class<?> clazz = Thread.currentThread().getContextClassLoader()
-                    .loadClass("com.hazelcast.connector.map.impl.MapAdapterImpl");
+                                   .loadClass("com.hazelcast.connector.map.impl.MapAdapterImpl");
             Constructor<?> constructor = clazz.getDeclaredConstructor(String.class);
             return (Hz3MapAdapter) constructor.newInstance(clientXml);
-        } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+        } catch (InvocationTargetException e) {
+            throw new JetException("Could not create instance of MapAdapterImpl", e.getCause());
+        } catch (InstantiationException | IllegalAccessException
                 | ClassNotFoundException | NoSuchMethodException e) {
             throw new HazelcastException(e);
         }

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/ReadMapOrCacheP.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/ReadMapOrCacheP.java
@@ -213,7 +213,9 @@ final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends AbstractP
 
         @Override
         public void close(Throwable error) {
-            hz3MapAdapter.shutdown();
+            if (hz3MapAdapter != null) {
+                hz3MapAdapter.shutdown();
+            }
         }
 
         @Override

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/WriteMapP.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/WriteMapP.java
@@ -30,7 +30,6 @@ import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Watermark;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -40,7 +39,6 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
-import static java.lang.Integer.max;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -171,9 +169,6 @@ final class WriteMapP<T, K, V> implements Processor {
         private final String mapName;
         private final FunctionEx<? super T, ? extends K> toKeyFn;
         private final FunctionEx<? super T, ? extends V> toValueFn;
-        private int maxParallelAsyncOps;
-
-        private transient Hz3MapAdapter hz3MapAdapter;
 
         Supplier(@Nonnull String clientXml, @Nonnull String mapName,
                         @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
@@ -183,12 +178,6 @@ final class WriteMapP<T, K, V> implements Processor {
             this.mapName = mapName;
             this.toKeyFn = toKeyFn;
             this.toValueFn = toValueFn;
-        }
-
-        @Override
-        public void init(@Nonnull Context context) throws Exception {
-            hz3MapAdapter = Hz3Util.createMapAdapter(clientXml);
-            maxParallelAsyncOps = max(1, MAX_PARALLELISM / context.localParallelism());
         }
 
         @Nonnull
@@ -202,9 +191,5 @@ final class WriteMapP<T, K, V> implements Processor {
                     .collect(toList());
         }
 
-        @Override
-        public void close(@Nullable Throwable error) throws Exception {
-            hz3MapAdapter.shutdown();
-        }
     }
 }

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/BaseHz3Test.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/BaseHz3Test.java
@@ -68,6 +68,21 @@ public class BaseHz3Test extends HazelcastTestSupport {
             + "    </network>\n"
             + "</hazelcast-client>\n";
 
+    // Client configuration with port where there is no Hz 3 instance running
+    protected static final String HZ3_DOWN_CLIENT_CONFIG =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\"\n"
+            + "                  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "                  xsi:schemaLocation=\"http://www.hazelcast.com/schema/client-config\n"
+            + "                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.12.xsd\">\n"
+            + "\n"
+            + "    <network>\n"
+            + "        <cluster-members>\n"
+            + "            <address>127.0.0.1:42000</address>\n"
+            + "        </cluster-members>\n"
+            + "    </network>\n"
+            + "</hazelcast-client>\n";
+
     protected HazelcastInstance hz3;
     protected Path customLibDir;
 

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SinksTest.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SinksTest.java
@@ -44,7 +44,7 @@ public class Hz3SinksTest extends BaseHz3Test {
                 new SimpleEntry<>(1, "a"),
                 new SimpleEntry<>(2, "b")
         );
-        Sink<Map.Entry<Integer, String>> sink = Hz3Sinks.map("test-map", HZ3_CLIENT_CONFIG);
+        Sink<Map.Entry<Integer, String>> sink = Hz3Sinks.remoteMap("test-map", HZ3_CLIENT_CONFIG);
         p.readFrom(source)
                 .writeTo(sink);
 
@@ -68,7 +68,7 @@ public class Hz3SinksTest extends BaseHz3Test {
                 new SimpleEntry<>(1, "a"),
                 new SimpleEntry<>(2, "b")
         );
-        Sink<Map.Entry<Integer, String>> sink = Hz3Sinks.map("test-map", HZ3_DOWN_CLIENT_CONFIG);
+        Sink<Map.Entry<Integer, String>> sink = Hz3Sinks.remoteMap("test-map", HZ3_DOWN_CLIENT_CONFIG);
         p.readFrom(source)
          .writeTo(sink);
 

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SourcesTest.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SourcesTest.java
@@ -17,7 +17,10 @@
 package com.hazelcast.connector;
 
 import com.hazelcast.collection.IList;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.BatchSource;
@@ -30,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 public class Hz3SourcesTest extends BaseHz3Test {
@@ -103,4 +107,50 @@ public class Hz3SourcesTest extends BaseHz3Test {
         assertThat(result.entrySet()).isEqualTo(items.entrySet());
     }
 
+    @Test
+    public void when_readFromInstanceDown_then_shouldThrowJetException() {
+        HazelcastInstance hz = createHazelcastInstance();
+
+        Pipeline p = Pipeline.create();
+        BatchSource<Map.Entry<Integer, String>> source = Hz3Sources.remoteMap("test-map", HZ3_DOWN_CLIENT_CONFIG);
+        p.readFrom(source)
+         .map(Map.Entry::getValue)
+         .writeTo(Sinks.list("test-result"));
+
+        JobConfig config = getJobConfig(source.name());
+        Job job = hz.getJet().newJob(p, config);
+
+        assertThatThrownBy(() -> job.join())
+                .hasStackTraceContaining(JetException.class.getName())
+                .hasStackTraceContaining("Unable to connect to any cluster");
+    }
+
+    @Test
+    public void when_tryToReadFromHz5Cluster_then_shouldThrowJetException() {
+        Config hz5Config = new Config();
+        hz5Config.getNetworkConfig().setPort(15701);
+        HazelcastInstance hz5 = Hazelcast.newHazelcastInstance(hz5Config);
+
+        try {
+            HazelcastInstance hz = createHazelcastInstance();
+
+            Pipeline p = Pipeline.create();
+            BatchSource<Map.Entry<Integer, String>> source = Hz3Sources.remoteMap(
+                    "test-map",
+                    HZ3_CLIENT_CONFIG.replace("3210", "15701") // point to Hz 5 instance
+            );
+            p.readFrom(source)
+             .map(Map.Entry::getValue)
+             .writeTo(Sinks.list("test-result"));
+
+            JobConfig config = getJobConfig(source.name());
+            Job job = hz.getJet().newJob(p, config);
+
+            assertThatThrownBy(() -> job.join())
+                    .hasStackTraceContaining(JetException.class.getName())
+                    .hasStackTraceContaining("Unable to connect to any cluster");
+        } finally {
+            hz5.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
When initializing the MapAdapterImpl when the target cluster is down (or
unreachable for any other reason, e.g. network) unwrap the exception so
the user gets a nicer message.

Fixes #19499
