### PR TITLE
Download Hazelcast 3 for Hz 3 connector using maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,24 @@
                     <suppressionFiles>owasp-check-suppressions.xml</suppressionFiles>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>get-hz-3</id>
+                        <goals>
+                            <goal>get</goal>
+                        </goals>
+                        <phase>generate-test-resources</phase>
+                        <configuration>
+                            <artifact>com.hazelcast:hazelcast:${hazelcast-3.version}</artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+                <inherited>false</inherited>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
The HazelcastVersionLocator.downloadFile sometimes fails to download the
file. Using Maven should be more reliable (maven retries 3 times by
default) and the method will pick the jar from the local repository.

Fixes #19783
