### PR TITLE
[5.0.1] Bump log4j2.version from 2.14.0 to 2.15.0 (#20144)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <kotlin.version>1.3.61</kotlin.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
-        <log4j2.version>2.14.0</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <mysql.connector.version>8.0.20</mysql.connector.version>
         <netty.version>4.1.63.Final</netty.version>
         <osgi.version>4.2.0</osgi.version>


### PR DESCRIPTION
Bumps `log4j2.version` from 2.14.0 to 2.15.0.

Updates `log4j-api` from 2.14.0 to 2.15.0

Updates `log4j-core` from 2.14.0 to 2.15.0

Updates `log4j-slf4j-impl` from 2.13.2 to 2.15.0

Backport of https://github.com/hazelcast/hazelcast/pull/20144

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:development
  update-type: version-update:semver-minor
- dependency-name: org.apache.logging.log4j:log4j-slf4j-impl
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit ad951d3b2fa1ff3412219c1d2e03a31ddf1b3011)

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
