### PR TITLE
Fix closing resources in NearCachePreloaderLock (#19693)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
@@ -36,15 +36,15 @@ class NearCachePreloaderLock {
     private final ILogger logger;
 
     private final File lockFile;
-    private final FileChannel channel;
+    private final RandomAccessFile randomAccessFile;
     private final FileLock lock;
 
     NearCachePreloaderLock(ILogger logger, String lockFilename) {
         this.logger = logger;
 
         this.lockFile = new File(lockFilename);
-        this.channel = openChannel(lockFile);
-        this.lock = acquireLock(lockFile, channel);
+        this.randomAccessFile = openRandomAccessFile(lockFile);
+        this.lock = acquireLock(lockFile, randomAccessFile.getChannel());
     }
 
     void release() {
@@ -57,7 +57,7 @@ class NearCachePreloaderLock {
         }
 
         try {
-            channel.close();
+            randomAccessFile.close();
         } catch (IOException e) {
             logger.severe("Problem while closing the channel " + lockFile, e);
         } finally {
@@ -87,9 +87,9 @@ class NearCachePreloaderLock {
         }
     }
 
-    private FileChannel openChannel(File lockFile) {
+    private static RandomAccessFile openRandomAccessFile(File lockFile) {
         try {
-            return new RandomAccessFile(lockFile, "rw").getChannel();
+            return new RandomAccessFile(lockFile, "rw");
         } catch (IOException e) {
             throw new HazelcastException("Cannot create lock file " + lockFile.getAbsolutePath(), e);
         }


### PR DESCRIPTION
Releasing lock closes now the RandomAccessFile, not only the FileChannel.

Fixes #19693

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
