### PR TITLE
Don't run SqlHadoopTest on Windows [5.0.z]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlHadoopTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlHadoopTest.java
@@ -55,6 +55,8 @@ public class SqlHadoopTest extends SqlTestSupport {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+        assumeThatNoWindowsOS();
+
         initialize(1, null);
         sqlService = instance().getSql();
 


### PR DESCRIPTION
Fixes #19217 on 5.0.z
Backport of #19669
