### PR TITLE
WAN target hostname fix

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -306,8 +306,12 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             LinkedAddresses that = (LinkedAddresses) o;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -298,7 +298,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
             this(mappedAddress, Collections.emptyList(), true);
         }
 
-        public LinkedAddresses(Address mappedAddress, List<Address> linkedAddresses, boolean primary) {
+        private LinkedAddresses(Address mappedAddress, List<Address> linkedAddresses, boolean primary) {
             this.mappedAddress = requireNonNull(mappedAddress);
             this.linkedAddresses = requireNonNull(linkedAddresses);
             this.primary = primary;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -289,7 +289,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
         }
     }
 
-    private static class LinkedAddresses {
+    private static final class LinkedAddresses {
         private final Address mappedAddress;
         private final List<Address> linkedAddresses;
         private final boolean primary;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerControl.java
@@ -143,9 +143,10 @@ public final class TcpServerControl {
                                        Collection<Address> remoteAddressAliases,
                                        MemberHandshake handshake) {
         final Address remoteAddress = new Address(connection.getRemoteSocketAddress());
-        if (connectionManager.planes[handshake.getPlaneIndex()].hasConnectionInProgress(remoteAddress)) {
+        Address connectedAddress = connectionManager.planes[handshake.getPlaneIndex()].getConnectedAddress(remoteAddress);
+        if (connectedAddress != null) {
             // this is the connection initiator side --> register the connection under the address that was requested
-            remoteEndpoint = remoteAddress;
+            remoteEndpoint = connectedAddress;
         }
         if (remoteEndpoint == null) {
             if (remoteAddressAliases == null) {


### PR DESCRIPTION
WAN historically has problems when connecting to target endpoints that
are defined by hostnames and not IPs. This fix aims to provide a fix
for that.

### The current behavior
The initator member establishes a connection to the target by using the
known hostname instead of using the IP for the reasons like the hostname
is the configured one and the users expect to see that in the logs etc.
During establishing the connection, the source registers the new
connection as in progress, with the configured hostname. If the target
responds with an IP in the handshake response, the source can't find the
address in its in progress connection list and drops the handshake
response, despite the handshake in fact was successful.

### The proposed change
Since the handshake is successful in this case, we have a mapping
problem only. This change solves it by registering the in-progress
connection with all of the addresses that it resolve, which are:
- `host`: the configured host or IP
- `canonicalHost`: the hostname `host` is resolved to
- `ip`: the resolved IP address of `host`

These - at most - three addresses are all registered and linked
together, treating `host` as the primary one. When processing the
handshake, the below address lookup algorithm is followed where
`remoteAddress` is the address from the handshake response of the
target:

```
if remoteAddress is registered as in-progress then
  if remoteAddress is registered as primary then
    return remoteAddress

  for linkedAddress in remoteAddress.linkedAddresses
    if linkedAddress is registered as in-progress and it is primary then
      return linkedAddress // we return the configured host here

return null
```

With this algorithm we can mark the in-progress connection as connected
and WAN replication can start operating.

#### Limitation of the proposal
This proposal does not work if the target responds with an address that
can't be resolved to with the configured hostname on the source side.

### Alternative option
Instead of connecting with the hostname, we can use the IP always. But
that would lead to harder to read configuration and it also can't be
used for DNS-based balancing (resolving the same hostname to different
IPs at different times).

### Alternative option #2
We can register in-progress connections with a UUID and make that UUID
part of the handshake request and response. It requires more changes
though and most probably it incurs compatibility problems.

Fixes #NNNN (point out issues this PR fixes, if any)

Forward-port (backport) of: #NNNN (link to PR which is the basis for this PR, if applicable)

EE PR: #NNNN (link to enterprise counterpart PR)

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
