### PR TITLE
[HZ-619] Development Release GH action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,6 +550,24 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven.javadoc.plugin.version}</version>
+                    <configuration>
+                        <maxmemory>1024</maxmemory>
+                        <excludePackageNames>${maven.javadoc.plugin.excludePackageNames}</excludePackageNames>
+                        <doclint>-missing</doclint>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                 </plugin>
@@ -973,20 +991,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.plugin.version}</version>
-                        <configuration>
-                            <maxmemory>1024</maxmemory>
-                            <excludePackageNames>${maven.javadoc.plugin.excludePackageNames}</excludePackageNames>
-                            <doclint>-missing</doclint>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
 
                     <plugin>
@@ -1015,22 +1019,30 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.plugin.version}</version>
-                        <configuration>
-                            <excludePackageNames>${maven.javadoc.plugin.excludePackageNames}</excludePackageNames>
-                            <doclint>-missing</doclint>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>release-devel</id>
+            <properties>
+                <javadoc>true</javadoc>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+            <distributionManagement>
+                <repository>
+                    <id>devel-repository</id>
+                    <url>https://hazelcast.jfrog.io/artifactory/devel</url>
+                </repository>
+            </distributionManagement>
         </profile>
 
         <profile>


### PR DESCRIPTION
GH action for creating development releases. They are deployed to https://repository.hazelcast.com/devel/ repository.

The idea is to run this GH action after every sprint. We just pass commit id and name of release DR (for example `5.1.DR3`).

As a PoC I ran it with current master and change the version to `5.0.DR1` - you can see the result here https://repository.hazelcast.com/ui/native/devel/com/hazelcast (we'll remove this `5.0.DR1` once this will be merged). It also created tag (in my fork since it was ran from the fork - https://github.com/olukas/hazelcast-enterprise/tree/v5.0.DR1).