### PR TITLE
Extend logging in the NodeMulticastListener

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -76,7 +76,7 @@ public class NodeMulticastListener implements MulticastListener {
             UUID uuidFromMaster = master.getUuid();
             UUID uuidInJoinRequest = joinMessage.getUuid();
             if (master != null && !uuidFromMaster.equals(uuidInJoinRequest)) {
-                String message = "New join request has been received from current master master address. "
+                String message = "New join request has been received from current master address. "
                         + "The UUID in the join request (" + uuidInJoinRequest + ") is different from the "
                         + "known master one (" + uuidFromMaster + "). Suspecting the master address: " + masterAddress;
                 logger.warning(message);


### PR DESCRIPTION
Resolves hazelcast/hazelcast-enterprise#4360

This change will help to identify problems when suspecting the master node in multicast joiner.