### PR TITLE
Fix Ringbuffer test failures

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -215,7 +215,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     private Map<ObjectNamespace, RingbufferContainer> getOrCreateRingbufferContainers(int partitionId) {
         final Map<ObjectNamespace, RingbufferContainer> partitionContainer = containers.get(partitionId);
         if (partitionContainer == null) {
-            containers.putIfAbsent(partitionId, new HashMap<>());
+            containers.putIfAbsent(partitionId, new ConcurrentHashMap<>());
         }
         return containers.get(partitionId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -17,13 +17,10 @@
 package com.hazelcast.ringbuffer.impl.operations;
 
 import com.hazelcast.core.IFunction;
-import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
-import com.hazelcast.ringbuffer.impl.RingbufferService;
-import com.hazelcast.ringbuffer.impl.RingbufferWaitNotifyKey;
 import com.hazelcast.spi.impl.operationservice.BlockingOperation;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
@@ -60,9 +57,7 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
 
     @Override
     public boolean shouldWait() {
-        RingbufferService service = getService();
-        ObjectNamespace namespace = RingbufferService.getRingbufferNamespace(name);
-        RingbufferContainer ringbuffer = service.getContainerOrNull(getPartitionId(), namespace);
+        RingbufferContainer ringbuffer = getRingBufferContainerOrNull();
 
         if (resultSet == null) {
             resultSet = new ReadResultSetImpl<>(minSize, maxSize, getNodeEngine().getSerializationService(), filter);
@@ -118,8 +113,7 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
 
     @Override
     public WaitNotifyKey getWaitKey() {
-        ObjectNamespace namespace = RingbufferService.getRingbufferNamespace(name);
-        return new RingbufferWaitNotifyKey(namespace, getPartitionId());
+        return getRingbufferWaitNotifyKey();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -43,13 +43,18 @@ public class ReadOneOperation extends AbstractRingBufferOperation implements Blo
 
     @Override
     public void beforeRun() throws Exception {
-        RingbufferContainer ringbuffer = getRingBufferContainer();
-        ringbuffer.checkBlockableReadSequence(sequence);
+        RingbufferContainer ringbuffer = getRingBufferContainerOrNull();
+        if (ringbuffer != null) {
+            ringbuffer.checkBlockableReadSequence(sequence);
+        }
     }
 
     @Override
     public boolean shouldWait() {
-        RingbufferContainer ringbuffer = getRingBufferContainer();
+        RingbufferContainer ringbuffer = getRingBufferContainerOrNull();
+        if (ringbuffer == null) {
+            return true;
+        }
         if (ringbuffer.isTooLargeSequence(sequence) || ringbuffer.isStaleSequence(sequence)) {
             //no need to wait, let the operation continue and fail in beforeRun
             return false;
@@ -66,8 +71,7 @@ public class ReadOneOperation extends AbstractRingBufferOperation implements Blo
 
     @Override
     public WaitNotifyKey getWaitKey() {
-        RingbufferContainer ringbuffer = getRingBufferContainer();
-        return ringbuffer.getRingEmptyWaitNotifyKey();
+        return getRingbufferWaitNotifyKey();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferDestroyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class RingbufferDestroyTest extends HazelcastTestSupport {
+
+    public static final String NAME = "ringbuffer-foo";
+
+    private static HazelcastInstance[] instances;
+    private Ringbuffer<String> ringbuffer;
+
+    @Before
+    public void setUp() throws Exception {
+        Config config = smallInstanceConfig();
+        config.addRingBufferConfig(new RingbufferConfig(NAME).setCapacity(10));
+        instances = createHazelcastInstances(config, 2);
+
+        ringbuffer = instances[0].getRingbuffer(NAME);
+    }
+
+    @Test
+    public void whenDestroyAfterAdd_thenRingbufferRemoved() {
+        ringbuffer.add("1");
+        ringbuffer.destroy();
+
+        assertTrueEventually(new AssertNoRingbufferContainerTask(), 10);
+    }
+
+    @Test
+    public void whenReadOneAfterDestroy_thenMustNotRecreateRingbuffer() {
+        ringbuffer.add("1");
+        ringbuffer.destroy();
+
+        spawn(() -> ringbuffer.readOne(0));
+
+        sleepMillis(100);
+
+        assertTrueEventually(new AssertNoRingbufferContainerTask(), 10);
+    }
+
+    @Test
+    public void whenReadManyAfterDestroy_thenMustNotRecreateRingbuffer() {
+        ringbuffer.add("1");
+        ringbuffer.destroy();
+
+        spawn(() -> ringbuffer.readManyAsync(0, 1, 1, null));
+
+        sleepMillis(100);
+
+        assertTrueEventually(new AssertNoRingbufferContainerTask(), 10);
+    }
+
+    private static class AssertNoRingbufferContainerTask implements AssertTask {
+        @Override
+        public void run() throws Exception {
+            for (HazelcastInstance instance : instances) {
+                final RingbufferService ringbufferService
+                        = getNodeEngineImpl(instance).getService(RingbufferService.SERVICE_NAME);
+
+                final Map<ObjectNamespace, RingbufferContainer> partitionContainers =
+                        ringbufferService.getContainers().get(ringbufferService.getRingbufferPartitionId(NAME));
+                assertNotNull(partitionContainers);
+                assertFalse(partitionContainers.containsKey(RingbufferService.getRingbufferNamespace(NAME)));
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperationTest.java
@@ -101,7 +101,7 @@ public class ReadOneOperationTest extends HazelcastTestSupport {
 
         ReadOneOperation op = getReadOneOperation(ringbuffer.tailSequence() + 1);
 
-        // since there is an item, we don't need to wait
+        // since there is no item, we should wait
         boolean shouldWait = op.shouldWait();
         assertTrue(shouldWait);
     }


### PR DESCRIPTION
Fixes #19696
ReliableTopicDestroyTest.whenDestroyedThenRingbufferRemoved
Created a simpler reproducer RingbufferDestroyTest.whenDestroyAfterAdd_thenRingbufferRemoved
The cause was recreation of the RingbufferContainer in ReadOneOperation.getWaitKey
This also addresses review comment from #19630.

Fixes #16469
RingbufferAddAllReadManyStressTest.whenShortTTLAndBigBuffer
The stress test is incorrect, the ReadManyOperation doesn't throw the
StaleSequenceException when head is stale and the items are just missing
in the result. This was introduced in #16303.

Also fixed HashMap->ConcurrentHashMap in RingbufferService.
This Map is modified from operation thread when RingbufferContainer is
created and also from destroyContainer, which may run directly on the
user's thread when the ringbuffer is local on the member.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

Will send a backport when approved.