### PR TITLE
Retry container start when port is allocated

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -154,7 +154,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
         MySQLContainer<?> container = mySqlContainer();
 
         try {
-            container.start();
+            startContainer(container);
 
             // given
             List<String> expectedRecords = Arrays.asList(

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -136,7 +136,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
             assertTrue(hz.getMap("results").isEmpty());
 
             // and DB starts
-            mysql.start();
+            startContainer(mysql);
             try {
                 // then source connects successfully
                 assertEqualsEventually(() -> hz.getMap("results").size(), 4);
@@ -346,7 +346,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         if (network != null) {
             mysql = mysql.withNetwork(network);
         }
-        mysql.start();
+        startContainer(mysql);
         return mysql;
     }
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -129,7 +129,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
             assertTrue(hz.getMap("results").isEmpty());
 
             // and DB starts
-            postgres.start();
+            startContainer(postgres);
             try {
                 // then source connects successfully
                 assertEqualsEventually(() -> hz.getMap("results").size(), 4);


### PR DESCRIPTION
When we use fixed port and quickly call container.stop() and
container.start() the port might not be properly relased, leading to
"port is already allocated" exception.

This introduces retry for tests where we use fixed port and stop/start a
container.

Fixes #19271
