### PR TITLE
Add logging for Kafka broker and Zookeeper in tests

### DIFF
--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -84,6 +84,16 @@
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -97,6 +107,12 @@
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
             <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/kafka/src/test/resources/log4j2.xml
+++ b/extensions/kafka/src/test/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.jet" level="debug"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
In #19754 we failed with
```
Timeout expired while initializing transactional state in 60000ms.
```
We don't have any Kafka/Zookeeper logs available.
Both Kafka and Zookeeper use slf4j->log4j. There is no log4j
configuration in the tests.

This commit configures logging via slf4j->log4j-slf4j-impl (using
Log4j2).

Kafka and Zookeeper are configured at info level.
com.hazelcast.jet package at debug level.

For the log granularity see the example logs of `WriteKafkaProcessor#stressTest_graceful_atLeastOnce` test for previous and new versions below:
<details><summary>Old version:</summary>

```
14:19:01,752 DEBUG || - [JobClassLoaderService] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Creating job classLoader for job 06f2-96fd-3a82-0001
14:19:01,753 DEBUG || - [JobClassLoaderService] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Create processor classloader map for job 06f2-96fd-3a82-0001
14:19:01,758 DEBUG || - [Planner] hz.thirsty_thompson.cached.thread-4 - Watermarks in the pipeline will be throttled to 1000
14:19:01,769  INFO || - [JobCoordinationService] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting job 06f2-96fd-3a82-0001 based on submit request
14:19:01,774  INFO || - [MasterJobContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Didn't find any snapshot to restore for job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001
14:19:01,774  INFO || - [MasterJobContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Start executing job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001, execution graph in DOT format:
digraph DAG {
	"src" [localParallelism=1];
	"kafkaSink" [localParallelism=1];
	"src" -> "kafkaSink" [queueSize=1024];
}
HINT: You can use graphviz or http://viz-js.com to visualize the printed graph.
14:19:01,775 DEBUG || - [MasterJobContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Building execution plan for job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001
14:19:01,777 DEBUG || - [MasterJobContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Built execution plans for job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001
14:19:01,777 DEBUG || - [InitExecutionOperation] hz.unruffled_thompson.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Initializing execution plan for job 06f2-96fd-3a82-0001, execution 06f2-96fd-3a83-0001 from [127.0.0.1]:5701
14:19:01,778 DEBUG || - [InitExecutionOperation] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Initializing execution plan for job 06f2-96fd-3a82-0001, execution 06f2-96fd-3a83-0001 from [127.0.0.1]:5701
14:19:01,778 DEBUG || - [JobClassLoaderService] hz.unruffled_thompson.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Creating job classLoader for job 06f2-96fd-3a82-0001
14:19:01,778 DEBUG || - [JobClassLoaderService] hz.unruffled_thompson.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Create processor classloader map for job 06f2-96fd-3a82-0001
14:19:01,783  INFO || - [JobExecutionService] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Execution plan for jobId=06f2-96fd-3a82-0001, jobName='06f2-96fd-3a82-0001', executionId=06f2-96fd-3a83-0001 initialized
14:19:01,783  INFO || - [JobExecutionService] hz.unruffled_thompson.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Execution plan for jobId=06f2-96fd-3a82-0001, jobName='06f2-96fd-3a82-0001', executionId=06f2-96fd-3a83-0001 initialized
14:19:01,784 DEBUG || - [MasterJobContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Init of job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001 was successful
14:19:01,784 DEBUG || - [MasterJobContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Executing job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001
14:19:01,784  INFO || - [JobExecutionService] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Start execution of job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001 from coordinator [127.0.0.1]:5701
14:19:01,784  INFO || - [JobExecutionService] hz.unruffled_thompson.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Start execution of job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001 from coordinator [127.0.0.1]:5701
14:19:01,785 DEBUG || - [WriteKafkaP] hz.unruffled_thompson.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#0] Actual pool size used: 2
14:19:01,785 DEBUG || - [JobCoordinationService] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001 snapshot is scheduled in 50ms
14:19:01,785 DEBUG || - [WriteKafkaP] hz.thirsty_thompson.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#1] Actual pool size used: 2
14:19:01,787 DEBUG || - [WriteKafkaP] hz.thirsty_thompson.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#1] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.1-0,producerId=-1,epoch=-1
14:19:01,787 DEBUG || - [WriteKafkaP] hz.unruffled_thompson.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#0] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.0-0,producerId=-1,epoch=-1
14:19:01,792  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 0
14:19:01,797  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 1
14:19:01,803  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 2
14:19:01,808  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 3
14:19:01,814  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 4
14:19:01,820  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 5
14:19:01,826  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 6
14:19:01,832  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 7
14:19:01,837  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 8
14:19:01,841 DEBUG || - [MasterSnapshotContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting snapshot 0 for job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001, flags: terminal=no,export=no, writing to: null
14:19:01,843  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 9
14:19:01,843 DEBUG || - [ExecutionContext] hz.thirsty_thompson.cached.thread-4 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting snapshot 0 phase 1 for job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001 on member
14:19:01,843 DEBUG || - [ExecutionContext] hz.unruffled_thompson.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Starting snapshot 0 phase 1 for job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001 on member
14:19:01,848 DEBUG || - [AsyncSnapshotWriterImpl] hz.thirsty_thompson.jet.cooperative.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Stats for src: keys=0, chunks=0, bytes=0
14:19:01,848  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 10
14:19:01,850 DEBUG || - [AsyncSnapshotWriterImpl] hz.unruffled_thompson.jet.cooperative.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Stats for src: keys=1, chunks=1, bytes=37
14:19:01,855  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 11
14:19:01,860  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 12
14:19:01,865  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 13
14:19:01,872  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 14
14:19:01,877  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 15
14:19:01,882  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 16
14:19:01,888  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 17
14:19:01,894  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 18
14:19:01,900  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 19
14:19:01,905  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 20
14:19:01,910  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 21
14:19:01,916  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 22
14:19:01,922  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 23
14:19:01,927  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 24
14:19:01,933  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 25
14:19:01,938  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 26
14:19:01,944  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 27
14:19:01,950  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 28
14:19:01,955  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 29
14:19:01,962  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 30
14:19:01,968  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 31
14:19:01,974  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 32
14:19:01,975 DEBUG |stressTest_graceful_exOnce| - [Job] stressTest_graceful_exOnce - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Sending RESTART_GRACEFUL request for job 06f2-96fd-3a82-0001 (name ??)
14:19:01,976 DEBUG || - [MasterSnapshotContext] hz.thirsty_thompson.cached.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Not beginning snapshot since one is already in progress job '06f2-96fd-3a82-0001', execution 06f2-96fd-3a83-0001
14:19:01,980  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 33
14:19:01,985  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 34
14:19:01,991  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 35
14:19:01,997  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 36
14:19:02,003  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 37
14:19:02,009  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 38
14:19:02,016  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 39
14:19:02,021  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 40
14:19:02,028  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 41
14:19:02,034  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 42
14:19:02,040  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 43
14:19:02,046  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 44
14:19:02,051  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 45
14:19:02,057  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 46
14:19:02,063  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 47
14:19:02,068  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 48
14:19:02,074  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 49
14:19:02,080  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 50
14:19:02,086  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 51
14:19:02,091  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 52
14:19:02,098  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 53
14:19:02,104  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 54
14:19:02,110  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 55
14:19:02,115  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 56
14:19:02,121  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 57
14:19:02,126  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 58
14:19:02,131 DEBUG || - [WriteKafkaP] hz.unruffled_thompson.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#0] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.0-1,producerId=-1,epoch=-1
14:19:02,131 DEBUG || - [WriteKafkaP] hz.thirsty_thompson.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#1] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.1-1,producerId=-1,epoch=-1
14:19:02,132  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 59
14:19:02,138  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 60
14:19:02,144  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 61
14:19:02,149  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 62
14:19:02,155  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 63
14:19:02,160  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 64
14:19:02,166  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 65
14:19:02,172  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 66
14:19:02,177  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 67
14:19:02,183  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 68
14:19:02,190  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 69
14:19:02,196  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 70
14:19:02,202  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 71
14:19:02,207  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 72
14:19:02,213  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 73
14:19:02,219  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 74
14:19:02,224  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 75
14:19:02,230  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 76
14:19:02,236  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 77
14:19:02,242  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 78
14:19:02,249  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 79
14:19:02,255  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 80
14:19:02,261  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 81
14:19:02,268  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 82
14:19:02,273  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 83
14:19:02,279  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 84
14:19:02,284  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 85
14:19:02,290  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 86
14:19:02,295  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 87
14:19:02,302  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 88
14:19:02,308  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 89
14:19:02,313  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 90
14:19:02,318  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 91
14:19:02,324  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 92
14:19:02,330  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 93
14:19:02,336  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 94
14:19:02,341  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 95
14:19:02,347  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 96
14:19:02,350 DEBUG || - [WriteKafkaP] hz.unruffled_thompson.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#0] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.2-0,producerId=-1,epoch=-1
14:19:02,350 DEBUG || - [WriteKafkaP] hz.thirsty_thompson.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#1] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.3-0,producerId=-1,epoch=-1
14:19:02,352  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 97
14:19:02,358  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 98
14:19:02,364  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 99
14:19:02,370  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 100
14:19:02,375  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 101
14:19:02,381  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 102
14:19:02,387  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 103
14:19:02,393  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 104
14:19:02,399  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 105
14:19:02,404  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 106
14:19:02,409  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 107
14:19:02,416  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 108
14:19:02,421  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 109
14:19:02,427  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 110
14:19:02,432  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 111
14:19:02,438  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 112
14:19:02,443  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 113
14:19:02,449  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 114
14:19:02,454  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 115
14:19:02,460  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 116
14:19:02,465  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 117
14:19:02,471  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 118
14:19:02,478  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 119
14:19:02,484  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 120
14:19:02,489  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 121
14:19:02,495  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 122
14:19:02,500  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 123
14:19:02,505  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 124
14:19:02,512  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 125
14:19:02,518  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 126
14:19:02,524  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 127
14:19:02,529  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 128
14:19:02,535  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 129
14:19:02,541  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 130
14:19:02,547  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 131
14:19:02,552  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 132
14:19:02,557  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 133
14:19:02,563  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 134
14:19:02,567 DEBUG || - [WriteKafkaP] hz.unruffled_thompson.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#0] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.2-1,producerId=-1,epoch=-1
14:19:02,567 DEBUG || - [WriteKafkaP] hz.thirsty_thompson.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#1] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.3-1,producerId=-1,epoch=-1
14:19:02,569  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 135
14:19:02,574  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 136
14:19:02,579  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 137
14:19:02,585  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 138
14:19:02,591  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 139
14:19:02,596  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 140
14:19:02,602  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 141
14:19:02,609  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 142
14:19:02,614  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 143
14:19:02,619  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 144
14:19:02,626  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 145
14:19:02,632  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 146
14:19:02,638  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 147
14:19:02,644  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 148
14:19:02,649  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 149
14:19:02,655  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 150
14:19:02,660  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 151
14:19:02,666  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 152
14:19:02,672  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 153
14:19:02,679  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 154
14:19:02,680 DEBUG || - [WriteKafkaP] hz.thirsty_thompson.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/kafkaSink#1] recover and abort jet.job-06f2-96fd-3a82-0001..kafkaSink.5-0,producerId=-1,epoch=-1
14:19:02,684  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 155
14:19:02,690  INFO || - [ConvenientSourceP] hz.unruffled_thompson.jet.blocking.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-96fd-3a82-0001/src#0] Output to ordinal 0: 156
...
```
</details>

<details><summary>New version:</summary>

```
14:24:45,794  INFO |stressTest_graceful_atLeastOnce| - [AdminUtils$] Time-limited test - Topic creation {"version":1,"partitions":{"12":[0],"8":[0],"19":[0],"4":[0],"15":[0],"11":[0],"9":[0],"13":[0],"16":[0],"5":[0],"10":[0],"6":[0],"1":[0],"17":[0],"14":[0],"0":[0],"2":[0],"18":[0],"7":[0],"3":[0]}}
14:24:45,797  INFO || - [KafkaController] controller-event-thread - [Controller id=0] New topics: [Set(8427e233-511e-41f7-a16c-2e9aee189bc7)], deleted topics: [Set()], new partition replica assignment [Map(8427e233-511e-41f7-a16c-2e9aee189bc7-3 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-7 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-12 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-0 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-11 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-8 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-15 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-6 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-2 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-9 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-19 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-16 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-1 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-10 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-5 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-14 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-17 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-13 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-4 -> Vector(0), 8427e233-511e-41f7-a16c-2e9aee189bc7-18 -> Vector(0))]
14:24:45,797  INFO || - [KafkaController] controller-event-thread - [Controller id=0] New partition creation callback for 8427e233-511e-41f7-a16c-2e9aee189bc7-3,8427e233-511e-41f7-a16c-2e9aee189bc7-7,8427e233-511e-41f7-a16c-2e9aee189bc7-12,8427e233-511e-41f7-a16c-2e9aee189bc7-0,8427e233-511e-41f7-a16c-2e9aee189bc7-11,8427e233-511e-41f7-a16c-2e9aee189bc7-8,8427e233-511e-41f7-a16c-2e9aee189bc7-15,8427e233-511e-41f7-a16c-2e9aee189bc7-6,8427e233-511e-41f7-a16c-2e9aee189bc7-2,8427e233-511e-41f7-a16c-2e9aee189bc7-9,8427e233-511e-41f7-a16c-2e9aee189bc7-19,8427e233-511e-41f7-a16c-2e9aee189bc7-16,8427e233-511e-41f7-a16c-2e9aee189bc7-1,8427e233-511e-41f7-a16c-2e9aee189bc7-10,8427e233-511e-41f7-a16c-2e9aee189bc7-5,8427e233-511e-41f7-a16c-2e9aee189bc7-14,8427e233-511e-41f7-a16c-2e9aee189bc7-17,8427e233-511e-41f7-a16c-2e9aee189bc7-13,8427e233-511e-41f7-a16c-2e9aee189bc7-4,8427e233-511e-41f7-a16c-2e9aee189bc7-18
14:24:45,800  INFO |stressTest_graceful_atLeastOnce| - [ConsumerConfig] stressTest_graceful_atLeastOnce - ConsumerConfig values: 
	auto.commit.interval.ms = 5000
	auto.offset.reset = earliest
	bootstrap.servers = [127.0.0.1:59241]
	check.crcs = true
	client.dns.lookup = default
	client.id = consumer0
	connections.max.idle.ms = 540000
	default.api.timeout.ms = 60000
	enable.auto.commit = true
	exclude.internal.topics = true
	fetch.max.bytes = 52428800
	fetch.max.wait.ms = 500
	fetch.min.bytes = 1
	group.id = cf2909cd-c08e-4321-afd7-b8b84a997094
	heartbeat.interval.ms = 3000
	interceptor.classes = []
	internal.leave.group.on.close = true
	isolation.level = read_committed
	key.deserializer = class org.apache.kafka.common.serialization.IntegerDeserializer
	max.partition.fetch.bytes = 1048576
	max.poll.interval.ms = 300000
	max.poll.records = 500
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	partition.assignment.strategy = [class org.apache.kafka.clients.consumer.RangeAssignor]
	receive.buffer.bytes = 65536
	reconnect.backoff.max.ms = 1000
	reconnect.backoff.ms = 50
	request.timeout.ms = 30000
	retry.backoff.ms = 100
	sasl.client.callback.handler.class = null
	sasl.jaas.config = null
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.login.callback.handler.class = null
	sasl.login.class = null
	sasl.login.refresh.buffer.seconds = 300
	sasl.login.refresh.min.period.seconds = 60
	sasl.login.refresh.window.factor = 0.8
	sasl.login.refresh.window.jitter = 0.05
	sasl.mechanism = GSSAPI
	security.protocol = PLAINTEXT
	send.buffer.bytes = 131072
	session.timeout.ms = 10000
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2, TLSv1.1, TLSv1]
	ssl.endpoint.identification.algorithm = https
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLS
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = null
	ssl.truststore.password = null
	ssl.truststore.type = JKS
	value.deserializer = class org.apache.kafka.common.serialization.StringDeserializer

14:24:45,802  INFO |stressTest_graceful_atLeastOnce| - [AppInfoParser] stressTest_graceful_atLeastOnce - Kafka version: 2.2.2
14:24:45,802  INFO |stressTest_graceful_atLeastOnce| - [AppInfoParser] stressTest_graceful_atLeastOnce - Kafka commitId: 1d348535a0a747d1
14:24:45,802  INFO |stressTest_graceful_atLeastOnce| - [KafkaConsumer] stressTest_graceful_atLeastOnce - [Consumer clientId=consumer0, groupId=cf2909cd-c08e-4321-afd7-b8b84a997094] Subscribed to topic(s): 8427e233-511e-41f7-a16c-2e9aee189bc7
14:24:45,803 DEBUG || - [JobClassLoaderService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Creating job classLoader for job 06f2-9843-680a-0001
14:24:45,803 DEBUG || - [JobClassLoaderService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Create processor classloader map for job 06f2-9843-680a-0001
14:24:45,804 DEBUG || - [Planner] hz.thirsty_antonelli.cached.thread-11 - Watermarks in the pipeline will be throttled to 1000
14:24:45,805  INFO || - [JobCoordinationService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting job 06f2-9843-680a-0001 based on submit request
14:24:45,807  INFO || - [MasterJobContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Didn't find any snapshot to restore for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001
14:24:45,807  INFO || - [MasterJobContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Start executing job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001, execution graph in DOT format:
digraph DAG {
	"src" [localParallelism=1];
	"kafkaSink" [localParallelism=1];
	"src" -> "kafkaSink" [queueSize=1024];
}
HINT: You can use graphviz or http://viz-js.com to visualize the printed graph.
14:24:45,807 DEBUG || - [MasterJobContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Building execution plan for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001
14:24:45,808 DEBUG || - [MasterJobContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Built execution plans for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001
14:24:45,808 DEBUG || - [InitExecutionOperation] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Initializing execution plan for job 06f2-9843-680a-0001, execution 06f2-9843-680b-0001 from [127.0.0.1]:5701
14:24:45,809  INFO || - [JobExecutionService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Execution plan for jobId=06f2-9843-680a-0001, jobName='06f2-9843-680a-0001', executionId=06f2-9843-680b-0001 initialized
14:24:45,809 DEBUG || - [InitExecutionOperation] hz.gracious_antonelli.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Initializing execution plan for job 06f2-9843-680a-0001, execution 06f2-9843-680b-0001 from [127.0.0.1]:5701
14:24:45,809 DEBUG || - [JobClassLoaderService] hz.gracious_antonelli.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Creating job classLoader for job 06f2-9843-680a-0001
14:24:45,809 DEBUG || - [JobClassLoaderService] hz.gracious_antonelli.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Create processor classloader map for job 06f2-9843-680a-0001
14:24:45,810  INFO || - [JobExecutionService] hz.gracious_antonelli.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Execution plan for jobId=06f2-9843-680a-0001, jobName='06f2-9843-680a-0001', executionId=06f2-9843-680b-0001 initialized
14:24:45,810 DEBUG || - [MasterJobContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Init of job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 was successful
14:24:45,810 DEBUG || - [MasterJobContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Executing job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001
14:24:45,810  INFO || - [JobExecutionService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Start execution of job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 from coordinator [127.0.0.1]:5701
14:24:45,811 DEBUG || - [WriteKafkaP] hz.thirsty_antonelli.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/kafkaSink#0] Actual pool size used: 1
14:24:45,811 DEBUG || - [JobCoordinationService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 snapshot is scheduled in 50ms
14:24:45,811  INFO || - [JobExecutionService] hz.gracious_antonelli.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Start execution of job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 from coordinator [127.0.0.1]:5701
14:24:45,811 DEBUG || - [WriteKafkaP] hz.gracious_antonelli.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/kafkaSink#1] Actual pool size used: 1
14:24:45,811  INFO || - [ProducerConfig] hz.thirsty_antonelli.jet.blocking.thread-1 - ProducerConfig values: 
	acks = 1
	batch.size = 16384
	bootstrap.servers = [127.0.0.1:59241]
	buffer.memory = 33554432
	client.dns.lookup = default
	client.id = 
	compression.type = none
	connections.max.idle.ms = 540000
	delivery.timeout.ms = 120000
	enable.idempotence = false
	interceptor.classes = []
	key.serializer = class org.apache.kafka.common.serialization.IntegerSerializer
	linger.ms = 0
	max.block.ms = 60000
	max.in.flight.requests.per.connection = 5
	max.request.size = 1048576
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	partitioner.class = class org.apache.kafka.clients.producer.internals.DefaultPartitioner
	receive.buffer.bytes = 32768
	reconnect.backoff.max.ms = 1000
	reconnect.backoff.ms = 50
	request.timeout.ms = 30000
	retries = 2147483647
	retry.backoff.ms = 100
	sasl.client.callback.handler.class = null
	sasl.jaas.config = null
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.login.callback.handler.class = null
	sasl.login.class = null
	sasl.login.refresh.buffer.seconds = 300
	sasl.login.refresh.min.period.seconds = 60
	sasl.login.refresh.window.factor = 0.8
	sasl.login.refresh.window.jitter = 0.05
	sasl.mechanism = GSSAPI
	security.protocol = PLAINTEXT
	send.buffer.bytes = 131072
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2, TLSv1.1, TLSv1]
	ssl.endpoint.identification.algorithm = https
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLS
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = null
	ssl.truststore.password = null
	ssl.truststore.type = JKS
	transaction.timeout.ms = 60000
	transactional.id = null
	value.serializer = class org.apache.kafka.common.serialization.StringSerializer

14:24:45,811  INFO || - [ProducerConfig] hz.gracious_antonelli.jet.blocking.thread-1 - ProducerConfig values: 
	acks = 1
	batch.size = 16384
	bootstrap.servers = [127.0.0.1:59241]
	buffer.memory = 33554432
	client.dns.lookup = default
	client.id = 
	compression.type = none
	connections.max.idle.ms = 540000
	delivery.timeout.ms = 120000
	enable.idempotence = false
	interceptor.classes = []
	key.serializer = class org.apache.kafka.common.serialization.IntegerSerializer
	linger.ms = 0
	max.block.ms = 60000
	max.in.flight.requests.per.connection = 5
	max.request.size = 1048576
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	partitioner.class = class org.apache.kafka.clients.producer.internals.DefaultPartitioner
	receive.buffer.bytes = 32768
	reconnect.backoff.max.ms = 1000
	reconnect.backoff.ms = 50
	request.timeout.ms = 30000
	retries = 2147483647
	retry.backoff.ms = 100
	sasl.client.callback.handler.class = null
	sasl.jaas.config = null
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.login.callback.handler.class = null
	sasl.login.class = null
	sasl.login.refresh.buffer.seconds = 300
	sasl.login.refresh.min.period.seconds = 60
	sasl.login.refresh.window.factor = 0.8
	sasl.login.refresh.window.jitter = 0.05
	sasl.mechanism = GSSAPI
	security.protocol = PLAINTEXT
	send.buffer.bytes = 131072
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2, TLSv1.1, TLSv1]
	ssl.endpoint.identification.algorithm = https
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLS
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = null
	ssl.truststore.password = null
	ssl.truststore.type = JKS
	transaction.timeout.ms = 60000
	transactional.id = null
	value.serializer = class org.apache.kafka.common.serialization.StringSerializer

14:24:45,813  INFO || - [AppInfoParser] hz.thirsty_antonelli.jet.blocking.thread-1 - Kafka version: 2.2.2
14:24:45,813  INFO || - [AppInfoParser] hz.thirsty_antonelli.jet.blocking.thread-1 - Kafka commitId: 1d348535a0a747d1
14:24:45,813  INFO || - [AppInfoParser] hz.gracious_antonelli.jet.blocking.thread-1 - Kafka version: 2.2.2
14:24:45,813  INFO || - [AppInfoParser] hz.gracious_antonelli.jet.blocking.thread-1 - Kafka commitId: 1d348535a0a747d1
14:24:45,813  INFO || - [ReplicaFetcherManager] data-plane-kafka-request-handler-2 - [ReplicaFetcherManager on broker 0] Removed fetcher for partitions Set(8427e233-511e-41f7-a16c-2e9aee189bc7-3, 8427e233-511e-41f7-a16c-2e9aee189bc7-7, 8427e233-511e-41f7-a16c-2e9aee189bc7-12, 8427e233-511e-41f7-a16c-2e9aee189bc7-0, 8427e233-511e-41f7-a16c-2e9aee189bc7-11, 8427e233-511e-41f7-a16c-2e9aee189bc7-8, 8427e233-511e-41f7-a16c-2e9aee189bc7-15, 8427e233-511e-41f7-a16c-2e9aee189bc7-6, 8427e233-511e-41f7-a16c-2e9aee189bc7-2, 8427e233-511e-41f7-a16c-2e9aee189bc7-9, 8427e233-511e-41f7-a16c-2e9aee189bc7-19, 8427e233-511e-41f7-a16c-2e9aee189bc7-16, 8427e233-511e-41f7-a16c-2e9aee189bc7-1, 8427e233-511e-41f7-a16c-2e9aee189bc7-10, 8427e233-511e-41f7-a16c-2e9aee189bc7-5, 8427e233-511e-41f7-a16c-2e9aee189bc7-14, 8427e233-511e-41f7-a16c-2e9aee189bc7-17, 8427e233-511e-41f7-a16c-2e9aee189bc7-13, 8427e233-511e-41f7-a16c-2e9aee189bc7-4, 8427e233-511e-41f7-a16c-2e9aee189bc7-18)
14:24:45,815  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-19, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,816  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-19, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,816  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-19 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,817  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-19 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-19
14:24:45,817  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 0
14:24:45,817  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-19 with initial high watermark 0
14:24:45,817  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-19 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-19 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,820  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-0, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,820  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-0, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,821  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-0 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,821  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-0 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-0
14:24:45,821  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-0 with initial high watermark 0
14:24:45,821  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-0 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-0 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,822  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 1
14:24:45,823  WARN || - [NetworkClient] kafka-producer-network-thread | producer-39 - [Producer clientId=producer-39] Error while fetching metadata with correlation id 1 : {8427e233-511e-41f7-a16c-2e9aee189bc7=LEADER_NOT_AVAILABLE}
14:24:45,823  INFO || - [Metadata] kafka-producer-network-thread | producer-39 - Cluster ID: BL1Q4-8eSXSIprN-Xn-SNw
14:24:45,824  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-16, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,825  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-16, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,825  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-16 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,826  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-16 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-16
14:24:45,826  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-16 with initial high watermark 0
14:24:45,826  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-16 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-16 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,828  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 2
14:24:45,829  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-13, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,829  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-13, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,830  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-13 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,830  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-13 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-13
14:24:45,830  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-13 with initial high watermark 0
14:24:45,830  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-13 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-13 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,833  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-10, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,833  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 3
14:24:45,833  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-10, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,834  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-10 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,834  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-10 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-10
14:24:45,834  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-10 with initial high watermark 0
14:24:45,834  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-10 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-10 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,837  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-7, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,838  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-7, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,838  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-7 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,838  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 4
14:24:45,838  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-7 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-7
14:24:45,838  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-7 with initial high watermark 0
14:24:45,838  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-7 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-7 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,841  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-4, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,842  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-4, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,842  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-4 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,843  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-4 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-4
14:24:45,843  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-4 with initial high watermark 0
14:24:45,843  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-4 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-4 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,843  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 5
14:24:45,846  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-1, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,847  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-1, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,847  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-1 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,847  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-1 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-1
14:24:45,847  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-1 with initial high watermark 0
14:24:45,847  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-1 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-1 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,849  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 6
14:24:45,851  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-17, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,851  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-17, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,852  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-17 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,852  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-17 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-17
14:24:45,852  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-17 with initial high watermark 0
14:24:45,852  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-17 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-17 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,855  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-14, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,855  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 7
14:24:45,856  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-14, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,856  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-14 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,856  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-14 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-14
14:24:45,856  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-14 with initial high watermark 0
14:24:45,857  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-14 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-14 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,860  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-11, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,861  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-11, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,861  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-11 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,861  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 8
14:24:45,861  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-11 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-11
14:24:45,861  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-11 with initial high watermark 0
14:24:45,861  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-11 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-11 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,864 DEBUG || - [MasterSnapshotContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting snapshot 0 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001, flags: terminal=no,export=no, writing to: null
14:24:45,864 DEBUG || - [ExecutionContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting snapshot 0 phase 1 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 on member
14:24:45,864 DEBUG || - [ExecutionContext] hz.gracious_antonelli.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Starting snapshot 0 phase 1 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 on member
14:24:45,865  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-18, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,865  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-18, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,865  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-18 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,866  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-18 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-18
14:24:45,866  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-18 with initial high watermark 0
14:24:45,866  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-18 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-18 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,867  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 9
14:24:45,867 DEBUG || - [AsyncSnapshotWriterImpl] hz.thirsty_antonelli.jet.cooperative.thread-0 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Stats for src: keys=1, chunks=1, bytes=37
14:24:45,869 DEBUG || - [AsyncSnapshotWriterImpl] hz.gracious_antonelli.jet.cooperative.thread-0 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Stats for src: keys=0, chunks=0, bytes=0
14:24:45,869  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-8, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,870  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-8, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,870  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-8 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,871  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-8 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-8
14:24:45,871  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-8 with initial high watermark 0
14:24:45,871  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-8 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-8 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,872 DEBUG || - [WriteKafkaP] hz.gracious_antonelli.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/kafkaSink#1] transaction not used, ignoring snapshot, txnId=null
14:24:45,872 DEBUG || - [AsyncSnapshotWriterImpl] hz.gracious_antonelli.jet.cooperative.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Stats for kafkaSink: keys=0, chunks=0, bytes=0
14:24:45,872 DEBUG || - [SnapshotPhase1Operation] hz.gracious_antonelli.jet.cooperative.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Snapshot 0 phase 1 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 finished successfully on member
14:24:45,873  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 10
14:24:45,874  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-15, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,875  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-15, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,875  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-15 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,875  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-15 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-15
14:24:45,875  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-15 with initial high watermark 0
14:24:45,875  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-15 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-15 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,878  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-5, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,879  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 11
14:24:45,879  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-5, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,879  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-5 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,879  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-5 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-5
14:24:45,879  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-5 with initial high watermark 0
14:24:45,880  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-5 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-5 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,882  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-12, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,883  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-12, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,883  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-12 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,883  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-12 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-12
14:24:45,883  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-12 with initial high watermark 0
14:24:45,883  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-12 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-12 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,884  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 12
14:24:45,886  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-2, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,886  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-2, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,887  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-2 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,887  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-2 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-2
14:24:45,887  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-2 with initial high watermark 0
14:24:45,887  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-2 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-2 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,890  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-9, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,890  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 13
14:24:45,891  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-9, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,891  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-9 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,892  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-9 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-9
14:24:45,892  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-9 with initial high watermark 0
14:24:45,892  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-9 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-9 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,895  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-6, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,895  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-6, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,896  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-6 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,896  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-6 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-6
14:24:45,896  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-6 with initial high watermark 0
14:24:45,896  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-6 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-6 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,897  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 14
14:24:45,899  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-3, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Loading producer state till offset 0 with message format version 2
14:24:45,900  INFO || - [Log] data-plane-kafka-request-handler-2 - [Log partition=8427e233-511e-41f7-a16c-2e9aee189bc7-3, dir=/var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694] Completed load of log with 1 segments, log start offset 0 and log end offset 0 in 0 ms
14:24:45,900  INFO || - [LogManager] data-plane-kafka-request-handler-2 - Created log for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-3 in /var/folders/cn/gkqtp17x6fjddcvdw9djc5j00000gn/T/kafka-766622883214391694 with properties {compression.type -> producer, message.format.version -> 2.2-IV1, file.delete.delay.ms -> 60000, max.message.bytes -> 1000012, min.compaction.lag.ms -> 0, message.timestamp.type -> CreateTime, min.insync.replicas -> 1, message.downconversion.enable -> true, segment.jitter.ms -> 0, preallocate -> false, index.interval.bytes -> 4096, min.cleanable.dirty.ratio -> 0.5, unclean.leader.election.enable -> false, retention.bytes -> -1, delete.retention.ms -> 86400000, cleanup.policy -> [delete], flush.ms -> 9223372036854775807, segment.bytes -> 1073741824, segment.ms -> 604800000, retention.ms -> 604800000, message.timestamp.difference.max.ms -> 9223372036854775807, segment.index.bytes -> 10485760, flush.messages -> 9223372036854775807}.
14:24:45,900  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-3 broker=0] No checkpointed highwatermark is found for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-3
14:24:45,900  INFO || - [Replica] data-plane-kafka-request-handler-2 - Replica loaded for partition 8427e233-511e-41f7-a16c-2e9aee189bc7-3 with initial high watermark 0
14:24:45,900  INFO || - [Partition] data-plane-kafka-request-handler-2 - [Partition 8427e233-511e-41f7-a16c-2e9aee189bc7-3 broker=0] 8427e233-511e-41f7-a16c-2e9aee189bc7-3 starts at Leader Epoch 0 from offset 0. Previous Leader Epoch was: -1
14:24:45,902  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 15
14:24:45,907  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 16
14:24:45,913  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 17
14:24:45,916  INFO || - [Metadata] kafka-producer-network-thread | producer-40 - Cluster ID: BL1Q4-8eSXSIprN-Xn-SNw
14:24:45,918  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 18
14:24:45,924  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 19
14:24:45,929  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 20
14:24:45,930 DEBUG || - [WriteKafkaP] hz.thirsty_antonelli.jet.blocking.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/kafkaSink#0] flush null
14:24:45,932 DEBUG || - [AsyncSnapshotWriterImpl] hz.thirsty_antonelli.jet.cooperative.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Stats for kafkaSink: keys=0, chunks=0, bytes=0
14:24:45,932 DEBUG || - [SnapshotPhase1Operation] hz.thirsty_antonelli.jet.cooperative.thread-1 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Snapshot 0 phase 1 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 finished successfully on member
14:24:45,932 DEBUG || - [MasterSnapshotContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Snapshot 0 phase 1 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 completed with status SUCCESS in 69ms, 37 bytes, 1 keys in 1 chunks, stored in '__jet.snapshot.06f2-9843-680a-0001.0', proceeding to phase 2
14:24:45,933 DEBUG || - [JobRepository] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Cleared snapshot data map __jet.snapshot.06f2-9843-680a-0001.1
14:24:45,933 DEBUG || - [ExecutionContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Starting snapshot 0 phase 2 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 on member
14:24:45,933 DEBUG || - [ExecutionContext] hz.gracious_antonelli.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Starting snapshot 0 phase 2 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 on member
14:24:45,935  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 21
14:24:45,935 DEBUG || - [SnapshotPhase2Operation] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Snapshot 0 phase 2 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 finished successfully on member
14:24:45,939 DEBUG || - [SnapshotPhase2Operation] hz.gracious_antonelli.jet.blocking.thread-1 - [127.0.0.1]:5702 [dev] [5.1-SNAPSHOT] Snapshot 0 phase 2 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 finished successfully on member
14:24:45,939 DEBUG || - [JobCoordinationService] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 snapshot is scheduled in 50ms
14:24:45,939 DEBUG || - [MasterSnapshotContext] hz.thirsty_antonelli.cached.thread-11 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] Snapshot 0 for job '06f2-9843-680a-0001', execution 06f2-9843-680b-0001 completed in 76ms, status=success
14:24:45,942  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 22
14:24:45,948  INFO || - [ConvenientSourceP] hz.thirsty_antonelli.jet.blocking.thread-2 - [127.0.0.1]:5701 [dev] [5.1-SNAPSHOT] [06f2-9843-680a-0001/src#0] Output to ordinal 0: 23
...
```
</details>