### PR TITLE
Update json-smart to 2.4.7 [5.0.1]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1402,7 +1402,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.4.1</version>
+                <version>2.4.7</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
Fixes #20023

Backport of #20026
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
