### PR TITLE
Implemented try-with-resources in JavaDefaultSerializers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/JavaDefaultSerializers.java
@@ -86,8 +86,7 @@ public final class JavaDefaultSerializers {
         }
 
         private Object read(InputStream in, ClassLoader classLoader) throws IOException {
-            try {
-                ObjectInputStream objectInputStream = newObjectInputStream(classLoader, classFilter, in);
+            try (ObjectInputStream objectInputStream = newObjectInputStream(classLoader, classFilter, in)) {
                 if (shared) {
                     return objectInputStream.readObject();
                 }


### PR DESCRIPTION
<PR description here>
Implemented a try-with-resources block in JavaDefaultSerializers to close `ObjectInputStream` after the try-block is done running.

Fixes #19695 
