### PR TITLE
chore: clearing blocking sonar blip #19703

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -284,21 +284,21 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
 
         private void newConnection(final EndpointQualifier qualifier, SocketChannel socketChannel) throws IOException {
             TcpServerConnectionManager connectionManager = server.getConnectionManager(qualifier);
-            Channel channel = connectionManager.newChannel(socketChannel, false);
-
-            if (logger.isFineEnabled()) {
-                logger.fine("Accepting socket connection from " + channel.socket().getRemoteSocketAddress());
-            }
-            serverContext.getAuditLogService()
-                .eventBuilder(AuditlogTypeIds.NETWORK_CONNECT)
-                .message("New connection accepted.")
-                .addParameter("qualifier", qualifier)
-                .addParameter("remoteAddress", socketChannel.getRemoteAddress())
-                .log();
-            if (serverContext.isSocketInterceptorEnabled(qualifier)) {
-                serverContext.executeAsync(() -> newConnection0(connectionManager, channel));
-            } else {
-                newConnection0(connectionManager, channel);
+            try (Channel channel = connectionManager.newChannel(socketChannel, false)) {
+                if (logger.isFineEnabled()) {
+                    logger.fine("Accepting socket connection from " + channel.socket().getRemoteSocketAddress());
+                }
+                serverContext.getAuditLogService()
+                    .eventBuilder(AuditlogTypeIds.NETWORK_CONNECT)
+                    .message("New connection accepted.")
+                    .addParameter("qualifier", qualifier)
+                    .addParameter("remoteAddress", socketChannel.getRemoteAddress())
+                    .log();
+                if (serverContext.isSocketInterceptorEnabled(qualifier)) {
+                    serverContext.executeAsync(() -> newConnection0(connectionManager, channel));
+                } else {
+                    newConnection0(connectionManager, channel);
+                }
             }
         }
 


### PR DESCRIPTION
<PR description here>

There was an unrelated additional validation issue that was uncovered. Warrants another issue and pr for resolution

`Dependency convergence error for com.google.errorprone:error_prone_annotations:2.3.4 paths to dependency are:`

Fixes #NNNN (point out issues this PR fixes, if any)

Forward-port (backport) of: #NNNN (link to PR which is the basis for this PR, if applicable)

EE PR: #NNNN (link to enterprise counterpart PR)

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
