### PR TITLE
Decrease test log level for com.hazelcast.cp.internal category

### DIFF
--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -31,10 +31,10 @@
         <!--<Logger name="com.hazelcast.internal.partition" level="debug"/>-->
         <!--<Logger name="com.hazelcast.internal.hotrestart.cluster" level="debug"/>-->
         <!--<Logger name="com.hazelcast.test.mocknetwork" level="debug"/>-->
+        <!--<Logger name="com.hazelcast.cp.internal" level="trace"/>-->
         <Logger name="com.hazelcast.client.impl.protocol.task" level="debug"/>
         <Logger name="com.hazelcast.client.impl.operations" level="debug"/>
         <Logger name="com.hazelcast.client.impl.spi.ClientListenerService" level="trace"/>
-        <Logger name="com.hazelcast.cp.internal" level="trace"/>
         <Logger name="com.hazelcast.jet" level="debug"/>
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientInvocationService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.connection.ClientConnectionManager" level="trace"/>-->


### PR DESCRIPTION
This PR comments out the generic TRACE log level for the CP subsystem.
It's a partial revert of #18051. The log level was originally increased to allow the #16574 issue investigation.
For more details see https://github.com/hazelcast/hazelcast/issues/16574#issuecomment-938663824