### PR TITLE
Excludes classes from serialized objects sampling

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/console/HazelcastCommandLineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/HazelcastCommandLineTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -65,7 +66,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category({QuickTest.class, ParallelJVMTest.class, SerializationSamplesExcluded.class})
 public class HazelcastCommandLineTest extends JetTestSupport {
 
     private static final String SOURCE_NAME = "source";

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -59,6 +59,7 @@ public class SamplingSerializationService implements InternalSerializationServic
     private static final String DUMMY_CLASS_PREFIX = "Dummy";
     private static final String TEST_CLASS_SUFFIX = "Test";
     private static final String TEST_PACKAGE_INFIX = ".test";
+    private static final String EXAMPLE_PACKAGE_PREFIX = "example.";
 
     protected final InternalSerializationService delegate;
 
@@ -280,7 +281,7 @@ public class SamplingSerializationService implements InternalSerializationServic
 
     public static boolean isTestClass(String className) {
         if (className.contains(TEST_CLASS_SUFFIX) || className.contains(TEST_PACKAGE_INFIX)
-                || className.contains(DUMMY_CLASS_PREFIX)) {
+                || className.contains(DUMMY_CLASS_PREFIX) || className.startsWith(EXAMPLE_PACKAGE_PREFIX)) {
             return true;
         }
         return false;

--- a/pom.xml
+++ b/pom.xml
@@ -1237,10 +1237,11 @@
                                 <exclude>**/jsr/**.java</exclude>
                                 <!-- code triggered by UserCodeDeploymentSmokeTest and OperationRunnerImplTest -->
                                 <!-- casts to SerializationServiceV1 and fails when Node is configured with the -->
-                                <!-- wrapper ClassRecordingSerializationService -->
-                                <exclude>**/UserCodeDeploymentSmokeTest.java</exclude>
+                                <!-- sampling serialization service -->
                                 <exclude>**/OperationRunnerImplTest.java</exclude>
                                 <exclude>**/**IT.java</exclude>
+                                <exclude>**/jet/**/*.java</exclude>
+                                <exclude>**/*Jet*.java</exclude>
                             </excludes>
                             <excludedGroups>
                                 com.hazelcast.test.annotation.SlowTest,


### PR DESCRIPTION
- exclude jet tests from generate-compatibility
samples profile
- HazelcastCommandLineTest executes jet jobs
which (a) are not backwards compatible anyway and
(b) uses classes outside the test classpath
(from a precompiled jar) and cannot be
deserialized
- Exclude example.* package as these are test
domain objects. Normally test domain objects
are not an issue, however the specific ones
also use compact serialization which is not
backwards compatible (being in beta in 5.0)

forward port of #19827 to `master` branch