### PR TITLE
Fix typo in CompactReader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -740,7 +740,7 @@ public interface CompactReader {
     OffsetDateTime[] readArrayOfTimestampWithTimezones(@Nonnull String fieldName, @Nullable OffsetDateTime[] defaultValue);
 
     /**
-     * Reads an array of arbitrary objects.
+     * Reads an array of compact objects.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -752,7 +752,7 @@ public interface CompactReader {
     <T> T[] readArrayOfCompacts(@Nonnull String fieldName, @Nullable Class<T> componentType);
 
     /**
-     * Reads an array of arbitrary objects or returns the default value.
+     * Reads an array of compact objects or returns the default value.
      *
      * @param fieldName    name of the field.
      * @param defaultValue default value to return if the field with the given name


### PR DESCRIPTION
Fixes a typo in CompactReader apidoc 


Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
