### PR TITLE
Remove Closable from BufferObjectDataInput

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlClientCompactQueryTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlClientCompactQueryTest.java
@@ -138,7 +138,7 @@ public class SqlClientCompactQueryTest extends HazelcastTestSupport {
                 + ", isFired BOOLEAN"
                 + ") TYPE " + IMapSqlConnector.TYPE_NAME + ' '
                 + "OPTIONS ("
-                + '\'' + OPTION_KEY_FORMAT + "'='" + "int" + '\''
+                + '\'' + OPTION_KEY_FORMAT + "'='int'"
                 + ", '" + OPTION_VALUE_FORMAT + "'='" + COMPACT_FORMAT + '\''
                 + ", '" + OPTION_VALUE_COMPACT_TYPE_NAME + "'='" + EmployeeDTO.class.getName() + '\''
                 + ")");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlClientCompactQueryTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlClientCompactQueryTest.java
@@ -86,6 +86,7 @@ public class SqlClientCompactQueryTest extends HazelcastTestSupport {
             config.setClassLoader(classLoader);
         }
         factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
     }
 
     @After
@@ -112,10 +113,37 @@ public class SqlClientCompactQueryTest extends HazelcastTestSupport {
                 + "OPTIONS ("
                 + '\'' + OPTION_KEY_FORMAT + "'='" + "int" + '\''
                 + ", '" + OPTION_VALUE_FORMAT + "'='" + COMPACT_FORMAT + '\''
-                + ", '" + OPTION_VALUE_COMPACT_TYPE_NAME + "'='" + "employee" + '\''
+                + ", '" + OPTION_VALUE_COMPACT_TYPE_NAME + "'='" + EmployeeDTO.class.getName() + '\''
                 + ")");
 
         SqlResult result = client.getSql().execute("SELECT * FROM test WHERE age >= 5");
+
+        assertThat(result).hasSize(5);
+    }
+
+    @Test
+    public void testQueryOnPrimitive_selectValue() {
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig());
+        IMap<Integer, Object> map = client.getMap("test");
+        for (int i = 0; i < 10; i++) {
+            map.put(i, new EmployeeDTO(i, i));
+        }
+
+        client.getSql().execute("CREATE MAPPING " + "test" + '('
+                + "__key INTEGER"
+                + ", age INTEGER"
+                + ", \"rank\" INTEGER"
+                + ", id BIGINT"
+                + ", isHired BOOLEAN"
+                + ", isFired BOOLEAN"
+                + ") TYPE " + IMapSqlConnector.TYPE_NAME + ' '
+                + "OPTIONS ("
+                + '\'' + OPTION_KEY_FORMAT + "'='" + "int" + '\''
+                + ", '" + OPTION_VALUE_FORMAT + "'='" + COMPACT_FORMAT + '\''
+                + ", '" + OPTION_VALUE_COMPACT_TYPE_NAME + "'='" + EmployeeDTO.class.getName() + '\''
+                + ")");
+
+        SqlResult result = client.getSql().execute("SELECT this FROM test WHERE age >= 5");
 
         assertThat(result).hasSize(5);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -16,24 +16,24 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.cluster.AddressChecker;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
-import com.hazelcast.internal.server.tcp.TcpServerContext;
 import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.server.tcp.TcpServerContext;
+import com.hazelcast.internal.util.ByteArrayProcessor;
+import com.hazelcast.internal.util.OsHelper;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.internal.util.ByteArrayProcessor;
-import com.hazelcast.internal.util.OsHelper;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -268,11 +268,7 @@ public final class MulticastService implements Runnable {
                             + ", Sender -> " + datagramPacketReceive.getAddress());
                     return null;
                 }
-                try {
-                    return input.readObject();
-                } finally {
-                    input.close();
-                }
+                return input.readObject();
             } catch (Exception e) {
                 if (e instanceof EOFException || e instanceof HazelcastSerializationException) {
                     long now = System.currentTimeMillis();

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataInput.java
@@ -19,11 +19,10 @@ package com.hazelcast.internal.nio;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-public interface BufferObjectDataInput extends ObjectDataInput, Closeable, DataReader, SerializationServiceSupport {
+public interface BufferObjectDataInput extends ObjectDataInput, DataReader, SerializationServiceSupport {
 
     int UTF_BUFFER_SIZE = 1024;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPool.java
@@ -58,7 +58,9 @@ public interface BufferPool {
     /**
      * Returns a BufferObjectDataInput back to the pool.
      *
-     * The implementation is free to not return the instance to the pool but just close it.
+     * The implementation is free to not return the instance to the pool
+     * In that case this call does not keep a reference to `BufferObjectDataInput` so that it could be garbage
+     * collected
      *
      * @param in the BufferObjectDataInput.
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPool.java
@@ -58,9 +58,9 @@ public interface BufferPool {
     /**
      * Returns a BufferObjectDataInput back to the pool.
      *
-     * The implementation is free to not return the instance to the pool
-     * In that case this call does not keep a reference to `BufferObjectDataInput` so that it could be garbage
-     * collected
+     * The implementation is free to not return the instance to the pool.
+     * In that case this call does not keep a reference to `BufferObjectDataInput` so that it can be
+     * garbage-collected.
      *
      * @param in the BufferObjectDataInput.
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
@@ -16,21 +16,18 @@
 
 package com.hazelcast.internal.serialization.impl.bufferpool;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.HeapData;
 
-import java.io.Closeable;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-import static com.hazelcast.internal.nio.IOUtil.closeResource;
-
 /**
  * Default {@link BufferPool} implementation.
- *
+ * <p>
  * This class is designed to that a subclass can be made. This is done for the Enterprise version.
  */
 public class BufferPoolImpl implements BufferPool {
@@ -63,7 +60,7 @@ public class BufferPoolImpl implements BufferPool {
 
         out.clear();
 
-        offerOrClose(outputQueue, out);
+        tryOffer(outputQueue, out);
     }
 
     @Override
@@ -84,12 +81,11 @@ public class BufferPoolImpl implements BufferPool {
 
         in.clear();
 
-        offerOrClose(inputQueue, in);
+        tryOffer(inputQueue, in);
     }
 
-    private static <C extends Closeable> void offerOrClose(Queue<C> queue, C item) {
+    private static <C> void tryOffer(Queue<C> queue, C item) {
         if (queue.size() == MAX_POOLED_ITEMS) {
-            closeResource(item);
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.serialization.impl.bufferpool;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.ConcurrentReferenceHashMap;
 
 import java.lang.ref.WeakReference;
@@ -30,28 +30,28 @@ import static com.hazelcast.internal.util.ConcurrentReferenceHashMap.ReferenceTy
 /**
  * A thread-local for {@link BufferPool}.
  *
- * The BufferPoolThreadLocal is not assigned to a static field, but as a member field of the SerializationService-instance.
- * It is unlike to the common use of a ThreadLocal where it assigned to a static field. The reason behind this is that the
+ * The BufferPoolThreadLocal is not assigned to a static field, but is a member field of the SerializationService instance.
+ * It is not like the common use of a ThreadLocal where it's assigned to a static field. The reason for this is that the
  * BufferPool instance belongs to a specific SerializationService instance (the buffer pool has buffers tied to a particular
  * SerializationService instance). By creating a ThreadLocal per SerializationService-instance, we obtain 'BufferPool per thread
  * per SerializationService-instance' semantics.
  *
  * <h1>BufferPool is tied to SerializationService-instance</h1>
  * The BufferPool contains e.g. {@link BufferObjectDataOutput} instances that have a reference to a specific
- * SerializationService-instance. So as long as there is a strong reference to the BufferPool, there is a strong reference
- * to the SerializationService-instance.
+ * SerializationService instance. So as long as there is a strong reference to the BufferPool, there is a strong reference
+ * to the SerializationService instance.
  *
  * <h1>The problem with regular ThreadLocals</h1>
- * In the Thread.threadLocal-map only the key (the ThreadLocal) is wrapped in a WeakReference. So when the ThreadLocal-instance
+ * In the Thread.threadLocal-map only the key (the ThreadLocal) is wrapped in a WeakReference. So when the ThreadLocal instance
  * dies, the WeakReference prevents a strong reference to the ThreadLocal and potentially at some point in the future, the map
- * entry with the null valued WeakReference-key and the strong reference to the the value removed. The problem is we have
+ * entry with the null-valued WeakReference-key and the strong reference to the value is removed. The problem is we have
  * no control when this happens and we could end up with a memory leak because there are strong references to e.g. the
  * SerializationService.
  *
  * <h1>BufferPoolThreadLocal wraps BufferPool also in WeakReference</h1>
  * To prevent this memory leak, the value (the BufferPool) in the Thread.threadLocals-map is also wrapped in a WeakReference
- * So if there is no strong reference to the BufferPool, the BufferPool is gc'ed. Even though there might by some empty key/value
- * WeakReferences in the Thread.threadLocal-map.
+ * So if there is no strong reference to the BufferPool, the BufferPool is gc'ed. Even though there might be some empty key/value
+ * WeakReferences in the Thread.threadLocal map.
  *
  * <h1>Strong references to the BufferPools</h1>
  * To prevent the BufferPool wrapped in a WeakReference to be gc'ed as soon as it is created, the BufferPool is also stored
@@ -61,7 +61,7 @@ import static com.hazelcast.internal.util.ConcurrentReferenceHashMap.ReferenceTy
  * This gives us the following behavior:
  * <ol>
  * <li>
- * As soon as the Thread, having the ThreadLocal in its Thread.threadLocals-map, dies, the Entry with the Thread as key
+ * As soon as the Thread, having the ThreadLocal in its Thread.threadLocals map, dies, the Entry with the Thread as key
  * will be removed from the ConcurrentReferenceHashMap at some point.
  * </li>
  * <li>
@@ -69,7 +69,7 @@ import static com.hazelcast.internal.util.ConcurrentReferenceHashMap.ReferenceTy
  * are no strong references to the BufferPool instances, and they get collected as well.
  * </li>
  * </ol>
- * So it can be that a Thread in its Thread.threadLocal-map will for some time have an empty weak-reference as key and value. But
+ * So it can be that a Thread in its Thread.threadLocal map will for some time have an empty weak reference as key and value. But
  * there won't be any references to the BufferPool/SerializationService.
  *
  * <h1>Performance</h1>

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableContextImpl.java
@@ -74,17 +74,16 @@ public final class PortableContextImpl implements PortableContext {
         if (!data.isPortable()) {
             throw new IllegalArgumentException("Data is not Portable!");
         }
-        try (BufferObjectDataInput in = serializationService.createObjectDataInput(data)) {
-            int factoryId = in.readInt();
-            int classId = in.readInt();
-            int version = in.readInt();
+        BufferObjectDataInput in = serializationService.createObjectDataInput(data);
+        int factoryId = in.readInt();
+        int classId = in.readInt();
+        int version = in.readInt();
 
-            ClassDefinition classDefinition = lookupClassDefinition(factoryId, classId, version);
-            if (classDefinition == null) {
-                classDefinition = readClassDefinition(in, factoryId, classId, version);
-            }
-            return classDefinition;
+        ClassDefinition classDefinition = lookupClassDefinition(factoryId, classId, version);
+        if (classDefinition == null) {
+            classDefinition = readClassDefinition(in, factoryId, classId, version);
         }
+        return classDefinition;
     }
 
     ClassDefinition readClassDefinition(BufferObjectDataInput in, int factoryId, int classId, int version)

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobClassLoaderFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobClassLoaderFactory.java
@@ -23,9 +23,9 @@ import java.io.Serializable;
  * An interface that can be implemented to provide custom class loader for Jet
  * job.
  * <p>
- * The classloader must be serializable: it is set in the {@link
+ * The classloader factory must be serializable: it is set in the {@link
  * JobConfig#setClassLoaderFactory config} and sent to members in a serialized
- * form.
+ * form. The returned ClassLoader doesn't have to be serializable.
  * <p>
  * It is useful in custom class-loading environments, for example in OSGi.
  *

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
@@ -64,7 +64,6 @@ public class ExplodeSnapshotP extends AbstractProcessor {
         return () -> uncheckCall(() -> {
             Object key = in.readObject();
             if (key == SnapshotDataValueTerminator.INSTANCE) {
-                in.close();
                 return null;
             }
             Object value = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -188,13 +188,13 @@ public class Networking {
 
     private void handleFlowControlPacket(Address fromAddr, byte[] packet) throws IOException {
         BufferObjectDataInput input = createObjectDataInput(nodeEngine, packet);
-        for (; ; ) {
+        for (;;) {
             final long executionId = input.readLong();
             if (executionId == TERMINAL_EXECUTION_ID) {
                 break;
             }
             final Map<SenderReceiverKey, SenderTasklet> senderMap = jobExecutionService.getSenderMap(executionId);
-            for (; ; ) {
+            for (;;) {
                 final int vertexId = input.readInt();
                 if (vertexId == TERMINAL_VERTEX_ID) {
                     break;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -187,24 +187,23 @@ public class Networking {
     }
 
     private void handleFlowControlPacket(Address fromAddr, byte[] packet) throws IOException {
-        try (BufferObjectDataInput input = createObjectDataInput(nodeEngine, packet)) {
-            for (;;) {
-                final long executionId = input.readLong();
-                if (executionId == TERMINAL_EXECUTION_ID) {
+        BufferObjectDataInput input = createObjectDataInput(nodeEngine, packet);
+        for (; ; ) {
+            final long executionId = input.readLong();
+            if (executionId == TERMINAL_EXECUTION_ID) {
+                break;
+            }
+            final Map<SenderReceiverKey, SenderTasklet> senderMap = jobExecutionService.getSenderMap(executionId);
+            for (; ; ) {
+                final int vertexId = input.readInt();
+                if (vertexId == TERMINAL_VERTEX_ID) {
                     break;
                 }
-                final Map<SenderReceiverKey, SenderTasklet> senderMap = jobExecutionService.getSenderMap(executionId);
-                for (;;) {
-                    final int vertexId = input.readInt();
-                    if (vertexId == TERMINAL_VERTEX_ID) {
-                        break;
-                    }
-                    int ordinal = input.readInt();
-                    int sendSeqLimitCompressed = input.readInt();
-                    final SenderTasklet t;
-                    if (senderMap != null && (t = senderMap.get(new SenderReceiverKey(vertexId, ordinal, fromAddr))) != null) {
-                        t.setSendSeqLimitCompressed(sendSeqLimitCompressed);
-                    }
+                int ordinal = input.readInt();
+                int sendSeqLimitCompressed = input.readInt();
+                final SenderTasklet t;
+                if (senderMap != null && (t = senderMap.get(new SenderReceiverKey(vertexId, ordinal, fromAddr))) != null) {
+                    t.setSendSeqLimitCompressed(sendSeqLimitCompressed);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -212,6 +212,9 @@ public class ExecutionContext implements DynamicMetricsProvider {
             } else {
                 // begin job execution
                 ClassLoader cl = jetServiceBackend.getJobClassLoaderService().getClassLoader(jobId);
+                if (cl == null) {
+                    cl = nodeEngine.getConfigClassLoader();
+                }
                 executionFuture = taskletExecService
                         .beginExecute(tasklets, cancellationFuture, cl)
                         .whenComplete(withTryCatch(logger, (r, t) -> setCompletionTime()))

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
@@ -301,7 +301,6 @@ public class ReceiverTasklet implements Tasklet {
                 }
                 totalItems += itemCount;
                 totalBytes += input.position();
-                input.close();
                 tracker.madeProgress();
             }
             bytesInCounter.inc(totalBytes);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolTest.java
@@ -17,12 +17,12 @@
 package com.hazelcast.internal.serialization.impl.bufferpool;
 
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -159,8 +159,6 @@ public class BufferPoolTest extends HazelcastTestSupport {
         bufferPool.returnInputBuffer(in);
 
         assertEquals(BufferPoolImpl.MAX_POOLED_ITEMS, bufferPool.inputQueue.size());
-        // we need to make sure that the in was closed since we are not going to pool it.
-        verify(in, times(1)).close();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolTest.java
@@ -33,8 +33,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -93,7 +91,7 @@ public class BufferPoolTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void returnOutputBuffer_whenOverflowing() throws IOException {
+    public void returnOutputBuffer_whenOverflowing() {
         for (int k = 0; k < BufferPoolImpl.MAX_POOLED_ITEMS; k++) {
             bufferPool.returnOutputBuffer(mock(BufferObjectDataOutput.class));
         }
@@ -102,8 +100,6 @@ public class BufferPoolTest extends HazelcastTestSupport {
         bufferPool.returnOutputBuffer(out);
 
         assertEquals(BufferPoolImpl.MAX_POOLED_ITEMS, bufferPool.outputQueue.size());
-        // we need to make sure that the out was closed since we are not going to pool it.
-        verify(out, times(1)).close();
     }
 
     @Test
@@ -150,7 +146,7 @@ public class BufferPoolTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void returnInputBuffer_whenOverflowing() throws IOException {
+    public void returnInputBuffer_whenOverflowing() {
         for (int k = 0; k < BufferPoolImpl.MAX_POOLED_ITEMS; k++) {
             bufferPool.returnInputBuffer(mock(BufferObjectDataInput.class));
         }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
@@ -166,19 +166,17 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
 
     private RingbufferContainer clone(RingbufferContainer original) {
         BufferObjectDataOutput out = serializationService.createObjectDataOutput(100000);
-        BufferObjectDataInput in = null;
         try {
             out.writeObject(original);
             byte[] bytes = out.toByteArray();
             sleepMillis(CLOCK_DIFFERENCE_MS);
-            in = serializationService.createObjectDataInput(bytes);
+            BufferObjectDataInput in = serializationService.createObjectDataInput(bytes);
             RingbufferContainer clone = in.readObject();
             return clone;
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {
             closeResource(out);
-            closeResource(in);
         }
     }
 


### PR DESCRIPTION
We have a new implementation of serialization which keeps the
reference of BufferObjectDataInput to read it from lazily instead
of reading it on deserialization.

The problem is that we are closing the BufferObjectDataInput in
several places where the lazy implementations can not work anymore.

As a solution, I removed Closeable from BufferObjectDataInput
after we realize that all the implementations we have just sets
internal buffers to null. There are no resources cleaned up,
therefore removing `close` implementations seems safe.

On other important change in the pr is in the `TaskletExecutionService`.
In `SqlClientCompactQueryTest` we are setting a `FilteringClassLoader`
to the hazelcast config. This classLoader is used by all the threads
created by hazelcast except cooperative threads of jet.
We have realized it when we can not reproduce the issue with single jvm.
The reason is turned out to be config class loader is not used by the
jet cooperative threads. As a solution:
1. Config class loader is set to context class loader of cooperative
threads.
2. Overriding the context class loader is prevented if jobClassLoader
is null. So we keep the behavior same if a class loader is set to
JobConfig. Otherwise, config class loader is used.

fixes https://github.com/hazelcast/hazelcast/issues/19952
