### PR TITLE
Fix tests on JDK 17 HZ-670 HZ-667

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonValue_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonValue_Test.java
@@ -21,19 +21,21 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import static com.hazelcast.internal.json.TestUtil.assertException;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.hazelcast.internal.json.TestUtil.RunnableEx;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import com.hazelcast.internal.json.TestUtil.RunnableEx;
-import com.hazelcast.test.annotation.QuickTest;
+import static com.hazelcast.internal.json.TestUtil.assertException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @Category(QuickTest.class)
 public class JsonValue_Test {
@@ -84,7 +86,7 @@ public class JsonValue_Test {
   @Test
   public void writeTo_doesNotCloseWriter() throws IOException {
     JsonValue value = new JsonObject();
-    Writer writer = spy(new StringWriter());
+    Writer writer = mock(StringWriter.class);
 
     value.writeTo(writer);
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -91,10 +91,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -398,8 +396,12 @@ public class IOUtilTest extends HazelcastTestSupport {
 
     @Test(expected = HazelcastException.class)
     public void testTouch_failsWhenLastModifiedCannotBeSet() {
-        File file = spy(newFile("touchMe"));
-        when(file.setLastModified(anyLong())).thenReturn(false);
+        File file = new File(tempFolder.getRoot(), "touchMe") {
+            @Override
+            public boolean setLastModified(long time) {
+                return false;
+            }
+        };
 
         touch(file);
     }


### PR DESCRIPTION
Fixed 2 tests failing due to problems with creating spies of classes from external modules

Fixes:
- https://hazelcast.atlassian.net/browse/HZ-667
- https://hazelcast.atlassian.net/browse/HZ-670

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

