### PR TITLE
Fix projection handling for select-by-key

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/SelectByKeyMapLogicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/SelectByKeyMapLogicalRules.java
@@ -112,6 +112,9 @@ final class SelectByKeyMapLogicalRules {
         }
     };
 
+    private SelectByKeyMapLogicalRules() {
+    }
+
     /**
      * Inline the projection from {@code table} into the projection given in {@code projects}.
      *
@@ -135,8 +138,5 @@ final class SelectByKeyMapLogicalRules {
         };
 
         return shuttle.apply(projects);
-    }
-
-    private SelectByKeyMapLogicalRules() {
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/SelectByKeyMapLogicalRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/SelectByKeyMapLogicalRules.java
@@ -17,14 +17,20 @@
 package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.jet.sql.impl.opt.OptUtils;
+import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
 import com.hazelcast.sql.impl.schema.map.PartitionedMapTable;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+
+import java.util.List;
 
 import static org.apache.calcite.plan.RelOptRule.none;
 import static org.apache.calcite.plan.RelOptRule.operand;
@@ -66,7 +72,7 @@ final class SelectByKeyMapLogicalRules {
                         scan.getRowType(),
                         table,
                         keyCondition,
-                        rexBuilder.identityProjects(scan.getRowType())
+                        pushProjectIntoTable(rexBuilder.identityProjects(scan.getRowType()), table)
                 );
                 call.transformTo(rel);
             }
@@ -99,12 +105,37 @@ final class SelectByKeyMapLogicalRules {
                         project.getRowType(),
                         table,
                         keyCondition,
-                        project.getProjects()
+                        pushProjectIntoTable(project.getProjects(), table)
                 );
                 call.transformTo(rel);
             }
         }
     };
+
+    /**
+     * Inline the projection from {@code table} into the projection given in {@code projects}.
+     *
+     * For example, the table's projection is {@code [4, 5]} (meaning
+     * the table outputs fifth and sixth fields from the underlying
+     * table), and {@code projects} is {@code [$1 + 5]} (meaning 5 added
+     * to the second field of the input). In this case the output will
+     * be {@code [$5 + 5]}.
+     */
+    private static List<RexNode> pushProjectIntoTable(List<RexNode> projects, RelOptTable input) {
+        HazelcastTable hzTable = input.unwrap(HazelcastTable.class);
+        assert hzTable != null;
+        List<RelDataTypeField> fieldList = input.getRowType().getFieldList();
+
+        RexShuttle shuttle =  new RexShuttle() {
+            @Override
+            public RexNode visitInputRef(RexInputRef ref) {
+                int index = ref.getIndex();
+                return new RexInputRef(hzTable.getProjects().get(index), fieldList.get(index).getType());
+            }
+        };
+
+        return shuttle.apply(projects);
+    }
 
     private SelectByKeyMapLogicalRules() {
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlFilterProjectTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlFilterProjectTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.sql;
 
+import com.hazelcast.jet.sql.impl.connector.map.model.Person;
 import com.hazelcast.jet.sql.impl.connector.test.TestAllTypesSqlConnector;
 import com.hazelcast.jet.sql.impl.connector.test.TestBatchSqlConnector;
 import com.hazelcast.map.IMap;
@@ -25,8 +26,6 @@ import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlService;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.Serializable;
 
 import static com.hazelcast.jet.core.TestUtil.createMap;
 import static java.util.Arrays.asList;
@@ -687,48 +686,10 @@ public class SqlFilterProjectTest extends SqlTestSupport {
     // test for https://github.com/hazelcast/hazelcast/issues/19983
     // Checks the case when select-by-key optimization is used, but the __key (the 0-th) field isn't selected.
     public void test_selectByKey_keyNotSelected() {
-        IMap<Integer, Integer> map = instance().getMap("m");
-        map.put(42, 43);
+        IMap<Long, Person> map = instance().getMap("test");
+        map.put(1L, new Person(10, "foo"));
 
-        createMapping("m", Integer.class, Integer.class);
-        assertRowsAnyOrder("select this from m where __key=42", singletonList(new Row(43)));
-    }
-
-    @Test
-    public void test_selectByKey_keyNotSelectWithObject() {
-        IMap<Long, TestValue> map = instance().getMap("test");
-        map.put(1L, new TestValue(10L, "test-value"));
-
-        createMapping("test", Long.class, TestValue.class);
-        assertRowsAnyOrder("select name from test where __key = 1", singletonList(new Row("test-value")));
-    }
-
-    public static class TestValue implements Serializable {
-        private Long id;
-        private String name;
-
-        public TestValue() {
-        }
-
-        public TestValue(final Long id, final String name) {
-            this.id = id;
-            this.name = name;
-        }
-
-        public Long getId() {
-            return id;
-        }
-
-        public void setId(final Long id) {
-            this.id = id;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(final String name) {
-            this.name = name;
-        }
+        createMapping("test", Long.class, Person.class);
+        assertRowsAnyOrder("select name from test where __key = 1", singletonList(new Row("foo")));
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlFilterProjectTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlFilterProjectTest.java
@@ -26,6 +26,8 @@ import com.hazelcast.sql.SqlService;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.Serializable;
+
 import static com.hazelcast.jet.core.TestUtil.createMap;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -690,5 +692,43 @@ public class SqlFilterProjectTest extends SqlTestSupport {
 
         createMapping("m", Integer.class, Integer.class);
         assertRowsAnyOrder("select this from m where __key=42", singletonList(new Row(43)));
+    }
+
+    @Test
+    public void test_selectByKey_keyNotSelectWithObject() {
+        IMap<Long, TestValue> map = instance().getMap("test");
+        map.put(1L, new TestValue(10L, "test-value"));
+
+        createMapping("test", Long.class, TestValue.class);
+        assertRowsAnyOrder("select name from test where __key = 1", singletonList(new Row("test-value")));
+    }
+
+    public static class TestValue implements Serializable {
+        private Long id;
+        private String name;
+
+        public TestValue() {
+        }
+
+        public TestValue(final Long id, final String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(final Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
     }
 }


### PR DESCRIPTION
Fixes #19983 (needs backporting to 5.0)

See the comment at `pushProjectIntoTable()` for description.