### PR TITLE
Fix the final position of a fixed size compact object

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -121,15 +121,15 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                     offsetReader = INT_OFFSET_READER;
                     finalPosition = variableOffsetsPosition + (numberOfVariableLengthFields * INT_SIZE_IN_BYTES);
                 }
-                //set the position to final so that the next one to read something from `in` can start from
-                //correct position
-                in.position(finalPosition);
             } else {
                 offsetReader = INT_OFFSET_READER;
                 variableOffsetsPosition = 0;
                 dataStartPosition = in.position();
                 finalPosition = dataStartPosition + schema.getFixedSizeFieldsLength();
             }
+            //set the position to final so that the next one to read something from `in` can start from
+            //correct position
+            in.position(finalPosition);
         } catch (IOException e) {
             throw illegalStateException(e);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -76,12 +76,14 @@ public class CompactStreamSerializerTest {
 
         ArrayList<Object> expected = new ArrayList<>();
         expected.add(node);
+        expected.add(employeeDTO);
         expected.add(employerDTO);
 
         Data data = serializationService.toData(expected);
         ArrayList<Object> arrayList = serializationService.toObject(data);
         assertEquals(node, arrayList.get(0));
-        assertEquals(employerDTO, arrayList.get(1));
+        assertEquals(employeeDTO, arrayList.get(1));
+        assertEquals(employerDTO, arrayList.get(2));
     }
 
     private InternalSerializationService createSerializationService() {


### PR DESCRIPTION
While reading a compact object from a stream of buffers
the end position was not set correctly if the compact is
consisting of only fixed size objects.
In this pr, we make sure that the position is moved to and of the
compact object so that next item can be read correctly.

related to https://github.com/hazelcast/hazelcast/issues/19952

backport of https://github.com/hazelcast/hazelcast/pull/19973