### PR TITLE
Allow healthchecks in Docker-default member configuration

### DIFF
--- a/hazelcast/src/main/config-template/hazelcast-assembly.xml
+++ b/hazelcast/src/main/config-template/hazelcast-assembly.xml
@@ -171,6 +171,13 @@
         <failure-detector>
             <icmp enabled="false"/>
         </failure-detector>
+        <!--
+            Configuration for REST endpoints. When it's enabled, it will allow healthcheck calls over the HTTP protocol.
+         -->
+        <rest-api enabled="@FILTER_BIND_ANY@">
+            <endpoint-group name="HEALTH_CHECK" enabled="true"/>
+            <endpoint-group name="CLUSTER_READ" enabled="false"/>
+        </rest-api>
     </network>
     <partition-group enabled="false"/>
     <executor-service name="default">

--- a/hazelcast/src/main/config-template/hazelcast-assembly.yaml
+++ b/hazelcast/src/main/config-template/hazelcast-assembly.yaml
@@ -111,6 +111,14 @@ hazelcast:
     failure-detector:
       icmp:
         enabled: false
+    # Configuration for REST endpoints. When it's enabled, it will allow healthcheck calls over the HTTP protocol.
+    rest-api:
+      enabled: @FILTER_BIND_ANY@
+      endpoint-groups:
+        HEALTH_CHECK:
+          enabled: true
+        CLUSTER_READ:
+          enabled: false
   # When you enable partition grouping, Hazelcast presents three choices
   # for you to configure partition groups. These are:
   #


### PR DESCRIPTION
This PR enables REST healthcheck endpoints in our Docker configurations.
It can be used when there are more services started within Docker and some of them should wait for Hazelcast to start.