### PR TITLE
Fix YAML schema

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-config-5.1.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.json
@@ -1645,6 +1645,10 @@
                 "type": "string",
                 "description": "Fully qualified class name."
               },
+              "factory-class-name": {
+                "type": "string",
+                "description": "Fully qualified name of the RingbufferStoreFactory implementation class."
+              },
               "properties": {
                 "type": "object"
               },
@@ -1652,10 +1656,7 @@
                 "type": "boolean",
                 "default": true
               }
-            },
-            "required": [
-              "class-name"
-            ]
+            }
           },
           "split-brain-protection-ref": {
             "type": "string",

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/ringbuffer/success.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/ringbuffer/success.json
@@ -20,6 +20,25 @@
           "merge-policy": {
             "class-name": "PutIfAbsentMergePolicy"
           }
+        },
+        "my-second-ringbuffer": {
+          "capacity": 10000,
+          "time-to-live-seconds": 0,
+          "backup-count": 1,
+          "async-backup-count": 0,
+          "in-memory-format": "BINARY",
+          "ringbuffer-store": {
+            "enabled": true,
+            "factory-class-name": "com.hazelcast.RingbufferStoreFactoryImpl",
+            "properties": {
+              "prop1": "prop1-value",
+              "prop2": "prop2-value"
+            }
+          },
+          "split-brain-protection-ref": "splitBrainProtectionRuleWithThreeNodes",
+          "merge-policy": {
+            "class-name": "PutIfAbsentMergePolicy"
+          }
         }
       }
     }


### PR DESCRIPTION
YAML schema for `RingbufferStore` was missing option to create store from the `RingbufferStoreFactory` implementation. This PR addresses  that issue.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
