### PR TITLE
Fix name of CLI commands in help text [5.0.z]

### DIFF
--- a/distribution/src/bin-filemode-755/hz-start
+++ b/distribution/src/bin-filemode-755/hz-start
@@ -25,7 +25,7 @@ findScriptDir
 #shellcheck source=bin-regular/common.sh
 
 if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
-    echo "Usage: hazelcast-start [-d]"
+    echo "Usage: $0 [-d]"
     echo "  -d, --daemon   Starts Hazelcast in daemon mode"
     exit 0
 elif [[ "$1" = "-d" ]] || [[ "$1" = "--daemon" ]]; then

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -91,7 +91,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
         "checkstyle:MethodCount",
 })
 @Command(
-        name = "hazelcast",
+        name = "hz-cli",
         description = "Utility to perform operations on a Hazelcast cluster.%n"
                 + "By default it uses the file config/hazelcast-client.xml to configure the client connection."
                 + "%n%n"


### PR DESCRIPTION
Fixes #19724

Backport of #20001


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
