### PR TITLE
Fix possibly infinite loop in handling index splits

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -164,7 +164,7 @@ final class MapIndexScanP extends AbstractProcessor {
                     split.peek();
                 } catch (MissingPartitionException e) {
                     splits.addAll(splitOnMigration(split));
-                    splits.remove(i--);
+                    splits.remove(i);
                     continue;
                 }
                 if (split.currentRow == null) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSplitBrainTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSplitBrainTest.java
@@ -1,0 +1,88 @@
+package com.hazelcast.jet.sql;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.IndexConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.core.JetSplitBrainTestSupport;
+import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static com.hazelcast.internal.partition.IPartition.MAX_BACKUP_COUNT;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({NightlyTest.class})
+public class SqlSplitBrainTest extends JetSplitBrainTestSupport {
+
+    @Override
+    protected void onConfigCreated(Config config) {
+        config.getJetConfig().setBackupCount(MAX_BACKUP_COUNT);
+        config.getJetConfig().setScaleUpDelayMillis(3000);
+    }
+
+    @Test
+    // test for https://github.com/hazelcast/hazelcast/issues/19472
+    public void test_indexScan() throws InterruptedException {
+        Thread[] threads = new Thread[2];
+        AtomicBoolean done = new AtomicBoolean();
+        AtomicInteger numQueries = new AtomicInteger();
+
+        Consumer<HazelcastInstance[]> beforeSplit = instances -> {
+            IMap<Integer, Integer> m = instances[0].getMap("m");
+            for (int i = 0; i < 10_000; i++) {
+                m.put(i, i);
+            }
+            m.addIndex(new IndexConfig().addAttribute("this"));
+            SqlTestSupport.createMapping(instances[0], "m", Integer.class, Integer.class);
+
+            for (int i = 0, threadsLength = threads.length; i < threadsLength; i++) {
+                HazelcastInstance inst = createHazelcastClient();
+                threads[i] = new Thread(() -> {
+                    int numQueriesLocal = 0;
+                    while (!done.get()) {
+                        try {
+                            //noinspection StatementWithEmptyBody
+                            for (SqlRow ignored : inst.getSql().execute("select * from m where this>100 and this<1000")) {
+                                // do nothing
+                            }
+                        } catch (Throwable e) {
+                            logger.info(e);
+                        }
+                        numQueriesLocal++;
+                    }
+                    numQueries.addAndGet(numQueriesLocal);
+                });
+                threads[i].start();
+
+                sleepSeconds(1);
+            }
+        };
+
+        testSplitBrain(1, 1, beforeSplit, null, null);
+
+        done.set(true);
+        boolean stuck = false;
+        for (Thread t : threads) {
+            t.join(5000);
+            if (t.isAlive()) {
+                logger.info("thread " + t + " stuck");
+                stuck = true;
+            }
+        }
+
+        logger.info("num queries executed: " + numQueries.get());
+
+        if (stuck) {
+            fail("some threads were stuck");
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSplitBrainTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSplitBrainTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.sql;
 
 import com.hazelcast.config.Config;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -96,7 +96,7 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
     protected void onConfigCreated(Config config) {
     }
 
-    final void testSplitBrain(int firstSubClusterSize, int secondSubClusterSize,
+    protected final void testSplitBrain(int firstSubClusterSize, int secondSubClusterSize,
                               Consumer<HazelcastInstance[]> beforeSplit,
                               BiConsumer<HazelcastInstance[], HazelcastInstance[]> onSplit,
                               Consumer<HazelcastInstance[]> afterMerge) {


### PR DESCRIPTION
SQL provides migration tolerance for index scans. When migration
happens, the same processor instance will handle the partition after
it's moved, making a remote operations to the new owner. Internally
it's implemented by using splits. Initially the processor starts with
one split, and if migrated partition is detected, it splits the initial
"split" into multiple ones, based on the number of new owners we now
need to talk to read data for the assigned partitions.

In the split-brain situation it happened that the Index-read operation
threw MissingPartitionException, however the PartitionService still
reported the old owner. Therefore the `splitOnMigration()` method didn't
actually split the partitions, but the same single split was used. And the
algorithm tried the new split again. And this went on infinitely.

The fix is that we don't try the split again, but continue with the next
split. This breaks the loop and the job can be cancelled. The old
implementation broke the requirement that the processor must return
control from time to time.

The problem reproduced only on 5.0, not on 5.1. I didn't investigate
why, but probably the partition owner is changed earlier and the
infinite loop terminated. We'll forward-port the fix to 5.1 anyway to
make the code more robust.

Fixes #19472