### PR TITLE
Complete job execution only once

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -478,17 +478,19 @@ public class JobExecutionService implements DynamicMetricsProvider {
      * Completes and cleans up execution of the given job
      */
     public void completeExecution(@Nonnull ExecutionContext executionContext, Throwable error) {
-        executionContexts.remove(executionContext.executionId());
-        JetDelegatingClassLoader jobClassLoader = jobClassloaderService.getClassLoader(executionContext.jobId());
-        try {
-            doWithClassLoader(jobClassLoader, () -> executionContext.completeExecution(error));
-        } finally {
-            if (!executionContext.isLightJob()) {
-                jobClassloaderService.tryRemoveClassloadersForJob(executionContext.jobId(), EXECUTION);
+        ExecutionContext removed = executionContexts.remove(executionContext.executionId());
+        if (removed != null) {
+            JetDelegatingClassLoader jobClassLoader = jobClassloaderService.getClassLoader(executionContext.jobId());
+            try {
+                doWithClassLoader(jobClassLoader, () -> executionContext.completeExecution(error));
+            } finally {
+                if (!executionContext.isLightJob()) {
+                    jobClassloaderService.tryRemoveClassloadersForJob(executionContext.jobId(), EXECUTION);
+                }
+                executionCompleted.inc();
+                executionContextJobIds.remove(executionContext.jobId());
+                logger.fine("Completed execution of " + executionContext.jobNameAndExecutionId());
             }
-            executionCompleted.inc();
-            executionContextJobIds.remove(executionContext.jobId());
-            logger.fine("Completed execution of " + executionContext.jobNameAndExecutionId());
         }
     }
 


### PR DESCRIPTION
There are calls to `completeExecution` from multiple places.
When there is a failure both on coordinator and other member,
but the coordinator is slow to process its own failure it's
possible that we end up with the following log

```
... calling completeExecution because execution terminated before it started
```

and call `completeExecution` twice.

It's the only place where we remove the ExecutionContext from `executionContexts`,
so we can use it to check if it runs for 2nd time.

Fixes #19262

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

Will send backport when approved.
