### PR TITLE
[BACKPORT 5.0.z] Make tests using multicast discovery more robust

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -20,6 +20,9 @@ import com.hazelcast.internal.cluster.Joiner;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.logging.ILogger;
+
+import java.util.UUID;
+
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.nio.Packet;
 
@@ -70,11 +73,17 @@ public class NodeMulticastListener implements MulticastListener {
             node.multicastService.send(response);
         } else if (joinMessage.getAddress().equals(masterAddress)) {
             MemberImpl master = node.getClusterService().getMember(masterAddress);
-            if (master != null && !master.getUuid().equals(joinMessage.getUuid())) {
-                String message = "New join request has been received from current master. Suspecting " + masterAddress;
-                logger.warning(message);
-                // I just make a local suspicion. Probably other nodes will eventually suspect as well.
-                clusterService.suspectMember(master, message, false);
+            if (master != null) {
+                UUID uuidFromMaster = master.getUuid();
+                UUID uuidInJoinRequest = joinMessage.getUuid();
+                if (!uuidFromMaster.equals(uuidInJoinRequest)) {
+                    String message = "New join request has been received from current master address. "
+                            + "The UUID in the join request (" + uuidInJoinRequest + ") is different from the "
+                            + "known master one (" + uuidFromMaster + "). Suspecting the master address: " + masterAddress;
+                    logger.warning(message);
+                    // I just make a local suspicion. Probably other nodes will eventually suspect as well.
+                    clusterService.suspectMember(master, message, false);
+                }
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -46,6 +46,7 @@ import java.net.URL;
 import java.util.Properties;
 
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
+import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.TestEnvironment.isSolaris;
 import static org.junit.Assert.assertEquals;
@@ -172,7 +173,7 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
         HazelcastInstance server2 = null;
 
         try {
-            Config config = new Config();
+            Config config = new Config().setClusterName(getTestMethodName());
             if (isSolaris()) {
                 config.setProperty(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE.getName(), "false");
             }
@@ -189,7 +190,8 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
             ICacheService cacheService2 = getCacheService(server2);
 
             // Create the hazelcast client instance
-            client = HazelcastClient.newHazelcastClient();
+            ClientConfig clientConfig = new ClientConfig().setClusterName(getTestMethodName());
+            client = HazelcastClient.newHazelcastClient(clientConfig);
 
             // Create the client cache manager
             CachingProvider cachingProvider = createClientCachingProvider(client);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientAutoDetectionDiscoveryTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
 import static com.hazelcast.test.TestEnvironment.isSolaris;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -46,6 +47,8 @@ public class ClientAutoDetectionDiscoveryTest extends HazelcastTestSupport {
     @Test
     public void defaultDiscovery() {
         Config c = new Config();
+        c.setClusterName(getTestMethodName());
+
         if (isSolaris()) {
             c.setProperty(ClusterProperty.MULTICAST_SOCKET_SET_INTERFACE.getName(), "false");
         }
@@ -53,7 +56,8 @@ public class ClientAutoDetectionDiscoveryTest extends HazelcastTestSupport {
         Hazelcast.newHazelcastInstance(c);
         Hazelcast.newHazelcastInstance(c);
 
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        ClientConfig clientConfig = new ClientConfig().setClusterName(getTestMethodName());
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         assertClusterSizeEventually(2, client);
     }
 


### PR DESCRIPTION
Fixes #19758 in `5.0.z`

Backport of: #19989, #19830, #19889

This PR improves logging in the `NodeMulticastListener` and it makes the multicast-using tests more robust by configuring the cluster name. The improvement is based on the fact the `ConfigCheck.isSameGroup()` method is called during join request verification - https://github.com/hazelcast/hazelcast/blob/v5.0/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java#L127
