### PR TITLE
Use hazelcast.yaml when hazelcast.xml is not available

### DIFF
--- a/distribution/src/bin-filemode-755/hz-start
+++ b/distribution/src/bin-filemode-755/hz-start
@@ -37,9 +37,18 @@ fi
 # HAZELCAST_CONFIG holds the configuration path.
 # If the the path is relative, it is relative to the Hazelcast installation directory (HAZELCAST_HOME).
 # The path can be absolute.
-# By default, it is set to $HAZELCAST_HOME/config/hazelcast.xml
+# By default, it is set to $HAZELCAST_HOME/config/hazelcast.xml, with fallback to $HAZELCAST_HOME/config/hazelcast.yaml
+# if the xml file is not present.
 if [ -z "$HAZELCAST_CONFIG" ]; then
     HAZELCAST_CONFIG="config/hazelcast.xml"
+    if [ ! -f "$HAZELCAST_HOME/$HAZELCAST_CONFIG" ]; then
+        HAZELCAST_CONFIG="config/hazelcast.yaml"
+    fi
+
+    if [ ! -f "$HAZELCAST_HOME/$HAZELCAST_CONFIG" ]; then
+        echo "Configuration file is missing. Create hazelcast.xml or hazelcast.yaml in $HAZELCAST_HOME/config or set the HAZELCAST_CONFIG environment variable."
+        exit 1
+    fi
 fi
 # if the first character is /, then this is an absolute path, use as is
 # otherwise prepend (HAZELCAST_HOME)

--- a/distribution/src/bin-filemode-755/hz-start
+++ b/distribution/src/bin-filemode-755/hz-start
@@ -44,9 +44,12 @@ if [ -z "$HAZELCAST_CONFIG" ]; then
     if [ ! -f "$HAZELCAST_HOME/$HAZELCAST_CONFIG" ]; then
         HAZELCAST_CONFIG="config/hazelcast.yaml"
     fi
+    if [ ! -f "$HAZELCAST_HOME/$HAZELCAST_CONFIG" ]; then
+        HAZELCAST_CONFIG="config/hazelcast.yml"
+    fi
 
     if [ ! -f "$HAZELCAST_HOME/$HAZELCAST_CONFIG" ]; then
-        echo "Configuration file is missing. Create hazelcast.xml or hazelcast.yaml in $HAZELCAST_HOME/config or set the HAZELCAST_CONFIG environment variable."
+        echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in $HAZELCAST_HOME/config or set the HAZELCAST_CONFIG environment variable."
         exit 1
     fi
 fi

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -1,6 +1,6 @@
 @echo off
 
-SETLOCAL
+SETLOCAL ENABLEDELAYEDEXPANSION
 
 if "x%JAVA_HOME%" == "x" (
     echo JAVA_HOME environment variable not available.
@@ -41,16 +41,13 @@ IF NOT "%JAVA_VERSION%" == "8" (
 
 REM HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
 if "x%HAZELCAST_CONFIG%" == "x" (
-    set HAZELCAST_CONFIG=config/hazelcast.xml
-
-    if not exist "%HAZELCAST_HOME%/%HAZELCAST_CONFIG%" (
+    if not exist "%HAZELCAST_HOME%/!HAZELCAST_CONFIG!" (
       set HAZELCAST_CONFIG=config/hazelcast.yaml
     )
-    if not exist "%HAZELCAST_HOME%/%HAZELCAST_CONFIG%" (
+    if not exist "%HAZELCAST_HOME%/!HAZELCAST_CONFIG!" (
       set HAZELCAST_CONFIG=config/hazelcast.yml
     )
-
-    if not exist "%HAZELCAST_HOME%/%HAZELCAST_CONFIG%" (
+    if not exist "%HAZELCAST_HOME%/!HAZELCAST_CONFIG!" (
       echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in %HAZELCAST_HOME%/config or set the HAZELCAST_CONFIG environment variable."
       exit /b 2
     )

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -41,14 +41,15 @@ IF NOT "%JAVA_VERSION%" == "8" (
 
 REM HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
 if "x%HAZELCAST_CONFIG%" == "x" (
-    if not exist "%HAZELCAST_HOME%/!HAZELCAST_CONFIG!" (
-      set HAZELCAST_CONFIG=config/hazelcast.yaml
+    set HAZELCAST_CONFIG=config\hazelcast.xml
+    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
+      set HAZELCAST_CONFIG=config\hazelcast.yaml
     )
-    if not exist "%HAZELCAST_HOME%/!HAZELCAST_CONFIG!" (
-      set HAZELCAST_CONFIG=config/hazelcast.yml
+    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
+      set HAZELCAST_CONFIG=config\hazelcast.yml
     )
-    if not exist "%HAZELCAST_HOME%/!HAZELCAST_CONFIG!" (
-      echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in %HAZELCAST_HOME%/config or set the HAZELCAST_CONFIG environment variable."
+    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
+      echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in %HAZELCAST_HOME%\config or set the HAZELCAST_CONFIG environment variable."
       exit /b 2
     )
 )

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -42,6 +42,18 @@ IF NOT "%JAVA_VERSION%" == "8" (
 REM HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
 if "x%HAZELCAST_CONFIG%" == "x" (
     set HAZELCAST_CONFIG=config/hazelcast.xml
+
+    if not exist "%HAZELCAST_HOME%/%HAZELCAST_CONFIG%" (
+      set HAZELCAST_CONFIG=config/hazelcast.yaml
+    )
+    if not exist "%HAZELCAST_HOME%/%HAZELCAST_CONFIG%" (
+      set HAZELCAST_CONFIG=config/hazelcast.yml
+    )
+
+    if not exist "%HAZELCAST_HOME%/%HAZELCAST_CONFIG%" (
+      echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in %HAZELCAST_HOME%/config or set the HAZELCAST_CONFIG environment variable."
+      exit /b 2
+    )
 )
 
 set JAVA_OPTS=%JAVA_OPTS%^


### PR DESCRIPTION
Users sometimes prefer to use yaml configuration.
When the hazelcast.xml is not available in the config folder then
hazelcast.yaml is tried.
If hazelcast.yaml is not available error message is shown with guidance
what to do.

Fixes #19727

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
