### PR TITLE
Remove stats map entry when queue is destroyed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
@@ -120,6 +120,11 @@ abstract class QueueProxySupport<E> extends AbstractDistributedObject<QueueServi
         invokeAndGet(operation);
     }
 
+    @Override
+    protected void postDestroy() {
+        getService().getStatsMap().remove(name);
+    }
+
     Object peekInternal() {
         PeekOperation operation = new PeekOperation(name);
         return invokeAndGetData(operation);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -373,6 +373,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         return ConcurrencyUtil.getOrPutIfAbsent(statsMap, name, localQueueStatsConstructorFunction);
     }
 
+    protected ConcurrentMap<String, LocalQueueStatsImpl> getStatsMap() {
+        return statsMap;
+    }
+
     @Override
     public TransactionalQueueProxy createTransactionalObject(String name, Transaction transaction) {
         return new TransactionalQueueProxy(nodeEngine, this, name, transaction);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueDestroyTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.collection.impl.queue.QueueService.SERVICE_NAME;
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class QueueDestroyTest extends HazelcastTestSupport  {
+
+    @Test
+    public void checkStatsMapEntryRemovedWhenQueueDestroyed() {
+        final int LOOP_COUNT = 10;
+        final int ADD_COUNT = 100;
+
+        HazelcastInstance hz = createHazelcastInstance(smallInstanceConfig());
+        QueueService qService = Util.getNodeEngine(hz).getService(SERVICE_NAME);
+
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            String queueName = String.valueOf(i);
+            IQueue<Integer> q = hz.getQueue(queueName);
+
+            for (int j = 0; j < ADD_COUNT; j++) {
+                q.add(j);
+            }
+            q.destroy();
+            assertEquals(0, qService.getStatsMap().size());
+        }
+    }
+}


### PR DESCRIPTION
Issue description is quite clear. One addition I would like to add is this:

If you have any operation on queue after destroying it, underlying container or statsMap entry can be recreated. For example, if you call q.size() after q.destroy() statsMap entry will be recreated. Same goes for q.add(). In both cases container is also recreated. This problem is out of the scope of this issue.

Fixes #19645

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
