### PR TITLE
Avoid need to open java.lang.reflect module on JDK17

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamNonFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamNonFinalMethodsTest.java
@@ -17,91 +17,83 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
-import java.lang.reflect.Field;
-import java.nio.ByteOrder;
 import java.util.Random;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ObjectDataInputStreamNonFinalMethodsTest {
 
     static final byte[] INIT_DATA = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    private InternalSerializationService mockSerializationService;
     private ObjectDataInputStream in;
-    private DataInputStream dataInputSpy;
-    private ByteArrayInputStream inputStream;
-    private ByteOrder byteOrder;
+    private TestInputStream inputStream;
 
     @Before
     public void before() throws Exception {
-        byteOrder = BIG_ENDIAN;
-        mockSerializationService = mock(InternalSerializationService.class);
-        when(mockSerializationService.getByteOrder()).thenReturn(byteOrder);
+        InternalSerializationService mockSerializationService = mock(InternalSerializationService.class);
+        when(mockSerializationService.getByteOrder()).thenReturn(BIG_ENDIAN);
 
-        inputStream = new ByteArrayInputStream(INIT_DATA);
-        in = new ObjectDataInputStream(inputStream, mockSerializationService);
-
-        Field field = ObjectDataInputStream.class.getDeclaredField("dataInput");
-        field.setAccessible(true);
-        DataInputStream dataInput = (DataInputStream) field.get(in);
-
-        dataInputSpy = spy(dataInput);
-
-        field.set(in, dataInputSpy);
+        inputStream = spy(new TestInputStream(INIT_DATA));
+        in = new ObjectDataInputStream(new DataInputStream(inputStream), mockSerializationService);
     }
 
     @Test
     public void testSkip() throws Exception {
         long someInput = new Random().nextLong();
         in.skip(someInput);
-        verify(dataInputSpy).skip(someInput);
+        verify(inputStream).skip(someInput);
     }
 
     @Test
     public void testAvailable() throws Exception {
         in.available();
-        verify(dataInputSpy).available();
+        verify(inputStream).available();
     }
 
     @Test
     public void testClose() throws Exception {
         in.close();
-        verify(dataInputSpy).close();
+        verify(inputStream).close();
     }
 
     @Test
-    public void testMark() throws Exception {
+    public void testMark() {
         int someInput = new Random().nextInt();
         in.mark(someInput);
-        verify(dataInputSpy).mark(someInput);
+        verify(inputStream).mark(someInput);
     }
 
     @Test
     public void testReset() throws Exception {
         in.reset();
-        verify(dataInputSpy).reset();
+        verify(inputStream).reset();
     }
 
     @Test
-    public void testMarkSupported() throws Exception {
+    public void testMarkSupported() {
         in.markSupported();
-        verify(dataInputSpy).markSupported();
+        verify(inputStream).markSupported();
+    }
+
+    static class TestInputStream extends ByteArrayInputStream {
+        TestInputStream(byte[] buf) {
+            super(buf);
+        }
     }
 }


### PR DESCRIPTION
Avoided need to open `java.lang.reflect` module on JDK17

- Related to https://github.com/hazelcast/hazelcast/pull/19896

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
