### PR TITLE
Make GenericRecord implementations threadSafe

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -238,6 +238,7 @@
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]ByteArrayObjectDataInput"/>
     <suppress checks="MethodCount|MagicNumber"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]ByteArrayObjectDataOutput"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]internal[\\/]nio[\\/]BufferObjectDataInput"/>
     <suppress checks="MethodCount|MagicNumber"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]ByteBufferObjectDataInput"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]ObjectDataInputStream"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/BufferObjectDataInput.java
@@ -19,12 +19,15 @@ package com.hazelcast.internal.nio;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
 public interface BufferObjectDataInput extends ObjectDataInput, DataReader, SerializationServiceSupport {
 
     int UTF_BUFFER_SIZE = 1024;
+
+    int readFully(byte[] bytes, int position, int off, int len) throws IOException;
 
     int read(int position) throws IOException;
 
@@ -63,6 +66,30 @@ public interface BufferObjectDataInput extends ObjectDataInput, DataReader, Seri
     short readShort(ByteOrder byteOrder) throws IOException;
 
     short readShort(int position, ByteOrder byteOrder) throws IOException;
+
+    @Nullable
+    boolean[] readBooleanArray(int position) throws IOException;
+
+    @Nullable
+    byte[] readByteArray(int position) throws IOException;
+
+    @Nullable
+    short[] readShortArray(int position) throws IOException;
+
+    @Nullable
+    int[] readIntArray(int position) throws IOException;
+
+    @Nullable
+    long[] readLongArray(int position) throws IOException;
+
+    @Nullable
+    float[] readFloatArray(int position) throws IOException;
+
+    @Nullable
+    double[] readDoubleArray(int position) throws IOException;
+
+    @Nullable
+    String readString(int position) throws IOException;
 
     int position();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactWithSchemaStreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactWithSchemaStreamSerializerAdapter.java
@@ -47,7 +47,8 @@ public class CompactWithSchemaStreamSerializerAdapter implements SerializerAdapt
 
     @Override
     public Object read(ObjectDataInput in) throws IOException {
-        return serializer.read((BufferObjectDataInput) in, true);
+        BufferObjectDataInput bufferObjectDataInput = (BufferObjectDataInput) in;
+        return serializer.read(bufferObjectDataInput, bufferObjectDataInput.position(), true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -72,9 +72,10 @@ import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
  */
 public class DefaultCompactReader extends CompactInternalGenericRecord implements CompactReader {
 
-    public DefaultCompactReader(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
+    public DefaultCompactReader(CompactStreamSerializer serializer, BufferObjectDataInput in, int readPosition,
+                                Schema schema,
                                 @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
-        super(serializer, in, schema, associatedClass, schemaIncludedInBinary);
+        super(serializer, in,  readPosition, schema, associatedClass, schemaIncludedInBinary);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
@@ -74,7 +74,7 @@ public class SerializingGenericRecordBuilder implements GenericRecordBuilder {
         }
         defaultCompactWriter.end();
         byte[] bytes = defaultCompactWriter.toByteArray();
-        return new DefaultCompactReader(serializer, bufferObjectDataInputFunc.apply(bytes), schema,
+        return new DefaultCompactReader(serializer, bufferObjectDataInputFunc.apply(bytes), 0, schema,
                 null, false);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
@@ -94,7 +94,7 @@ public class SerializingGenericRecordCloner implements GenericRecordBuilder {
             byte[] bytes = cw.toByteArray();
             Class associatedClass = genericRecord.getAssociatedClass();
             BufferObjectDataInput dataInput = bufferObjectDataInputFunc.apply(bytes);
-            return new DefaultCompactReader(serializer, dataInput, schema, associatedClass, false);
+            return new DefaultCompactReader(serializer, dataInput, 0, schema, associatedClass, false);
         } catch (IOException e) {
             throw new HazelcastSerializationException(e);
         }


### PR DESCRIPTION
CompactInternalGenericRecord no longer modifies
`position` field of ByteArrayObjectDataOutput
when reading fields.