### PR TITLE
[BACKPORT] Change the default cluster-name as it interferes with other tests

### DIFF
--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SourcesTest.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/test/java/com/hazelcast/connector/Hz3SourcesTest.java
@@ -127,7 +127,7 @@ public class Hz3SourcesTest extends BaseHz3Test {
 
     @Test
     public void when_tryToReadFromHz5Cluster_then_shouldThrowJetException() {
-        Config hz5Config = new Config();
+        Config hz5Config = new Config().setClusterName("hz3-test");
         hz5Config.getNetworkConfig().setPort(15701);
         HazelcastInstance hz5 = Hazelcast.newHazelcastInstance(hz5Config);
 


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/19657

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible

