### PR TITLE
MC-1039 - disable data access for MC

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1128,6 +1128,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(managementCenterConfig);
         assertTrue(managementCenterConfig.isScriptingEnabled());
         assertTrue(managementCenterConfig.isConsoleEnabled());
+        assertTrue(managementCenterConfig.isDataAccessEnabled());
         Set<String> tis = managementCenterConfig.getTrustedInterfaces();
         assertEquals(1, tis.size());
         assertEquals("10.1.2.*", tis.iterator().next());

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -37,7 +37,7 @@
             <hz:instance-name>test-instance</hz:instance-name>
             <hz:cluster-name>${cluster.name}-fullConfig</hz:cluster-name>
             <hz:license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</hz:license-key>
-            <hz:management-center scripting-enabled="true" console-enabled="true">
+            <hz:management-center scripting-enabled="true" console-enabled="true" data-access-enabled="true">
                 <hz:trusted-interfaces>
                     <hz:interface>10.1.2.*</hz:interface>
                 </hz:trusted-interfaces>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.1.xsd
@@ -2814,6 +2814,7 @@
         </xs:sequence>
         <xs:attribute name="scripting-enabled" type="xs:boolean"/>
         <xs:attribute name="console-enabled" type="xs:boolean"/>
+        <xs:attribute name="data-access-enabled" type="xs:boolean"/>
     </xs:complexType>
 
     <xs:complexType name="trusted-interfaces">

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.1.xsd
@@ -2814,7 +2814,7 @@
         </xs:sequence>
         <xs:attribute name="scripting-enabled" type="xs:boolean"/>
         <xs:attribute name="console-enabled" type="xs:boolean"/>
-        <xs:attribute name="data-access-enabled" type="xs:boolean"/>
+        <xs:attribute name="data-access-enabled" type="xs:boolean" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="trusted-interfaces">

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -198,7 +198,8 @@ public class ConfigXmlGenerator {
         if (mcConfig != null) {
             gen.open("management-center",
                     "scripting-enabled", mcConfig.isScriptingEnabled(),
-                    "console-enabled", mcConfig.isConsoleEnabled());
+                    "console-enabled", mcConfig.isConsoleEnabled(),
+                    "data-access-enabled", mcConfig.isDataAccessEnabled());
             trustedInterfacesXmlGenerator(gen, mcConfig.getTrustedInterfaces());
             gen.close();
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -32,6 +32,8 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
 
     private boolean consoleEnabled;
 
+    private boolean dataAccessEnabled = true;
+
     private final Set<String> trustedInterfaces = newSetFromMap(new ConcurrentHashMap<>());
 
     public ManagementCenterConfig() {
@@ -82,6 +84,17 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
      */
     public boolean isConsoleEnabled() {
         return consoleEnabled;
+    }
+
+    // TODO
+    public boolean isDataAccessEnabled() {
+        return dataAccessEnabled;
+    }
+
+    // TODO
+    public ManagementCenterConfig setDataAccessEnabled(boolean dataAccessEnabled) {
+        this.dataAccessEnabled = dataAccessEnabled;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -87,7 +87,7 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
     }
 
     /**
-     * Enables/disables data access for Management Center.
+     * Enables/disables access to contents of Hazelcast data structures (for instance map entries) for Management Center.
      * Management Center can't access the data if at least one member has the data access disabled.
      * <p>
      * Default value for this config element is {@code true}.
@@ -102,7 +102,8 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
     }
 
     /**
-     * Returns if data access for Management Center is allowed ({@code true}) or disallowed ({@code false}).
+     * Returns if Management Center is allowed to access contents of Hazelcast data structures
+     * (for instance map entries) ({@code true}) or disallowed ({@code false}).
      */
     public boolean isDataAccessEnabled() {
         return dataAccessEnabled;

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -86,15 +86,26 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
         return consoleEnabled;
     }
 
-    // TODO
-    public boolean isDataAccessEnabled() {
-        return dataAccessEnabled;
-    }
-
-    // TODO
+    /**
+     * Enables/disables data access for Management Center.
+     * Management Center can't access the data if at least one member has the data access disabled.
+     * <p>
+     * Default value for this config element is {@code true}.
+     *
+     * @param dataAccessEnabled {@code true} to allow data access for Management Center, {@code false} to disallow
+     * @return this management center config instance
+     * @since 5.1
+     */
     public ManagementCenterConfig setDataAccessEnabled(boolean dataAccessEnabled) {
         this.dataAccessEnabled = dataAccessEnabled;
         return this;
+    }
+
+    /**
+     * Returns if data access for Management Center is allowed ({@code true}) or disallowed ({@code false}).
+     */
+    public boolean isDataAccessEnabled() {
+        return dataAccessEnabled;
     }
 
     /**
@@ -146,7 +157,7 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
 
     @Override
     public int hashCode() {
-        return Objects.hash(scriptingEnabled, consoleEnabled, trustedInterfaces);
+        return Objects.hash(scriptingEnabled, consoleEnabled, dataAccessEnabled, trustedInterfaces);
     }
 
     @Override
@@ -162,6 +173,7 @@ public final class ManagementCenterConfig implements TrustedInterfacesConfigurab
         }
         ManagementCenterConfig other = (ManagementCenterConfig) obj;
         return scriptingEnabled == other.scriptingEnabled && consoleEnabled == other.consoleEnabled
+                && dataAccessEnabled == other.dataAccessEnabled
                 && Objects.equals(trustedInterfaces, other.trustedInterfaces);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2709,6 +2709,11 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             managementCenterConfig.setConsoleEnabled(getBooleanValue(getTextContent(consoleEnabledNode)));
         }
 
+        Node dataAccessEnabledNode = getNamedItemNode(node, "data-access-enabled");
+        if (dataAccessEnabledNode != null) {
+            managementCenterConfig.setDataAccessEnabled(getBooleanValue(getTextContent(dataAccessEnabledNode)));
+        }
+
         for (Node n : childElements(node)) {
             if (matches("trusted-interfaces", cleanNodeName(n))) {
                 handleTrustedInterfaces(managementCenterConfig, n);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
@@ -48,6 +48,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
     boolean socketInterceptorEnabled;
     boolean scriptingEnabled;
     boolean consoleEnabled;
+    boolean mcDataAccessEnabled;
 
     public List<String> getMemberList() {
         return memberList;
@@ -129,6 +130,14 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         this.consoleEnabled = consoleEnabled;
     }
 
+    public boolean isMcDataAccessEnabled() {
+        return mcDataAccessEnabled;
+    }
+
+    public void setMcDataAccessEnabled(boolean mcDataAccessEnabled) {
+        this.mcDataAccessEnabled = mcDataAccessEnabled;
+    }
+
     @Override
     public TimedMemberState clone() throws CloneNotSupportedException {
         TimedMemberState state = (TimedMemberState) super.clone();
@@ -142,6 +151,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         state.setSocketInterceptorEnabled(socketInterceptorEnabled);
         state.setScriptingEnabled(scriptingEnabled);
         state.setConsoleEnabled(consoleEnabled);
+        state.setMcDataAccessEnabled(mcDataAccessEnabled);
         return state;
     }
 
@@ -164,6 +174,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         root.add("socketInterceptorEnabled", socketInterceptorEnabled);
         root.add("scriptingEnabled", scriptingEnabled);
         root.add("consoleEnabled", consoleEnabled);
+        root.add("mcDataAccessEnabled", mcDataAccessEnabled);
         return root;
     }
 
@@ -185,6 +196,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         socketInterceptorEnabled = getBoolean(json, "socketInterceptorEnabled");
         scriptingEnabled = getBoolean(json, "scriptingEnabled");
         consoleEnabled = getBoolean(json, "consoleEnabled");
+        mcDataAccessEnabled = getBoolean(json, "mcDataAccessEnabled");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -135,6 +135,7 @@ public class TimedMemberStateFactory {
         ManagementCenterConfig managementCenterConfig = instance.node.getConfig().getManagementCenterConfig();
         timedMemberState.setScriptingEnabled(managementCenterConfig.isScriptingEnabled());
         timedMemberState.setConsoleEnabled(managementCenterConfig.isConsoleEnabled());
+        timedMemberState.setMcDataAccessEnabled(managementCenterConfig.isDataAccessEnabled());
 
         return timedMemberState;
     }

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.json
@@ -292,7 +292,7 @@
           "default": false
         },
         "data-access-enabled": {
-          "description": "TODO.",
+          "description": "Set to true to allow data access for Management Center execution on the member, false to disallow. Management Center can't access the data if at least one member has the data access disabled.",
           "type": "boolean",
           "default": true
         },

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.json
@@ -291,6 +291,11 @@
           "type": "boolean",
           "default": false
         },
+        "data-access-enabled": {
+          "description": "TODO.",
+          "type": "boolean",
+          "default": true
+        },
         "trusted-interfaces": {
           "type": "array",
           "items": {

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.json
@@ -292,7 +292,7 @@
           "default": false
         },
         "data-access-enabled": {
-          "description": "Set to true to allow data access for Management Center execution on the member, false to disallow. Management Center can't access the data if at least one member has the data access disabled.",
+          "description": "Set to true to allow Management Center access to contents of Hazelcast data structures (for instance map entries), false to disallow. Management Center can't access the data if at least one member has the data access disabled.",
           "type": "boolean",
           "default": true
         },

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
@@ -2629,6 +2629,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="data-access-enabled" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    TODO
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="security">
         <xs:all>

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
@@ -2632,7 +2632,7 @@
         <xs:attribute name="data-access-enabled" type="xs:boolean" default="true">
             <xs:annotation>
                 <xs:documentation>
-                    Set to true to allow data access for Management Center execution on the member, false to disallow. Management Center can't access the data if at least one member has the data access disabled.
+                    True to allow Management Center access to contents of Hazelcast data structures (for instance map entries), false to disallow. Management Center can't access the data if at least one member has the data access disabled.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
@@ -2629,10 +2629,10 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="data-access-enabled" type="xs:boolean">
+        <xs:attribute name="data-access-enabled" type="xs:boolean" default="true">
             <xs:annotation>
                 <xs:documentation>
-                    TODO
+                    Set to true to allow data access for Management Center execution on the member, false to disallow. Management Center can't access the data if at least one member has the data access disabled.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -105,9 +105,12 @@
         Set to true to allow scripting on the member, false to disallow.
         Default value is false.
         * console-enabled:
-        Set to true to allow console commands execution on the member, false to disallow
+        Set to true to allow console commands execution on the member, false to disallow.
         Default value is false.
-        * data-access-enabled TODO
+        * data-access-enabled
+        Set to true to allow data access for Management Center via SQL Browser or Map Browser, false to disallow.
+        Management Center can't access the data if at least one member has the data access disabled.
+        Default value is true.
 
         Hazelcast's Open Source edition provides the Management Center with monitoring at most 3 members
         in your cluster. To use it for more members, you need to have either a Management Center,

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -107,12 +107,13 @@
         * console-enabled:
         Set to true to allow console commands execution on the member, false to disallow
         Default value is false.
+        * data-access-enabled TODO
 
         Hazelcast's Open Source edition provides the Management Center with monitoring at most 3 members
         in your cluster. To use it for more members, you need to have either a Management Center,
         Hazelcast Enterprise or Hazelcast Enterprise HD license.
     -->
-    <management-center scripting-enabled="false" console-enabled="false"/>
+    <management-center scripting-enabled="false" console-enabled="false" data-access-enabled="true"/>
     <!--
         The <properties> element lets you add properties to some of the Hazelcast elements used to configure some of
         the Hazelcast modules.

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -108,7 +108,7 @@
         Set to true to allow console commands execution on the member, false to disallow.
         Default value is false.
         * data-access-enabled
-        Set to true to allow data access for Management Center via SQL Browser or Map Browser, false to disallow.
+        Set to true to allow Management Center access to contents of Hazelcast data structures (for instance map entries), false to disallow.
         Management Center can't access the data if at least one member has the data access disabled.
         Default value is true.
 

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -95,7 +95,9 @@ hazelcast:
   # * console-enabled:
   # Set to true to allow console commands execution on the member, false to disallow
   # Default value is false.
-  #
+  # * data-access-enabled:
+  TODO
+
   # Hazelcast's Open Source edition provides the Management Center with monitoring at most 3 members
   # in your cluster. To use it for more members, you need to have either a Management Center,
   # Hazelcast Enterprise or Hazelcast Enterprise HD license.
@@ -103,6 +105,7 @@ hazelcast:
   management-center:
     scripting-enabled: false
     console-enabled: false
+    data-access-enabled: false
   #
   # The "properties" mapping lets you add properties to some of the Hazelcast elements used to configure some of
   # the Hazelcast modules.

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -96,7 +96,9 @@ hazelcast:
   # Set to true to allow console commands execution on the member, false to disallow
   # Default value is false.
   # * data-access-enabled:
-  TODO
+  # Set to true to allow data access for Management Center via SQL Browser or Map Browser, false to disallow.
+  # Management Center can't access the data if at least one member has the data access disabled.
+  # Default value is true.
 
   # Hazelcast's Open Source edition provides the Management Center with monitoring at most 3 members
   # in your cluster. To use it for more members, you need to have either a Management Center,
@@ -105,7 +107,7 @@ hazelcast:
   management-center:
     scripting-enabled: false
     console-enabled: false
-    data-access-enabled: false
+    data-access-enabled: true
   #
   # The "properties" mapping lets you add properties to some of the Hazelcast elements used to configure some of
   # the Hazelcast modules.

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -96,7 +96,7 @@ hazelcast:
   # Set to true to allow console commands execution on the member, false to disallow
   # Default value is false.
   # * data-access-enabled:
-  # Set to true to allow data access for Management Center via SQL Browser or Map Browser, false to disallow.
+  # Set to true to allow Management Center access to contents of Hazelcast data structures (for instance map entries), false to disallow.
   # Management Center can't access the data if at least one member has the data access disabled.
   # Default value is true.
 

--- a/hazelcast/src/main/resources/hazelcast-security-hardened.xml
+++ b/hazelcast/src/main/resources/hazelcast-security-hardened.xml
@@ -41,8 +41,9 @@
     <!-- 
       Explicitly disable the scripting operations and the console commands sent from the Management center.
       The default value for both attributes is false already so this one is just to be sure and explicit.
+      Also disable access to the data for Management Center. The data access is enabled by default.
      -->
-    <management-center scripting-enabled="false" console-enabled="false" data-access-enabled="true" />
+    <management-center scripting-enabled="false" console-enabled="false" data-access-enabled="false" />
 
     <!--
       Explicitly disable the user-code deployments. I.e. allow only code which already is on the classpath.

--- a/hazelcast/src/main/resources/hazelcast-security-hardened.xml
+++ b/hazelcast/src/main/resources/hazelcast-security-hardened.xml
@@ -42,7 +42,7 @@
       Explicitly disable the scripting operations and the console commands sent from the Management center.
       The default value for both attributes is false already so this one is just to be sure and explicit.
      -->
-    <management-center scripting-enabled="false" console-enabled="false" />
+    <management-center scripting-enabled="false" console-enabled="false" data-access-enabled="true" />
 
     <!--
       Explicitly disable the user-code deployments. I.e. allow only code which already is on the classpath.

--- a/hazelcast/src/main/resources/hazelcast-security-hardened.yaml
+++ b/hazelcast/src/main/resources/hazelcast-security-hardened.yaml
@@ -30,6 +30,7 @@ hazelcast:
     # The default value for both attributes is false already so this one is just to be sure and explicit.
     scripting-enabled: false
     console-enabled: false
+    data-access-enabled: true
 
   user-code-deployment:
     # Explicitly disable the user-code deployments. I.e. allow only code which already is on the classpath.

--- a/hazelcast/src/main/resources/hazelcast-security-hardened.yaml
+++ b/hazelcast/src/main/resources/hazelcast-security-hardened.yaml
@@ -28,9 +28,10 @@ hazelcast:
   management-center:
     # Explicitly disable the scripting operations and the console commands sent from the Management center.
     # The default value for both attributes is false already so this one is just to be sure and explicit.
+    # Also disable access to the data for Management Center. The data access is enabled by default.
     scripting-enabled: false
     console-enabled: false
-    data-access-enabled: true
+    data-access-enabled: false
 
   user-code-deployment:
     # Explicitly disable the user-code deployments. I.e. allow only code which already is on the classpath.

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1810,7 +1810,8 @@ public class ConfigCompatibilityChecker {
         boolean check(ManagementCenterConfig c1, ManagementCenterConfig c2) {
             return c1 == c2 || (c1 != null && c2 != null
                     && (c1.isScriptingEnabled() == c2.isScriptingEnabled())
-                    && (c1.isConsoleEnabled() == c2.isConsoleEnabled()))
+                    && (c1.isConsoleEnabled() == c2.isConsoleEnabled())
+                    && (c1.isDataAccessEnabled() == c2.isDataAccessEnabled()))
                     && nullSafeEqual(c1.getTrustedInterfaces(), c2.getTrustedInterfaces());
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -867,6 +867,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         ManagementCenterConfig managementCenterConfig = new ManagementCenterConfig()
                 .setScriptingEnabled(false)
                 .setConsoleEnabled(false)
+                .setDataAccessEnabled(true)
                 .setTrustedInterfaces(newHashSet("192.168.1.1"));
 
         Config config = new Config()
@@ -877,6 +878,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         ManagementCenterConfig xmlMCConfig = xmlConfig.getManagementCenterConfig();
         assertEquals(managementCenterConfig.isScriptingEnabled(), xmlMCConfig.isScriptingEnabled());
         assertEquals(managementCenterConfig.isConsoleEnabled(), xmlMCConfig.isConsoleEnabled());
+        assertEquals(managementCenterConfig.isDataAccessEnabled(), xmlMCConfig.isDataAccessEnabled());
         assertEquals(managementCenterConfig.getTrustedInterfaces(), xmlMCConfig.getTrustedInterfaces());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ManagementCenterConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ManagementCenterConfigTest.java
@@ -24,10 +24,12 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -36,59 +38,31 @@ public class ManagementCenterConfigTest extends HazelcastTestSupport {
     private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
     @Test
-    public void testScriptingDisabledByDefault() {
+    public void testDefaultConfig() {
         HazelcastInstance hz = factory.newHazelcastInstance();
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+        checkConfig(hz);
     }
 
     @Test
-    public void testConsoleDisabledByDefault() {
-        HazelcastInstance hz = factory.newHazelcastInstance();
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isConsoleEnabled());
-    }
-
-    @Test
-    public void testScriptingDisabled_whenProgrammaticConfig() {
+    public void testProgrammaticConfig() {
         HazelcastInstance hz = factory.newHazelcastInstance(new Config());
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+        checkConfig(hz);
     }
 
     @Test
-    public void testConsoleDisabled_whenProgrammaticConfig() {
-        HazelcastInstance hz = factory.newHazelcastInstance(new Config());
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isConsoleEnabled());
-    }
-
-    @Test
-    public void testScriptingDisabled_whenXmlConfig() {
+    public void testXmlConfig() {
         InMemoryXmlConfig xmlConfig = new InMemoryXmlConfig("<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n"
                 + "<management-center />\n"
                 + "</hazelcast>");
         HazelcastInstance hz = factory.newHazelcastInstance(xmlConfig);
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+        checkConfig(hz);
     }
 
     @Test
-    public void testConsoleDisabled_whenXmlConfig() {
-        InMemoryXmlConfig xmlConfig = new InMemoryXmlConfig("<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n"
-                + "<management-center />\n"
-                + "</hazelcast>");
-        HazelcastInstance hz = factory.newHazelcastInstance(xmlConfig);
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isConsoleEnabled());
-    }
-
-    @Test
-    public void testScriptingDisabled_whenYamlConfig() {
+    public void testYamlConfig() {
         InMemoryYamlConfig yamlConfig = new InMemoryYamlConfig("hazelcast:\n  cluster-name: name\n");
         HazelcastInstance hz = factory.newHazelcastInstance(yamlConfig);
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
-    }
-
-    @Test
-    public void testConsoleDisabled_whenYamlConfig() {
-        InMemoryYamlConfig yamlConfig = new InMemoryYamlConfig("hazelcast:\n  cluster-name: name\n");
-        HazelcastInstance hz = factory.newHazelcastInstance(yamlConfig);
-        Assert.assertFalse(hz.getConfig().getManagementCenterConfig().isConsoleEnabled());
+        checkConfig(hz);
     }
 
     @Test
@@ -97,5 +71,11 @@ public class ManagementCenterConfigTest extends HazelcastTestSupport {
         EqualsVerifier.forClass(ManagementCenterConfig.class)
                       .suppress(Warning.NONFINAL_FIELDS)
                       .verify();
+    }
+
+    private void checkConfig(HazelcastInstance hz) {
+        assertFalse(hz.getConfig().getManagementCenterConfig().isScriptingEnabled());
+        assertFalse(hz.getConfig().getManagementCenterConfig().isConsoleEnabled());
+        assertTrue(hz.getConfig().getManagementCenterConfig().isDataAccessEnabled());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -883,7 +883,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<management-center scripting-enabled='true' console-enabled='true'>"
+                + "<management-center scripting-enabled='true' console-enabled='true' data-access-enabled='true'>"
                 + "  <trusted-interfaces>\n"
                 + "    <interface>127.0.0.1</interface>\n"
                 + "    <interface>192.168.1.*</interface>\n"
@@ -896,6 +896,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
         assertTrue(mcConfig.isScriptingEnabled());
         assertTrue(mcConfig.isConsoleEnabled());
+        assertTrue(mcConfig.isDataAccessEnabled());
         assertEquals(2, mcConfig.getTrustedInterfaces().size());
         assertTrue(mcConfig.getTrustedInterfaces().containsAll(ImmutableSet.of("127.0.0.1", "192.168.1.*")));
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -883,7 +883,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<management-center scripting-enabled='true' console-enabled='true' data-access-enabled='true'>"
+                + "<management-center scripting-enabled='true' console-enabled='true' data-access-enabled='false'>"
                 + "  <trusted-interfaces>\n"
                 + "    <interface>127.0.0.1</interface>\n"
                 + "    <interface>192.168.1.*</interface>\n"
@@ -896,7 +896,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
         assertTrue(mcConfig.isScriptingEnabled());
         assertTrue(mcConfig.isConsoleEnabled());
-        assertTrue(mcConfig.isDataAccessEnabled());
+        assertFalse(mcConfig.isDataAccessEnabled());
         assertEquals(2, mcConfig.getTrustedInterfaces().size());
         assertTrue(mcConfig.getTrustedInterfaces().containsAll(ImmutableSet.of("127.0.0.1", "192.168.1.*")));
     }
@@ -914,6 +914,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
         assertFalse(mcConfig.isScriptingEnabled());
         assertFalse(mcConfig.isConsoleEnabled());
+        assertTrue(mcConfig.isDataAccessEnabled());
     }
 
     @Override
@@ -926,6 +927,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
         assertFalse(mcConfig.isScriptingEnabled());
         assertFalse(mcConfig.isConsoleEnabled());
+        assertTrue(mcConfig.isDataAccessEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -910,6 +910,7 @@ public class YamlConfigBuilderTest
 
         assertFalse(mcConfig.isScriptingEnabled());
         assertFalse(mcConfig.isConsoleEnabled());
+        assertTrue(mcConfig.isDataAccessEnabled());
     }
 
     @Override
@@ -922,6 +923,7 @@ public class YamlConfigBuilderTest
 
         assertFalse(mcConfig.isScriptingEnabled());
         assertFalse(mcConfig.isConsoleEnabled());
+        assertTrue(mcConfig.isDataAccessEnabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -883,6 +883,7 @@ public class YamlConfigBuilderTest
                 + "  management-center:\n"
                 + "    scripting-enabled: true\n"
                 + "    console-enabled: true\n"
+                + "    data-access-enabled: false\n"
                 + "    trusted-interfaces:\n"
                 + "      - 127.0.0.1\n"
                 + "      - 192.168.1.*\n";
@@ -892,6 +893,7 @@ public class YamlConfigBuilderTest
 
         assertTrue(mcConfig.isScriptingEnabled());
         assertTrue(mcConfig.isConsoleEnabled());
+        assertFalse(mcConfig.isDataAccessEnabled());
         assertEquals(2, mcConfig.getTrustedInterfaces().size());
         assertTrue(mcConfig.getTrustedInterfaces().containsAll(ImmutableSet.of("127.0.0.1", "192.168.1.*")));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
@@ -85,6 +85,8 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertTrue(cloned.isSslEnabled());
         assertTrue(cloned.isLite());
         assertFalse(cloned.isScriptingEnabled());
+        assertFalse(cloned.isConsoleEnabled());
+        assertTrue(cloned.isMcDataAccessEnabled());
         assertNotNull(cloned.toString());
     }
 
@@ -101,6 +103,8 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertTrue(deserialized.isSslEnabled());
         assertTrue(deserialized.isLite());
         assertFalse(deserialized.isScriptingEnabled());
+        assertFalse(deserialized.isConsoleEnabled());
+        assertTrue(deserialized.isMcDataAccessEnabled());
         assertNotNull(deserialized.toString());
     }
 

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/management-center/multiple-failures.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/management-center/multiple-failures.json
@@ -4,6 +4,7 @@
       "management-center": {
         "scripting-enabled": null,
         "console-enabled": null,
+        "data-access-enabled": null,
         "other": true,
         "trusted-interfaces": {}
       }
@@ -35,6 +36,13 @@
         "message": "expected type: Boolean, found: Null"
       },
       {
+        "schemaLocation": "#/definitions/ManagementCenter/properties/data-access-enabled",
+        "pointerToViolation": "#/hazelcast/management-center/data-access-enabled",
+        "causingExceptions": [],
+        "keyword": "type",
+        "message": "expected type: Boolean, found: Null"
+      },
+      {
         "schemaLocation": "#/definitions/ManagementCenter/properties/trusted-interfaces",
         "pointerToViolation": "#/hazelcast/management-center/trusted-interfaces",
         "causingExceptions": [],
@@ -42,6 +50,6 @@
         "message": "expected type: JSONArray, found: JSONObject"
       }
     ],
-    "message": "4 schema violations found"
+    "message": "5 schema violations found"
   }
 }

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/management-center/success.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/management-center/success.json
@@ -3,7 +3,8 @@
     "hazelcast": {
       "management-center": {
         "scripting-enabled": false,
-        "console-enabled": false
+        "console-enabled": false,
+        "data-access-enabled": false
       }
     }
   },

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -44,7 +44,7 @@
     <cluster-name>my-cluster</cluster-name>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <instance-name>dummy</instance-name>
-    <management-center scripting-enabled="false" console-enabled="false">
+    <management-center scripting-enabled="false" console-enabled="false" data-access-enabled="true">
         <trusted-interfaces>
             <interface>10.10.1.*</interface>
             <interface>10.10.2.*</interface>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -40,6 +40,7 @@ hazelcast:
   management-center:
     scripting-enabled: false
     console-enabled: false
+    data-access-enabled: false
     trusted-interfaces:
       - 10.10.1.*
       - 10.10.2.*

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -40,7 +40,7 @@ hazelcast:
   management-center:
     scripting-enabled: false
     console-enabled: false
-    data-access-enabled: false
+    data-access-enabled: true
     trusted-interfaces:
       - 10.10.1.*
       - 10.10.2.*


### PR DESCRIPTION
Adds a `data-access-enabled` property to `management-center` member config. Actual checks are performed on the Management Center side.

Fixes https://hazelcast.atlassian.net/browse/MC-1039

No breaking changes.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible