### PR TITLE
Fix SplitBrainTest#when_newMemberIsAddedAfterClusterSizeFallsBelowQuorumSize_then_jobRestartDoesNotSucceed

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -312,11 +312,15 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
         // Start another instance so the job can restart and be cleaned up correctly
         HazelcastInstance instance7 = createHazelcastInstance(createConfig());
         waitAllForSafeState(newArrayList(instances[0], instance6, instance7));
-        assertJobStatusEventually(job, RUNNING);
+        assertTrueEventually(() -> assertStatusRunningOrCompleted(job.getStatus()), 5);
     }
 
     private void assertStatusNotRunningOrStarting(JobStatus status) {
         assertTrue("status=" + status, status == NOT_RUNNING || status == STARTING);
+    }
+
+    private void assertStatusRunningOrCompleted(JobStatus status) {
+        assertTrue("status=" + status, status == RUNNING || status == COMPLETED);
     }
 
     @Test


### PR DESCRIPTION
The source of the failure is assertTrueEventually. Because it's only
sufficient to assert conditions that eventually become true and then
always remain true. It tries to run assert task 5 times per second, and
can miss if a condition is true at one period time and then false again
(anyway, there is no chance to try it continuously). See:
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java#L1253

In this test, although job starts to run (job status becomes RUNNING
for some period of time), it completes very quickly and changes its
status to COMPLETED, so assert tasks trials may not coincide with
this RUNNING state period.

Fixes: #19868

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

