### PR TITLE
[4.1.z BACKPORT] MC-1019 REST API phonehome metrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
@@ -17,12 +17,8 @@
 package com.hazelcast.internal.ascii;
 
 import com.hazelcast.internal.nio.ascii.TextDecoder;
-import com.hazelcast.internal.server.ServerConnection;
 
 public interface CommandParser  {
-    TextCommand parser(TextDecoder decoder, String cmd, int space);
 
-    default TextCommand parser(TextDecoder decoder, String cmd, int space, ServerConnection connection) {
-        return parser(decoder, cmd, space);
-    }
+    TextCommand parser(TextDecoder decoder, String cmd, int space);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
@@ -39,4 +39,11 @@ public interface TextCommand extends OutboundFrame {
     boolean readFrom(ByteBuffer src);
 
     boolean writeTo(ByteBuffer dst);
+
+    /**
+     * Called from TextCommandService right before TextCommand is put to outboundQueue
+     */
+    default void beforeSendResponse(TextCommandService textCommandService) {
+
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandService.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.ascii;
 
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.ascii.memcache.Stats;
+import com.hazelcast.internal.ascii.rest.RestCallCollector;
 
 import java.util.Map;
 import java.util.Set;
@@ -74,6 +75,8 @@ public interface TextCommandService {
     long incrementDecrMissCount();
 
     long incrementTouchCount();
+
+    RestCallCollector getRestCallCollector();
 
     /**
      * Returns the size of the distributed queue instance with the specified name

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -35,6 +35,7 @@ import com.hazelcast.internal.ascii.rest.HttpDeleteCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpGetCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpHeadCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpPostCommandProcessor;
+import com.hazelcast.internal.ascii.rest.RestCallCollector;
 import com.hazelcast.internal.ascii.rest.RestValue;
 import com.hazelcast.internal.nio.Protocols;
 import com.hazelcast.internal.nio.ascii.TextEncoder;
@@ -102,6 +103,7 @@ public class TextCommandServiceImpl implements TextCommandService {
     private final AtomicLong decrementHits = new AtomicLong();
     private final AtomicLong decrementMisses = new AtomicLong();
     private final long startTime = Clock.currentTimeMillis();
+    private final RestCallCollector restCallCollector = new RestCallCollector();
 
     private final Node node;
     private final HazelcastInstance hazelcast;
@@ -233,6 +235,11 @@ public class TextCommandServiceImpl implements TextCommandService {
     }
 
     @Override
+    public RestCallCollector getRestCallCollector() {
+        return restCallCollector;
+    }
+
+    @Override
     public void processRequest(TextCommand command) {
         startResponseThreadIfNotRunning();
         node.nodeEngine.getExecutionService().execute("hz:text", new CommandExecutor(command));
@@ -359,6 +366,7 @@ public class TextCommandServiceImpl implements TextCommandService {
 
     @Override
     public void sendResponse(TextCommand textCommand) {
+        textCommand.beforeSendResponse(this);
         if (!textCommand.shouldReply() || textCommand.getRequestId() == -1) {
             throw new RuntimeException("Shouldn't reply " + textCommand);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -18,14 +18,21 @@ package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.AbstractTextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
+import com.hazelcast.internal.ascii.TextCommandService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_200;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_204;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_400;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_403;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_404;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_500;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_503;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
@@ -35,14 +42,6 @@ public abstract class HttpCommand extends AbstractTextCommand {
     public static final byte[] CONTENT_TYPE_PLAIN_TEXT = stringToBytes("text/plain");
     public static final byte[] CONTENT_TYPE_JSON = stringToBytes("application/json");
     public static final byte[] CONTENT_TYPE_BINARY = stringToBytes("application/binary");
-    public static final byte[] RES_200 = stringToBytes("HTTP/1.1 200 OK\r\n");
-    public static final byte[] RES_400 = stringToBytes("HTTP/1.1 400 Bad Request\r\n");
-    public static final byte[] RES_403 = stringToBytes("HTTP/1.1 403 Forbidden\r\n");
-    public static final byte[] RES_404 = stringToBytes("HTTP/1.1 404 Not Found\r\n");
-    public static final byte[] RES_100 = stringToBytes("HTTP/1.1 100 Continue\r\n\r\n");
-    public static final byte[] RES_204 = stringToBytes("HTTP/1.1 204 No Content\r\n");
-    public static final byte[] RES_503 = stringToBytes("HTTP/1.1 503 Service Unavailable\r\n");
-    public static final byte[] RES_500 = stringToBytes("HTTP/1.1 500 Internal Server Error\r\n");
 
     static final String HEADER_CONTENT_TYPE = "content-type: ";
     static final String HEADER_CONTENT_LENGTH = "content-length: ";
@@ -56,14 +55,14 @@ public abstract class HttpCommand extends AbstractTextCommand {
     protected final String uri;
     protected ByteBuffer response;
     protected boolean nextLine;
-
+    private final RestCallExecution executionDetails = new RestCallExecution();
 
     public HttpCommand(TextCommandConstants.TextCommandType type, String uri) {
         super(type);
         this.uri = uri;
         // the command line was parsed already, let's start with clear next line
         this.nextLine = true;
-
+        executionDetails.setRequestPath(uri);
     }
 
     @Override
@@ -79,60 +78,61 @@ public abstract class HttpCommand extends AbstractTextCommand {
      * Prepares a {@link HttpURLConnection#HTTP_NO_CONTENT} response.
      */
     public void send204() {
-        setResponse(RES_204, null, null);
+        setResponse(SC_204, null, null);
     }
 
     /**
      * Prepares a {@link HttpURLConnection#HTTP_BAD_REQUEST} response.
      */
     public void send400() {
-        setResponse(RES_400, null, null);
+        setResponse(SC_400, null, null);
     }
 
     /**
      * Prepares a {@link HttpURLConnection#HTTP_FORBIDDEN} response.
      */
     public void send403() {
-        setResponse(RES_403, null, null);
+        setResponse(SC_403, null, null);
     }
 
     /**
      * Prepares a {@link HttpURLConnection#HTTP_NOT_FOUND} response.
      */
     public void send404() {
-        setResponse(RES_404, null, null);
+        setResponse(SC_404, null, null);
     }
 
     /**
      * Prepares a {@link HttpURLConnection#HTTP_INTERNAL_ERROR} response.
      */
     public void send500() {
-        setResponse(RES_500, null, null);
+        setResponse(SC_500, null, null);
     }
 
     /**
      * Prepares a {@link HttpURLConnection#HTTP_UNAVAILABLE} response.
      */
     public void send503() {
-        setResponse(RES_503, null, null);
+        setResponse(SC_503, null, null);
     }
 
     /**
      * Prepares an empty {@link HttpURLConnection#HTTP_OK} response.
      */
     public void send200() {
-        setResponse(RES_200, null, null);
+        setResponse(SC_200, null, null);
     }
 
     /**
      * Prepares a HTTP response with no content and the provided status line and
      * response headers.
      *
-     * @param statusLine the HTTP response status line
+     * @param statusCode the HTTP response status code
      * @param headers    the map of response headers
      */
-    public void setResponse(@Nonnull byte[] statusLine,
+    public void setResponse(HttpStatusCode statusCode,
                             @Nullable Map<String, Object> headers) {
+        byte[] statusLine = statusCode.statusLine;
         int size = statusLine.length;
         byte[] len = stringToBytes(String.valueOf(0));
         size += CONTENT_LENGTH.length;
@@ -160,19 +160,80 @@ public abstract class HttpCommand extends AbstractTextCommand {
         }
         response.put(TextCommandConstants.RETURN);
         response.flip();
+        setStatusCode(statusCode.code);
     }
 
     /**
      * Prepares a response with the provided status line, binary-encoded
      * content type and response.
+     * The format of response:
+     *       Status-Line (that includes CRLF itself);
+     *       for each header in header do:
+     *          header + CLRF
+     *       done;
+     *       CRLF;
+     *       response-body;
      *
-     * @param statusLine  the binary-encoded HTTP response status line
+     * @param statusCode the HTTP response status code
+     * @param headers    the map of response headers (In addition to these, we also
+     *                   add the content-length header)
+     * @param value       binary-encoded response content value
+     */
+    public void setResponseWithHeaders(HttpStatusCode statusCode,
+                                       @Nullable Map<String, Object> headers,
+                                       @Nullable byte[] value) {
+        byte[] statusLine = statusCode.statusLine;
+        int valueSize = (value == null) ? 0 : value.length;
+        byte[] len = stringToBytes(String.valueOf(valueSize));
+        int size = statusLine.length;
+
+        size += CONTENT_LENGTH.length;
+        size += len.length;
+        size += TextCommandConstants.RETURN.length;
+        if (headers != null) {
+            for (Map.Entry<String, Object> entry : headers.entrySet()) {
+                size += stringToBytes(entry.getKey() + ": ").length;
+                size += stringToBytes(entry.getValue().toString()).length;
+                size += TextCommandConstants.RETURN.length;
+            }
+        }
+        size += TextCommandConstants.RETURN.length;
+        size += valueSize;
+
+        this.response = ByteBuffer.allocate(size);
+        response.put(statusLine);
+        response.put(CONTENT_LENGTH);
+        response.put(len);
+        response.put(TextCommandConstants.RETURN);
+        if (headers != null) {
+            for (Map.Entry<String, Object> entry : headers.entrySet()) {
+                response.put(stringToBytes(entry.getKey() + ": "));
+                response.put(stringToBytes(entry.getValue().toString()));
+                response.put(TextCommandConstants.RETURN);
+            }
+        }
+        response.put(TextCommandConstants.RETURN);
+
+        if (value != null) {
+            response.put(value);
+        }
+        response.flip();
+        setStatusCode(statusCode.code);
+    }
+
+
+    /**
+     * Prepares a response with the provided status line, binary-encoded
+     * content type and response.
+     *
+     * @param statusCode  the HTTP response status code
      * @param contentType binary-encoded response content type
      * @param value       binary-encoded response content value
      */
-    public void setResponse(@Nonnull byte[] statusLine,
+    public void setResponse(HttpStatusCode statusCode,
                             @Nullable byte[] contentType,
                             @Nullable byte[] value) {
+        byte[] statusLine = statusCode.statusLine;
         int valueSize = (value == null) ? 0 : value.length;
         byte[] len = stringToBytes(String.valueOf(valueSize));
         int size = statusLine.length;
@@ -201,6 +262,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
             response.put(value);
         }
         response.flip();
+        setStatusCode(statusCode.code);
     }
 
     @Override
@@ -234,5 +296,23 @@ public abstract class HttpCommand extends AbstractTextCommand {
                 + '\''
                 + '}'
                 + super.toString();
+    }
+
+    public RestCallExecution getExecutionDetails() {
+        return executionDetails;
+    }
+
+    void setStatusCode(int statusCode) {
+        int existingStatusCode = executionDetails.getStatusCode();
+        if (existingStatusCode > 0) {
+            throw new IllegalStateException("can not set statusCode to " + statusCode + ", it is already " + existingStatusCode);
+        }
+        executionDetails.setStatusCode(statusCode);
+    }
+
+    @Override
+    public void beforeSendResponse(TextCommandService textCommandService) {
+        RestCallCollector collector = textCommandService.getRestCallCollector();
+        collector.collectExecution(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import com.hazelcast.internal.ascii.CommandParser;
+import com.hazelcast.internal.ascii.TextCommand;
+import com.hazelcast.internal.ascii.memcache.ErrorCommand;
+import com.hazelcast.internal.nio.ascii.TextDecoder;
+
+import java.util.StringTokenizer;
+
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
+
+abstract class HttpCommandParser<HC extends HttpCommand> implements CommandParser {
+
+    @Override
+    public final TextCommand parser(TextDecoder decoder, String cmd, int space) {
+        StringTokenizer st = new StringTokenizer(cmd);
+        st.nextToken();
+        String uri;
+        if (st.hasMoreTokens()) {
+            uri = st.nextToken();
+        } else {
+            return new ErrorCommand(ERROR_CLIENT);
+        }
+        return createHttpCommand(decoder, uri);
+    }
+
+    abstract HC createHttpCommand(TextDecoder decoder, String uri);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -39,13 +39,13 @@ import java.net.URLDecoder;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_BINARY;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_PLAIN_TEXT;
-import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_200;
 import static com.hazelcast.internal.ascii.rest.HttpCommandProcessor.ResponseType.FAIL;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_200;
 import static com.hazelcast.internal.util.StringUtil.bytesToString;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 
-public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcessor<T> {
+public abstract class HttpCommandProcessor<T extends HttpCommand> extends AbstractTextCommandProcessor<T> {
     public static final String URI_MAPS = "/hazelcast/rest/maps/";
     public static final String URI_QUEUES = "/hazelcast/rest/queues/";
     public static final String URI_WAN_BASE_URL = "/hazelcast/rest/wan";
@@ -95,10 +95,12 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_LOCAL_CP_MEMBER_URL = URI_CP_MEMBERS_URL + "/local";
 
     protected final ILogger logger;
+    protected final RestCallCollector restCallCollector;
 
     protected HttpCommandProcessor(TextCommandService textCommandService, ILogger logger) {
         super(textCommandService);
         this.logger = logger;
+        this.restCallCollector = textCommandService.getRestCallCollector();
     }
 
     /**
@@ -114,31 +116,31 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
         if (value == null) {
             command.send204();
         } else {
-            prepareResponse(RES_200, command, value);
+            prepareResponse(SC_200, command, value);
         }
     }
 
     /**
      * Prepares a response with the provided status line and response value.
      *
-     * @param statusLine the binary-encoded HTTP response status line
+     * @param statusCode the HTTP response status code
      * @param command    the HTTP request
      * @param value      the response value to send
      */
-    protected void prepareResponse(@Nonnull byte[] statusLine,
+    protected void prepareResponse(HttpStatusCode statusCode,
                                    @Nonnull HttpCommand command,
                                    @Nonnull Object value) {
         if (value instanceof byte[]) {
-            command.setResponse(statusLine, CONTENT_TYPE_BINARY, (byte[]) value);
+            command.setResponse(statusCode, CONTENT_TYPE_BINARY, (byte[]) value);
         } else if (value instanceof RestValue) {
             RestValue restValue = (RestValue) value;
-            command.setResponse(statusLine, restValue.getContentType(), restValue.getValue());
+            command.setResponse(statusCode, restValue.getContentType(), restValue.getValue());
         } else if (value instanceof HazelcastJsonValue || value instanceof JsonValue) {
-            command.setResponse(statusLine, CONTENT_TYPE_JSON, stringToBytes(value.toString()));
+            command.setResponse(statusCode, CONTENT_TYPE_JSON, stringToBytes(value.toString()));
         } else if (value instanceof String) {
-            command.setResponse(statusLine, CONTENT_TYPE_PLAIN_TEXT, stringToBytes((String) value));
+            command.setResponse(statusCode, CONTENT_TYPE_PLAIN_TEXT, stringToBytes((String) value));
         } else {
-            command.setResponse(statusLine, CONTENT_TYPE_BINARY, textCommandService.toByteArray(value));
+            command.setResponse(statusCode, CONTENT_TYPE_BINARY, textCommandService.toByteArray(value));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
@@ -16,27 +16,12 @@
 
 package com.hazelcast.internal.ascii.rest;
 
-import com.hazelcast.internal.ascii.CommandParser;
-import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.internal.ascii.memcache.ErrorCommand;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
 
-import java.util.StringTokenizer;
-
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
-
-public class HttpDeleteCommandParser implements CommandParser {
+public class HttpDeleteCommandParser extends HttpCommandParser<HttpDeleteCommand> {
 
     @Override
-    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
-        StringTokenizer st = new StringTokenizer(cmd);
-        st.nextToken();
-        String uri;
-        if (st.hasMoreTokens()) {
-            uri = st.nextToken();
-        } else {
-            return new ErrorCommand(ERROR_CLIENT);
-        }
+    HttpDeleteCommand createHttpCommand(TextDecoder decoder, String uri) {
         return new HttpDeleteCommand(uri);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
@@ -19,6 +19,8 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.util.StringUtil;
 
+import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.MAP;
+
 public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteCommand> {
 
     public HttpDeleteCommandProcessor(TextCommandService textCommandService) {
@@ -46,13 +48,16 @@ public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteC
     }
 
     private void handleMap(HttpDeleteCommand command, String uri) {
+        command.getExecutionDetails().setObjectType(MAP);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         if (indexEnd == -1) {
             String mapName = uri.substring(URI_MAPS.length());
             textCommandService.deleteAll(mapName);
+            command.getExecutionDetails().setObjectName(mapName);
             command.send200();
         } else {
             String mapName = uri.substring(URI_MAPS.length(), indexEnd);
+            command.getExecutionDetails().setObjectName(mapName);
             String key = uri.substring(indexEnd + 1);
             key = StringUtil.stripTrailingSlash(key);
             textCommandService.delete(mapName, key);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
@@ -16,27 +16,13 @@
 
 package com.hazelcast.internal.ascii.rest;
 
-import com.hazelcast.internal.ascii.CommandParser;
-import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.internal.ascii.memcache.ErrorCommand;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
 
-import java.util.StringTokenizer;
-
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
-
-public class HttpGetCommandParser implements CommandParser {
+public class HttpGetCommandParser
+        extends HttpCommandParser<HttpGetCommand> {
 
     @Override
-    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
-        StringTokenizer st = new StringTokenizer(cmd);
-        st.nextToken();
-        String uri;
-        if (st.hasMoreTokens()) {
-            uri = st.nextToken();
-        } else {
-            return new ErrorCommand(ERROR_CLIENT);
-        }
+    HttpGetCommand createHttpCommand(TextDecoder decoder, String uri) {
         return new HttpGetCommand(uri);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -42,6 +42,9 @@ import java.util.Collection;
 import java.util.concurrent.CompletionStage;
 
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_500;
+import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.MAP;
+import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.QUEUE;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 
 @SuppressWarnings({"checkstyle:methodcount"})
@@ -97,7 +100,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
             command.send400();
         } catch (Throwable e) {
             logger.warning("An error occurred while handling request " + command, e);
-            prepareResponse(HttpCommand.RES_500, command, exceptionResponse(e));
+            prepareResponse(SC_500, command, exceptionResponse(e));
         }
 
         if (sendResponse) {
@@ -362,8 +365,10 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
     }
 
     private void handleQueue(HttpGetCommand command, String uri) {
+        command.getExecutionDetails().setObjectType(QUEUE);
         int indexEnd = uri.indexOf('/', URI_QUEUES.length());
         String queueName = uri.substring(URI_QUEUES.length(), indexEnd);
+        command.getExecutionDetails().setObjectName(queueName);
         String secondStr = (uri.length() > (indexEnd + 1)) ? uri.substring(indexEnd + 1) : null;
 
         if (QUEUE_SIZE_COMMAND.equalsIgnoreCase(secondStr)) {
@@ -377,9 +382,11 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
     }
 
     private void handleMap(HttpGetCommand command, String uri) {
+        command.getExecutionDetails().setObjectType(MAP);
         uri = StringUtil.stripTrailingSlash(uri);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         String mapName = uri.substring(URI_MAPS.length(), indexEnd);
+        command.getExecutionDetails().setObjectName(mapName);
         String key = uri.substring(indexEnd + 1);
         Object value = textCommandService.get(mapName, key);
         prepareResponse(command, value);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
@@ -16,27 +16,12 @@
 
 package com.hazelcast.internal.ascii.rest;
 
-import com.hazelcast.internal.ascii.CommandParser;
-import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.internal.ascii.memcache.ErrorCommand;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
 
-import java.util.StringTokenizer;
-
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
-
-public class HttpHeadCommandParser implements CommandParser {
+public class HttpHeadCommandParser extends HttpCommandParser<HttpHeadCommand> {
 
     @Override
-    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
-        StringTokenizer st = new StringTokenizer(cmd);
-        st.nextToken();
-        String uri;
-        if (st.hasMoreTokens()) {
-            uri = st.nextToken();
-        } else {
-            return new ErrorCommand(ERROR_CLIENT);
-        }
+    HttpHeadCommand createHttpCommand(TextDecoder decoder, String uri) {
         return new HttpHeadCommand(uri);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
@@ -26,7 +26,7 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_200;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_200;
 
 public class HttpHeadCommandProcessor extends HttpCommandProcessor<HttpHeadCommand> {
 
@@ -72,7 +72,7 @@ public class HttpHeadCommandProcessor extends HttpCommandProcessor<HttpHeadComma
         headervals.put("MigrationQueueSize", migrationQueueSize);
         headervals.put("ClusterSize", clusterSize);
 
-        command.setResponse(RES_200, headervals);
+        command.setResponse(SC_200, headervals);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -26,6 +26,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_100;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class HttpPostCommand extends HttpCommand {
@@ -46,12 +47,10 @@ public class HttpPostCommand extends HttpCommand {
     private ByteBuffer data;
     private String contentType;
     private ByteBuffer lineBuffer = ByteBuffer.allocate(INITIAL_CAPACITY);
-    private ServerConnection connection;
 
-    public HttpPostCommand(TextDecoder decoder, String uri, ServerConnection connection) {
+    public HttpPostCommand(TextDecoder decoder, String uri) {
         super(HTTP_POST, uri);
         this.decoder = decoder;
-        this.connection = connection;
     }
 
     /**
@@ -237,11 +236,11 @@ public class HttpPostCommand extends HttpCommand {
         } else if (!chunked && currentLine.startsWith(HEADER_CHUNKED)) {
             chunked = true;
         } else if (currentLine.startsWith(HEADER_EXPECT_100)) {
-            decoder.sendResponse(new NoOpCommand(RES_100));
+            decoder.sendResponse(new NoOpCommand(SC_100.statusLine));
         }
     }
 
     protected ServerConnection getConnection() {
-        return connection;
+        return decoder.getConnection();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
@@ -16,33 +16,12 @@
 
 package com.hazelcast.internal.ascii.rest;
 
-import com.hazelcast.internal.ascii.CommandParser;
-import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.internal.ascii.memcache.ErrorCommand;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
-import com.hazelcast.internal.server.ServerConnection;
 
-import java.util.StringTokenizer;
-
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
-
-public class HttpPostCommandParser implements CommandParser {
+public class HttpPostCommandParser extends HttpCommandParser<HttpPostCommand> {
 
     @Override
-    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
-        throw new IllegalStateException();
-    }
-
-    @Override
-    public TextCommand parser(TextDecoder decoder, String cmd, int space, ServerConnection connection) {
-        StringTokenizer st = new StringTokenizer(cmd);
-        st.nextToken();
-        String uri;
-        if (st.hasMoreTokens()) {
-            uri = st.nextToken();
-        } else {
-            return new ErrorCommand(ERROR_CLIENT);
-        }
-        return new HttpPostCommand(decoder, uri, connection);
+    HttpPostCommand createHttpCommand(TextDecoder decoder, String uri) {
+        return new HttpPostCommand(decoder, uri);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -35,10 +35,15 @@ import java.io.UnsupportedEncodingException;
 import java.util.UUID;
 
 import static com.hazelcast.cp.CPGroup.METADATA_CP_GROUP_NAME;
-import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_400;
-import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_403;
+import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
 import static com.hazelcast.internal.ascii.rest.HttpCommandProcessor.ResponseType.FAIL;
 import static com.hazelcast.internal.ascii.rest.HttpCommandProcessor.ResponseType.SUCCESS;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_200;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_400;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_403;
+import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_500;
+import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.MAP;
+import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.QUEUE;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
@@ -115,14 +120,14 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 command.send404();
             }
         } catch (HttpBadRequestException e) {
-            prepareResponse(RES_400, command, response(FAIL, "message", e.getMessage()));
+            prepareResponse(SC_400, command, response(FAIL, "message", e.getMessage()));
             sendResponse = true;
         } catch (HttpForbiddenException e) {
-            prepareResponse(RES_403, command, response(FAIL, "message", "unauthenticated"));
+            prepareResponse(SC_403, command, response(FAIL, "message", "unauthenticated"));
             sendResponse = true;
         } catch (Throwable e) {
             logger.warning("An error occurred while handling request " + command, e);
-            prepareResponse(HttpCommand.RES_500, command, exceptionResponse(e));
+            prepareResponse(SC_500, command, exceptionResponse(e));
         }
 
         if (sendResponse) {
@@ -212,6 +217,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String simpleValue = null;
         String suffix;
         int baseUriLength = URI_QUEUES.length();
+        command.getExecutionDetails().setObjectType(QUEUE);
         if (uri.endsWith("/")) {
             int requestedUriLength = uri.length();
             if (baseUriLength == requestedUriLength) {
@@ -230,6 +236,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             queueName = suffix.substring(0, indexSlash);
             simpleValue = suffix.substring(indexSlash + 1);
         }
+        command.getExecutionDetails().setObjectName(queueName);
         byte[] data;
         byte[] contentType;
         if (simpleValue == null) {
@@ -248,12 +255,14 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     }
 
     private void handleMap(HttpPostCommand command, String uri) {
+        command.getExecutionDetails().setObjectType(MAP);
         uri = StringUtil.stripTrailingSlash(uri);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         if (indexEnd == -1) {
             throw new HttpBadRequestException("Missing map name");
         }
         String mapName = uri.substring(URI_MAPS.length(), indexEnd);
+        command.getExecutionDetails().setObjectName(mapName);
         String key = uri.substring(indexEnd + 1);
         byte[] data = command.getData();
         textCommandService.put(mapName, key, new RestValue(data, command.getContentType()), -1);
@@ -274,7 +283,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String publisherId = params[3];
         String mapName = params[4];
         UUID uuid = getNode().getNodeEngine().getWanReplicationService()
-                             .syncMap(wanRepName, publisherId, mapName);
+                .syncMap(wanRepName, publisherId, mapName);
         prepareResponse(cmd, response(SUCCESS, "message", "Sync initiated", "uuid", uuid.toString()));
     }
 
@@ -292,7 +301,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         final String wanRepName = params[2];
         final String publisherId = params[3];
         UUID uuid = getNode().getNodeEngine().getWanReplicationService()
-                             .syncAllMaps(wanRepName, publisherId);
+                .syncAllMaps(wanRepName, publisherId);
         prepareResponse(cmd, response(SUCCESS, "message", "Sync initiated", "uuid", uuid.toString()));
     }
 
@@ -345,8 +354,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         dto.fromJson(Json.parse(wanConfigJson).asObject());
 
         AddWanConfigResult result = getNode().getNodeEngine()
-                                             .getWanReplicationService()
-                                             .addWanReplicationConfig(dto.getConfig());
+                .getWanReplicationService()
+                .addWanReplicationConfig(dto.getConfig());
         JsonObject res = response(SUCCESS, "message", "WAN configuration added.");
         res.add("addedPublisherIds", Json.array(result.getAddedPublisherIds().toArray(new String[]{})));
         res.add("ignoredPublisherIds", Json.array(result.getIgnoredPublisherIds().toArray(new String[]{})));
@@ -428,16 +437,16 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         }
 
         getCpSubsystemManagementService().promoteToCPMember()
-                                         .whenCompleteAsync((response, t) -> {
-                                             if (t == null) {
-                                                 command.send200();
-                                                 textCommandService.sendResponse(command);
-                                             } else {
-                                                 logger.warning("Error while promoting CP member.", t);
-                                                 command.send500();
-                                                 textCommandService.sendResponse(command);
-                                             }
-                                         });
+                .whenCompleteAsync((response, t) -> {
+                    if (t == null) {
+                        command.send200();
+                        textCommandService.sendResponse(command);
+                    } else {
+                        logger.warning("Error while promoting CP member.", t);
+                        command.send500();
+                        textCommandService.sendResponse(command);
+                    }
+                });
     }
 
     private void handleRemoveCPMember(final HttpPostCommand command) {
@@ -445,22 +454,22 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String prefix = URI_CP_MEMBERS_URL + "/";
         final UUID cpMemberUid = UUID.fromString(uri.substring(prefix.length(), uri.indexOf('/', prefix.length())).trim());
         getCpSubsystem().getCPSubsystemManagementService()
-                        .removeCPMember(cpMemberUid)
-                        .whenCompleteAsync((respone, t) -> {
-                            if (t == null) {
-                                command.send200();
-                                textCommandService.sendResponse(command);
-                            } else {
-                                logger.warning("Error while removing CP member " + cpMemberUid, t);
-                                if (peel(t) instanceof IllegalArgumentException) {
-                                    command.send400();
-                                } else {
-                                    command.send500();
-                                }
+                .removeCPMember(cpMemberUid)
+                .whenCompleteAsync((respone, t) -> {
+                    if (t == null) {
+                        command.send200();
+                        textCommandService.sendResponse(command);
+                    } else {
+                        logger.warning("Error while removing CP member " + cpMemberUid, t);
+                        if (peel(t) instanceof IllegalArgumentException) {
+                            command.send400();
+                        } else {
+                            command.send500();
+                        }
 
-                                textCommandService.sendResponse(command);
-                            }
-                        });
+                        textCommandService.sendResponse(command);
+                    }
+                });
     }
 
     private void handleCPGroup(HttpPostCommand command) throws UnsupportedEncodingException {
@@ -488,21 +497,21 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         final long sessionId = Long.parseLong(uri.substring(i + suffix.length(), uri.indexOf('/', i + suffix.length())));
 
         getCpSubsystem().getCPSessionManagementService()
-                        .forceCloseSession(groupName, sessionId)
-                        .whenCompleteAsync((response, t) -> {
-                            if (t == null) {
-                                if (response) {
-                                    command.send200();
-                                } else {
-                                    command.send400();
-                                }
-                                textCommandService.sendResponse(command);
-                            } else {
-                                logger.warning("Error while closing CP session", t);
-                                command.send500();
-                                textCommandService.sendResponse(command);
-                            }
-                        });
+                .forceCloseSession(groupName, sessionId)
+                .whenCompleteAsync((response, t) -> {
+                    if (t == null) {
+                        if (response) {
+                            command.send200();
+                        } else {
+                            command.send400();
+                        }
+                        textCommandService.sendResponse(command);
+                    } else {
+                        logger.warning("Error while closing CP session", t);
+                        command.send500();
+                        textCommandService.sendResponse(command);
+                    }
+                });
     }
 
     private void handleForceDestroyCPGroup(final HttpPostCommand command) {
@@ -516,38 +525,38 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         }
 
         getCpSubsystem().getCPSubsystemManagementService()
-                        .forceDestroyCPGroup(groupName)
-                        .whenCompleteAsync((response, t) -> {
-                            if (t == null) {
-                                command.send200();
-                                textCommandService.sendResponse(command);
-                            } else {
-                                logger.warning("Error while destroying CP group " + groupName, t);
-                                if (peel(t) instanceof IllegalArgumentException) {
-                                    command.send400();
-                                } else {
-                                    command.send500();
-                                }
-                                textCommandService.sendResponse(command);
-                            }
-                        });
+                .forceDestroyCPGroup(groupName)
+                .whenCompleteAsync((response, t) -> {
+                    if (t == null) {
+                        command.send200();
+                        textCommandService.sendResponse(command);
+                    } else {
+                        logger.warning("Error while destroying CP group " + groupName, t);
+                        if (peel(t) instanceof IllegalArgumentException) {
+                            command.send400();
+                        } else {
+                            command.send500();
+                        }
+                        textCommandService.sendResponse(command);
+                    }
+                });
     }
 
     private void handleResetCPSubsystem(final HttpPostCommand command) throws UnsupportedEncodingException {
         decodeParamsAndAuthenticate(command, 2);
 
         getCpSubsystem().getCPSubsystemManagementService()
-                        .reset()
-                        .whenCompleteAsync((response, t) -> {
-                            if (t == null) {
-                                command.send200();
-                                textCommandService.sendResponse(command);
-                            } else {
-                                logger.warning("Error while resetting CP subsystem", t);
-                                command.send500();
-                                textCommandService.sendResponse(command);
-                            }
-                        });
+                .reset()
+                .whenCompleteAsync((response, t) -> {
+                    if (t == null) {
+                        command.send200();
+                        textCommandService.sendResponse(command);
+                    } else {
+                        logger.warning("Error while resetting CP subsystem", t);
+                        command.send500();
+                        textCommandService.sendResponse(command);
+                    }
+                });
     }
 
     private CPSubsystemManagementService getCpSubsystemManagementService() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpStatusCode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpStatusCode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import static com.hazelcast.internal.util.StringUtil.stringToBytes;
+
+public enum HttpStatusCode {
+
+    SC_100(100, stringToBytes("HTTP/1.1 100 Continue\r\n")),
+    SC_200(200, stringToBytes("HTTP/1.1 200 OK\r\n")),
+    SC_204(204, stringToBytes("HTTP/1.1 204 No Content\r\n")),
+    SC_400(400, stringToBytes("HTTP/1.1 400 Bad Request\r\n")),
+    SC_403(403, stringToBytes("HTTP/1.1 403 Forbidden\r\n")),
+    SC_404(404, stringToBytes("HTTP/1.1 404 Not Found\r\n")),
+    SC_500(500, stringToBytes("HTTP/1.1 500 Internal Server Error\r\n")),
+    SC_503(503, stringToBytes("HTTP/1.1 503 Service Unavailable\r\n"))
+    ;
+
+    final int code;
+    final byte[] statusLine;
+
+    HttpStatusCode(int code, byte[] statusLine) {
+        this.code = code;
+        this.statusLine = statusLine;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import com.hazelcast.internal.ascii.TextCommandConstants;
+import com.hazelcast.internal.util.counters.MwCounter;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RestCallCollector {
+
+    public static final int SET_SIZE_LIMIT = 1000;
+
+    private static class RequestIdentifier {
+
+        private final TextCommandConstants.TextCommandType method;
+        private final String path;
+
+        RequestIdentifier(TextCommandConstants.TextCommandType method, String path) {
+            this.method = method;
+            this.path = path;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RequestIdentifier that = (RequestIdentifier) o;
+            return method.equals(that.method) && path.equals(that.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(method, path);
+        }
+
+        public String getPath() {
+            return path;
+        }
+    }
+
+    private final MwCounter mapPostSuccCount = MwCounter.newMwCounter();
+    private final MwCounter mapPostFailCount = MwCounter.newMwCounter();
+    private final MwCounter mapGetSuccCount = MwCounter.newMwCounter();
+    private final MwCounter mapGetFailCount = MwCounter.newMwCounter();
+    private final MwCounter mapDeleteSuccCount = MwCounter.newMwCounter();
+    private final MwCounter mapDeleteFailCount = MwCounter.newMwCounter();
+    private final MwCounter mapTotalRequestCount = MwCounter.newMwCounter();
+    private final MwCounter queuePostSuccCount = MwCounter.newMwCounter();
+    private final MwCounter queuePostFailCount = MwCounter.newMwCounter();
+    private final MwCounter queueGetSuccCount = MwCounter.newMwCounter();
+    private final MwCounter queueGetFailCount = MwCounter.newMwCounter();
+    private final MwCounter queueDeleteSuccCount = MwCounter.newMwCounter();
+    private final MwCounter queueDeleteFailCount = MwCounter.newMwCounter();
+    private final MwCounter queueTotalRequestCount = MwCounter.newMwCounter();
+
+    private final MwCounter requestCount = MwCounter.newMwCounter();
+    private final ConcurrentHashMap.KeySetView<RequestIdentifier, Boolean> uniqueRequests = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap.KeySetView<String, Boolean> accessedMaps = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap.KeySetView<String, Boolean> accessedQueues = ConcurrentHashMap.newKeySet();
+
+    void collectExecution(HttpCommand command) {
+        RestCallExecution execution = command.getExecutionDetails();
+        TextCommandConstants.TextCommandType type = command.getType();
+        updateRequestCounters(type, execution);
+        String objectName = execution.getObjectName();
+        updateAccessedObjectSets(execution, objectName);
+        switch (type) {
+            case HTTP_POST:
+                handlePost(execution);
+                break;
+            case HTTP_GET:
+                handleGet(execution);
+                break;
+            case HTTP_DELETE:
+                handleDelete(execution);
+                break;
+            default:
+                // no-op
+        }
+    }
+
+    private void handleDelete(RestCallExecution execution) {
+        RestCallExecution.ObjectType objectType = execution.getObjectType();
+        if (objectType == null) {
+            return;
+        }
+        switch (objectType) {
+            case MAP:
+                (execution.isSuccess() ? mapDeleteSuccCount : mapDeleteFailCount).inc();
+                break;
+            case QUEUE:
+                (execution.isSuccess() ? queueDeleteSuccCount : queueDeleteFailCount).inc();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + objectType);
+        }
+    }
+
+    private void handleGet(RestCallExecution execution) {
+        RestCallExecution.ObjectType objectType = execution.getObjectType();
+        if (objectType == null) {
+            return;
+        }
+        switch (objectType) {
+            case MAP:
+                (execution.isSuccess() ? mapGetSuccCount : mapGetFailCount).inc();
+                break;
+            case QUEUE:
+                (execution.isSuccess() ? queueGetSuccCount : queueGetFailCount).inc();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + execution.getObjectType());
+        }
+    }
+
+    private void handlePost(RestCallExecution execution) {
+        RestCallExecution.ObjectType objectType = execution.getObjectType();
+        if (objectType == null) {
+            return;
+        }
+        switch (objectType) {
+            case MAP:
+                (execution.isSuccess() ? mapPostSuccCount : mapPostFailCount).inc();
+                break;
+            case QUEUE:
+                (execution.isSuccess() ? queuePostSuccCount : queuePostFailCount).inc();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + execution.getObjectType());
+        }
+    }
+
+    private void updateAccessedObjectSets(RestCallExecution execution, String objectName) {
+        if (objectName == null) {
+            return;
+        }
+        RestCallExecution.ObjectType objectType = execution.getObjectType();
+        if (objectType == null) {
+            return;
+        }
+        switch (objectType) {
+            case MAP:
+                accessedMaps.add(objectName);
+                break;
+            case QUEUE:
+                accessedQueues.add(objectName);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + objectType);
+        }
+    }
+
+    private void updateRequestCounters(TextCommandConstants.TextCommandType type, RestCallExecution execution) {
+        if (uniqueRequests.size() < SET_SIZE_LIMIT) {
+            uniqueRequests.add(new RequestIdentifier(type, execution.getRequestPath()));
+        }
+        requestCount.inc();
+        RestCallExecution.ObjectType objectType = execution.getObjectType();
+        if (objectType == null) {
+            return;
+        }
+        switch (objectType) {
+            case MAP:
+                mapTotalRequestCount.inc();
+                break;
+            case QUEUE:
+                queueTotalRequestCount.inc();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + objectType);
+        }
+    }
+
+    public String getMapPostSuccessCount() {
+        return String.valueOf(mapPostSuccCount.get());
+    }
+
+    public String getMapPostFailureCount() {
+        return String.valueOf(mapPostFailCount.get());
+    }
+
+    public String getRequestCount() {
+        return String.valueOf(requestCount.get());
+    }
+
+    public String getUniqueRequestCount() {
+        return String.valueOf(uniqueRequests.size());
+    }
+
+    public String getMapGetSuccessCount() {
+        return String.valueOf(mapGetSuccCount.get());
+    }
+
+    public String getMapGetFailureCount() {
+        return String.valueOf(mapGetFailCount.get());
+    }
+
+    public String getQueuePostSuccessCount() {
+        return String.valueOf(queuePostSuccCount.get());
+    }
+
+    public String getQueuePostFailureCount() {
+        return String.valueOf(queuePostFailCount.get());
+    }
+
+    public String getQueueDeleteSuccessCount() {
+        return String.valueOf(queueDeleteSuccCount.get());
+    }
+
+    public String getQueueDeleteFailureCount() {
+        return String.valueOf(queueDeleteFailCount.get());
+    }
+
+    public String getAccessedMapCount() {
+        return String.valueOf(accessedMaps.size());
+    }
+
+    public String getAccessedQueueCount() {
+        return String.valueOf(accessedQueues.size());
+    }
+
+    public String getMapDeleteSuccessCount() {
+        return String.valueOf(mapDeleteSuccCount.get());
+    }
+
+    public String getMapDeleteFailureCount() {
+        return String.valueOf(mapDeleteSuccCount.get());
+    }
+
+    public String getTotalMapRequestCount() {
+        return String.valueOf(mapTotalRequestCount.get());
+    }
+
+    public String getTotalQueueRequestCount() {
+        return String.valueOf(queueTotalRequestCount.get());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallExecution.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallExecution.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+class RestCallExecution {
+
+    enum ObjectType {
+        MAP, QUEUE
+    }
+
+    private String requestPath;
+    private ObjectType objectType;
+    private String objectName;
+    private int statusCode;
+
+    public String getRequestPath() {
+        return requestPath;
+    }
+
+    public void setRequestPath(String requestPath) {
+        this.requestPath = requestPath;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public void setObjectName(String objectName) {
+        this.objectName = objectName;
+    }
+
+    public ObjectType getObjectType() {
+        return objectType;
+    }
+
+    public void setObjectType(ObjectType objectType) {
+        this.objectType = objectType;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @SuppressWarnings("checkstyle:magicnumber")
+    public boolean isSuccess() {
+        return statusCode < 400;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
@@ -198,7 +198,7 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
             String operation = (space == -1) ? cmd : cmd.substring(0, space);
             CommandParser commandParser = textParsers.getParser(operation);
             if (commandParser != null) {
-                command = commandParser.parser(this, cmd, space, connection);
+                command = commandParser.parser(this, cmd, space);
             } else {
                 command = new ErrorCommand(UNKNOWN);
             }
@@ -214,5 +214,9 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
     public void closeConnection() {
         connection.close(null, null);
+    }
+
+    public ServerConnection getConnection() {
+        return connection;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -61,8 +61,9 @@ public class PhoneHome {
         hazelcastNode = node;
         logger = hazelcastNode.getLogger(PhoneHome.class);
         basePhoneHomeUrl = baseUrl;
-        metricsCollectorList = new ArrayList<>(additionalCollectors.length + 7);
+        metricsCollectorList = new ArrayList<>(additionalCollectors.length + 8);
         Collections.addAll(metricsCollectorList,
+                new RestApiMetricsCollector(),
                 new BuildInfoCollector(), new ClusterInfoCollector(), new ClientInfoCollector(),
                 new MapInfoCollector(), new OSInfoCollector(), new DistributedObjectCounterCollector(),
                 new CacheInfoCollector(), new CPSubsystemInfoCollector());

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -25,6 +25,7 @@ public enum PhoneHomeMetrics {
     CLIENT_ENDPOINT_COUNT("cssz"),
     JAVA_VERSION_OF_SYSTEM("jvmv"),
     BUILD_VERSION("version"),
+    JET_BUILD_VERSION("jetv"),
     JAVA_CLASSPATH("classpath"),
 
     //CLIENT INFO METRICS
@@ -135,9 +136,39 @@ public enum PhoneHomeMetrics {
      */
     DOCKER("dck"),
 
-    //CP SUBSYSTEM METRICS
-    CP_SUBSYSTEM_ENABLED("cp");
+    //JET METRICS
+    JET_ENABLED("jet"),
+    JET_RESOURCE_UPLOAD_ENABLED("jetrsup"),
+    JET_JOBS_SUBMITTED("jetjobss"),
 
+    // SQL METRICS
+    SQL_QUERIES_SUBMITTED("sqlqs"),
+
+    //CP SUBSYSTEM METRICS
+    CP_SUBSYSTEM_ENABLED("cp"),
+
+    // REST API metrics
+    REST_ENABLED("restenabled"),
+    REST_MAP_GET_SUCCESS("restmapgetsucc"),
+    REST_MAP_GET_FAILURE("restmapgetfail"),
+    REST_MAP_POST_SUCCESS("restmappostsucc"),
+    REST_MAP_POST_FAILURE("restmappostfail"),
+    REST_MAP_DELETE_SUCCESS("restmapdeletesucc"),
+    REST_MAP_DELETE_FAILURE("restmapdeletefail"),
+    REST_MAP_TOTAL_REQUEST_COUNT("restmaprequestct"),
+    REST_ACCESSED_MAP_COUNT("restmapct"),
+
+    REST_QUEUE_POST_SUCCESS("restqueuepostsucc"),
+    REST_QUEUE_POST_FAILURE("restqueuepostfail"),
+    REST_QUEUE_GET_SUCCESS("restqueuegetsucc"),
+    REST_QUEUE_GET_FAILURE("restqueuegetfail"),
+    REST_QUEUE_DELETE_SUCCESS("restqueuedeletesucc"),
+    REST_QUEUE_DELETE_FAILURE("restqueuedeletefail"),
+    REST_QUEUE_TOTAL_REQUEST_COUNT("restqueuerequestct"),
+    REST_ACCESSED_QUEUE_COUNT("restqueuect"),
+
+    REST_REQUEST_COUNT("restrequestct"),
+    REST_UNIQUE_REQUEST_COUNT("restuniqrequestct");
     private final String query;
 
     PhoneHomeMetrics(String query) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/RestApiMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/RestApiMetricsCollector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.phonehome;
+
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.ascii.rest.RestCallCollector;
+
+import java.util.function.BiConsumer;
+
+public class RestApiMetricsCollector implements MetricsCollector {
+
+    @Override
+    public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
+        RestCallCollector collector = node.getTextCommandService().getRestCallCollector();
+        String enabled = node.getConfig().getNetworkConfig().getRestApiConfig().isEnabledAndNotEmpty() ? "1" : "0";
+        metricsConsumer.accept(PhoneHomeMetrics.REST_ENABLED, enabled);
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_POST_SUCCESS, collector.getMapPostSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_POST_FAILURE, collector.getMapPostFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_DELETE_SUCCESS, collector.getMapDeleteSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_DELETE_FAILURE, collector.getMapDeleteFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_GET_SUCCESS, collector.getMapGetSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_GET_FAILURE, collector.getMapGetFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_MAP_TOTAL_REQUEST_COUNT, collector.getTotalMapRequestCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_ACCESSED_MAP_COUNT, collector.getAccessedMapCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_POST_SUCCESS, collector.getQueuePostSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_POST_FAILURE, collector.getQueuePostFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_GET_SUCCESS, collector.getQueuePostSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_GET_FAILURE, collector.getQueuePostFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_DELETE_SUCCESS, collector.getQueueDeleteSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_DELETE_FAILURE, collector.getQueueDeleteFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_ACCESSED_QUEUE_COUNT, collector.getAccessedQueueCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_TOTAL_REQUEST_COUNT, collector.getTotalQueueRequestCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_REQUEST_COUNT, collector.getRequestCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_UNIQUE_REQUEST_COUNT, collector.getUniqueRequestCount());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -417,10 +417,10 @@ public class HTTPCommunicator {
         return doPost(url, clusterName, clusterPassword);
     }
 
-    static class ConnectionResponse {
-        final String response;
-        final int responseCode;
-        final Map<String, List<String>> responseHeaders;
+    public static class ConnectionResponse {
+        public final String response;
+        public final int responseCode;
+        public final Map<String, List<String>> responseHeaders;
 
         ConnectionResponse(CloseableHttpResponse httpResponse) throws IOException {
             int responseCode = httpResponse.getStatusLine().getStatusCode();
@@ -440,6 +440,16 @@ public class HTTPCommunicator {
             this.response = responseStr;
             this.responseHeaders = responseHeaders;
         }
+
+        @Override
+        public String toString() {
+            StringBuilder str = new StringBuilder("HTTP ").append(responseCode).append("\r\n");
+            responseHeaders.forEach((name, values) -> {
+                values.forEach(headerValue -> str.append(name).append(": ").append(headerValue).append("\r\n"));
+            });
+            str.append("\r\n");
+            return str.append(response).toString();
+        }
     }
 
     private ConnectionResponse doHead(String url) throws IOException {
@@ -455,7 +465,7 @@ public class HTTPCommunicator {
         }
     }
 
-    private ConnectionResponse doGet(String url) throws IOException {
+    public ConnectionResponse doGet(String url) throws IOException {
         CloseableHttpClient client = newClient();
         CloseableHttpResponse response = null;
         try {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
@@ -45,6 +45,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+
 import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
 import java.io.IOException;
@@ -54,12 +59,10 @@ import java.nio.file.Paths;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.test.Accessors.getNode;
 import static org.mockito.Mockito.when;
@@ -68,12 +71,12 @@ import static org.mockito.Mockito.when;
 @Category(QuickTest.class)
 public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
 
-    private static ContainsPattern containingParam(String paramName, String expectedValue) {
+    static ContainsPattern containingParam(String paramName, String expectedValue) {
         return new ContainsPattern(paramName + "=" + expectedValue);
     }
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().jettyHeaderBufferSize(16384));
+    public WireMockRule wireMockRule = new WireMockRule();
 
     private Node node;
     private PhoneHome phoneHome;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.phonehome;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.ascii.HTTPCommunicator;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestAwareInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.hazelcast.instance.impl.TestUtil.getNode;
+import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_MAPS;
+import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_QUEUES;
+import static com.hazelcast.internal.util.phonehome.PhoneHomeIntegrationTest.containingParam;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class RESTClientPhoneHomeTest {
+
+    protected final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
+
+    @BeforeClass
+    public static void beforeClass() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private HazelcastInstance instance;
+
+    private HTTPCommunicator http;
+
+    @Before
+    public void setUp() {
+        instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
+        http = new HTTPCommunicator(instance);
+        stubFor(post(urlPathEqualTo("/ping")).willReturn(aResponse().withStatus(200)));
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    protected Config createConfig() {
+        return smallInstanceConfig();
+    }
+
+    protected Config createConfigWithRestEnabled() {
+        Config config = createConfig();
+        RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
+        config.getNetworkConfig().setRestApiConfig(restApiConfig);
+        return config;
+    }
+
+    @Test
+    public void mapOperations()
+            throws IOException {
+        assertEquals(200, http.mapPut("my-map", "key", "value"));
+        assertEquals(200, http.mapPut("my-map", "key2", "value2"));
+        assertEquals(400, http.doPost(http.getUrl(URI_MAPS), "value").responseCode);
+        assertEquals(204, http.mapGet("my-other-map", "key").responseCode);
+        assertEquals(400, http.doGet(http.getUrl(URI_MAPS)).responseCode);
+        assertEquals(400, http.doGet(http.getUrl(URI_MAPS)).responseCode);
+        assertEquals(200, http.mapDelete("my-map", "key"));
+
+        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
+        phoneHome.phoneHome(false);
+
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("restenabled", "1"))
+                .withRequestBody(containingParam("restmaprequestct", "7"))
+                .withRequestBody(containingParam("restqueuerequestct", "0"))
+                .withRequestBody(containingParam("restrequestct", "7"))
+                .withRequestBody(containingParam("restuniqrequestct", "6"))
+                .withRequestBody(containingParam("restmappostsucc", "2"))
+                .withRequestBody(containingParam("restmappostfail", "1"))
+                .withRequestBody(containingParam("restmapgetsucc", "1"))
+                .withRequestBody(containingParam("restmapgetfail", "2"))
+                .withRequestBody(containingParam("restmapdeletesucc", "1"))
+                .withRequestBody(containingParam("restmapct", "2"))
+                .withRequestBody(containingParam("restqueuepostsucc", "0"))
+                .withRequestBody(containingParam("restqueuepostfail", "0"))
+        );
+    }
+
+    @Test
+    public void queueOperations() throws IOException {
+        assertEquals(200, http.queueOffer("my-queue", "a"));
+        assertEquals(200, http.queueOffer("my-queue", "b"));
+        assertEquals(400, http.doPost(http.getUrl(URI_QUEUES)).responseCode);
+        assertEquals(200, http.queuePoll("my-queue", 10).responseCode);
+        assertEquals(200, http.queuePoll("my-queue", 10).responseCode);
+
+        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
+        phoneHome.phoneHome(false);
+
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("restmappostsucc", "0"))
+                .withRequestBody(containingParam("restmappostfail", "0"))
+                .withRequestBody(containingParam("restmaprequestct", "0"))
+                .withRequestBody(containingParam("restqueuerequestct", "5"))
+                .withRequestBody(containingParam("restrequestct", "5"))
+                .withRequestBody(containingParam("restqueuepostsucc", "2"))
+                .withRequestBody(containingParam("restqueuepostfail", "1"))
+                .withRequestBody(containingParam("restqueuedeletesucc", "0"))
+                .withRequestBody(containingParam("restqueuedeletefail", "0"))
+                .withRequestBody(containingParam("restqueuegetsucc", "2"))
+                .withRequestBody(containingParam("restqueuect", "1"))
+        );
+    }
+
+}


### PR DESCRIPTION
Fixes MC-1019

Backport of: #19893

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
