### PR TITLE
MC-1075 - fix ReliableTopic totalPublishes metric

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableMessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableMessageRunner.java
@@ -50,11 +50,6 @@ public class ClientReliableMessageRunner<E> extends MessageRunner<E> {
     }
 
     @Override
-    protected void updateStatistics() {
-
-    }
-
-    @Override
     protected Member getMember(ReliableTopicMessage m) {
         Member member = null;
         if (m.getPublisherAddress() != null) {

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -51,8 +51,6 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
 
     protected String name;
 
-    protected ReliableTopicService reliableTopicService;
-
     public AbstractRingBufferOperation() {
     }
 
@@ -139,7 +137,8 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
      * is actually called on ReliableTopic and reports the statistics to {@link ReliableTopicService}.
      */
     protected void reportReliableTopicPublish(int publishCount) {
-        reportReliableTopicStat(publishCount, (topic) -> getReliableTopicService().incrementPublishes(topic));
+        reportReliableTopicStat(publishCount, (topic) ->
+                getReliableTopicService().getLocalTopicStats(topic).incrementPublishes());
     }
 
     /**
@@ -147,17 +146,18 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
      * is actually called on ReliableTopic and reports the statistics to {@link ReliableTopicService}.
      */
     protected void reportReliableTopicReceived(int receivedCount) {
-        reportReliableTopicStat(receivedCount, (topic) -> getReliableTopicService().incrementReceivedMessages(topic));
+        reportReliableTopicStat(receivedCount, (topic) ->
+                getReliableTopicService().getLocalTopicStats(topic).incrementReceives());
     }
 
-    private void reportReliableTopicStat(int count, Consumer<String> statsReposter) {
+    private void reportReliableTopicStat(int count, Consumer<String> statsReporter) {
         if (name.startsWith(RingbufferService.TOPIC_RB_PREFIX)) {
             String reliableTopicName = name.substring(RingbufferService.TOPIC_RB_PREFIX.length());
-            IntStream.range(0, count).forEach((val) -> statsReposter.accept(reliableTopicName));
+            IntStream.range(0, count).forEach((i) -> statsReporter.accept(reliableTopicName));
         }
     }
 
-    protected ReliableTopicService getReliableTopicService() {
+    private ReliableTopicService getReliableTopicService() {
         return getNodeEngine().getService(ReliableTopicService.SERVICE_NAME);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -17,6 +17,8 @@
 package com.hazelcast.ringbuffer.impl.operations;
 
 import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.internal.services.ServiceNamespaceAware;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -25,10 +27,9 @@ import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.operationservice.NamedOperation;
-import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
-import com.hazelcast.internal.services.ServiceNamespaceAware;
+import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 
 import java.io.IOException;
 
@@ -48,11 +49,17 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
 
     protected String name;
 
+    protected ReliableTopicService reliableTopicService;
+
     public AbstractRingBufferOperation() {
     }
 
     public AbstractRingBufferOperation(String name) {
         this.name = name;
+    }
+
+    protected ReliableTopicService getReliableTopicService() {
+        return getNodeEngine().getService(ReliableTopicService.SERVICE_NAME);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.ringbuffer.impl.operations;
 
 import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.internal.monitor.impl.LocalTopicStatsImpl;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespaceAware;
 import com.hazelcast.logging.ILogger;
@@ -134,7 +135,7 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
 
     /**
      * ReliableTopic is built on top of RingBuffer. This method determines if 'publish' operation
-     * is actually called on ReliableTopic and reports the statistics to {@link ReliableTopicService}.
+     * is actually called on ReliableTopic and reports the statistics to {@link LocalTopicStatsImpl}.
      */
     protected void reportReliableTopicPublish(int publishCount) {
         reportReliableTopicStat(publishCount, (topic) ->
@@ -143,7 +144,7 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
 
     /**
      * ReliableTopic is built on top of RingBuffer. This method determines if 'read' operation
-     * is actually called on ReliableTopic and reports the statistics to {@link ReliableTopicService}.
+     * is actually called on ReliableTopic and reports the statistics to {@link LocalTopicStatsImpl}.
      */
     protected void reportReliableTopicReceived(int receivedCount) {
         reportReliableTopicStat(receivedCount, (topic) ->

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -17,21 +17,19 @@
 package com.hazelcast.ringbuffer.impl.operations;
 
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
-import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.stream.IntStream;
 
 import static com.hazelcast.ringbuffer.OverflowPolicy.FAIL;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_ALL_OPERATION;
@@ -74,11 +72,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
 
     @Override
     public void afterRun() throws Exception {
-        if (name.startsWith(RingbufferService.TOPIC_RB_PREFIX)) {
-            IntStream.range(0, items.length)
-                    .forEach((val) -> getReliableTopicService().incrementPublishes(
-                            name.substring(RingbufferService.TOPIC_RB_PREFIX.length())));
-        }
+        reportReliableTopicPublish(items.length);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -30,6 +31,7 @@ import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.stream.IntStream;
 
 import static com.hazelcast.ringbuffer.OverflowPolicy.FAIL;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_ALL_OPERATION;
@@ -68,6 +70,15 @@ public class AddAllOperation extends AbstractRingBufferOperation
         }
 
         lastSequence = ringbuffer.addAll(items);
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        if (name.startsWith(RingbufferService.TOPIC_RB_PREFIX)) {
+            IntStream.range(0, items.length)
+                    .forEach((val) -> getReliableTopicService().incrementPublishes(
+                            name.substring(RingbufferService.TOPIC_RB_PREFIX.length())));
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
-import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
@@ -71,9 +70,7 @@ public class AddOperation extends AbstractRingBufferOperation implements Notifie
 
     @Override
     public void afterRun() throws Exception {
-        if (name.startsWith(RingbufferService.TOPIC_RB_PREFIX)) {
-            getReliableTopicService().incrementPublishes(name.substring(RingbufferService.TOPIC_RB_PREFIX.length()));
-        }
+        reportReliableTopicPublish(1);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -17,16 +17,17 @@
 package com.hazelcast.ringbuffer.impl.operations;
 
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
@@ -66,6 +67,13 @@ public class AddOperation extends AbstractRingBufferOperation implements Notifie
         }
 
         resultSequence = ringbuffer.add(item);
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        if (name.startsWith(RingbufferService.TOPIC_RB_PREFIX)) {
+            getReliableTopicService().incrementPublishes(name.substring(RingbufferService.TOPIC_RB_PREFIX.length()));
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -97,6 +97,11 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
     }
 
     @Override
+    public void afterRun() throws Exception {
+        reportReliableTopicReceived(resultSet.size());
+    }
+
+    @Override
     public Object getResponse() {
         return resultSet;
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -71,6 +71,11 @@ public class ReadOneOperation extends AbstractRingBufferOperation implements Blo
     }
 
     @Override
+    public void afterRun() throws Exception {
+        reportReliableTopicReceived(1);
+    }
+
+    @Override
     public void onWaitExpire() {
         //todo:
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
@@ -110,7 +110,7 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
                 ReliableTopicMessage message = result.get(i);
                 try {
                     listener.storeSequence(result.getSequence(i));
-                    process(message);
+                    listener.onMessage(toMessage(message));
                 } catch (Throwable t) {
                     if (terminate(t)) {
                         cancel();
@@ -131,19 +131,6 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
             }
         }
     }
-
-    /**
-     * Processes the message by increasing the local topic stats and
-     * calling the user supplied listener.
-     *
-     * @param message the reliable topic message
-     */
-    private void process(ReliableTopicMessage message) {
-        updateStatistics();
-        listener.onMessage(toMessage(message));
-    }
-
-    protected abstract void updateStatistics();
 
     private Message<E> toMessage(ReliableTopicMessage m) {
         Member member = getMember(m);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageRunner.java
@@ -41,11 +41,6 @@ public class ReliableMessageRunner<E> extends MessageRunner<E> {
     }
 
     @Override
-    protected void updateStatistics() {
-        proxy.localTopicStats.incrementReceives();
-    }
-
-    @Override
     protected Member getMember(ReliableTopicMessage m) {
         return clusterService.getMember(m.getPublisherAddress());
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -170,19 +170,15 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
             switch (overloadPolicy) {
                 case ERROR:
                     addOrFail(message);
-                    localTopicStats.incrementPublishes();
                     break;
                 case DISCARD_OLDEST:
                     addOrOverwrite(message);
-                    localTopicStats.incrementPublishes();
                     break;
                 case DISCARD_NEWEST:
                     ringbuffer.addAsync(message, OverflowPolicy.FAIL).toCompletableFuture().get();
-                    localTopicStats.incrementPublishes();
                     break;
                 case BLOCK:
                     addWithBackoff(Collections.singleton(message));
-                    localTopicStats.incrementPublishes();
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
@@ -289,19 +285,15 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
                         throw new TopicOverloadException(
                                 String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
                     }
-                    localTopicStats.incrementPublishes();
                     break;
                 case DISCARD_OLDEST:
                     ringbuffer.addAllAsync(messages, OverflowPolicy.OVERWRITE).toCompletableFuture().get();
-                    localTopicStats.incrementPublishes();
                     break;
                 case DISCARD_NEWEST:
                     ringbuffer.addAllAsync(messages, OverflowPolicy.FAIL).toCompletableFuture().get();
-                    localTopicStats.incrementPublishes();
                     break;
                 case BLOCK:
                     addWithBackoff(messages);
-                    localTopicStats.incrementPublishes();
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
@@ -368,7 +360,6 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
                 returnFuture.completeExceptionally(t);
             } else {
                 returnFuture.complete(null);
-                messages.forEach(p -> localTopicStats.incrementPublishes());
             }
         });
         return returnFuture;
@@ -387,7 +378,6 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
                         pauseMillis, MILLISECONDS);
             } else {
                 returnFuture.complete(null);
-                localTopicStats.incrementPublishes();
             }
         });
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -348,7 +348,6 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
                         "Failed to publish messages: " + payload + " on topic:" + getName()));
             } else {
                 returnFuture.complete(null);
-                messages.forEach(p -> localTopicStats.incrementPublishes());
             }
         });
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
@@ -31,6 +31,7 @@ import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.LocalTopicStats;
 
 import java.util.Map;
@@ -43,7 +44,8 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.RELIABLE_
 import static com.hazelcast.internal.metrics.impl.ProviderHelper.provide;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutSynchronized;
 
-public class ReliableTopicService implements ManagedService, RemoteService, StatisticsAwareService, DynamicMetricsProvider {
+public class ReliableTopicService implements ManagedService, RemoteService,
+        StatisticsAwareService<LocalTopicStats>, DynamicMetricsProvider {
 
     public static final String SERVICE_NAME = "hz:impl:reliableTopicService";
     private final ConcurrentMap<String, LocalTopicStatsImpl> statsMap = new ConcurrentHashMap<>();
@@ -65,6 +67,16 @@ public class ReliableTopicService implements ManagedService, RemoteService, Stat
     @Override
     public void destroyDistributedObject(String objectName, boolean local) {
         statsMap.remove(objectName);
+    }
+
+    /**
+     * Increments the number of published messages on the ITopic
+     * with the name {@code topicName}.
+     *
+     * @param topicName the name of the {@link ITopic}
+     */
+    public void incrementPublishes(String topicName) {
+        getLocalTopicStats(topicName).incrementPublishes();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
@@ -80,6 +80,16 @@ public class ReliableTopicService implements ManagedService, RemoteService,
     }
 
     /**
+     * Increments the number of received messages on the ITopic
+     * with the name {@code topicName}.
+     *
+     * @param topicName the name of the {@link ITopic}
+     */
+    public void incrementReceivedMessages(String topicName) {
+        getLocalTopicStats(topicName).incrementReceives();
+    }
+
+    /**
      * Returns reliable topic statistics local to this member
      * for the reliable topic with {@code name}.
      *

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
@@ -31,7 +31,6 @@ import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.LocalTopicStats;
 
 import java.util.Map;
@@ -67,26 +66,6 @@ public class ReliableTopicService implements ManagedService, RemoteService,
     @Override
     public void destroyDistributedObject(String objectName, boolean local) {
         statsMap.remove(objectName);
-    }
-
-    /**
-     * Increments the number of published messages on the ITopic
-     * with the name {@code topicName}.
-     *
-     * @param topicName the name of the {@link ITopic}
-     */
-    public void incrementPublishes(String topicName) {
-        getLocalTopicStats(topicName).incrementPublishes();
-    }
-
-    /**
-     * Increments the number of received messages on the ITopic
-     * with the name {@code topicName}.
-     *
-     * @param topicName the name of the {@link ITopic}
-     */
-    public void incrementReceivedMessages(String topicName) {
-        getLocalTopicStats(topicName).incrementReceives();
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/topic/ClientReliableTopicStatsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.topic;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.monitor.impl.LocalTopicStatsImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.impl.reliable.ReliableMessageListenerMock;
+import com.hazelcast.topic.impl.reliable.ReliableTopicService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.Accessors.getNode;
+import static com.hazelcast.topic.impl.reliable.ReliableTopicService.SERVICE_NAME;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientReliableTopicStatsTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance instance;
+    private ITopic<String> topic;
+
+    @Before
+    public void setup() {
+        instance = hazelcastFactory.newHazelcastInstance(new Config());
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        String name = randomMapName("reliableTopic-");
+        topic = client.getReliableTopic(name);
+        topic.addMessageListener(new ReliableMessageListenerMock());
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void publish_countStats() {
+        topic.publish("message1");
+        topic.publishAsync("message2");
+
+        assertTrueEventually(() -> {
+            ReliableTopicService service = getNode(instance).getNodeEngine().getService(SERVICE_NAME);
+            LocalTopicStatsImpl localTopicStats = service.getLocalTopicStats(topic.getName());
+            assertEquals(2, localTopicStats.getPublishOperationCount());
+            assertEquals(2, localTopicStats.getReceiveOperationCount());
+        });
+    }
+
+    @Test
+    public void publishAll_countStats() throws Exception {
+        topic.publishAll(asList("message1", "message2", "message3"));
+        topic.publishAllAsync(asList("message4", "message5", "message6"));
+
+        assertTrueEventually(() -> {
+            ReliableTopicService service = getNode(instance).getNodeEngine().getService(SERVICE_NAME);
+            LocalTopicStatsImpl localTopicStats = service.getLocalTopicStats(topic.getName());
+            assertEquals(6, localTopicStats.getPublishOperationCount());
+            assertEquals(6, localTopicStats.getReceiveOperationCount());
+        });
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -139,7 +139,7 @@ public abstract class HazelcastTestSupport {
     private TestHazelcastInstanceFactory factory;
 
     static {
-        ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 10);
+        ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 120);
         LOGGER.fine("ASSERT_TRUE_EVENTUALLY_TIMEOUT = " + ASSERT_TRUE_EVENTUALLY_TIMEOUT);
         ASSERT_COMPLETES_STALL_TOLERANCE = getInteger("hazelcast.assertCompletes.stallTolerance", 20);
         LOGGER.fine("ASSERT_COMPLETES_STALL_TOLERANCE = " + ASSERT_COMPLETES_STALL_TOLERANCE);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -139,7 +139,7 @@ public abstract class HazelcastTestSupport {
     private TestHazelcastInstanceFactory factory;
 
     static {
-        ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 120);
+        ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 10);
         LOGGER.fine("ASSERT_TRUE_EVENTUALLY_TIMEOUT = " + ASSERT_TRUE_EVENTUALLY_TIMEOUT);
         ASSERT_COMPLETES_STALL_TOLERANCE = getInteger("hazelcast.assertCompletes.stallTolerance", 20);
         LOGGER.fine("ASSERT_COMPLETES_STALL_TOLERANCE = " + ASSERT_COMPLETES_STALL_TOLERANCE);

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
@@ -53,7 +53,6 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
     private ReliableTopicProxy<String> topic;
     private HazelcastInstance local;
     private HazelcastInstance[] instances;
-//    private HazelcastInstance remote;
 
     @Before
     public void setup() {
@@ -68,7 +67,6 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
 
         instances = newInstances(config);
         local = instances[0];
-//        remote = instances[instances.length - 1];
         HazelcastInstance target = instances[instances.length - 1];
 
         String name = randomNameOwnedBy(target, "reliableTopic");


### PR DESCRIPTION
Previously ReliableTopic stats (published/received messages) were reported only when `ReliableTopicProxy` was used. No stats were reported If `ClientReliableTopicProxy` was used. Since ReliableTopic is always backed by a RingBuffer, we can report ReliableTopic stats from the RB operations if the RB name has a prefix `"_hz_rb_"`


Fixes https://github.com/hazelcast/hazelcast/issues/19555

Breaking changes (list specific methods/types/messages):
- none