### PR TITLE
Fix eviction max size policy test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -139,7 +139,7 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
             IMap<Object, Object> map2 = nodes.get(2).getMap(mapName);
             long totalBackupEntryCount = getTotalBackupEntryCount(map1, map2);
             assertTrue("totalBackupEntryCount=" + totalBackupEntryCount, ((nodeCount - 1) * perNodeMaxSize)
-                    + (PARTITION_COUNT / nodeCount - 1) >= totalBackupEntryCount);
+                    + (PARTITION_COUNT / (nodeCount - 1)) >= totalBackupEntryCount);
         });
     }
 


### PR DESCRIPTION
Removes (hopefully) flakiness from EvictionMaxSizePolicyTest by disabling parallelism of migrations and by relaxing assertions

Fixes https://github.com/hazelcast/hazelcast/issues/19206

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible