### PR TITLE
MC-1019 fixing broken "restmapdeletefail" phonehome metric 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.util.StringUtil;
 
 import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.MAP;
+import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.QUEUE;
 
 public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteCommand> {
 
@@ -69,7 +70,9 @@ public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteC
         // Poll an item from the default queue in 3 seconds
         // http://127.0.0.1:5701/hazelcast/rest/queues/default/3
         int indexEnd = uri.indexOf('/', URI_QUEUES.length());
+        command.getExecutionDetails().setObjectType(QUEUE);
         String queueName = uri.substring(URI_QUEUES.length(), indexEnd);
+        command.getExecutionDetails().setObjectName(queueName);
         String secondStr = (uri.length() > (indexEnd + 1)) ? uri.substring(indexEnd + 1) : null;
         int seconds = (secondStr == null) ? 0 : Integer.parseInt(secondStr);
         Object value = textCommandService.poll(queueName, seconds);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
@@ -244,7 +244,7 @@ public class RestCallCollector {
     }
 
     public String getMapDeleteFailureCount() {
-        return String.valueOf(mapDeleteSuccCount.get());
+        return String.valueOf(mapDeleteFailCount.get());
     }
 
     public String getTotalMapRequestCount() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
@@ -223,6 +223,14 @@ public class RestCallCollector {
         return String.valueOf(queuePostFailCount.get());
     }
 
+    public String getQueueGetSuccessCount() {
+        return String.valueOf(queueGetSuccCount.get());
+    }
+
+    public String getQueueGetFailureCount() {
+        return String.valueOf(queueGetFailCount.get());
+    }
+
     public String getQueueDeleteSuccessCount() {
         return String.valueOf(queueDeleteSuccCount.get());
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/RestApiMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/RestApiMetricsCollector.java
@@ -38,8 +38,8 @@ public class RestApiMetricsCollector implements MetricsCollector {
         metricsConsumer.accept(PhoneHomeMetrics.REST_ACCESSED_MAP_COUNT, collector.getAccessedMapCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_POST_SUCCESS, collector.getQueuePostSuccessCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_POST_FAILURE, collector.getQueuePostFailureCount());
-        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_GET_SUCCESS, collector.getQueuePostSuccessCount());
-        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_GET_FAILURE, collector.getQueuePostFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_GET_SUCCESS, collector.getQueueGetSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_GET_FAILURE, collector.getQueueGetFailureCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_DELETE_SUCCESS, collector.getQueueDeleteSuccessCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_DELETE_FAILURE, collector.getQueueDeleteFailureCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_ACCESSED_QUEUE_COUNT, collector.getAccessedQueueCount());

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -517,7 +517,7 @@ public class HTTPCommunicator {
         }
     }
 
-    private ConnectionResponse doDelete(String url) throws IOException {
+    public ConnectionResponse doDelete(String url) throws IOException {
         CloseableHttpClient client = newClient();
         CloseableHttpResponse response = null;
         try {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
@@ -107,7 +107,7 @@ public class RESTClientPhoneHomeTest {
                 .withRequestBody(containingParam("restenabled", "1"))
                 .withRequestBody(containingParam("restmaprequestct", "7"))
                 .withRequestBody(containingParam("restqueuerequestct", "0"))
-                .withRequestBody(containingParam("restrequestct", "9"))
+                .withRequestBody(containingParam("restrequestct", "7"))
                 .withRequestBody(containingParam("restuniqrequestct", "6"))
                 .withRequestBody(containingParam("restmappostsucc", "2"))
                 .withRequestBody(containingParam("restmappostfail", "1"))

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
@@ -107,7 +107,7 @@ public class RESTClientPhoneHomeTest {
                 .withRequestBody(containingParam("restenabled", "1"))
                 .withRequestBody(containingParam("restmaprequestct", "7"))
                 .withRequestBody(containingParam("restqueuerequestct", "0"))
-                .withRequestBody(containingParam("restrequestct", "7"))
+                .withRequestBody(containingParam("restrequestct", "9"))
                 .withRequestBody(containingParam("restuniqrequestct", "6"))
                 .withRequestBody(containingParam("restmappostsucc", "2"))
                 .withRequestBody(containingParam("restmappostfail", "1"))
@@ -128,6 +128,8 @@ public class RESTClientPhoneHomeTest {
         assertEquals(400, http.doPost(http.getUrl(URI_QUEUES)).responseCode);
         assertEquals(200, http.queuePoll("my-queue", 10).responseCode);
         assertEquals(200, http.queuePoll("my-queue", 10).responseCode);
+        assertEquals(204, http.doDelete(http.getUrl(URI_QUEUES) + "my-queue/10").responseCode);
+        assertEquals(400, http.doDelete(http.getUrl(URI_QUEUES) + "my-queue").responseCode);
 
         PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
         phoneHome.phoneHome(false);
@@ -136,12 +138,12 @@ public class RESTClientPhoneHomeTest {
                 .withRequestBody(containingParam("restmappostsucc", "0"))
                 .withRequestBody(containingParam("restmappostfail", "0"))
                 .withRequestBody(containingParam("restmaprequestct", "0"))
-                .withRequestBody(containingParam("restqueuerequestct", "5"))
-                .withRequestBody(containingParam("restrequestct", "5"))
+                .withRequestBody(containingParam("restqueuerequestct", "7"))
+                .withRequestBody(containingParam("restrequestct", "7"))
                 .withRequestBody(containingParam("restqueuepostsucc", "2"))
                 .withRequestBody(containingParam("restqueuepostfail", "1"))
-                .withRequestBody(containingParam("restqueuedeletesucc", "0"))
-                .withRequestBody(containingParam("restqueuedeletefail", "0"))
+                .withRequestBody(containingParam("restqueuedeletesucc", "1"))
+                .withRequestBody(containingParam("restqueuedeletefail", "1"))
                 .withRequestBody(containingParam("restqueuegetsucc", "2"))
                 .withRequestBody(containingParam("restqueuect", "1"))
         );

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
@@ -114,6 +114,7 @@ public class RESTClientPhoneHomeTest {
                 .withRequestBody(containingParam("restmapgetsucc", "1"))
                 .withRequestBody(containingParam("restmapgetfail", "2"))
                 .withRequestBody(containingParam("restmapdeletesucc", "1"))
+                .withRequestBody(containingParam("restmapdeletefail", "0"))
                 .withRequestBody(containingParam("restmapct", "2"))
                 .withRequestBody(containingParam("restqueuepostsucc", "0"))
                 .withRequestBody(containingParam("restqueuepostfail", "0"))


### PR DESCRIPTION
It was the same as `"restmapdeletesucc"`

Follow-up of MC-1019

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
