### PR TITLE
[BACKPORT 5.0.z] Add empty value and short license string check for hazelcast.licensekey overriding config

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -122,8 +122,6 @@
               files="com[\\/]hazelcast[\\/]config[\\/]MapConfig"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]SerializationConfig"/>
     <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]internal[\\/]config[\\/]MemberDomConfigProcessor"/>
-    <suppress checks="MagicNumber" files="com[\\/]hazelcast[\\/]internal[\\/]config[\\/]override[\\/]ExternalConfigurationOverride"/>
-
     <!-- YAML -->
     <suppress checks="BooleanExpressionComplexity" files="com[\\/]hazelcast[\\/]internal[\\/]yaml[\\/]YamlUtil"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
@@ -37,6 +37,7 @@ import static java.util.stream.Collectors.joining;
  */
 public class ExternalConfigurationOverride {
 
+    private static final int LICENSE_KEY_VISIBLE_CHAR_COUNT = 5;
     private static final ILogger LOGGER = Logger.getLogger(ExternalConfigurationOverride.class);
 
     public Config overwriteMemberConfig(Config config) {
@@ -83,11 +84,12 @@ public class ExternalConfigurationOverride {
                   properties.entrySet().stream()
                     .filter(e -> !unprocessed.containsKey(e.getKey()))
                     .map(e -> {
-                        if (e.getKey().equals("hazelcast.licensekey")) {
+                        if (e.getKey().equals("hazelcast.licensekey")
+                                && !e.getValue().isEmpty() && e.getValue().length() > LICENSE_KEY_VISIBLE_CHAR_COUNT) {
                             String[] licenceKeyParts = e.getValue().split("#");
                             String originalKeyPart = licenceKeyParts[licenceKeyParts.length - 1];
-                            return e.getKey() + "=" + originalKeyPart.substring(0, 5) + "*********"
-                                    + originalKeyPart.substring(originalKeyPart.length() - 5) ;
+                            return e.getKey() + "=" + originalKeyPart.substring(0, LICENSE_KEY_VISIBLE_CHAR_COUNT) + "*********"
+                                    + originalKeyPart.substring(originalKeyPart.length() - LICENSE_KEY_VISIBLE_CHAR_COUNT);
                         } else {
                             return e.getKey() + "=" + e.getValue();
                         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -670,6 +670,24 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
     }
 
+    @Test
+    public void shouldHandleEmptyLicenseKey() throws Exception {
+        Config config = new Config();
+
+        withEnvironmentVariable("HZ_LICENSEKEY", "")
+                .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        assertEquals(config.getLicenseKey(), "");
+    }
+
+    @Test
+    public void shouldHandleShortLicenseKey() throws Exception {
+        Config config = new Config();
+
+        withEnvironmentVariable("HZ_LICENSEKEY", "foo")
+                .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        assertEquals(config.getLicenseKey(), "foo");
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void shouldHandleRestApiConfigInvalidEntry() throws Exception {
         Config config = new Config();


### PR DESCRIPTION
With this check, "java.lang.IllegalArgumentException: License key can not be empty." or "InvalidLicenseException" will be thrown instead of "StringIndexOutOfBoundsException"

Fixes #19849

Backport of: https://github.com/hazelcast/hazelcast/pull/19942