### PR TITLE
[HZ-600] (wip) introduce tstore configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/DeviceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DeviceConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeviceConfig {
+
+    /**
+     * Default block size.
+     */
+    public static final int DEFAULT_BLOCK_SIZE = 4096;
+    /**
+     * Default device name.
+     */
+    public static final String DEFAULT_NAME = "hz-device";
+
+    private String name;
+    private String baseDir;
+    private int blockSize;
+    private long capacity;
+
+    public DeviceConfig() {
+        blockSize = DEFAULT_BLOCK_SIZE;
+        name = DEFAULT_NAME;
+    }
+
+    public DeviceConfig(DeviceConfig deviceConfig) {
+        requireNonNull(deviceConfig);
+        name = deviceConfig.getName();
+        baseDir = deviceConfig.getBaseDir();
+        blockSize = deviceConfig.getBlockSize();
+        capacity = deviceConfig.getCapacity();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public DeviceConfig setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getBaseDir() {
+        return baseDir;
+    }
+
+    public DeviceConfig setBaseDir(String baseDir) {
+        this.baseDir = baseDir;
+        return this;
+    }
+
+    public int getBlockSize() {
+        return blockSize;
+    }
+
+    public DeviceConfig setBlockSize(int blockSize) {
+        this.blockSize = blockSize;
+        return this;
+    }
+
+    public long getCapacity() {
+        return capacity;
+    }
+
+    public DeviceConfig setCapacity(long capacity) {
+        this.capacity = capacity;
+        return this;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DeviceConfig)) {
+            return false;
+        }
+
+        DeviceConfig that = (DeviceConfig) o;
+
+        if (blockSize != that.blockSize) {
+            return false;
+        }
+        if (capacity != that.capacity) {
+            return false;
+        }
+        if (!Objects.equals(name, that.name)) {
+            return false;
+        }
+        return Objects.equals(baseDir, that.baseDir);
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (baseDir != null ? baseDir.hashCode() : 0);
+        result = 31 * result + blockSize;
+        result = 31 * result + (int) (capacity ^ (capacity >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DeviceConfig{"
+                + "name='" + name + '\''
+                + ", baseDir='" + baseDir + '\''
+                + ", blockSize=" + blockSize
+                + ", capacity=" + capacity
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/HybridLogConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HybridLogConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static java.util.Objects.requireNonNull;
+
+public class HybridLogConfig {
+
+    /**
+     * Default page size.
+     */
+    public static final int DEFAULT_PAGE_SIZE = 4096;
+    /**
+     * Default mutable region fraction.
+     */
+    public static final double DEFAULT_MUTABLE_REGION_RATIO = 0.9;
+
+    private int pageSize;
+    private int inMemoryPageCount;
+
+    private double mutableRegionRatio;
+
+    public HybridLogConfig() {
+        pageSize = DEFAULT_PAGE_SIZE;
+        mutableRegionRatio = DEFAULT_MUTABLE_REGION_RATIO;
+    }
+
+    public HybridLogConfig(HybridLogConfig hybridLogConfig) {
+        requireNonNull(hybridLogConfig);
+        pageSize = hybridLogConfig.getPageSize();
+        inMemoryPageCount = hybridLogConfig.getInMemoryPageCount();
+        mutableRegionRatio = hybridLogConfig.getMutableRegionRatio();
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public HybridLogConfig setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+        return this;
+    }
+
+    public int getInMemoryPageCount() {
+        return inMemoryPageCount;
+    }
+
+    public HybridLogConfig setInMemoryPageCount(int inMemoryPageCount) {
+        this.inMemoryPageCount = inMemoryPageCount;
+        return this;
+    }
+
+    public double getMutableRegionRatio() {
+        return mutableRegionRatio;
+    }
+
+    public HybridLogConfig setMutableRegionRatio(double mutableRegionRatio) {
+        this.mutableRegionRatio = mutableRegionRatio;
+        return this;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HybridLogConfig)) {
+            return false;
+        }
+
+        HybridLogConfig that = (HybridLogConfig) o;
+
+        if (pageSize != that.pageSize) {
+            return false;
+        }
+        if (inMemoryPageCount != that.inMemoryPageCount) {
+            return false;
+        }
+        return Double.compare(that.mutableRegionRatio, mutableRegionRatio) == 0;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result;
+        long temp;
+        result = pageSize;
+        result = 31 * result + inMemoryPageCount;
+        temp = Double.doubleToLongBits(mutableRegionRatio);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "HybridLogConfig{"
+                + "pageSize=" + pageSize
+                + ", inMemoryPageCount=" + inMemoryPageCount
+                + ", mutableRegionRatio=" + mutableRegionRatio
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -136,6 +136,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
             .setEvictionPolicy(DEFAULT_EVICTION_POLICY)
             .setMaxSizePolicy(DEFAULT_MAX_SIZE_POLICY)
             .setSize(DEFAULT_MAX_SIZE);
+    private TieredStoreConfig tieredStoreConfig = new TieredStoreConfig();
 
     public MapConfig() {
     }
@@ -173,6 +174,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         this.dataPersistenceConfig = new DataPersistenceConfig(config.dataPersistenceConfig);
         this.merkleTreeConfig = new MerkleTreeConfig(config.merkleTreeConfig);
         this.eventJournalConfig = new EventJournalConfig(config.eventJournalConfig);
+        this.tieredStoreConfig = new TieredStoreConfig(config.tieredStoreConfig);
     }
 
     /**
@@ -764,6 +766,26 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
     }
 
     /**
+     * Gets the {@code TieredStoreConfig} for this {@code MapConfig}
+     *
+     * @return tiered-store config
+     */
+    public TieredStoreConfig getTieredStoreConfig() {
+        return tieredStoreConfig;
+    }
+
+    /**
+     * Sets the {@code TieredStoreConfig} for this {@code MapConfig}
+     *
+     * @param tieredStoreConfig tiered-store config
+     * @return this {@code MapConfig} instance
+     */
+    public MapConfig setTieredStoreConfig(TieredStoreConfig tieredStoreConfig) {
+        this.tieredStoreConfig = checkNotNull(tieredStoreConfig, "tieredStoreConfig cannot be null");
+        return this;
+    }
+
+    /**
      * Get current value cache settings
      *
      * @return current value cache settings
@@ -871,6 +893,9 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         if (!dataPersistenceConfig.equals(that.dataPersistenceConfig)) {
             return false;
         }
+        if (!tieredStoreConfig.equals(that.tieredStoreConfig)) {
+            return false;
+        }
 
         return hotRestartConfig.equals(that.hotRestartConfig);
     }
@@ -904,6 +929,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         result = 31 * result + eventJournalConfig.hashCode();
         result = 31 * result + hotRestartConfig.hashCode();
         result = 31 * result + dataPersistenceConfig.hashCode();
+        result = 31 * result + tieredStoreConfig.hashCode();
         return result;
     }
 
@@ -935,6 +961,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
                 + ", cacheDeserializedValues=" + cacheDeserializedValues
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", entryStatsEnabled=" + perEntryStatsEnabled
+                + ", tieredStoreConfig=" + tieredStoreConfig
                 + '}';
     }
 
@@ -982,6 +1009,9 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         if (out.getVersion().isGreaterOrEqual(Versions.V5_0)) {
             out.writeObject(dataPersistenceConfig);
         }
+        if (out.getVersion().isGreaterOrEqual(Versions.V5_1)) {
+            out.writeObject(tieredStoreConfig);
+        }
     }
 
     @Override
@@ -1017,6 +1047,9 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         }
         if (in.getVersion().isGreaterOrEqual(Versions.V5_0)) {
             setDataPersistenceConfig(in.readObject());
+        }
+        if (in.getVersion().isGreaterOrEqual(Versions.V5_1)) {
+            setTieredStoreConfig(in.readObject());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/TieredStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TieredStoreConfig.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class TieredStoreConfig {
+
+    private HybridLogConfig hybridLogConfig;
+    private DeviceConfig deviceConfig;
+    private boolean enabled;
+
+    public TieredStoreConfig() {
+        hybridLogConfig = new HybridLogConfig();
+        deviceConfig = new DeviceConfig();
+    }
+
+    public TieredStoreConfig(TieredStoreConfig tieredStoreConfig) {
+        requireNonNull(tieredStoreConfig);
+        enabled = tieredStoreConfig.isEnabled();
+        hybridLogConfig = new HybridLogConfig(tieredStoreConfig.getHybridLogConfig());
+        deviceConfig = new DeviceConfig(tieredStoreConfig.getDeviceConfig());
+    }
+
+    public HybridLogConfig getHybridLogConfig() {
+        return hybridLogConfig;
+    }
+
+    public TieredStoreConfig setHybridLogConfig(HybridLogConfig hybridLogConfig) {
+        this.hybridLogConfig = hybridLogConfig;
+        return this;
+    }
+
+    public DeviceConfig getDeviceConfig() {
+        return deviceConfig;
+    }
+
+    public TieredStoreConfig setDeviceConfig(DeviceConfig deviceConfig) {
+        this.deviceConfig = deviceConfig;
+        return this;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public TieredStoreConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TieredStoreConfig)) {
+            return false;
+        }
+
+        TieredStoreConfig that = (TieredStoreConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (!Objects.equals(hybridLogConfig, that.hybridLogConfig)) {
+            return false;
+        }
+        return Objects.equals(deviceConfig, that.deviceConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hybridLogConfig != null ? hybridLogConfig.hashCode() : 0;
+        result = 31 * result + (deviceConfig != null ? deviceConfig.hashCode() : 0);
+        result = 31 * result + (enabled ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TieredStoreConfig{"
+                + "hybridLogConfig=" + hybridLogConfig
+                + ", deviceConfig=" + deviceConfig
+                + ", enabled=" + enabled
+                + '}';
+    }
+}

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.json
@@ -1458,6 +1458,65 @@
                 }
               }
             }
+          },
+          "tiered-store": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false
+              },
+              "hybridlog": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "page-size": {
+                    "type": "integer",
+                    "minimum": 128,
+                    "default": 4096,
+                    "description": "page size in bytes"
+                  },
+                  "in-memory-page-count": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 65536,
+                    "description": "in memory page count"
+                  },
+                  "mutable-region-ratio": {
+                    "type": "number",
+                    "minimum": 0.1,
+                    "default": 0.9,
+                    "description": "(approximate) fraction of mutable region in the in-memory part of the hybrid log."
+                  }
+                }
+              },
+              "device": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "default": "hz-device",
+                    "description": "The device name"
+                  },
+                  "base-dir": {
+                    "type": "string",
+                    "description": "Base directory for local device or prefix for the remote objects of this device"
+                  },
+                  "block-size": {
+                    "type": "integer",
+                    "minimum": 128,
+                    "default": 4096,
+                    "description": "Device block/sector size in bytes. The default is 4096."
+                  },
+                  "capacity": {
+                    "type": "number",
+                    "description": "Device capacity in KB."
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.0.xsd
@@ -293,6 +293,7 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="query-caches" type="query-caches" minOccurs="0"/>
+            <xs:element name="tiered-store" type="tiered-store" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:annotation>
@@ -4083,6 +4084,105 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:complexType name="hybridlog">
+        <xs:annotation>
+            <xs:documentation>
+                todo:
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="page-size" type="xs:unsignedInt" minOccurs="0" default="4096">
+                <xs:annotation>
+                    <xs:documentation>
+                        page size in bytes
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="in-memory-page-count" type="xs:unsignedInt" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        in memory page count
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mutable-region-ratio" type="xs:double" minOccurs="0" default="0.9">
+                <xs:annotation>
+                    <xs:documentation>
+                        (approximate) fraction of mutable region in the in-memory part of the hybrid log.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="device">
+        <xs:annotation>
+            <xs:documentation>
+                todo:
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" type="xs:string" minOccurs="0" default="hz-device">
+                <xs:annotation>
+                    <xs:documentation>
+                        The device name.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="base-dir" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Base directory for local device or prefix for the remote objects of this device
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="block-size" type="xs:unsignedInt" minOccurs="0" default="4096">
+                <xs:annotation>
+                    <xs:documentation>
+                        Device block/sector size in bytes. The default is 4096.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="xs:unsignedLong" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Device capacity in KB.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="tiered-store">
+        <xs:annotation>
+            <xs:documentation>
+                todo
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="hybridlog" type="hybridlog">
+                <xs:annotation>
+                    <xs:documentation>
+                        todo:
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="device">
+                <xs:annotation>
+                    <xs:documentation>
+                        todo:
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if Tiered-Store is enabled, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
     <xs:complexType name="crdt-replication">
         <xs:all>
             <xs:element name="replication-period-millis" type="xs:unsignedInt" minOccurs="0">

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -394,6 +394,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testPersistence();
 
     @Test
+    public abstract void testTieredStore();
+
+    @Test
     public abstract void testPersistenceEncryptionAtRest_whenJavaKeyStore();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/DeviceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DeviceConfigTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class DeviceConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
+        EqualsVerifier.forClass(DeviceConfig.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/HybridLogConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HybridLogConfigTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HybridLogConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
+        EqualsVerifier.forClass(HybridLogConfig.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/TieredStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TieredStoreConfigTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class TieredStoreConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
+        EqualsVerifier.forClass(TieredStoreConfig.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3048,6 +3048,55 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testTieredStore() {
+        // hybridlog parameters
+        int pageSize = 8192;
+        long inMemoryPageCount = 100_000L;
+        double mutableFraction = 0.85;
+
+        // device parameters
+        String deviceName = "ext4_device";
+        String baseDir = "/";
+        int blockSize = 2048;
+        long capacity = 1L << 15;
+
+        String xml = HAZELCAST_START_TAG
+                + "<map name=\"my-map\">"
+                + "    <tiered-store enabled=\"true\">"
+                + "        <hybridlog>"
+                + "            <page-size>" + pageSize + "</page-size>"
+                + "            <in-memory-page-count>" + inMemoryPageCount + "</in-memory-page-count>"
+                + "            <mutable-region-ratio>" + mutableFraction + "</mutable-region-ratio>"
+                + "        </hybridlog>"
+                + "        <device>"
+                + "            <name>" + deviceName + "</name>"
+                + "            <base-dir>" + baseDir + "</base-dir>"
+                + "            <block-size>" + blockSize + "</block-size>"
+                + "            <capacity>" + capacity + "</capacity>"
+                + "        </device>"
+                + "    </tiered-store>"
+                + "</map>\n"
+                + HAZELCAST_END_TAG;
+
+
+        Config config = new InMemoryXmlConfig(xml);
+        TieredStoreConfig tieredStoreConfig = config.getMapConfig("my-map").getTieredStoreConfig();
+        assertTrue(tieredStoreConfig.isEnabled());
+
+        HybridLogConfig hlogConfig = tieredStoreConfig.getHybridLogConfig();
+        assertEquals(pageSize, hlogConfig.getPageSize());
+        assertEquals(inMemoryPageCount, hlogConfig.getInMemoryPageCount());
+        assertEquals(mutableFraction, hlogConfig.getMutableRegionRatio(), 0.001);
+
+        DeviceConfig deviceConfig = tieredStoreConfig.getDeviceConfig();
+        assertEquals(deviceName, deviceConfig.getName());
+        assertEquals(baseDir, deviceConfig.getBaseDir());
+        assertEquals(blockSize, deviceConfig.getBlockSize());
+        assertEquals(capacity, deviceConfig.getCapacity());
+    }
+
+    @Override
+    @Test
     public void testHotRestartEncryptionAtRest_whenJavaKeyStore() {
         int keySize = 16;
         String keyStorePath = "/tmp/keystore.p12";

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3061,6 +3061,52 @@ public class YamlConfigBuilderTest
 
     @Override
     @Test
+    public void testTieredStore() {
+        // hybridlog parameters
+        int pageSize = 8192;
+        long inMemoryPageCount = 100_000L;
+        double mutableFraction = 0.85;
+
+        // device parameters
+        String deviceName = "ext4_device";
+        String baseDir = "/";
+        int blockSize = 2048;
+        long capacity = 1L << 15;
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    my-map:\n"
+                + "      tiered-store:\n"
+                + "        enabled: true\n"
+                + "        hybridlog:\n"
+                + "          page-size: " + pageSize + "\n"
+                + "          in-memory-page-count: " + inMemoryPageCount + "\n"
+                + "          mutable-region-ratio: " + mutableFraction + "\n"
+                + "        device:\n"
+                + "          name: " + deviceName + "\n"
+                + "          base-dir: " + baseDir + "\n"
+                + "          block-size: " + blockSize + "\n"
+                + "          capacity: " + capacity + "\n";
+
+        Config config = new InMemoryYamlConfig(yaml);
+        TieredStoreConfig tieredStoreConfig = config.getMapConfig("my-map").getTieredStoreConfig();
+        assertTrue(tieredStoreConfig.isEnabled());
+
+        HybridLogConfig hlogConfig = tieredStoreConfig.getHybridLogConfig();
+        assertEquals(pageSize, hlogConfig.getPageSize());
+        assertEquals(inMemoryPageCount, hlogConfig.getInMemoryPageCount());
+        assertEquals(mutableFraction, hlogConfig.getMutableRegionRatio(), 0.001);
+
+        DeviceConfig deviceConfig = tieredStoreConfig.getDeviceConfig();
+        assertEquals(deviceName, deviceConfig.getName());
+        assertEquals(baseDir, deviceConfig.getBaseDir());
+        assertEquals(blockSize, deviceConfig.getBlockSize());
+        assertEquals(capacity, deviceConfig.getCapacity());
+    }
+
+    @Override
+    @Test
     public void testHotRestartEncryptionAtRest_whenJavaKeyStore() {
         int keySize = 16;
         String keyStorePath = "/tmp/keystore.p12";


### PR DESCRIPTION
currently changes are made to hazelcast 5.0 config schema, during merge of tstore to master, those changes will be applied to 5.1 and removed from 5.0.

Checklist:
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
