### PR TITLE
Don't run onClusterRestart on failover code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -834,7 +834,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return clientExtension.getJet();
     }
 
-    public void onClusterChange() {
+    /**
+     * This is called only on cluster change when the failover(blue/green) client is used.
+     */
+    public void beforeClusterChange() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Resetting local state of the client, because of a cluster change.");
 
@@ -849,7 +852,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager.reset();
     }
 
-    public void onClusterRestart() {
+    /**
+     * Called when a cluster id change without failover client is used.
+     */
+    public void afterClusterRestart() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Clearing local state of the client, because of a cluster restart.");
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -440,7 +440,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
                                                                      CandidateClusterContext nextContext) {
         currentContext.destroy();
 
-        client.onClusterChange();
+        client.beforeClusterChange();
 
         nextContext.start();
 
@@ -917,7 +917,13 @@ public class TcpClientConnectionManager implements ClientConnectionManager {
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onClusterRestart();
+                if (!failoverConfigProvided) {
+                    //in the failover client, there is no restart.
+                    //A cluster id change should always be handled as cluster change.
+                    // Note that at this point client.beforeClusterChange()
+                    // is already called to clear local state in the failover client.
+                    client.afterClusterRestart();
+                }
             }
             checkClientState(connection, switchingToNextCluster);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -215,7 +215,8 @@ public class ClientClusterServiceImpl
             }
             MemberListSnapshot clusterViewSnapshot = memberListSnapshot.get();
             // This check is necessary so that when handling auth response, it will not
-            // intervene with client failover logic
+            // intervene with client failover logic.
+            // EMPTY_SNAPSHOT is set only on #reset
             if (clusterViewSnapshot != EMPTY_SNAPSHOT) {
                 memberListSnapshot.set(new MemberListSnapshot(0, clusterViewSnapshot.members));
             }
@@ -224,6 +225,7 @@ public class ClientClusterServiceImpl
 
     /**
      * Clears the member list and fires member removed event for members in the list.
+     * This is called onClusterRestart which is detected via change of the cluster id.
      */
     public void clearMemberList() {
         List<MembershipEvent> events = null;
@@ -246,6 +248,10 @@ public class ClientClusterServiceImpl
         }
     }
 
+    /**
+     * This is called only on cluster change when the failover(blue/green) client is used.
+     * Here we set EMPTY_SNAPSHOT to memberListSnapshot so that a subsequent connection
+     */
     public void reset() {
         synchronized (clusterViewLock) {
             if (logger.isFineEnabled()) {


### PR DESCRIPTION
Added explanation for non-trivial methods of the ClientClusterService.

renamed onClusterChange to beforeClusterChange and
renamed onClusterRestart to afterClusterRestart
to make it clear when they are called. Also added javadoc for those.

While writing javadoc, it become more clear that onClusterRestart
should not be called on failover client. Refactored that as well.
