### PR TITLE
[backport] Fix HazelcastCommandLineTest on Windows (#19636)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/console/HazelcastCommandLineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/HazelcastCommandLineTest.java
@@ -513,7 +513,8 @@ public class HazelcastCommandLineTest extends JetTestSupport {
         try {
             run("submit", testJarFile.toString());
             String actual = captureErr();
-            assertThat(actual).contains("WARNING: Hazelcast code detected in the jar: com/hazelcast/jet/testjob/HazelcastBootstrap.class. Hazelcast dependency should be set with the 'provided' scope or equivalent.");
+            String pathToClass = Paths.get("com", "hazelcast", "jet", "testjob", "HazelcastBootstrap.class").toString();
+            assertThat(actual).contains("WARNING: Hazelcast code detected in the jar: " + pathToClass + ". Hazelcast dependency should be set with the 'provided' scope or equivalent.");
         } finally {
             System.setErr(oldErr);
             IOUtil.deleteQuietly(testJarFile.toFile());


### PR DESCRIPTION
Made assertion platform agnostic

Fixes https://github.com/hazelcast/hazelcast/issues/19636

Related to: https://github.com/hazelcast/hazelcast/pull/19512

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible

Forward-port (backport) of: #19647 