### PR TITLE
Make logging tests JDK17 ready HZ-665 #19877

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggerTest.java
@@ -17,13 +17,11 @@
 package com.hazelcast.logging;
 
 import com.hazelcast.cluster.Member;
+import com.hazelcast.instance.SimpleMemberImpl;
 import com.hazelcast.test.HazelcastTestSupport;
 
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 abstract class AbstractLoggerTest extends HazelcastTestSupport {
 
@@ -36,15 +34,15 @@ abstract class AbstractLoggerTest extends HazelcastTestSupport {
     static {
         LogRecord logRecord = new LogRecord(Level.WARNING, MESSAGE);
         logRecord.setThrown(THROWABLE);
-        logRecord.setLoggerName("AbstractLogFactoryTest");
+        logRecord.setLoggerName(AbstractLoggerTest.class.getSimpleName());
 
         LogRecord logRecordOff = new LogRecord(Level.OFF, MESSAGE);
         logRecordOff.setThrown(THROWABLE);
-        logRecordOff.setLoggerName("AbstractLogFactoryTest");
+        logRecordOff.setLoggerName(AbstractLoggerTest.class.getSimpleName());
 
-        Member member = mock(Member.class);
+        Member member = new SimpleMemberImpl();
 
-        LOG_EVENT = new LogEvent(spy(logRecord), member);
-        LOG_EVENT_OFF = new LogEvent(spy(logRecordOff), member);
+        LOG_EVENT = new LogEvent(logRecord, member);
+        LOG_EVENT_OFF = new LogEvent(logRecordOff, member);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4jTrackingAppender.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4jTrackingAppender.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.logging;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Log4jTrackingAppender extends AppenderSkeleton {
+
+    private int hits;
+    private final String trackedLoggerName;
+
+    Log4jTrackingAppender(String trackedLoggerName) {
+        this.trackedLoggerName = trackedLoggerName;
+        this.name = trackedLoggerName + "TestAppender";
+    }
+
+    static Log4jTrackingAppender registerTrackingAppender(String loggerName) {
+        Log4jTrackingAppender testAppender = new Log4jTrackingAppender(loggerName);
+        org.apache.log4j.Logger.getLogger(loggerName).addAppender(testAppender);
+        return testAppender;
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+    @Override
+    protected void append(LoggingEvent event) {
+        if (trackedLoggerName.equals(event.getLoggerName())) {
+            hits++;
+        }
+    }
+
+    void assertNumberOfLoggedEvents(int expected) {
+        assertThat(hits).as("Expected %d log events but got %d", expected, hits).isEqualTo(expected);
+    }
+
+    void assertNoLoggedEvents() {
+        assertNumberOfLoggedEvents(0);
+    }
+}


### PR DESCRIPTION
Made logging tests passing on JDK 17 without opening modules only for tests. 

- Fixes https://github.com/hazelcast/hazelcast/issues/19877 
- Fixes https://hazelcast.atlassian.net/browse/HZ-665

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
