### PR TITLE
Upgrade equalsverifier library to work with JDK17 HZ-656

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1823,7 +1823,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.5.5</version>
+            <version>3.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgraded Equalsverifier library to 3.8. 

Issue: https://hazelcast.atlassian.net/browse/HZ-656

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
