### PR TITLE
Remove support for `char` and `char[]` from Compact

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldOperations.java
@@ -142,7 +142,7 @@ public final class FieldOperations {
 
             @Override
             public void writeFieldFromRecordToWriter(DefaultCompactWriter writer, GenericRecord genericRecord, String fieldName) {
-                writer.writeChar(fieldName, genericRecord.getChar(fieldName));
+                throw new UnsupportedOperationException("Compact format does not support writing a char field");
             }
 
             @Override
@@ -173,7 +173,7 @@ public final class FieldOperations {
 
             @Override
             public void writeFieldFromRecordToWriter(DefaultCompactWriter writer, GenericRecord record, String fieldName) {
-                writer.writeArrayOfChars(fieldName, record.getArrayOfChars(fieldName));
+                throw new UnsupportedOperationException("Compact format does not support writing an array of chars field");
             }
 
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -69,7 +69,7 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setChar(@Nonnull String fieldName, char value) {
-        return write(fieldName, value, FieldKind.CHAR);
+        throw new UnsupportedOperationException("Compact format does not support writing a char field");
     }
 
     @Nonnull
@@ -147,7 +147,7 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setArrayOfChars(@Nonnull String fieldName, @Nullable char[] value) {
-        return write(fieldName, value, FieldKind.ARRAY_OF_CHARS);
+        throw new UnsupportedOperationException("Compact format does not support writing an array of chars field");
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -52,7 +52,6 @@ import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.SHO
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BYTES;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_CHARS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACTS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATES;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMALS;
@@ -316,12 +315,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public char getChar(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
-        try {
-            return in.readChar(readFixedSizePosition(fd));
-        } catch (IOException e) {
-            throw illegalStateException(e);
-        }
+        throw new UnsupportedOperationException("Compact format does not support reading a char field");
     }
 
     @Override
@@ -438,7 +432,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Override
     @Nullable
     public char[] getArrayOfChars(@Nonnull String fieldName) {
-        return getVariableSize(fieldName, ARRAY_OF_CHARS, ObjectDataInput::readCharArray);
+        throw new UnsupportedOperationException("Compact format does not support reading an array of chars field");
     }
 
     @Override
@@ -926,7 +920,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     public Character getCharFromArray(@Nonnull String fieldName, int index) {
-        return getFixedSizeFieldFromArray(fieldName, ARRAY_OF_CHARS, ObjectDataInput::readChar, index);
+        throw new UnsupportedOperationException("Compact format does not support reading from an array of chars field");
     }
 
     public Integer getIntFromArray(@Nonnull String fieldName, int index) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -29,7 +29,6 @@ import java.time.OffsetDateTime;
 
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BYTES;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_CHARS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACTS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATES;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMALS;
@@ -51,7 +50,6 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMPS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONES;
 import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.BYTE;
-import static com.hazelcast.nio.serialization.FieldKind.CHAR;
 import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.DATE;
 import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
@@ -148,16 +146,6 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
     @Override
     public double readDouble(@Nonnull String fieldName, double defaultValue) {
         return isFieldExists(fieldName, DOUBLE) ? getDouble(fieldName) : defaultValue;
-    }
-
-    @Override
-    public char readChar(@Nonnull String fieldName) {
-        return getChar(fieldName);
-    }
-
-    @Override
-    public char readChar(@Nonnull String fieldName, char defaultValue) {
-        return isFieldExists(fieldName, CHAR) ? getChar(fieldName) : defaultValue;
     }
 
     @Override
@@ -261,17 +249,6 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
     @Override
     public boolean[] readArrayOfBooleans(@Nonnull String fieldName, @Nullable boolean[] defaultValue) {
         return isFieldExists(fieldName, ARRAY_OF_BOOLEANS) ? getArrayOfBooleans(fieldName) : defaultValue;
-    }
-
-    @Override
-    public char[] readArrayOfChars(@Nonnull String fieldName) {
-        return getArrayOfChars(fieldName);
-    }
-
-    @Nullable
-    @Override
-    public char[] readArrayOfChars(@Nonnull String fieldName, @Nullable char[] defaultValue) {
-        return isFieldExists(fieldName, ARRAY_OF_CHARS) ? getArrayOfChars(fieldName) : defaultValue;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
@@ -42,8 +42,6 @@ import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
 import static com.hazelcast.nio.serialization.FieldKind.BYTE;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BYTES;
-import static com.hazelcast.nio.serialization.FieldKind.CHAR;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_CHARS;
 import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACTS;
 import static com.hazelcast.nio.serialization.FieldKind.DATE;
@@ -191,16 +189,6 @@ public class DefaultCompactWriter implements CompactWriter {
     }
 
     @Override
-    public void writeChar(@Nonnull String fieldName, char value) {
-        int position = getFixedSizeFieldPosition(fieldName, CHAR);
-        try {
-            out.writeChar(position, value);
-        } catch (IOException e) {
-            throw illegalStateException(e);
-        }
-    }
-
-    @Override
     public void writeShort(@Nonnull String fieldName, short value) {
         int position = getFixedSizeFieldPosition(fieldName, SHORT);
         try {
@@ -313,11 +301,6 @@ public class DefaultCompactWriter implements CompactWriter {
     @Override
     public void writeArrayOfBooleans(@Nonnull String fieldName, @Nullable boolean[] values) {
         writeVariableSizeField(fieldName, ARRAY_OF_BOOLEANS, values, DefaultCompactWriter::writeBooleanBits);
-    }
-
-    @Override
-    public void writeArrayOfChars(@Nonnull String fieldName, @Nullable char[] values) {
-        writeVariableSizeField(fieldName, ARRAY_OF_CHARS, values, ObjectDataOutput::writeCharArray);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -36,7 +36,6 @@ import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.exce
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.exceptionForUnexpectedNullValueInArray;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BYTES;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_CHARS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACTS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATES;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMALS;
@@ -58,7 +57,6 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMPS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONES;
 import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.BYTE;
-import static com.hazelcast.nio.serialization.FieldKind.CHAR;
 import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.DATE;
 import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
@@ -135,7 +133,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
 
     @Override
     public char getChar(@Nonnull String fieldName) {
-        return get(fieldName, CHAR);
+        throw new UnsupportedOperationException("Compact format does not support reading a char field");
     }
 
     @Override
@@ -244,7 +242,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     @Override
     @Nullable
     public char[] getArrayOfChars(@Nonnull String fieldName) {
-        return get(fieldName, ARRAY_OF_CHARS);
+        throw new UnsupportedOperationException("Compact format does not support reading an array of chars field");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecordBuilder.java
@@ -60,5 +60,4 @@ public class DeserializedGenericRecordBuilder extends AbstractGenericRecordBuild
         return this;
     }
 
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BYTES;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_CHARS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACTS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATES;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMALS;
@@ -63,7 +62,6 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMPS;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONES;
 import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.BYTE;
-import static com.hazelcast.nio.serialization.FieldKind.CHAR;
 import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.DATE;
 import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
@@ -266,13 +264,6 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                     }
                 };
                 writers[index] = (w, o) -> w.writeBoolean(name, field.getBoolean(o));
-            } else if (Character.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (fieldExists(schema, name, CHAR)) {
-                        field.setChar(o, reader.readChar(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeChar(name, field.getChar(o));
             } else if (String.class.equals(type)) {
                 readers[index] = (reader, schema, o) -> {
                     if (fieldExists(schema, name, STRING)) {
@@ -427,13 +418,6 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfDoubles(name, (double[]) field.get(o));
-                } else if (Character.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (fieldExists(schema, name, ARRAY_OF_CHARS)) {
-                            field.set(o, reader.readArrayOfChars(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfChars(name, (char[]) field.get(o));
                 } else if (Boolean.class.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_BOOLEANS, ARRAY_OF_NULLABLE_BOOLEANS)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
@@ -82,11 +82,6 @@ public final class SchemaWriter implements CompactWriter {
     }
 
     @Override
-    public void writeChar(@Nonnull String fieldName, char value) {
-        addField(new FieldDescriptor(fieldName, FieldKind.CHAR));
-    }
-
-    @Override
     public void writeDouble(@Nonnull String fieldName, double value) {
         addField(new FieldDescriptor(fieldName, FieldKind.DOUBLE));
     }
@@ -139,11 +134,6 @@ public final class SchemaWriter implements CompactWriter {
     @Override
     public void writeArrayOfBooleans(@Nonnull String fieldName, @Nullable boolean[] values) {
         addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_BOOLEANS));
-    }
-
-    @Override
-    public void writeArrayOfChars(@Nonnull String fieldName, @Nullable char[] values) {
-        addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_CHARS));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
@@ -121,9 +121,7 @@ public class SerializingGenericRecordBuilder implements GenericRecordBuilder {
     @Override
     @Nonnull
     public GenericRecordBuilder setChar(@Nonnull String fieldName, char value) {
-        checkIfAlreadyWritten(fieldName);
-        defaultCompactWriter.writeChar(fieldName, value);
-        return this;
+        throw new UnsupportedOperationException("Compact format does not support writing a char field");
     }
 
     @Override
@@ -281,9 +279,7 @@ public class SerializingGenericRecordBuilder implements GenericRecordBuilder {
     @Override
     @Nonnull
     public GenericRecordBuilder setArrayOfChars(@Nonnull String fieldName, @Nullable char[] value) {
-        checkIfAlreadyWritten(fieldName);
-        defaultCompactWriter.writeArrayOfChars(fieldName, value);
-        return this;
+        throw new UnsupportedOperationException("Compact format does not support writing an array of chars field");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
@@ -153,11 +153,7 @@ public class SerializingGenericRecordCloner implements GenericRecordBuilder {
     @Override
     @Nonnull
     public GenericRecordBuilder setChar(@Nonnull String fieldName, char value) {
-        checkTypeWithSchema(schema, fieldName, FieldKind.CHAR);
-        if (fields.putIfAbsent(fieldName, () -> cw.writeChar(fieldName, value)) != null) {
-            throw new HazelcastSerializationException("Field can only be written once");
-        }
-        return this;
+        throw new UnsupportedOperationException("Compact format does not support writing a char field");
     }
 
     @Override
@@ -353,11 +349,7 @@ public class SerializingGenericRecordCloner implements GenericRecordBuilder {
     @Override
     @Nonnull
     public GenericRecordBuilder setArrayOfChars(@Nonnull String fieldName, @Nullable char[] value) {
-        checkTypeWithSchema(schema, fieldName, FieldKind.ARRAY_OF_CHARS);
-        if (fields.putIfAbsent(fieldName, () -> cw.writeArrayOfChars(fieldName, value)) != null) {
-            throw new HazelcastSerializationException("Field can only be written once");
-        }
-        return this;
+        throw new UnsupportedOperationException("Compact format does not support writing an array of chars field");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -196,28 +196,6 @@ public interface CompactReader {
     double readDouble(@Nonnull String fieldName, double defaultValue);
 
     /**
-     * Reads a 16-bit unsigned integer.
-     *
-     * @param fieldName name of the field.
-     * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
-     */
-    char readChar(@Nonnull String fieldName);
-
-    /**
-     * Reads a 16-bit unsigned integer or returns the default value.
-     *
-     * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
-     * @return the value or the default value of the field.
-     */
-    char readChar(@Nonnull String fieldName, char defaultValue);
-
-    /**
      * Reads an UTF-8 encoded string.
      *
      * @param fieldName name of the field.
@@ -449,31 +427,6 @@ public interface CompactReader {
      */
     @Nullable
     byte[] readArrayOfBytes(@Nonnull String fieldName, @Nullable byte[] defaultValue);
-
-    /**
-     * Reads an array of 16-bit unsigned integers.
-     *
-     * @param fieldName name of the field.
-     * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
-     */
-    @Nullable
-    char[] readArrayOfChars(@Nonnull String fieldName);
-
-    /**
-     * Reads an array of 16-bit unsigned integers or returns the default value.
-     *
-     * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
-     * @return the value or the default value of the field.
-     */
-    @Nullable
-    char[] readArrayOfChars(@Nonnull String fieldName, @Nullable char[] defaultValue);
-
 
     /**
      * Reads an array of 16-bit two's complement signed integers.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactWriter.java
@@ -91,14 +91,6 @@ public interface CompactWriter {
     void writeDouble(@Nonnull String fieldName, double value);
 
     /**
-     * Writes a 16-bit unsigned integer.
-     *
-     * @param fieldName name of the field.
-     * @param value     to be written.
-     */
-    void writeChar(@Nonnull String fieldName, char value);
-
-    /**
      * Writes an UTF-8 encoded string.
      *
      * @param fieldName name of the field.
@@ -169,14 +161,6 @@ public interface CompactWriter {
      * @param value     to be written.
      */
     void writeArrayOfBytes(@Nonnull String fieldName, @Nullable byte[] value);
-
-    /**
-     * Writes an array of 16-bit unsigned integers.
-     *
-     * @param fieldName name of the field.
-     * @param value     to be written.
-     */
-    void writeArrayOfChars(@Nonnull String fieldName, @Nullable char[] value);
 
     /**
      * Writes an array of 16-bit two's complement signed integers.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -51,7 +51,6 @@ public final class CompactTestUtil {
 
         GenericRecord innerRecord = GenericRecordBuilder.compact("inner")
                 .setArrayOfBytes("b", inner.bb)
-                .setArrayOfChars("c", inner.cc)
                 .setArrayOfShorts("s", inner.ss)
                 .setArrayOfInts("i", inner.ii)
                 .setArrayOfLongs("l", inner.ll)
@@ -68,7 +67,6 @@ public final class CompactTestUtil {
         return GenericRecordBuilder.compact("main")
                 .setByte("b", mainDTO.b)
                 .setBoolean("bool", mainDTO.bool)
-                .setChar("c", mainDTO.c)
                 .setShort("s", mainDTO.s)
                 .setInt("i", mainDTO.i)
                 .setLong("l", mainDTO.l)
@@ -96,7 +94,7 @@ public final class CompactTestUtil {
         NamedDTO[] nn = new NamedDTO[2];
         nn[0] = new NamedDTO("name", 123);
         nn[1] = new NamedDTO("name", 123);
-        InnerDTO inner = new InnerDTO(new boolean[]{true, false}, new byte[]{0, 1, 2}, new char[]{'c', 'h', 'a', 'r'},
+        InnerDTO inner = new InnerDTO(new boolean[]{true, false}, new byte[]{0, 1, 2},
                 new short[]{3, 4, 5}, new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
                 new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321}, nn,
                 new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
@@ -113,7 +111,7 @@ public final class CompactTestUtil {
                 new LocalDateTime[]{LocalDateTime.now(), null},
                 new OffsetDateTime[]{OffsetDateTime.now()});
 
-        return new MainDTO((byte) 113, true, 'x', (short) -500, 56789, -50992225L, 900.5678f,
+        return new MainDTO((byte) 113, true, (short) -500, 56789, -50992225L, 900.5678f,
                 -897543.3678909d, "this is main object created for testing!", inner,
                 new BigDecimal("12312313"), LocalTime.now(), LocalDate.now(), LocalDateTime.now(), OffsetDateTime.now(),
                 (byte) 113, true, (short) -500, 56789, -50992225L, 900.5678f,

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -44,6 +44,7 @@ import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createMainDTO;
 import static com.hazelcast.nio.serialization.GenericRecordBuilder.compact;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -199,6 +200,30 @@ public class GenericRecordTest {
 
         assertEquals(2, newRecord.getInt("foo"));
         assertEquals(100, newRecord.getLong("bar"));
+    }
+
+    @Test
+    public void testReadWriteChar() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            compact("writeChar").setChar("c", 'a');
+        });
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            GenericRecord record = compact("readChar").build();
+            record.getChar("c");
+        });
+    }
+
+    @Test
+    public void testReadWriteCharArray() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            compact("writeCharArray").setArrayOfChars("ca", new char[]{'c'});
+        });
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            GenericRecord record = compact("readCharArray").build();
+            record.getArrayOfChars("ca");
+        });
     }
 
     private String trySetAndGetMessage(String fieldName, int value, GenericRecordBuilder cloneBuilder) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/reader/CompactStreamSerializerValueReaderSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/reader/CompactStreamSerializerValueReaderSpecTest.java
@@ -179,7 +179,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
      * <li>scenario(input, result.float_, adjustedPath + "float_"),</li>
      * <li>scenario(input, result.double_, adjustedPath + "double_"),</li>
      * <li>scenario(input, result.boolean_, adjustedPath + "boolean_"),</li>
-     * <li>scenario(input, result.char_, adjustedPath + "char_"),</li>
      * <li>scenario(input, result.string_, adjustedPath + "string_"),</li>
      * </ul>
      */
@@ -274,14 +273,14 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
      * PrimitiveObject. For example: "objectArray.primitive_" will be expanded two-fold, the object array and primitive
      * types will be expanded as follows:
      * <ul>
-     * <li>objects[0].byte, objects[0].short, objects[0].char, ... for all primitive types</li>
-     * <li>objects[1].byte, objects[1].short, objects[1].char, ...</li>
-     * <li>objects[2].byte, objects[2].short, objects[2].char, ...</li>
+     * <li>objects[0].byte, objects[0].short, ... for all primitive types</li>
+     * <li>objects[1].byte, objects[1].short, ...</li>
+     * <li>objects[2].byte, objects[2].short, ...</li>
      * </ul>
      * <p>
      * B.) Then the [any] case will be expanded too:
      * <ul>
-     * <li>objects[any].byte, objects[any].short, objects[any].char, ... for all primitive types</li>
+     * <li>objects[any].byte, objects[any].short, ... for all primitive types</li>
      * </ul>
      * <p>
      * The expected result should be the object that contains the object array - that's the general contract.
@@ -593,8 +592,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
                         "objects[any].objects[any].int_", p),
                 scenario(input, list(null, p1.long_, p10.long_, p20.long_),
                         "objects[any].objects[any].long_", p),
-                scenario(input, list(null, p1.char_, p10.char_, p20.char_),
-                        "objects[any].objects[any].char_", p),
                 scenario(input, list(null, p1.float_, p10.float_, p20.float_),
                         "objects[any].objects[any].float_", p),
                 scenario(input, list(null, p1.double_, p10.double_, p20.double_),
@@ -617,7 +614,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
                 scenario(inputEmpty, null, "objects[any].objects[any].short_", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].int_", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].long_", p),
-                scenario(inputEmpty, null, "objects[any].objects[any].char_", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].float_", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].double_", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].boolean_", p),
@@ -635,7 +631,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
                 scenario(inputNull, null, "objects[any].objects[any].short_", p),
                 scenario(inputNull, null, "objects[any].objects[any].int_", p),
                 scenario(inputNull, null, "objects[any].objects[any].long_", p),
-                scenario(inputNull, null, "objects[any].objects[any].char_", p),
                 scenario(inputNull, null, "objects[any].objects[any].float_", p),
                 scenario(inputNull, null, "objects[any].objects[any].double_", p),
                 scenario(inputNull, null, "objects[any].objects[any].boolean_", p),
@@ -673,8 +668,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
                         "objects[any].objects[any].ints[any]", p),
                 scenario(input, list(null, p10.longs, p20.longs),
                         "objects[any].objects[any].longs[any]", p),
-                scenario(input, list(null, p10.chars, p20.chars),
-                        "objects[any].objects[any].chars[any]", p),
                 scenario(input, list(null, p10.floats, p20.floats),
                         "objects[any].objects[any].floats[any]", p),
                 scenario(input, list(null, p10.doubles, p20.doubles),
@@ -698,7 +691,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
                 scenario(inputEmpty, null, "objects[any].objects[any].shorts[any]", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].ints[any]", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].longs[any]", p),
-                scenario(inputEmpty, null, "objects[any].objects[any].chars[any]", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].floats[any]", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].doubles[any]", p),
                 scenario(inputEmpty, null, "objects[any].objects[any].booleans[any]", p),
@@ -715,7 +707,6 @@ public class CompactStreamSerializerValueReaderSpecTest extends HazelcastTestSup
                 scenario(inputNull, null, "objects[any].objects[any].shorts[any]", p),
                 scenario(inputNull, null, "objects[any].objects[any].ints[any]", p),
                 scenario(inputNull, null, "objects[any].objects[any].longs[any]", p),
-                scenario(inputNull, null, "objects[any].objects[any].chars[any]", p),
                 scenario(inputNull, null, "objects[any].objects[any].floats[any]", p),
                 scenario(inputNull, null, "objects[any].objects[any].doubles[any]", p),
                 scenario(inputNull, null, "objects[any].objects[any].booleans[any]", p),

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/reader/CompactValueReaderTestStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/reader/CompactValueReaderTestStructure.java
@@ -35,7 +35,6 @@ public class CompactValueReaderTestStructure {
     public enum PrimitiveFields {
         Byte("byte_"),
         Boolean("boolean_"),
-        Char("char_"),
         Short("short_"),
         Int("int_"),
         Long("long_"),
@@ -50,7 +49,6 @@ public class CompactValueReaderTestStructure {
 
         ByteArray("bytes"),
         BooleanArray("booleans"),
-        CharArray("chars"),
         ShortArray("shorts"),
         IntArray("ints"),
         LongArray("longs"),
@@ -85,13 +83,13 @@ public class CompactValueReaderTestStructure {
         final String field;
 
         static List<PrimitiveFields> getPrimitives() {
-            return asList(Boolean, Byte, Char, Short, Int, Long, Float, Double, UTF, BigDecimal, LocalTime,
+            return asList(Boolean, Byte, Short, Int, Long, Float, Double, UTF, BigDecimal, LocalTime,
                     LocalDate, LocalDateTime, OffsetDateTime, NullableBoolean, NullableByte, NullableShort,
                     NullableInteger, NullableInteger, NullableLong, NullableFloat, NullableDouble);
         }
 
         static List<PrimitiveFields> getPrimitiveArrays() {
-            return asList(BooleanArray, ByteArray, CharArray, ShortArray, IntArray, LongArray, FloatArray, DoubleArray,
+            return asList(BooleanArray, ByteArray, ShortArray, IntArray, LongArray, FloatArray, DoubleArray,
                     UTFArray, BigDecimalArray, LocalTimeArray, LocalDateArray, LocalDateTimeArray, OffsetDateTimeArray,
                     NullableBooleanArray, NullableByteArray, NullableShortArray, NullableIntegerArray, NullableLongArray,
                     NullableFloatArray, NullableDoubleArray
@@ -109,7 +107,6 @@ public class CompactValueReaderTestStructure {
         long long_;
         float float_;
         double double_;
-        char char_;
         String string_;
         BigDecimal bigDecimal_;
         LocalTime localTime_;
@@ -124,7 +121,6 @@ public class CompactValueReaderTestStructure {
         long[] longs;
         float[] floats;
         double[] doubles;
-        char[] chars;
         String[] strings;
         BigDecimal[] bigDecimals;
         LocalTime[] localTimes;
@@ -162,7 +158,6 @@ public class CompactValueReaderTestStructure {
             long_ = seed + 40;
             float_ = seed + 50.01f;
             double_ = seed + 60.01d;
-            char_ = (char) (seed + 'a');
 
             Random rnd = new Random(seed);
             if (init == Init.FULL) {
@@ -173,7 +168,6 @@ public class CompactValueReaderTestStructure {
                 longs = new long[]{seed + 41, seed + 42, seed + 43};
                 floats = new float[]{seed + 51.01f, seed + 52.01f, seed + 53.01f};
                 doubles = new double[]{seed + 61.01f, seed + 62.01f, seed + 63.01f};
-                chars = new char[]{(char) (seed + 'b'), (char) (seed + 'c'), (char) (seed + 'd')};
                 strings = new String[]{seed + 81 + "text", seed + 82 + "text", seed + 83 + "text"};
                 localTime_ = LocalTime.of(17, 41, 47, 874000000);
                 localDate_ = LocalDate.of(1, 1, 1);
@@ -225,7 +219,6 @@ public class CompactValueReaderTestStructure {
                 floats = new float[]{};
                 doubles = new double[]{};
                 booleans = new boolean[]{};
-                chars = new char[]{};
                 strings = new String[]{};
                 bigDecimals = new BigDecimal[]{};
                 localTimes = new LocalTime[]{};
@@ -282,8 +275,6 @@ public class CompactValueReaderTestStructure {
                     return byte_;
                 case Boolean:
                     return boolean_;
-                case Char:
-                    return char_;
                 case Short:
                     return short_;
                 case Int:
@@ -331,8 +322,6 @@ public class CompactValueReaderTestStructure {
                     return bytes;
                 case Boolean:
                     return booleans;
-                case Char:
-                    return chars;
                 case Short:
                     return shorts;
                 case Int:
@@ -360,8 +349,6 @@ public class CompactValueReaderTestStructure {
                     return bytes;
                 case BooleanArray:
                     return booleans;
-                case CharArray:
-                    return chars;
                 case ShortArray:
                     return shorts;
                 case IntArray:

--- a/hazelcast/src/test/java/example/serialization/InnerDTO.java
+++ b/hazelcast/src/test/java/example/serialization/InnerDTO.java
@@ -27,7 +27,6 @@ public class InnerDTO {
 
     public boolean[] bools;
     public byte[] bb;
-    public char[] cc;
     public short[] ss;
     public int[] ii;
     public long[] ll;
@@ -55,7 +54,7 @@ public class InnerDTO {
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
-    public InnerDTO(boolean[] bools, byte[] bb, char[] cc, short[] ss, int[] ii, long[] ll, float[] ff, double[] dd, NamedDTO[] nn,
+    public InnerDTO(boolean[] bools, byte[] bb, short[] ss, int[] ii, long[] ll, float[] ff, double[] dd, NamedDTO[] nn,
                     BigDecimal[] bigDecimals, LocalTime[] localTimes, LocalDate[] localDates,
                     LocalDateTime[] localDateTimes, OffsetDateTime[] offsetDateTimes,
                     Boolean[] nullableBools, Byte[] nullableBytes, Short[] nullableShorts, Integer[] nullableIntegers,
@@ -64,7 +63,6 @@ public class InnerDTO {
                     OffsetDateTime[] nullableOffsetDateTimes) {
         this.bools = bools;
         this.bb = bb;
-        this.cc = cc;
         this.ss = ss;
         this.ii = ii;
         this.ll = ll;
@@ -100,7 +98,6 @@ public class InnerDTO {
         InnerDTO that = (InnerDTO) o;
         return Arrays.equals(bb, that.bb)
                 && Arrays.equals(bools, that.bools)
-                && Arrays.equals(cc, that.cc)
                 && Arrays.equals(ss, that.ss)
                 && Arrays.equals(ii, that.ii)
                 && Arrays.equals(ll, that.ll)
@@ -128,7 +125,6 @@ public class InnerDTO {
     public int hashCode() {
         int result = Arrays.hashCode(bb);
         result = 31 * result + Arrays.hashCode(bools);
-        result = 31 * result + Arrays.hashCode(cc);
         result = 31 * result + Arrays.hashCode(ss);
         result = 31 * result + Arrays.hashCode(ii);
         result = 31 * result + Arrays.hashCode(ll);
@@ -159,7 +155,6 @@ public class InnerDTO {
         return "InnerDTO{"
                 + "+ bools=" + Arrays.toString(bools)
                 + "+ bb=" + Arrays.toString(bb)
-                + ", + cc=" + Arrays.toString(cc)
                 + ", + ss=" + Arrays.toString(ss)
                 + ", + ii=" + Arrays.toString(ii)
                 + ", + ll=" + Arrays.toString(ll)

--- a/hazelcast/src/test/java/example/serialization/MainDTO.java
+++ b/hazelcast/src/test/java/example/serialization/MainDTO.java
@@ -28,7 +28,6 @@ public class MainDTO {
 
     public byte b;
     public boolean bool;
-    public char c;
     public short s;
     public int i;
     public long l;
@@ -52,14 +51,13 @@ public class MainDTO {
     MainDTO() {
     }
 
-    public MainDTO(byte b, boolean bool, char c, short s, int i, long l, float f, double d, String str, InnerDTO p,
+    public MainDTO(byte b, boolean bool, short s, int i, long l, float f, double d, String str, InnerDTO p,
                    BigDecimal bigDecimal, LocalTime localTime, LocalDate localDate, LocalDateTime localDateTime,
                    OffsetDateTime offsetDateTime,
                    Byte nullableB, Boolean nullableBool, Short nullableS, Integer nullableI,
                    Long nullableL, Float nullableF, Double nullableD) {
         this.b = b;
         this.bool = bool;
-        this.c = c;
         this.s = s;
         this.i = i;
         this.l = l;
@@ -97,9 +95,6 @@ public class MainDTO {
             return false;
         }
         if (bool != mainDTO.bool) {
-            return false;
-        }
-        if (c != mainDTO.c) {
             return false;
         }
         if (s != mainDTO.s) {
@@ -168,11 +163,10 @@ public class MainDTO {
         long temp;
         result = b;
         result = 31 * result + (bool ? 1 : 0);
-        result = 31 * result + (int) c;
         result = 31 * result + (int) s;
         result = 31 * result + i;
         result = 31 * result + (int) (l ^ (l >>> 32));
-        result = 31 * result + (f != +0.0f ? Float.floatToIntBits(f) : 0);
+        result = 31 * result + (f != 0.0f ? Float.floatToIntBits(f) : 0);
         temp = Double.doubleToLongBits(d);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         result = 31 * result + (str != null ? str.hashCode() : 0);
@@ -197,7 +191,6 @@ public class MainDTO {
         return "MainDTO{"
                 + "+ b=" + b
                 + ", + bool=" + bool
-                + ", + c=" + c
                 + ", + s=" + s
                 + ", + i=" + i
                 + ", + l=" + l


### PR DESCRIPTION
We have decided to not support `char` and `char[]` types on the compact
given that it is not a common type in other languages and we plan
to add support for unsigned integers.

It is true that for the Java users this might be a drawback but we think
`char` type is not widely used and currently, it is not possible to
use it in other parts of the Hazelcast, such as SQL. Hence, we think
our decision to remove it is justified.