### PR TITLE
Fix minor typos in docs

### DIFF
--- a/docs/design/jet/021-sql-rolling-upgrade.md
+++ b/docs/design/jet/021-sql-rolling-upgrade.md
@@ -131,7 +131,7 @@ random member - it might not be from the larger same-version group. To
 address this, we need to add member-to-member variants of `SqlExecute`,
 `SqlFetch` and `SqlCancel` operations so that a query submitted from a
 non-smart client can be redirected to execute on a member from the
-larger same-version subset. This wil also address the current limitation
+larger same-version subset. This will also address the current limitation
 that SQL queries can't be submitted from lite members.
 
 ### LoadBalancer changes

--- a/docs/design/merge/01-merge-changes.md
+++ b/docs/design/merge/01-merge-changes.md
@@ -62,7 +62,7 @@ Hazelcast repository continues its development as with a next major version.
 
 There are 2 outstanding items to resolve:
 - some checkstyle rules were ignored for Jet code
-- Jet had some stricker rules regarding public javadoc, this is now not in
+- Jet had some stricter rules regarding public javadoc, this is now not in
   place, ideally we should apply it to the whole product
 
 ## Distribution

--- a/docs/design/security/01_dynamic_security_scanning.md
+++ b/docs/design/security/01_dynamic_security_scanning.md
@@ -204,7 +204,7 @@ To have a possibility to scan the current codebase new Docker images will be pub
 on Docker push to our repositories (`hazelcast`, `hazelcast-enterprise`).
 Each repository will have a "snapshot counterpart" in the `hazelcast-dockerfiles` GitHub organization.
 The new snapshot repositories will contain `Dockerfiles` used to build the snapshot images.
-Branch names in snapshot repositories will mirror the names in the base reporitories.
+Branch names in snapshot repositories will mirror the names in the base repositories.
 
 Docker tags will be based on branch names. E.g.:
 * `master` -> `master` (+ `latest`)

--- a/docs/design/sql/04-parallel-execution.md
+++ b/docs/design/sql/04-parallel-execution.md
@@ -48,7 +48,7 @@ queue. Partition of the message is used to determine the exact thread which will
 
 The partition pool has the following advantages:
 1. Only one thread processes messages with the given partition so that processing logic may use less synchronization.
-1. Dedicated thread queues reduce contention on enqueue/deque operations.
+1. Dedicated thread queues reduce contention on enqueue/dequeue operations.
 
 However, there is no load balancing in the partition pool: a single long-running task may delay other tasks from the same 
 partition indefinitely. An imbalance between partitions may cause low resource utilization.

--- a/docs/design/sql/07-concurrent-hd-datastructure.md
+++ b/docs/design/sql/07-concurrent-hd-datastructure.md
@@ -340,7 +340,7 @@ This helps to avoid two potential performance problems:
 - It minimizes the `readLock/releaseLock` calls count on the leaf node. Without batching every `next()` call on the iterator 
   would require the current leaf node locking, checking that it has not changed, producing one on-heap result entry and
   releasing the leaf node. With batching this overhead is minimized.
-- If iterator's current node has been changed, the iterator has to be re-synchrnized, that means a navigation from the root node 
+- If iterator's current node has been changed, the iterator has to be re-synchronized, that means a navigation from the root node 
   to the appropriate new leaf node is required. The iterator batching minimizes this overhead as well.
 
 In the current implementation the batch size is `1000`.    


### PR DESCRIPTION
Fixes some minor typos in the documentation.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
