### PR TITLE
Convert staleJoinPreventionDuration to not static field

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -88,6 +88,7 @@ import static java.lang.String.format;
 public class ClusterJoinManager {
 
     public static final String STALE_JOIN_PREVENTION_DURATION_PROP = "hazelcast.stale.join.prevention.duration.seconds";
+    private static final int DEFAULT_STALE_JOIN_PREVENTION_DURATION_IN_SECS = 30;
     private static final int CLUSTER_OPERATION_RETRY_COUNT = 100;
 
     private final ILogger logger;
@@ -113,8 +114,8 @@ public class ClusterJoinManager {
     private final ConcurrentMap<UUID, Long> leftMembersUuids = new ConcurrentHashMap<>();
     private final long maxWaitMillisBeforeJoin;
     private final long waitMillisBeforeJoin;
-
     private final long staleJoinPreventionDurationInMillis;
+
     private long firstJoinRequest;
     private long timeToStartJoin;
     private volatile boolean joinInProgress;
@@ -131,7 +132,8 @@ public class ClusterJoinManager {
 
         maxWaitMillisBeforeJoin = node.getProperties().getMillis(ClusterProperty.MAX_WAIT_SECONDS_BEFORE_JOIN);
         waitMillisBeforeJoin = node.getProperties().getMillis(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN);
-        staleJoinPreventionDurationInMillis = TimeUnit.SECONDS.toMillis(Integer.getInteger(STALE_JOIN_PREVENTION_DURATION_PROP, 30));
+        staleJoinPreventionDurationInMillis = TimeUnit.SECONDS.toMillis(
+            Integer.getInteger(STALE_JOIN_PREVENTION_DURATION_PROP, DEFAULT_STALE_JOIN_PREVENTION_DURATION_IN_SECS));
     }
 
     boolean isJoinInProgress() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -114,7 +114,7 @@ public class ClusterJoinManager {
     private final long maxWaitMillisBeforeJoin;
     private final long waitMillisBeforeJoin;
 
-    private long staleJoinPreventionDurationInMillis;
+    private final long staleJoinPreventionDurationInMillis;
     private long firstJoinRequest;
     private long timeToStartJoin;
     private volatile boolean joinInProgress;


### PR DESCRIPTION
We need to override this property in the EE side tests. We cannot
achieve this when it's static.
It's prerequisite for solving https://github.com/hazelcast/hazelcast-enterprise/issues/4290

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4318

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

