### PR TITLE
Fix Hz 3 jar URI on Windows [5.0.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/hz3/Hazelcast3Proxy.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/hz3/Hazelcast3Proxy.java
@@ -60,7 +60,7 @@ public class Hazelcast3Proxy {
         try {
             File hazelcastJar = locateVersion("3.12.12", new File("target"), false)[HAZELCAST_JAR_INDEX];
             URLClassLoader classLoader = new ChildFirstClassLoader(
-                    new URL[]{new URL("file:" + hazelcastJar.toPath().toAbsolutePath())},
+                    new URL[]{hazelcastJar.toURI().toURL()},
                     Hazelcast3Proxy.class.getClassLoader()
             );
             Object config = buildHz3Config(xmlConfig, classLoader);


### PR DESCRIPTION
Fixes #19608 on 5.0.z
Backport of #19671
