### PR TITLE
Use Method.getParameterCount() where possible

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1283,8 +1283,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 if (!requiresArg) {
                     return method;
                 }
-                Class<?>[] args = method.getParameterTypes();
-                if (args.length != 1) {
+                if (method.getParameterCount() != 1) {
                     continue;
                 }
                 Class<?> arg = method.getParameterTypes()[0];

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -88,7 +88,7 @@ abstract class MethodProbe implements ProbeFunction {
                     method.getDeclaringClass().getName(), method.getName()));
         }
 
-        if (method.getParameterTypes().length != 0) {
+        if (method.getParameterCount() != 0) {
             throw new IllegalArgumentException(format("@Probe method '%s.%s' can't have arguments",
                     method.getDeclaringClass().getName(), method.getName()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InstantiationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InstantiationUtils.java
@@ -79,10 +79,10 @@ public final class InstantiationUtils {
     }
 
     private static boolean isParamsMatching(Constructor<?> constructor, Object[] params) {
-        Class<?>[] constructorParamTypes = constructor.getParameterTypes();
-        if (constructorParamTypes.length != params.length) {
+        if (constructor.getParameterCount() != params.length) {
             return false;
         }
+        Class<?>[] constructorParamTypes = constructor.getParameterTypes();
         for (int i = 0; i < constructorParamTypes.length; i++) {
             Class<?> constructorParamType = constructorParamTypes[i];
             Object param = params[i];

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigVersionTest.java
@@ -57,7 +57,7 @@ public class DynamicConfigVersionTest {
         for (Method method : allConfigMethods) {
             String methodName = method.getName();
             if (methodName.startsWith("add") && methodName.endsWith("Config")) {
-                assert method.getParameterTypes().length == 1;
+                assert method.getParameterCount() == 1;
                 Class klass = method.getParameterTypes()[0];
                 boolean isMappedToVersion = CONFIG_TO_VERSION.get(klass) != null
                         || NON_DYNAMIC_CONFIG_CLASSES.contains(klass);

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
@@ -142,7 +142,7 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
         if (!method.getName().startsWith("get") && !method.getName().startsWith("is")) {
             return false;
         }
-        if (method.getParameterTypes().length != 0) {
+        if (method.getParameterCount() != 0) {
             return false;
         }
         return !void.class.equals(method.getReturnType());


### PR DESCRIPTION
Hi,

this PR changes `Method.getParameterTypes().length` to `Method.getParameterCount()` in order to avoid unnecessary cloning of the underlying params array.

Let me know what you think and also - since it's my first contribution to the project - if I should have done something different.

Cheers,
Christoph

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
