### PR TITLE
MC-635 changing the default value of the queue.maxAge metric to 0

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalQueueStatsImpl.java
@@ -41,7 +41,7 @@ import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 public class LocalQueueStatsImpl implements LocalQueueStats {
 
-    public static final long DEFAULT_MAX_AGE = Long.MIN_VALUE;
+    public static final long DEFAULT_MAX_AGE = 0;
     public static final long DEFAULT_MIN_AGE = Long.MAX_VALUE;
     private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_OFFERS =
             newUpdater(LocalQueueStatsImpl.class, "numberOfOffers");

--- a/hazelcast/src/test/java/com/hazelcast/client/queue/QueueResetAgeStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/queue/QueueResetAgeStatisticsTest.java
@@ -75,7 +75,7 @@ public class QueueResetAgeStatisticsTest
         ClientInvocation invocation = new ClientInvocation(client, clientMessage, "my-queue");
         invocation.invoke().get();
         LocalQueueStats statsAfterReset = member.getQueue("my-queue").getLocalQueueStats();
-        assertEquals(Long.MIN_VALUE, statsAfterReset.getMaxAge());
+        assertEquals(0, statsAfterReset.getMaxAge());
         assertEquals(Long.MAX_VALUE, statsAfterReset.getMinAge());
         assertEquals(0, statsAfterReset.getAverageAge());
 


### PR DESCRIPTION
Related to MC-635

Follow-up of #19625

Changes the default value of the `queue.maxAge` metric to `0`. This is necessary to make the reset visible on the MC side. The problem with using `Long.MIN_VALUE` is that MC considers such metrics as [missing values](https://github.com/hazelcast/management-center/blob/f1e713e2d79be116f134d1c75e5be7e1dfa0716e/src/main/java/com/hazelcast/webmonitor/metrics/impl/utils/ValueUtil.java#L23) and [ignores them](https://github.com/hazelcast/management-center/blob/master/src/main/java/com/hazelcast/webmonitor/service/metrics/MetricsConsumer.java#L185). Therefore, after reset, still the pre-reset value is used as the current value of `queue.maxAge`, so in the end the value doesn't change on the UI.

This default was previously discussed [here](https://github.com/hazelcast/hazelcast/pull/19625#discussion_r720252068). Re-reading that thread, I can't see any harm in using `0` as the default instead of `Long.MIN_VALUE`.



Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
