### PR TITLE
Fix logging configuration in hz-start.bat [5.0.z]

### DIFF
--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -49,6 +49,12 @@ set JAVA_OPTS=%JAVA_OPTS%^
  "-Dlog4j.configurationFile=file:%HAZELCAST_HOME%\config\log4j2.properties"^
  "-Dhazelcast.config=%HAZELCAST_HOME%\%HAZELCAST_CONFIG%"
 
+if "x%LOGGING_LEVEL%" == "x" (
+    set LOGGING_LEVEL=INFO
+)
+
+set "LOGGING_PATTERN=%%d [%%highlight{${LOG_LEVEL_PATTERN:-%%5p}}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}] [%%style{%%t{1.}}{cyan}] [%%style{%%c{1.}}{blue}]: %%m%%n"
+
 set CLASSPATH="%HAZELCAST_HOME%\lib\*;%HAZELCAST_HOME%\bin\user-lib;%HAZELCAST_HOME%\bin\user-lib\*";%CLASSPATH%
 
 ECHO ########################################


### PR DESCRIPTION
Fixes #19838
Backport of #20012 to `5.0.z`

Displays proper log messages instead of the blank screen.