### PR TITLE
Allow empty values for config properties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -390,7 +390,7 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public Config setProperty(String name, String value) {
+    public Config setProperty(@Nonnull String name, @Nonnull String value) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -532,7 +532,7 @@ public class Config {
      */
     public Config setProperty(@Nonnull String name, @Nonnull String value) {
         isNotNull(name, "name");
-        isNotNull(name, "value");
+        isNotNull(value, "value");
         properties.put(name, value);
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -526,13 +526,13 @@ public class Config {
      * @param name  property name
      * @param value value of the property
      * @return this config instance
+     * @throws IllegalArgumentException if either {@code name} or {@code value} is {@code null}
      * @see <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#system-properties">
      * Hazelcast System Properties</a>
      */
-    public Config setProperty(String name, String value) {
-        if (isNullOrEmptyAfterTrim(name) || isNullOrEmptyAfterTrim(value)) {
-            throw new IllegalArgumentException("Name and value must be not null.");
-        }
+    public Config setProperty(@Nonnull String name, @Nonnull String value) {
+        isNotNull(name, "name");
+        isNotNull(name, "value");
         properties.put(name, value);
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -526,12 +526,15 @@ public class Config {
      * @param name  property name
      * @param value value of the property
      * @return this config instance
-     * @throws IllegalArgumentException if either {@code name} or {@code value} is {@code null}
+     * @throws IllegalArgumentException if either {@code value} is {@code null} or if {@code name} is empty or
+     *                                  {@code null}
      * @see <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#system-properties">
      * Hazelcast System Properties</a>
      */
     public Config setProperty(@Nonnull String name, @Nonnull String value) {
-        isNotNull(name, "name");
+        if (isNullOrEmptyAfterTrim(name)) {
+            throw new IllegalArgumentException("argument 'name' can't be null or empty");
+        }
         isNotNull(value, "value");
         properties.put(name, value);
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -160,7 +160,7 @@ public class DynamicConfigurationAwareConfig extends Config {
     }
 
     @Override
-    public Config setProperty(String name, String value) {
+    public Config setProperty(@Nonnull String name, @Nonnull String value) {
         return staticConfig.setProperty(name, value);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
@@ -261,6 +261,11 @@ public class ConfigTest extends HazelcastTestSupport {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testSetConfigPropertyNameEmpty() {
+        config.setProperty(" ", "test");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testSetConfigPropertyValueNull() {
         config.setProperty("test", null);
     }


### PR DESCRIPTION
Disallowing the empty values breaks the EE build and sometimes they might be needed. Also, the original issue was about null values.