### PR TITLE
fix(19692) - BufferObjectDataInput close when packet version is mismatched.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -266,6 +266,7 @@ public final class MulticastService implements Runnable {
                             + "Verify that the sender Node, doesn't have symmetric-encryption on. This -> "
                             + Packet.VERSION + ", Incoming -> " + packetVersion
                             + ", Sender -> " + datagramPacketReceive.getAddress());
+                    input.close();
                     return null;
                 }
                 try {


### PR DESCRIPTION
BufferObjectDataInput close when the packet version is mismatched.

Fixes #19692 

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
