### PR TITLE
Fix flaky Log4jLoggerTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggerTest.java
@@ -19,7 +19,9 @@ package com.hazelcast.logging;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.SimpleMemberImpl;
 import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
 
+import javax.annotation.Nonnull;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -28,21 +30,21 @@ abstract class AbstractLoggerTest extends HazelcastTestSupport {
     static final String MESSAGE = "Any message";
     static final Throwable THROWABLE = new Exception("expected exception");
 
-    static final LogEvent LOG_EVENT;
-    static final LogEvent LOG_EVENT_OFF;
+    protected LogEvent LOG_EVENT;
+    protected LogEvent LOG_EVENT_OFF;
 
-    static {
-        LogRecord logRecord = new LogRecord(Level.WARNING, MESSAGE);
+    @Before
+    public void setUpAbstract() {
+        LOG_EVENT = createLogEvent(Level.WARNING, "loggerWarn");
+        LOG_EVENT_OFF = createLogEvent(Level.OFF, "loggerOff");
+    }
+
+    @Nonnull
+    private static LogEvent createLogEvent(Level level, String loggerName) {
+        LogRecord logRecord = new LogRecord(level, MESSAGE);
         logRecord.setThrown(THROWABLE);
-        logRecord.setLoggerName(AbstractLoggerTest.class.getSimpleName());
-
-        LogRecord logRecordOff = new LogRecord(Level.OFF, MESSAGE);
-        logRecordOff.setThrown(THROWABLE);
-        logRecordOff.setLoggerName(AbstractLoggerTest.class.getSimpleName());
-
+        logRecord.setLoggerName(loggerName);
         Member member = new SimpleMemberImpl();
-
-        LOG_EVENT = new LogEvent(logRecord, member);
-        LOG_EVENT_OFF = new LogEvent(logRecordOff, member);
+        return new LogEvent(logRecord, member);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.logging;
 
 import com.hazelcast.logging.Log4jFactory.Log4jLogger;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class Log4jLoggerTest extends AbstractLoggerTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.logging;
 
 import com.hazelcast.logging.Log4jFactory.Log4jLogger;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class Log4jLoggerTest extends AbstractLoggerTest {
 


### PR DESCRIPTION
The parallel runner may run multiple tests at the same time using same
logger instance because they are reused for tests logEvent_shouldLog and
logEvent_withLogLevelOff_shouldNotLog.

Fixes #19976 (test failure seen in PR builder of #19999)