### PR TITLE
Increase assertion timeout in `ClientMapLockTest#testLockTTLExpires_usingIsLocked`

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -435,7 +435,7 @@ public class ClientMapLockTest {
             public void run() throws Exception {
                 assertFalse(map.isLocked(key));
             }
-        }, 10);
+        });
     }
 
     @Test


### PR DESCRIPTION
This test failed in one of the maintenance runs against the 4.2.z branch, but not
much is changed in that part of the codebase, so, it must also apply to
master as well.

The test logs do not contain any suspicious lines for this test, it fails after
10 seconds, when the assertion timeout is passed, and the lock is still locked
despite the 2 seconds lease time.

I have gone over the implementation, but I couldn't find any buggy behavior
that would lead to such a failure.

That lead me to think that the test failed due to timing issues, and somehow
the thread that should schedule the expiration of lock couldn't be scheduled
in the assertion timeout seconds. I have verified that, if I delay the
expiration task, the test fails with the exact same logs. Moreover, the
diagnostics logs in the failed run show that the system was under heavy
load, so that might lead to such problems.

Closes #18742 