### PR TITLE
Use jobId to sort JetService#getJobs when 2 jobs have same creationTime [5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -559,8 +559,12 @@ public class JobCoordinationService {
                     }
 
                     jobs.entrySet().stream()
-                            .sorted(comparing(Entry<Long, Long>::getValue).reversed())
-                            .forEach(entry -> result.add(tuple2(entry.getKey(), false)));
+                        .sorted(
+                                comparing(Entry<Long, Long>::getValue)
+                                        .thenComparing(Entry::getKey)
+                                        .reversed()
+                        )
+                        .forEach(entry -> result.add(tuple2(entry.getKey(), false)));
                 } else {
                     for (Long jobId : jobRepository.getAllJobIds()) {
                         result.add(tuple2(jobId, false));


### PR DESCRIPTION
Fixes #18961 in 5.0.z
Backport of #19682