### PR TITLE
Rename the hot-restart metrics prefix

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -186,16 +186,6 @@ public final class MetricDescriptorConstants {
     public static final String HD_METRIC_ENTRY_COUNT = "entryCount";
     // ===[/HD]=========================================================
 
-    // ===[HOT-RESTART]=================================================
-    public static final String HOTRESTART_PREFIX = "hot-restart";
-    public static final String HOTRESTART_METRIC_VAL_OCCUPANCY = "valOccupancy";
-    public static final String HOTRESTART_METRIC_VAL_GARBAGE = "valGarbage";
-    public static final String HOTRESTART_METRIC_TOMB_OCCUPANCY = "tombOccupancy";
-    public static final String HOTRESTART_METRIC_TOMB_GARBAGE = "tombGarbage";
-    public static final String HOTRESTART_METRIC_GC_LIVE_VALUES = "liveValues";
-    public static final String HOTRESTART_METRIC_GC_LIVE_TOMBSTONES = "liveTombstones";
-    // ===[/HOT-RESTART]================================================
-
     // ===[LIST]=======================================================
     public static final String LIST_PREFIX = "list";
     public static final String LIST_METRIC_LAST_ACCESS_TIME = "lastAccessTime";
@@ -444,6 +434,16 @@ public final class MetricDescriptorConstants {
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_STAMP = "stateStamp";
     public static final String PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_MEMBER_GROUP_SIZE = "memberGroupsSize";
     // ===[/PARTITIONS]=================================================
+
+    // ===[PERSISTENCE]=================================================
+    public static final String PERSISTENCE_PREFIX = "persistence";
+    public static final String PERSISTENCE_METRIC_VAL_OCCUPANCY = "valOccupancy";
+    public static final String PERSISTENCE_METRIC_VAL_GARBAGE = "valGarbage";
+    public static final String PERSISTENCE_METRIC_TOMB_OCCUPANCY = "tombOccupancy";
+    public static final String PERSISTENCE_METRIC_TOMB_GARBAGE = "tombGarbage";
+    public static final String PERSISTENCE_METRIC_GC_LIVE_VALUES = "liveValues";
+    public static final String PERSISTENCE_METRIC_GC_LIVE_TOMBSTONES = "liveTombstones";
+    // ===[/PERSISTENCE]================================================
 
     // ===[PN COUNTER]==================================================
     public static final String PNCOUNTER_PREFIX = "pnCounter";


### PR DESCRIPTION
This pr renames `hot-restart` metric prefix to `persistence` 
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4289

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
