### PR TITLE
[HZ-643] toHazelcastType(SqlTypeName) -> toHazelcastType(RelDataType) refactor

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/HazelcastSqlToRelConverter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/HazelcastSqlToRelConverter.java
@@ -203,7 +203,7 @@ public final class HazelcastSqlToRelConverter extends SqlToRelConverter {
                 // The operand of the outer cast is validated as a SMALLINT, however the operand, thanks to the
                 // simplification in RexBuilder.makeCast(), is converted to a literal [42:SMALLINT]. And LiteralUtils converts
                 // this operand to [42:TINYINT] - we have to use the literal's type instead of the validated operand type.
-                QueryDataType actualFromType = HazelcastTypeUtils.toHazelcastType(literal.getTypeName());
+                QueryDataType actualFromType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(literal.getTypeName());
                 toType.getConverter().convertToSelf(actualFromType.getConverter(), literal.getValue());
             } catch (Exception e) {
                 throw literalConversionException(validator, call, literal, toType, e);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/cost/CostUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/cost/CostUtils.java
@@ -112,7 +112,7 @@ public final class CostUtils {
         int res = 0;
 
         for (RelDataTypeField field : rel.getRowType().getFieldList()) {
-            res += HazelcastTypeUtils.toHazelcastType(field.getType().getSqlTypeName()).getTypeFamily().getEstimatedSize();
+            res += HazelcastTypeUtils.toHazelcastType(field.getType()).getTypeFamily().getEstimatedSize();
         }
 
         return res;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
@@ -497,7 +497,7 @@ public final class IndexResolver {
 
         int columnIndex = ((RexInputRef) operand).getIndex();
 
-        QueryDataType type = HazelcastTypeUtils.toHazelcastType(operand.getType().getSqlTypeName());
+        QueryDataType type = HazelcastTypeUtils.toHazelcastType(operand.getType());
 
         // Create a value with "allowNulls=true"
         IndexFilterValue filterValue = new IndexFilterValue(
@@ -1349,8 +1349,8 @@ public final class IndexResolver {
                     return from;
                 }
 
-                QueryDataTypeFamily fromFamily = HazelcastTypeUtils.toHazelcastType(fromType.getSqlTypeName()).getTypeFamily();
-                QueryDataTypeFamily toFamily = HazelcastTypeUtils.toHazelcastType(toType.getSqlTypeName()).getTypeFamily();
+                QueryDataTypeFamily fromFamily = HazelcastTypeUtils.toHazelcastType(fromType).getTypeFamily();
+                QueryDataTypeFamily toFamily = HazelcastTypeUtils.toHazelcastType(toType).getTypeFamily();
 
                 if (QueryDataTypeUtils.isNumeric(fromFamily) && QueryDataTypeUtils.isNumeric(toFamily)) {
                     // Converting between numeric types

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operand/TypedOperandChecker.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operand/TypedOperandChecker.java
@@ -146,6 +146,6 @@ public class TypedOperandChecker extends AbstractOperandChecker {
     private QueryDataType getTargetHazelcastType() {
         return type != null
                 ? HazelcastTypeUtils.toHazelcastType(type)
-                : HazelcastTypeUtils.toHazelcastType(targetTypeName);
+                : HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(targetTypeName);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/predicate/HazelcastBetweenOperator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/predicate/HazelcastBetweenOperator.java
@@ -108,7 +108,7 @@ public final class HazelcastBetweenOperator extends HazelcastInfixOperator {
                         callBinding.getOperandType(2)
                 ));
 
-        QueryDataType winnerQueryDataType = toHazelcastType(winningType.getSqlTypeName());
+        QueryDataType winnerQueryDataType = toHazelcastType(winningType);
 
         // Set more flexible parameter converter that allows TINYINT/SMALLINT/INTEGER -> BIGINT conversions.
         if (winnerQueryDataType.getTypeFamily().isNumeric()) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/predicate/HazelcastComparisonPredicateUtils.java
@@ -94,8 +94,8 @@ public final class HazelcastComparisonPredicateUtils {
             RelDataType lowType,
             int lowIndex
     ) {
-        QueryDataType highHZType = HazelcastTypeUtils.toHazelcastType(highType.getSqlTypeName());
-        QueryDataType lowHZType = HazelcastTypeUtils.toHazelcastType(lowType.getSqlTypeName());
+        QueryDataType highHZType = HazelcastTypeUtils.toHazelcastType(highType);
+        QueryDataType lowHZType = HazelcastTypeUtils.toHazelcastType(lowType);
 
         if (highHZType.getTypeFamily().isNumeric()) {
             // Set flexible parameter converter that allows TINYINT/SMALLINT/INTEGER -> BIGINT conversions

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/typeinference/BinaryOperatorOperandTypeInference.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/typeinference/BinaryOperatorOperandTypeInference.java
@@ -48,7 +48,7 @@ public final class BinaryOperatorOperandTypeInference implements SqlOperandTypeI
             operandTypes[i] = binding.getOperandType(i);
 
             if (!operandTypes[i].equals(binding.getValidator().getUnknownType())) {
-                if (hasParameters && toHazelcastType(operandTypes[i].getSqlTypeName()).getTypeFamily().isNumericInteger()) {
+                if (hasParameters && toHazelcastType(operandTypes[i]).getTypeFamily().isNumericInteger()) {
                     // If we are here, the operands are a parameter and a numeric expression.
                     // We widen the type of the numeric expression to BIGINT, so that an expression `1 > ?` is resolved to
                     // `(BIGINT)1 > (BIGINT)?` rather than `(TINYINT)1 > (TINYINT)?`

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/typeinference/CoalesceOperandTypeInference.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operators/typeinference/CoalesceOperandTypeInference.java
@@ -59,7 +59,7 @@ public final class CoalesceOperandTypeInference implements SqlOperandTypeInferen
             operandTypes[i] = binding.getOperandType(i);
 
             if (!operandTypes[i].equals(binding.getValidator().getUnknownType())) {
-                if (hasParameters && toHazelcastType(operandTypes[i].getSqlTypeName()).getTypeFamily().isNumericInteger()) {
+                if (hasParameters && toHazelcastType(operandTypes[i]).getTypeFamily().isNumericInteger()) {
                     // If there are parameters in the operands, widen all the integers to BIGINT so that an expression
                     // `COALESCE(1, ?)` is resolved to `COALESCE((BIGINT)1, (BIGINT)?)` rather than
                     // `COALESCE((TINYINT)1, (TINYINT)?)`

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastType.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastType.java
@@ -37,6 +37,6 @@ public class HazelcastType extends BasicSqlType {
 
     @Override
     protected void generateTypeString(StringBuilder sb, boolean withDetail) {
-        sb.append(HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(typeName).getTypeFamily().getPublicType());
+        sb.append(HazelcastTypeUtils.toHazelcastType(this).getTypeFamily().getPublicType());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastType.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastType.java
@@ -37,6 +37,6 @@ public class HazelcastType extends BasicSqlType {
 
     @Override
     protected void generateTypeString(StringBuilder sb, boolean withDetail) {
-        sb.append(HazelcastTypeUtils.toHazelcastType(typeName).getTypeFamily().getPublicType());
+        sb.append(HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(typeName).getTypeFamily().getPublicType());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtils.java
@@ -34,11 +34,9 @@ import java.util.Map;
 
 import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static org.apache.calcite.sql.type.SqlTypeFamily.INTERVAL_DAY_TIME;
-import static org.apache.calcite.sql.type.SqlTypeName.DAY_INTERVAL_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.INTERVAL_DAY_SECOND;
 import static org.apache.calcite.sql.type.SqlTypeName.INTERVAL_YEAR_MONTH;
 import static org.apache.calcite.sql.type.SqlTypeName.OTHER;
-import static org.apache.calcite.sql.type.SqlTypeName.YEAR_INTERVAL_TYPES;
 
 /**
  * Provides utilities to map from Calcite's {@link SqlTypeName} to {@link

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtils.java
@@ -311,18 +311,7 @@ public final class HazelcastTypeUtils {
     }
 
     public static int precedenceOf(RelDataType type) {
-        SqlTypeName typeName = type.getSqlTypeName();
-        QueryDataType hzType;
-
-        if (YEAR_INTERVAL_TYPES.contains(typeName)) {
-            hzType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(INTERVAL_YEAR_MONTH);
-        } else if (DAY_INTERVAL_TYPES.contains(typeName)) {
-            hzType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(INTERVAL_DAY_SECOND);
-        } else {
-            hzType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(typeName);
-        }
-
-        return hzType.getTypeFamily().getPrecedence();
+        return toHazelcastType(type).getTypeFamily().getPrecedence();
     }
 
     public static boolean canCast(RelDataType sourceType, RelDataType targetType) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtils.java
@@ -112,7 +112,7 @@ public final class HazelcastTypeUtils {
 
     public static QueryDataType toHazelcastType(RelDataType relDataType) {
         if (relDataType.getSqlTypeName() != OTHER) {
-            return toHazelcastType(relDataType.getSqlTypeName());
+            return toHazelcastTypeFromSqlTypeName(relDataType.getSqlTypeName());
         }
         final RelDataTypeFamily typeFamily = relDataType.getFamily();
 
@@ -123,7 +123,7 @@ public final class HazelcastTypeUtils {
         throw new IllegalArgumentException("Unexpected SQL type: " + relDataType);
     }
 
-    public static QueryDataType toHazelcastType(SqlTypeName sqlTypeName) {
+    public static QueryDataType toHazelcastTypeFromSqlTypeName(SqlTypeName sqlTypeName) {
         SqlTypeFamily sqlTypeNameFamily = sqlTypeName.getFamily();
         if (sqlTypeNameFamily == SqlTypeFamily.INTERVAL_YEAR_MONTH) {
             return QueryDataType.INTERVAL_YEAR_MONTH;
@@ -312,14 +312,15 @@ public final class HazelcastTypeUtils {
 
     public static int precedenceOf(RelDataType type) {
         SqlTypeName typeName = type.getSqlTypeName();
+        QueryDataType hzType;
 
         if (YEAR_INTERVAL_TYPES.contains(typeName)) {
-            typeName = INTERVAL_YEAR_MONTH;
+            hzType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(INTERVAL_YEAR_MONTH);
         } else if (DAY_INTERVAL_TYPES.contains(typeName)) {
-            typeName = INTERVAL_DAY_SECOND;
+            hzType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(INTERVAL_DAY_SECOND);
+        } else {
+            hzType = HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(typeName);
         }
-
-        QueryDataType hzType = HazelcastTypeUtils.toHazelcastType(typeName);
 
         return hzType.getTypeFamily().getPrecedence();
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtilsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtilsTest.java
@@ -55,25 +55,26 @@ public class HazelcastTypeUtilsTest {
         assertSame(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, HazelcastTypeUtils.toCalciteType(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME));
     }
 
+    // TODO add/refactor into RelDataType -> QueryDataType test
     @Test
     public void testCalciteToHazelcast() {
-        assertSame(QueryDataType.VARCHAR, HazelcastTypeUtils.toHazelcastType(SqlTypeName.VARCHAR));
+        assertSame(QueryDataType.VARCHAR, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.VARCHAR));
 
-        assertSame(QueryDataType.BOOLEAN, HazelcastTypeUtils.toHazelcastType(SqlTypeName.BOOLEAN));
+        assertSame(QueryDataType.BOOLEAN, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.BOOLEAN));
 
-        assertSame(QueryDataType.TINYINT, HazelcastTypeUtils.toHazelcastType(SqlTypeName.TINYINT));
-        assertSame(QueryDataType.SMALLINT, HazelcastTypeUtils.toHazelcastType(SqlTypeName.SMALLINT));
-        assertSame(QueryDataType.INT, HazelcastTypeUtils.toHazelcastType(SqlTypeName.INTEGER));
-        assertSame(QueryDataType.BIGINT, HazelcastTypeUtils.toHazelcastType(SqlTypeName.BIGINT));
+        assertSame(QueryDataType.TINYINT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TINYINT));
+        assertSame(QueryDataType.SMALLINT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.SMALLINT));
+        assertSame(QueryDataType.INT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.INTEGER));
+        assertSame(QueryDataType.BIGINT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.BIGINT));
 
-        assertSame(QueryDataType.DECIMAL, HazelcastTypeUtils.toHazelcastType(SqlTypeName.DECIMAL));
+        assertSame(QueryDataType.DECIMAL, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.DECIMAL));
 
-        assertSame(QueryDataType.REAL, HazelcastTypeUtils.toHazelcastType(SqlTypeName.REAL));
-        assertSame(QueryDataType.DOUBLE, HazelcastTypeUtils.toHazelcastType(SqlTypeName.DOUBLE));
+        assertSame(QueryDataType.REAL, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.REAL));
+        assertSame(QueryDataType.DOUBLE, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.DOUBLE));
 
-        assertSame(QueryDataType.DATE, HazelcastTypeUtils.toHazelcastType(SqlTypeName.DATE));
-        assertSame(QueryDataType.TIME, HazelcastTypeUtils.toHazelcastType(SqlTypeName.TIME));
-        assertSame(QueryDataType.TIMESTAMP, HazelcastTypeUtils.toHazelcastType(SqlTypeName.TIMESTAMP));
-        assertSame(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME, HazelcastTypeUtils.toHazelcastType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE));
+        assertSame(QueryDataType.DATE, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.DATE));
+        assertSame(QueryDataType.TIME, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TIME));
+        assertSame(QueryDataType.TIMESTAMP, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TIMESTAMP));
+        assertSame(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE));
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtilsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeUtilsTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -55,26 +56,32 @@ public class HazelcastTypeUtilsTest {
         assertSame(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, HazelcastTypeUtils.toCalciteType(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME));
     }
 
-    // TODO add/refactor into RelDataType -> QueryDataType test
     @Test
     public void testCalciteToHazelcast() {
-        assertSame(QueryDataType.VARCHAR, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.VARCHAR));
+        assertSame(QueryDataType.JSON, HazelcastTypeUtils.toHazelcastType(HazelcastJsonType.TYPE));
+        assertSame(QueryDataType.JSON, HazelcastTypeUtils.toHazelcastType(HazelcastJsonType.TYPE_NULLABLE));
 
-        assertSame(QueryDataType.BOOLEAN, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.BOOLEAN));
+        assertSame(QueryDataType.VARCHAR, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.VARCHAR)));
 
-        assertSame(QueryDataType.TINYINT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TINYINT));
-        assertSame(QueryDataType.SMALLINT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.SMALLINT));
-        assertSame(QueryDataType.INT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.INTEGER));
-        assertSame(QueryDataType.BIGINT, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.BIGINT));
+        assertSame(QueryDataType.BOOLEAN, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.BOOLEAN)));
 
-        assertSame(QueryDataType.DECIMAL, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.DECIMAL));
+        assertSame(QueryDataType.TINYINT, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.TINYINT)));
+        assertSame(QueryDataType.SMALLINT, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.SMALLINT)));
+        assertSame(QueryDataType.INT, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.INTEGER)));
+        assertSame(QueryDataType.BIGINT, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.BIGINT)));
 
-        assertSame(QueryDataType.REAL, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.REAL));
-        assertSame(QueryDataType.DOUBLE, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.DOUBLE));
+        assertSame(QueryDataType.DECIMAL, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.DECIMAL)));
 
-        assertSame(QueryDataType.DATE, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.DATE));
-        assertSame(QueryDataType.TIME, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TIME));
-        assertSame(QueryDataType.TIMESTAMP, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TIMESTAMP));
-        assertSame(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME, HazelcastTypeUtils.toHazelcastTypeFromSqlTypeName(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE));
+        assertSame(QueryDataType.REAL, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.REAL)));
+        assertSame(QueryDataType.DOUBLE, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.DOUBLE)));
+
+        assertSame(QueryDataType.DATE, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.DATE)));
+        assertSame(QueryDataType.TIME, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.TIME)));
+        assertSame(QueryDataType.TIMESTAMP, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.TIMESTAMP)));
+        assertSame(QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME, HazelcastTypeUtils.toHazelcastType(type(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)));
+    }
+
+    private RelDataType type(SqlTypeName typeName) {
+        return HazelcastTypeFactory.INSTANCE.createSqlType(typeName);
     }
 }


### PR DESCRIPTION
WIP.
Fixes #19826.

Refactor was not applicable for some contexts, hence the `toHazelcastTypeFromSqlTypeName`.