### PR TITLE
Make unused logger method deprecated

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -197,7 +197,9 @@ public interface ILogger {
      * Logs a LogEvent.
      *
      * @param logEvent the logEvent to log
+     * @deprecated Since 5.1, the method is unused
      */
+    @Deprecated
     void log(LogEvent logEvent);
 
     /**


### PR DESCRIPTION
Marked unused `com.hazelcast.logging.ILogger#log(com.hazelcast.logging.LogEvent)` as deprecated

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
