### PR TITLE
Follow-up for EXISTS SQL joins

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/ObjectArrayKey.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/ObjectArrayKey.java
@@ -73,11 +73,11 @@ public final class ObjectArrayKey implements DataSerializable {
     }
 
     public static ObjectArrayKey project(Object[] row, int[] indices) {
-        Object[] hashKeys = new Object[indices.length];
+        Object[] key = new Object[indices.length];
         for (int i = 0; i < indices.length; i++) {
-            hashKeys[i] = row[indices[i]];
+            key[i] = row[indices[i]];
         }
-        return new ObjectArrayKey(hashKeys);
+        return new ObjectArrayKey(key);
     }
 
     /**
@@ -88,12 +88,6 @@ public final class ObjectArrayKey implements DataSerializable {
      * @return the projection function
      */
     public static FunctionEx<Object[], ObjectArrayKey> projectFn(int[] indices) {
-        return row -> {
-            Object[] key = new Object[indices.length];
-            for (int i = 0; i < indices.length; i++) {
-                key[i] = row[indices[i]];
-            }
-            return new ObjectArrayKey(key);
-        };
+        return row -> project(row, indices);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
@@ -38,7 +38,7 @@ import com.hazelcast.jet.sql.impl.connector.SqlConnector.VertexWithInputConfig;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorUtil;
 import com.hazelcast.jet.sql.impl.connector.map.IMapSqlConnector;
 import com.hazelcast.jet.sql.impl.opt.ExpressionValues;
-import com.hazelcast.jet.sql.impl.processors.HashJoinProcessor;
+import com.hazelcast.jet.sql.impl.processors.SqlHashJoinP;
 import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
@@ -312,7 +312,7 @@ public class CreateDagVisitor {
 
         Vertex joinVertex = dag.newUniqueVertex(
                 "Hash Join",
-                HashJoinProcessor.supplier(
+                SqlHashJoinP.supplier(
                         joinInfo,
                         rel.getRight().getRowType().getFieldCount()
                 )

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/SqlHashJoinPTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/SqlHashJoinPTest.java
@@ -42,7 +42,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.calcite.rel.core.JoinRelType.INNER;
 import static org.apache.calcite.rel.core.JoinRelType.LEFT;
 
-public class HashJoinProcessorTest extends SqlTestSupport {
+public class SqlHashJoinPTest extends SqlTestSupport {
     private static final int LOW_PRIORITY = 10;
     private static final int HIGH_PRIORITY = 1;
 
@@ -149,7 +149,7 @@ public class HashJoinProcessorTest extends SqlTestSupport {
             List<Object[]> output
     ) {
 
-        ProcessorSupplier processor = HashJoinProcessor.supplier(
+        ProcessorSupplier processor = SqlHashJoinP.supplier(
                 new JetJoinInfo(joinType, leftEquiJoinIndices, rightEquiJoinIndices, nonEquiCondition, null),
                 rightInputColumnCount
         );


### PR DESCRIPTION
Minor follow-up changes to #19729.

I refactored the `countNestedExists` a bit because it didn't actually return the count. But the end result is the same: we return `true` where previously a non-zero value was returned.

We had `HashJoinP` (in Jet since long ago) and a new `HashJoinProcessor`. I renamed the latter to `SqlHashJoinP`.