### PR TITLE
Sonar blocker issues 19694

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -18,13 +18,14 @@ package com.hazelcast.nio;
 
 import javax.annotation.Nullable;
 import java.io.DataInput;
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
 /**
  * Provides serialization methods for arrays of primitive types.
  */
-public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVersionAware {
+public interface ObjectDataInput extends DataInput,Closeable, VersionAware, WanProtocolVersionAware {
 
     /**
      * @deprecated for the sake of better naming. Use {@link #readString()} instead

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -18,14 +18,13 @@ package com.hazelcast.nio;
 
 import javax.annotation.Nullable;
 import java.io.DataInput;
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
 /**
  * Provides serialization methods for arrays of primitive types.
  */
-public interface ObjectDataInput extends DataInput,Closeable, VersionAware, WanProtocolVersionAware {
+public interface ObjectDataInput extends DataInput, VersionAware, WanProtocolVersionAware {
 
     /**
      * @deprecated for the sake of better naming. Use {@link #readString()} instead

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -493,11 +493,7 @@ class OperationRunnerImpl extends OperationRunner implements StaticMetricsProvid
     private long extractOperationCallId(Data data) throws IOException {
         ObjectDataInput input = ((SerializationServiceV1) node.getSerializationService())
                 .initDataSerializableInputAndSkipTheHeader(data);
-        try{
-            return input.readLong();
-        }finally {
-            input.close();
-        }
+        return input.readLong();
     }
 
     private void setOperationResponseHandler(Operation op) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -493,7 +493,11 @@ class OperationRunnerImpl extends OperationRunner implements StaticMetricsProvid
     private long extractOperationCallId(Data data) throws IOException {
         ObjectDataInput input = ((SerializationServiceV1) node.getSerializationService())
                 .initDataSerializableInputAndSkipTheHeader(data);
-        return input.readLong();
+        try{
+            return input.readLong();
+        }finally {
+            input.close();
+        }
     }
 
     private void setOperationResponseHandler(Operation op) {


### PR DESCRIPTION
Closes the object for ObjectDataInput in OperationRunnerImpl -> extractOperationCallId()
Fixes #19694

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
