### PR TITLE
Use correct scope for avro-mapred in dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1416,7 +1416,6 @@
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-mapred</artifactId>
                 <version>${avro.version}</version>
-                <scope>provided</scope>
                 <exclusions>
                     <!-- The following dependencies are not needed for our use of Avro -->
                     <exclusion>


### PR DESCRIPTION
Bug introduced in https://github.com/hazelcast/hazelcast/pull/19631

Fixes failing files-it
