### PR TITLE
Fix failure in SplitBrainTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -306,6 +306,10 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
         assertJobStatusEventually(job, NOT_RUNNING, 10);
         createHazelcastInstance(createConfig());
         assertTrueAllTheTime(() -> assertStatusNotRunningOrStarting(job.getStatus()), 5);
+
+        // The test ends with a cluster size 2, which is below quorum
+        // Start another instance so the job can restart and be cleaned up correctly
+        createHazelcastInstance(createConfig());
     }
 
     private void assertStatusNotRunningOrStarting(JobStatus status) {


### PR DESCRIPTION
The test ends with a job in NOT_RUNNING state
and termination mode RESTART_FORCEFUL, so it
cannot be cancelled in test cleanup.

Fixes #19560

This is 5.0 backport of #19562