### PR TITLE
Change default value for hazelcast.logging.emoji.enabled on Windows

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -55,4 +55,13 @@ public final class OsHelper {
     public static boolean isMac() {
         return (OS.contains("mac") || OS.contains("darwin"));
     }
+
+    /**
+     * Returns {@code true} if the system is a Windows.
+     *
+     * @return {@code true} if the current system is a Windows one.
+     */
+    public static boolean isWindows() {
+        return OS.contains("windows");
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -31,6 +31,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
 import com.hazelcast.internal.diagnostics.HealthMonitorLevel;
+import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.QueryResultSizeExceededException;
@@ -1733,7 +1734,8 @@ public final class ClusterProperty {
      *
      * @since 5.0
      */
-    public static final HazelcastProperty LOG_EMOJI_ENABLED = new HazelcastProperty("hazelcast.logging.emoji.enabled", true);
+    public static final HazelcastProperty LOG_EMOJI_ENABLED = new HazelcastProperty("hazelcast.logging.emoji.enabled",
+            !OsHelper.isWindows());
 
     /**
      * When set to any not-{@code null} value, security recommendations are logged on INFO level during the node start. The


### PR DESCRIPTION
This PR disables emojis in default configs on Windows systems.

Windows systems still don't default `file.encoding` to UTF-8 and it struggles to display UTF-8 in the command console (and/or PowerShell).