### PR TITLE
Do not execute cluster ops when querying node state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -130,8 +130,6 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         int clusterSize = clusterService.getMembers().size();
 
         InternalPartitionService partitionService = node.getPartitionService();
-        boolean memberStateSafe = partitionService.isMemberStateSafe();
-        boolean clusterSafe = memberStateSafe && !partitionService.hasOnGoingMigration();
         long migrationQueueSize = partitionService.getMigrationQueueSize();
 
         String healthParameter = uri.substring(URI_HEALTH_URL.length());
@@ -144,7 +142,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_STATE)) {
             prepareResponse(command, Json.value(clusterState.toString()));
         } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_SAFE)) {
-            if (clusterSafe) {
+            if (isClusterSafe()) {
                 command.send200();
             } else {
                 command.send503();
@@ -157,7 +155,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
             JsonObject response = new JsonObject()
                     .add("nodeState", nodeState.toString())
                     .add("clusterState", clusterState.toString())
-                    .add("clusterSafe", clusterSafe)
+                    .add("clusterSafe", isClusterSafe())
                     .add("migrationQueueSize", migrationQueueSize)
                     .add("clusterSize", clusterSize);
             prepareResponse(command, response);
@@ -166,8 +164,10 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         }
     }
 
-    private static String booleanToString(boolean b) {
-        return Boolean.toString(b).toUpperCase(StringUtil.LOCALE_INTERNAL);
+    private boolean isClusterSafe() {
+        InternalPartitionService partitionService = textCommandService.getNode().getPartitionService();
+        boolean memberStateSafe = partitionService.isMemberStateSafe();
+        return memberStateSafe && !partitionService.hasOnGoingMigration();
     }
 
     private void handleGetClusterVersion(HttpGetCommand command) {


### PR DESCRIPTION
Changes handling of health check rest endpoint
so that cluster operations are only used when
required by the queried endpoint.

(cherry picked from commit fbb75e19256ec5e0771721c77ca83d5f9b91a526)

Backport of #19829 to `5.0.z`