### PR TITLE
Do not try to start background task during map#destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -132,7 +132,7 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     }
 
     /**
-     * @see RemoteService#destroyDistributedObject(String) for IMap
+     * @see RemoteService#destroyDistributedObject(String)
      */
     @Override
     public boolean destroyNearCache(String mapName) {


### PR DESCRIPTION
Stumbled upon this during big data tests. Harmless but annoying ...
```
	at com.hazelcast.internal.nearcache.impl.invalidation.BatchInvalidator.checkBackgroundTaskIsRunning(BatchInvalidator.java:166)
	at com.hazelcast.internal.nearcache.impl.invalidation.BatchInvalidator.newInvalidation(BatchInvalidator.java:78)
	at com.hazelcast.internal.nearcache.impl.invalidation.Invalidator.newClearInvalidation(Invalidator.java:104)
	at com.hazelcast.internal.nearcache.impl.invalidation.Invalidator.invalidateAllKeys(Invalidator.java:84)
	at com.hazelcast.internal.nearcache.impl.invalidation.Invalidator.destroy(Invalidator.java:141)
	at com.hazelcast.internal.nearcache.impl.invalidation.BatchInvalidator.destroy(BatchInvalidator.java:202)
	at com.hazelcast.map.impl.nearcache.MapNearCacheManager.destroyNearCache(MapNearCacheManager.java:139)
	at com.hazelcast.map.impl.MapServiceContextImpl.destroyMap(MapServiceContextImpl.java:416)
	at com.hazelcast.map.impl.MapRemoteService.destroyDistributedObject(MapRemoteService.java:67)
	at com.hazelcast.map.impl.MapService.destroyDistributedObject(MapService.java:199)
	at com.hazelcast.internal.services.RemoteService.destroyDistributedObject(RemoteService.java:68)
	at com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl.destroyLocalDistributedObject(ProxyServiceImpl.java:188)
	at com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl.destroyDistributedObject(ProxyServiceImpl.java:176)
	at com.hazelcast.spi.impl.AbstractDistributedObject.destroy(AbstractDistributedObject.java:72)
	at com.hazelcast.simulator.tests.map.MigrationPerfTest.tearDown(MigrationPerfTest.java:140)
```