### PR TITLE
Remove spacing in the PR template causing a visual bug in GitHub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,6 @@ Checklist:
 - [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
 - [ ] Label `Add to Release Notes` or `Not Release Notes content` set
 - [ ] Request reviewers if possible
-
 - [ ] Send backports/forwardports if fix needs to be applied to past/future releases
-
 - [ ] New public APIs have `@Nonnull/@Nullable` annotations
 - [ ] New public APIs have `@since` tags in Javadoc


### PR DESCRIPTION
I originally add this spacing to more easily identify different sections in the template but in some cases it causes this:

[image](https://user-images.githubusercontent.com/40149584/137507365-306eccb7-5619-4635-bfdb-9aba9771533b.png)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
