### PR TITLE
Use default value for OWASP failBuildOnCVSS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,6 @@
                     <format>ALL</format>
                     <skipProvidedScope>true</skipProvidedScope>
                     <nodeAuditAnalyzerEnabled>false</nodeAuditAnalyzerEnabled>
-                    <failBuildOnCVSS>10</failBuildOnCVSS>
                     <suppressionFiles>owasp-check-suppressions.xml</suppressionFiles>
                 </configuration>
             </plugin>


### PR DESCRIPTION
OWASP run currently fails due to:
```
One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '10.0'
```
We're using it for OWASP report generation which we check. We don't want to fail our build for it. We should use default value there which means: _" The default is 11 which means since the CVSS scores are 0-10, by default the build will never fail."_ (https://jeremylong.github.io/DependencyCheck/dependency-check-maven/aggregate-mojo.html#failBuildOnCVSS)