### PR TITLE
Fix apidoc of Compactable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -41,7 +41,7 @@ public final class CompactUtil {
                                                                                   @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
                 + "null value can not be read via getArrayOf" + methodSuffix + " methods. "
-                + "Use getArrayOf" + methodSuffix + " instead.");
+                + "Use getArrayOfNullable" + methodSuffix + " instead.");
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/Compactable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/Compactable.java
@@ -31,7 +31,7 @@ import com.hazelcast.nio.serialization.compact.CompactSerializer;
 public interface Compactable<T> {
 
     /**
-     * Returns the compact serializer that will be used the serialize
+     * Returns the compact serializer that will be used to serialize
      * instances of class {@code T}.
      */
     CompactSerializer<T> getCompactSerializer();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/Compactable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/Compactable.java
@@ -21,10 +21,10 @@ import com.hazelcast.nio.serialization.compact.CompactSerializer;
 /**
  * Interface to customize how an object is written in Compact Format.
  * One can either implement `CompactSerializer` and register
- * it via {@link com.hazelcast.config.CompactSerializationConfig#register(Class, CompactSerializer)}
+ * it via {@link com.hazelcast.config.CompactSerializationConfig#register(Class, String, CompactSerializer)}
  * or the serialized object can implement this interface so that the serialization
  * system gets the related compact serializer. This interface is used by code
- * generation an not intended to be a public API.
+ * generation and not intended to be a public API.
  *
  * @param <T> Type of the object to be serialized
  */


### PR DESCRIPTION
Fixes a typo and a broken link in Compactable

Breaking changes (list specific methods/types/messages):

None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
