### PR TITLE
Fix possible NPE in NodeMulticastListener

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -73,15 +73,17 @@ public class NodeMulticastListener implements MulticastListener {
             node.multicastService.send(response);
         } else if (joinMessage.getAddress().equals(masterAddress)) {
             MemberImpl master = node.getClusterService().getMember(masterAddress);
-            UUID uuidFromMaster = master.getUuid();
-            UUID uuidInJoinRequest = joinMessage.getUuid();
-            if (master != null && !uuidFromMaster.equals(uuidInJoinRequest)) {
-                String message = "New join request has been received from current master address. "
-                        + "The UUID in the join request (" + uuidInJoinRequest + ") is different from the "
-                        + "known master one (" + uuidFromMaster + "). Suspecting the master address: " + masterAddress;
-                logger.warning(message);
-                // I just make a local suspicion. Probably other nodes will eventually suspect as well.
-                clusterService.suspectMember(master, message, false);
+            if (master != null) {
+                UUID uuidFromMaster = master.getUuid();
+                UUID uuidInJoinRequest = joinMessage.getUuid();
+                if (!uuidFromMaster.equals(uuidInJoinRequest)) {
+                    String message = "New join request has been received from current master address. "
+                            + "The UUID in the join request (" + uuidInJoinRequest + ") is different from the "
+                            + "known master one (" + uuidFromMaster + "). Suspecting the master address: " + masterAddress;
+                    logger.warning(message);
+                    // I just make a local suspicion. Probably other nodes will eventually suspect as well.
+                    clusterService.suspectMember(master, message, false);
+                }
             }
         }
     }


### PR DESCRIPTION
This pr aims to fix a possible NPE that can happen in 
`UUID uuidFromMaster = master.getUuid();` call. 
I noticed it while reviewing this pr: https://github.com/hazelcast/hazelcast-enterprise/pull/4394
This didn't catch my eye while reviewing the actual pr that caused this.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

