### PR TITLE
Set system property with instance tracking file for audit [5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InstanceTrackingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InstanceTrackingUtil.java
@@ -37,6 +37,11 @@ import static com.hazelcast.internal.util.StringUtil.resolvePlaceholders;
  */
 public final class InstanceTrackingUtil {
 
+    /**
+     * System property that is set with the instance tracking full file path.
+     * This property then can be audited via jcmd.
+     */
+    public static final String HAZELCAST_CONFIG_INSTANCE_TRACKING_FILE = "hazelcast.config.instance.tracking.file";
 
     private InstanceTrackingUtil() {
     }
@@ -62,6 +67,10 @@ public final class InstanceTrackingUtil {
         try {
             String trackingFileContents = getInstanceTrackingContent(formatPattern, placeholderValues);
             Path file = getInstanceTrackingFilePath(fileName, placeholderValues);
+
+            // Set the instance tracking file path to a system property so it can be audited
+            System.setProperty(HAZELCAST_CONFIG_INSTANCE_TRACKING_FILE, file.toString());
+
             logger.fine("Writing instance tracking information to " + file);
             Files.write(file, trackingFileContents.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {

--- a/hazelcast/src/test/java/com/hazelcast/instance/InstanceTrackingInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/InstanceTrackingInfoTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.instance;
 import com.hazelcast.config.Config;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.util.InstanceTrackingUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -36,6 +37,7 @@ import java.nio.file.Files;
 import java.util.function.Consumer;
 
 import static com.hazelcast.internal.util.StringUtil.bytesToString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -97,6 +99,20 @@ public class InstanceTrackingInfoTest extends HazelcastTestSupport {
         assertNotNull(files);
         assertEquals(1, files.length);
         assertEquals("dummy", bytesToString(Files.readAllBytes(files[0].toPath())));
+    }
+
+    @Test
+    public void whenInstanceTrackingEnabled_thenFileSetInSystemProperty() throws IOException {
+        Config config = new Config();
+        File tempFile = tempFolder.newFile();
+        config.getInstanceTrackingConfig()
+              .setEnabled(true)
+              .setFileName(tempFile.getAbsolutePath());
+
+        createHazelcastInstance(config);
+
+        assertThat(System.getProperty(InstanceTrackingUtil.HAZELCAST_CONFIG_INSTANCE_TRACKING_FILE))
+                .isEqualTo(tempFile.getAbsolutePath());
     }
 
     private void assertTrackingFileContents(String pattern, Consumer<String> contentAssertion) throws IOException {


### PR DESCRIPTION
Some customers need to audit that all Hazelcast processes running in
their infrastructure have the instance tracking filename set correctly
in the configuration.

The system property is auditable by jcmd command from outside of the
process.

Backport of #19928
