### PR TITLE
Move dependency plugin in distribution module to prepare-package phase

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -57,7 +57,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>
@@ -74,7 +74,7 @@
                     </execution>
                     <execution>
                         <id>copy-hz3</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>


### PR DESCRIPTION
Recent addition of dependency plugin to root module changed the order of
assembly and dependency plugins in distribution module - both defined in
package phase.

Moving dependency plugin to prepare-package ensures that it is run
before assembly plugin.
