### PR TITLE
Better toString for arrays in peek

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
@@ -29,7 +29,9 @@ import com.hazelcast.jet.impl.util.WrappingProcessorMetaSupplier;
 import com.hazelcast.jet.impl.util.WrappingProcessorSupplier;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import static com.hazelcast.function.PredicateEx.alwaysTrue;
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
@@ -45,6 +47,37 @@ import static com.hazelcast.jet.impl.util.Util.checkSerializable;
  * @since Jet 3.0
  */
 public final class DiagnosticProcessors {
+
+    /**
+     * A function that uses `Object.toString()` for non-arrays,
+     * `Arrays.toString()` for arrays of primitive types and
+     * `Arrays.deepToString()` for `Object[]`. Used for `peek()`
+     * function in the DAG and Pipeline API.
+     *
+     * @since 5.1
+     */
+    public static final FunctionEx<Object, String> PEEK_DEFAULT_TO_STRING = o -> {
+        if (o instanceof Object[]) {
+            return Arrays.deepToString((Object[]) o);
+        } else if (o instanceof byte[]) {
+            return Arrays.toString((byte[]) o);
+        } else if (o instanceof short[]) {
+            return Arrays.toString((short[]) o);
+        } else if (o instanceof int[]) {
+            return Arrays.toString((int[]) o);
+        } else if (o instanceof long[]) {
+            return Arrays.toString((long[]) o);
+        } else if (o instanceof float[]) {
+            return Arrays.toString((float[]) o);
+        } else if (o instanceof double[]) {
+            return Arrays.toString((double[]) o);
+        } else if (o instanceof boolean[]) {
+            return Arrays.toString((boolean[]) o);
+        } else {
+            return Objects.toString(o);
+        }
+    };
+
     private DiagnosticProcessors() {
     }
 
@@ -77,7 +110,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeLoggerP() {
-        return writeLoggerP(Object::toString);
+        return writeLoggerP(PEEK_DEFAULT_TO_STRING);
     }
 
     /**
@@ -101,7 +134,7 @@ public final class DiagnosticProcessors {
      * passed to {@code shouldLogFn} and {@code toStringFn}.
      *
      * @param toStringFn  a function that returns the string representation of the item.
-     *                    You can use {@code Object::toString}.
+     *                    You can use {@link #PEEK_DEFAULT_TO_STRING}.
      * @param shouldLogFn a function to filter the logged items. You can use {@link
      *                    PredicateEx#alwaysTrue()
      *                    alwaysTrue()} as a pass-through filter when you don't need any
@@ -160,7 +193,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier peekInputP(@Nonnull ProcessorMetaSupplier wrapped) {
-        return peekInputP(Object::toString, alwaysTrue(), wrapped);
+        return peekInputP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -172,7 +205,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorSupplier peekInputP(@Nonnull ProcessorSupplier wrapped) {
-        return peekInputP(Object::toString, alwaysTrue(), wrapped);
+        return peekInputP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -184,7 +217,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static SupplierEx<Processor> peekInputP(@Nonnull SupplierEx<Processor> wrapped) {
-        return peekInputP(Object::toString, alwaysTrue(), wrapped);
+        return peekInputP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -220,7 +253,7 @@ public final class DiagnosticProcessors {
      * {@code shouldLogFn} or {@code toStringFn}.
      *
      * @param toStringFn  a function that returns the string representation of the item.
-     *                    You can use {@code Object::toString}.
+     *                    You can use {@link #PEEK_DEFAULT_TO_STRING}.
      * @param shouldLogFn a function to filter the logged items. You can use {@link
      *                    PredicateEx#alwaysTrue()
      *                    alwaysTrue()} as a pass-through filter when you don't need any
@@ -278,7 +311,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier peekOutputP(@Nonnull ProcessorMetaSupplier wrapped) {
-        return peekOutputP(Object::toString, alwaysTrue(), wrapped);
+        return peekOutputP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -290,7 +323,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorSupplier peekOutputP(@Nonnull ProcessorSupplier wrapped) {
-        return peekOutputP(Object::toString, alwaysTrue(), wrapped);
+        return peekOutputP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -302,7 +335,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static SupplierEx<Processor> peekOutputP(@Nonnull SupplierEx<Processor> wrapped) {
-        return peekOutputP(Object::toString, alwaysTrue(), wrapped);
+        return peekOutputP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -320,7 +353,7 @@ public final class DiagnosticProcessors {
      * </ol>
      *
      * @param toStringFn  a function that returns the string representation of the item.
-     *                    You can use {@code Object::toString}
+     *                    You can use {@code DEFAULT_TO_STRING}
      * @param shouldLogFn a function to filter the logged items. You can use {@link
      *                    PredicateEx#alwaysTrue()
      *                    alwaysTrue()} as a pass-through filter when you don't need any
@@ -380,7 +413,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static SupplierEx<Processor> peekSnapshotP(@Nonnull SupplierEx<Processor> wrapped) {
-        return peekSnapshotP(Object::toString, alwaysTrue(), wrapped);
+        return peekSnapshotP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -391,7 +424,7 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier peekSnapshotP(@Nonnull ProcessorMetaSupplier wrapped) {
-        return peekSnapshotP(Object::toString, alwaysTrue(), wrapped);
+        return peekSnapshotP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 
     /**
@@ -403,6 +436,6 @@ public final class DiagnosticProcessors {
      */
     @Nonnull
     public static ProcessorSupplier peekSnapshotP(@Nonnull ProcessorSupplier wrapped) {
-        return peekSnapshotP(Object::toString, alwaysTrue(), wrapped);
+        return peekSnapshotP(PEEK_DEFAULT_TO_STRING, alwaysTrue(), wrapped);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
@@ -56,6 +56,7 @@ public final class DiagnosticProcessors {
      *
      * @since 5.1
      */
+    @SuppressWarnings("checkstyle:ReturnCount")
     public static final FunctionEx<Object, String> PEEK_DEFAULT_TO_STRING = o -> {
         if (o instanceof Object[]) {
             return Arrays.deepToString((Object[]) o);

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -25,7 +25,7 @@ import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
-import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -41,6 +41,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static com.hazelcast.function.PredicateEx.alwaysTrue;
+import static com.hazelcast.jet.core.processor.DiagnosticProcessors.PEEK_DEFAULT_TO_STRING;
 
 /**
  * The common aspect of {@link BatchStage batch} and {@link StreamStage
@@ -68,7 +69,7 @@ public interface GeneralStage<T> extends Stage {
     /**
      * Attaches a mapping stage which applies the given function to each input
      * item independently and emits the function's result as the output item.
-     * If the result is {@code null}, it emits nothing. Therefore this stage
+     * If the result is {@code null}, it emits nothing. Therefore, this stage
      * can be used to implement filtering semantics as well.
      * <p>
      * This sample takes a stream of names and outputs the names in lowercase:
@@ -279,7 +280,7 @@ public interface GeneralStage<T> extends Stage {
      * item. The mapping function receives another parameter, the service
      * object, which Jet will create using the supplied {@code serviceFactory}.
      * <p>
-     * If the mapping result is {@code null}, it emits nothing. Therefore this
+     * If the mapping result is {@code null}, it emits nothing. Therefore, this
      * stage can be used to implement filtering semantics as well.
      * <p>
      * This sample takes a stream of stock items and sets the {@code detail}
@@ -554,7 +555,7 @@ public interface GeneralStage<T> extends Stage {
      * lookup is merged with the item and emitted.
      * <p>
      * If the result of the mapping is {@code null}, it emits nothing.
-     * Therefore this stage can be used to implement filtering semantics as
+     * Therefore, this stage can be used to implement filtering semantics as
      * well.
      * <p>
      * The mapping logic is equivalent to:
@@ -602,7 +603,7 @@ public interface GeneralStage<T> extends Stage {
      * merged with the item and emitted.
      * <p>
      * If the result of the mapping is {@code null}, it emits nothing.
-     * Therefore this stage can be used to implement filtering semantics as
+     * Therefore, this stage can be used to implement filtering semantics as
      * well.
      * <p>
      * The mapping logic is equivalent to:
@@ -648,7 +649,7 @@ public interface GeneralStage<T> extends Stage {
      * merged with the item and emitted.
      * <p>
      * If the result of the mapping is {@code null}, it emits nothing.
-     * Therefore this stage can be used to implement filtering semantics as
+     * Therefore, this stage can be used to implement filtering semantics as
      * well.
      * <p>
      * The mapping logic is equivalent to:
@@ -702,7 +703,7 @@ public interface GeneralStage<T> extends Stage {
      * the item and emitted.
      * <p>
      * If the result of the mapping is {@code null}, it emits nothing.
-     * Therefore this stage can be used to implement filtering semantics as
+     * Therefore, this stage can be used to implement filtering semantics as
      * well.
      * <p>
      * The mapping logic is equivalent to:
@@ -767,7 +768,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param stage1        the stage to hash-join with this one
@@ -814,7 +815,7 @@ public interface GeneralStage<T> extends Stage {
      * before reaching {@code #mapToOutputFn}.
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param stage1        the stage to hash-join with this one
@@ -860,7 +861,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @param stage1        the first stage to join
@@ -889,7 +890,7 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
-     * Attaches to this and the two supplied stages a inner hash-joining stage
+     * Attaches to this and the two supplied stages an inner hash-joining stage
      * and returns it. This stage plays the role of the <em>primary stage</em>
      * in the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
      * package javadoc} for a detailed description of the hash-join transform.
@@ -911,7 +912,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * <p>
@@ -972,7 +973,7 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      * <p>
      * This operation is subject to memory limits. See {@link
-     * InstanceConfig#setMaxProcessorAccumulatedRecords(long)} for more
+     * JetConfig#setMaxProcessorAccumulatedRecords(long)} for more
      * information.
      *
      * @return the newly attached stage
@@ -1154,7 +1155,7 @@ public interface GeneralStage<T> extends Stage {
      * them. When timestamps are added at this moment, source partitions won't
      * be coalesced properly and will be treated as a single stream. The
      * allowed lag will need to cover for the additional disorder introduced by
-     * merging the streams. The streams are merged in an unpredictable order
+     * merging the streams. The streams are merged in an unpredictable order,
      * and it can happen, for example, that after the job was suspended for a
      * long time, there can be a very recent event in partition1 and a very old
      * event partition2. If partition1 happens to be merged first, the recent
@@ -1165,9 +1166,9 @@ public interface GeneralStage<T> extends Stage {
      * withTimestamps()}.
      * <p>
      * <b>Warning:</b> make sure the property you access in {@code timestampFn}
-     * isn't null, it would fail the job. Also that there are no nonsensical
-     * values such as -1, MIN_VALUE, 2100-01-01 etc - we'll treat those as real
-     * timestamps and they can cause unspecified behaviour.
+     * isn't null, it would fail the job. Also, that there are no nonsensical
+     * values such as -1, MIN_VALUE, 2100-01-01 etc. - we'll treat those as real
+     * timestamps, and they can cause unspecified behaviour.
      *
      * @param timestampFn a function that returns the timestamp for each item,
      *                    typically in milliseconds. It must be stateless and {@linkplain
@@ -1207,9 +1208,9 @@ public interface GeneralStage<T> extends Stage {
      *     logs the string at the INFO level to the log category {@code
      *     com.hazelcast.jet.impl.processor.PeekWrappedP.<vertexName>#<processorIndex>}
      * </li></ol>
-     * The stage logs each item on whichever cluster member it happens to
-     * receive it. Its primary purpose is for development use, when running Jet
-     * on a local machine.
+     * The stage logs each item on the cluster member that outputs it. Its
+     * primary purpose is for development use, when running Jet on a local
+     * machine.
      * <p>
      * Note that peek after {@link #rebalance(FunctionEx)} operation is not supported.
      * <p>
@@ -1248,9 +1249,9 @@ public interface GeneralStage<T> extends Stage {
      *     logs the string at the INFO level to the log category {@code
      *     com.hazelcast.jet.impl.processor.PeekWrappedP.<vertexName>#<processorIndex>}
      * </li></ol>
-     * The stage logs each item on whichever cluster member it happens to
-     * receive it. Its primary purpose is for development use, when running Jet
-     * on a local machine.
+     * The stage logs each item on the cluster member that outputs it. Its
+     * primary purpose is for development use, when running Jet on a local
+     * machine.
      * <p>
      * Note that peek after {@link #rebalance(FunctionEx)} operation is not supported.
      * <p>
@@ -1277,9 +1278,9 @@ public interface GeneralStage<T> extends Stage {
      * each item the stage emits, it logs the result of its {@code toString()}
      * method at the INFO level to the log category {@code
      * com.hazelcast.jet.impl.processor.PeekWrappedP.<vertexName>#<processorIndex>}.
-     * The stage logs each item on whichever cluster member it happens to
-     * receive it. Its primary purpose is for development use, when running Jet
-     * on a local machine.
+     * The stage logs each item on the cluster member that outputs it. Its
+     * primary purpose is for development use, when running Jet on a local
+     * machine.
      * <p>
      * Note that peek after {@link #rebalance(FunctionEx)} is not supported.
      *
@@ -1289,7 +1290,7 @@ public interface GeneralStage<T> extends Stage {
      */
     @Nonnull
     default GeneralStage<T> peek() {
-        return peek(alwaysTrue(), Object::toString);
+        return peek(alwaysTrue(), PEEK_DEFAULT_TO_STRING);
     }
 
     /**


### PR DESCRIPTION
The default toString method for arrays returns something like
`[Ljava.lang.String;@f6f4d33`. This commit uses `Arrays.toString()`
instead.

This is not 100% b-w compatible, the logged text can potentially be very
large, and it's not the same as in previous version, but we still do it
for these reasons:

- the exact output format wasn't specified

- peek functions are meant for development. We don't expect them to be
used for production (though it's possible)

- the old format wasn't very useful for automatic parsing, maybe only
for checking instance equality.
