### PR TITLE
Bump compact format cluster version check

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
@@ -40,8 +40,13 @@ public final class Versions {
      */
     public static final Version V5_0 = Version.of(5, 0);
 
-    public static final Version PREVIOUS_CLUSTER_VERSION = V4_2;
-    public static final Version CURRENT_CLUSTER_VERSION = V5_0;
+    /**
+     * Cluster version 5.1
+     */
+    public static final Version V5_1 = Version.of(5, 1);
+
+    public static final Version PREVIOUS_CLUSTER_VERSION = V5_0;
+    public static final Version CURRENT_CLUSTER_VERSION = V5_1;
 
     private Versions() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/MemberSchemaService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/MemberSchemaService.java
@@ -81,8 +81,8 @@ public class MemberSchemaService implements ManagedService, PreJoinAwareService,
     }
 
     public CompletableFuture<Schema> getAsync(long schemaId) {
-        if (!nodeEngine.getClusterService().getClusterVersion().isEqualTo(Versions.V5_0)) {
-            throw new UnsupportedOperationException("The BETA compact format can only be used with 5.0 cluster");
+        if (!nodeEngine.getClusterService().getClusterVersion().isEqualTo(Versions.V5_1)) {
+            throw new UnsupportedOperationException("The BETA compact format can only be used with 5.1 cluster");
         }
         Schema schema = getLocal(schemaId);
         if (schema != null) {
@@ -132,8 +132,8 @@ public class MemberSchemaService implements ManagedService, PreJoinAwareService,
     }
 
     public CompletableFuture<Void> putAsync(Schema schema) {
-        if (!nodeEngine.getClusterService().getClusterVersion().isEqualTo(Versions.V5_0)) {
-            throw new UnsupportedOperationException("The BETA compact format can only be used with 5.0 cluster");
+        if (!nodeEngine.getClusterService().getClusterVersion().isEqualTo(Versions.V5_1)) {
+            throw new UnsupportedOperationException("The BETA compact format can only be used with 5.1 cluster");
         }
         long schemaId = schema.getSchemaId();
         if (getLocal(schemaId) != null) {


### PR DESCRIPTION
We only guarantee same minor version compatibility for the compact format.
Hence, we needed to bump the version used in the check to 5.1
as the master now points to 5.1-SNAPSHOT.