### PR TITLE
Fix JarScannerTest on Windows builds

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/JarScannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/JarScannerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.jar.JarFile;
 
@@ -50,7 +51,8 @@ public class JarScannerTest {
         try (JarFile jarFile = new JarFile(dummyJarFile.toFile())) {
             List<String> classFiles = JarScanner.findClassFiles(jarFile, "SomeClass");
 
-            assertThat(classFiles).contains("com/example/SomeClass.class");
+            String pathToClass = Paths.get("com", "example", "SomeClass.class").toString();
+            assertThat(classFiles).contains(pathToClass);
         }
     }
 


### PR DESCRIPTION
Made path assertion platform agnostic

Fixes https://github.com/hazelcast/hazelcast/issues/19628

Related to: https://github.com/hazelcast/hazelcast/pull/19512

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible