### PR TITLE
Remove spotbugs leftovers

### DIFF
--- a/.github/workflows/docker_snapshot.yml
+++ b/.github/workflows/docker_snapshot.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           mvn -f hazelcast/pom.xml -B \
             -Dmaven.site.skip=true -Dmaven.javadoc.skip=true \
-            -Dcheckstyle.skip -Dspotbugs.skip clean install -DskipTests
+            -Dcheckstyle.skip clean install -DskipTests
           rm hazelcast/hazelcast/target/*-sources.jar \
             hazelcast/hazelcast/target/*-tests.jar || true
           cp hazelcast/hazelcast/target/hazelcast-*.jar hazelcast.jar
@@ -75,7 +75,7 @@ jobs:
         run: |
           mvn -f hazelcast-enterprise/pom.xml -B -Dmaven.test.skip=true \
             -Dmaven.site.skip=true -Dmaven.javadoc.skip=true \
-            -Dcheckstyle.skip -Dspotbugs.skip clean install -DskipTests
+            -Dcheckstyle.skip clean install -DskipTests
           rm hazelcast-enterprise/hazelcast-enterprise/target/*-sources.jar \
             hazelcast-enterprise/hazelcast-enterprise/target/*-tests.jar || true
           cp hazelcast-enterprise/hazelcast-enterprise/target/hazelcast-enterprise-*.jar hazelcast-enterprise.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1244,7 +1244,6 @@
             </activation>
             <properties>
                 <checkstyle.skip>true</checkstyle.skip>
-                <spotbugs.skip>true</spotbugs.skip>
                 <skipTests>true</skipTests>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
                 <maven.source.skip>true</maven.source.skip>


### PR DESCRIPTION
Removed references to `spotbugs.skip` flag. Spotbugs was removed here: https://github.com/hazelcast/hazelcast/commit/a89075a68026689311dfe537789304d2f1c7d620

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
