### PR TITLE
[BACKPORT] Remove stats map entry when queue is destroyed (#19716)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -288,6 +288,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         if (container != null) {
             container.destroy();
         }
+        statsMap.remove(name);
         nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, name);
         splitBrainProtectionConfigCache.remove(name);
     }
@@ -371,6 +372,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     public LocalQueueStatsImpl getLocalQueueStatsImpl(String name) {
         return ConcurrencyUtil.getOrPutIfAbsent(statsMap, name, localQueueStatsConstructorFunction);
+    }
+
+    protected ConcurrentMap<String, LocalQueueStatsImpl> getStatsMap() {
+        return statsMap;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueDestroyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.Accessors;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.function.Supplier;
+
+import static com.hazelcast.collection.impl.queue.QueueService.SERVICE_NAME;
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class QueueDestroyTest extends HazelcastTestSupport {
+
+    private static final int LOOP_COUNT = 10;
+    private static final int ADD_COUNT = 100;
+
+    private static final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameterized.Parameter
+    public Supplier<HazelcastInstance> instanceSupplier;
+
+    @Parameterized.Parameters(name = "instance={0}")
+    public static Supplier<HazelcastInstance>[] parameters() {
+        return new Supplier[]{hazelcastFactory::newHazelcastClient,
+                () -> hazelcastFactory.newHazelcastInstance(smallInstanceConfig())};
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void checkStatsMapEntryRemovedWhenQueueDestroyed() {
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(smallInstanceConfig());
+        HazelcastInstance destroyerInstance = instanceSupplier.get();
+        QueueService qService = Accessors.getService(member, SERVICE_NAME);
+
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            String queueName = String.valueOf(i);
+            IQueue<Integer> q = destroyerInstance.getQueue(queueName);
+
+            for (int j = 0; j < ADD_COUNT; j++) {
+                q.add(j);
+            }
+            q.destroy();
+            assertEquals(0, qService.getStatsMap().size());
+        }
+    }
+}


### PR DESCRIPTION
(cherry picked from commit d55d0b8ec1301d3cb2dfece2496cc6ae9dc1acc7)

Backport of: #19716

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
