### PR TITLE
Adjust delay for scanJobs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -1173,6 +1173,7 @@ public class JobCoordinationService {
 
     // runs periodically to restart jobs on coordinator failure and perform GC
     private void scanJobs() {
+        long scanStart = System.currentTimeMillis();
         long nextScanDelay = maxJobScanPeriodInMillis;
         try {
             // explicit check for master because we don't want to use shorter delay on non-master nodes
@@ -1190,6 +1191,11 @@ public class JobCoordinationService {
         } catch (Throwable e) {
             logger.severe("Scanning jobs failed", e);
         }
+
+        // Adjust the delay by the time taken by the scan to avoid accumulating more and more job results with each scan
+        long scanTime = System.currentTimeMillis() - scanStart;
+        nextScanDelay = Math.max(0, nextScanDelay - scanTime);
+
         ExecutionService executionService = nodeEngine.getExecutionService();
         executionService.schedule(this::scanJobs, nextScanDelay, MILLISECONDS);
     }


### PR DESCRIPTION
I have the following theory that explains the increasing job cleanup
time which existed even before introduction of light jobs.

- We remove job results after reaching a threshold (1050 by default), we
keep N newest results.
- We accumulate job results in the 5s period.
- These results are cleaned, it takes some time.
- While cleaning the results we accumulate some more, these are cleaned
up in next cycle. The next cycle is scheduled in 5 s. There are now more
results to clean up.
- Repeat.

This commit makes the next cleanup run sooner (5 s - cleanup time).

It is still possible that we accumulate more job results than we are
able to cleanup. This commit doesn't handle such scenario.

Issue: #19113

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible