### PR TITLE
Fix QueueStatisticsTest#testAge

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStatisticsTest.java
@@ -157,6 +157,7 @@ public class QueueStatisticsTest extends HazelcastTestSupport {
         IQueue<VersionedObject<String>> queue = newQueue();
         queue.offer(new VersionedObject<>("maxAgeItem", 0));
         queue.offer(new VersionedObject<>("minAgeItem", 1));
+        sleepAtLeastMillis(100);
         queue.poll();
         queue.poll();
 


### PR DESCRIPTION
Looking at the logs of the test failures, it seems max age, min age,
and average age were equal to their default values (0, Long.MAX_VALUE, 0)
despite there being offer and poll operations.

That could only happen if in the `QueueContainer#age` method, we calculate
the elapsed time as some non-positive value.

So, this attempts to fix this problem by sleeping for a while between offer
and poll operations.

Note: I was thinking of changing the if condition on the aforementioned from
`elapsed <= 0` to `elapsed < 0`. If you think it makes sense, I could also
do that.

Closes: #19909 
Closes: #19911 