### PR TITLE
[HZ-757] Support sub-queries and VALUES() execution in JOIN arguments

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastSqlValidator.java
@@ -79,7 +79,6 @@ import static com.hazelcast.jet.sql.impl.connector.SqlConnectorUtil.getJetSqlCon
 import static com.hazelcast.jet.sql.impl.validate.ValidatorResource.RESOURCE;
 import static java.util.Objects.requireNonNull;
 import static org.apache.calcite.sql.SqlKind.AGGREGATE;
-import static org.apache.calcite.sql.SqlKind.VALUES;
 
 /**
  * Hazelcast-specific SQL validator.
@@ -315,31 +314,16 @@ public class HazelcastSqlValidator extends SqlValidatorImplBridge {
     protected void validateJoin(SqlJoin join, SqlValidatorScope scope) {
         super.validateJoin(join, scope);
 
-        SqlBasicVisitor<Void> joinChecker = new SqlBasicVisitor<Void>() {
-            @Override
-            public Void visit(SqlCall call) {
-                if (call.getKind() == VALUES) {
-                    throw newValidationError(join, RESOURCE.joiningValuesNotSupported());
-                }
-
-                return call.getOperator().acceptCall(this, call);
-            }
-        };
-
         switch (join.getJoinType()) {
             case INNER:
             case COMMA:
             case CROSS:
-                join.getRight().accept(joinChecker);
-                break;
             case LEFT:
-                join.getRight().accept(joinChecker);
                 if (containsStreamingSource(join.getRight())) {
                     throw newValidationError(join, RESOURCE.streamingSourceOnWrongSide());
                 }
                 break;
             case RIGHT:
-                join.getLeft().accept(joinChecker);
                 if (containsStreamingSource(join.getLeft())) {
                     throw newValidationError(join, RESOURCE.streamingSourceOnWrongSide());
                 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastSqlValidator.java
@@ -318,9 +318,7 @@ public class HazelcastSqlValidator extends SqlValidatorImplBridge {
         SqlBasicVisitor<Void> joinChecker = new SqlBasicVisitor<Void>() {
             @Override
             public Void visit(SqlCall call) {
-                if (call.getKind() == SqlKind.SELECT) {
-                    throw newValidationError(join, RESOURCE.joiningSubqueryNotSupported());
-                } else if (call.getKind() == VALUES) {
+                if (call.getKind() == VALUES) {
                     throw newValidationError(join, RESOURCE.joiningValuesNotSupported());
                 }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/ValidatorResource.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/ValidatorResource.java
@@ -34,12 +34,6 @@ public interface ValidatorResource {
     @BaseMessage("Unknown argument name ''{0}''")
     ExInst<SqlValidatorException> unknownArgumentName(String name);
 
-    @BaseMessage("Sub-query not supported on the right side of a (LEFT) JOIN or the left side of a RIGHT JOIN")
-    ExInst<SqlValidatorException> joiningSubqueryNotSupported();
-
-    @BaseMessage("VALUES clause not supported on the right side of a (LEFT) JOIN or the left side of a RIGHT JOIN")
-    ExInst<SqlValidatorException> joiningValuesNotSupported();
-
     @BaseMessage("Grouping/aggregations over non-windowed, non-ordered streaming source not supported")
     ExInst<SqlValidatorException> streamingAggregationsOverNonOrderedSourceNotSupported();
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlJoinTest.java
@@ -629,21 +629,19 @@ public class SqlJoinTest {
 
         @Test
         public void test_joinSubquery() {
-            String leftName = randomName();
-            TestBatchSqlConnector.create(sqlService, leftName, 1);
-
             String mapName = randomName();
-            createMapping(mapName, int.class, String.class);
-            instance().getMap(mapName).put(1, "value-1");
+            createMapping(mapName, int.class, int.class);
+            instance().getMap(mapName).put(1, 1);
 
-            assertThatThrownBy(() ->
-                    sqlService.execute(
-                            "SELECT 1 " +
-                                    "FROM " + leftName + " AS l " +
-                                    "JOIN (SELECT * FROM " + mapName + ") AS m ON l.v = m.__key"
-                    ))
-                    .hasCauseInstanceOf(QueryException.class)
-                    .hasMessageContaining("Sub-query not supported on the right side of a (LEFT) JOIN or the left side of a RIGHT JOIN");
+            String mapName2 = randomName();
+            createMapping(mapName2, int.class, int.class);
+            instance().getMap(mapName).put(1, 2);
+
+            assertRowsAnyOrder("SELECT * FROM " + mapName + " AS m1" +
+                            " JOIN (SELECT * FROM " + mapName2 + ") AS m2" +
+                            " ON m1.__key = m2.__key",
+                    singletonList(new Row(1, 1, 1, 2))
+            );
         }
 
         @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlJoinTest.java
@@ -647,15 +647,13 @@ public class SqlJoinTest {
 
         @Test
         public void test_joinValues() {
-            String leftName = randomName();
-            TestBatchSqlConnector.create(sqlService, leftName, 1);
+            String leftName = "map";
+            createMapping(leftName, int.class, int.class);
+            instance().getMap(leftName).put(1, 1);
 
-            assertThatThrownBy(() ->
-                    sqlService.execute(
-                            "SELECT * FROM " + leftName + " l JOIN (VALUES (1)) AS r (__key) ON l.v = r.__key"
-                    ))
-                    .hasCauseInstanceOf(QueryException.class)
-                    .hasMessageContaining("VALUES clause not supported on the right side of a (LEFT) JOIN or the left side of a RIGHT JOIN");
+            assertRowsAnyOrder("SELECT * FROM " + leftName + " l JOIN (VALUES (1, 1)) AS r ON true",
+                    singletonList(new Row(1, 1, (byte) 1, (byte) 1))
+            );
         }
     }
 
@@ -1257,16 +1255,23 @@ public class SqlJoinTest {
         }
 
         @Test
-        public void test_whenOuterJoinUseValuesClause_thenExceptionThrown() {
+        public void test_whenOuterJoinUseValuesClause() {
             String batchName = randomName();
             IMap<Integer, Integer> map = instance().getMap(batchName);
             createMapping(batchName, int.class, int.class);
             map.put(1, 1);
 
-            assertThatThrownBy(() -> sqlService.execute(
-                    "SELECT * FROM " + joinClause(batchName, "(VALUES(1,2))") + " ON true"))
-                    .hasCauseInstanceOf(QueryException.class)
-                    .hasMessageContaining("VALUES clause not supported on the right side of a (LEFT) JOIN or the left side of a RIGHT JOIN");
+            Row expectedRow;
+            if (joinType == OuterJoinType.LEFT) {
+                expectedRow = new Row(1, 1, (byte) 1, (byte) 2);
+            } else {
+                expectedRow = new Row((byte) 1, (byte) 2, 1, 1);
+            }
+
+            assertRowsAnyOrder(
+                    "SELECT * FROM " + joinClause(batchName, "(VALUES(1,2))") + " ON true",
+                    singletonList(expectedRow)
+            );
         }
 
         private String joinClause(


### PR DESCRIPTION
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
