### PR TITLE
Fix Add and AddAll ringbuffer operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -87,8 +87,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
 
     @Override
     public WaitNotifyKey getNotifiedKey() {
-        RingbufferContainer ringbuffer = getRingBufferContainer();
-        return ringbuffer.getRingEmptyWaitNotifyKey();
+        return getRingbufferWaitNotifyKey();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -75,8 +75,7 @@ public class AddOperation extends AbstractRingBufferOperation implements Notifie
 
     @Override
     public WaitNotifyKey getNotifiedKey() {
-        RingbufferContainer ringbuffer = getRingBufferContainer();
-        return ringbuffer.getRingEmptyWaitNotifyKey();
+        return getRingbufferWaitNotifyKey();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferDestroyTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static org.assertj.core.util.Lists.newArrayList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -51,6 +53,14 @@ public class RingbufferDestroyTest extends HazelcastTestSupport {
     @Test
     public void whenDestroyAfterAdd_thenRingbufferRemoved() {
         ringbuffer.add("1");
+        ringbuffer.destroy();
+
+        assertTrueEventually(new AssertNoRingbufferContainerTask(), 10);
+    }
+
+    @Test
+    public void whenDestroyAfterAddAllAsync_thenRingbufferRemoved() throws Exception {
+        ringbuffer.addAllAsync(newArrayList("1"), OverflowPolicy.FAIL).toCompletableFuture().get();
         ringbuffer.destroy();
 
         assertTrueEventually(new AssertNoRingbufferContainerTask(), 10);


### PR DESCRIPTION
In #19788 I forgot to use the `AbstractRingBufferOperation#getRingbufferWaitNotifyKey` in `AddOperation` and `AddAllOperation` so we actually didn't fix the #19696 issue properly.

Discovered in backport PR #19835, already part of that, so no need to backport.
