### PR TITLE
Avoid opening java.util module for tests on JDK17 HZ-687

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/EnvConfigProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/EnvConfigProvider.java
@@ -24,14 +24,16 @@ import java.util.Map;
 class EnvConfigProvider implements ConfigProvider {
 
     private final EnvVariablesConfigParser envVariablesConfigParser;
+    private final Map<String, String> envVariables;
 
-    EnvConfigProvider(EnvVariablesConfigParser envVariablesConfigParser) {
+    EnvConfigProvider(EnvVariablesConfigParser envVariablesConfigParser, Map<String, String> envVariables) {
         this.envVariablesConfigParser = envVariablesConfigParser;
+        this.envVariables = envVariables;
     }
 
     @Override
     public Map<String, String> properties() {
-        return Collections.unmodifiableMap(envVariablesConfigParser.parse(System.getenv()));
+        return Collections.unmodifiableMap(envVariablesConfigParser.parse(envVariables));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
@@ -47,6 +47,9 @@ public class ExternalConfigurationOverride {
         this(System.getenv(), System::getProperties);
     }
 
+    /**
+     * Used externally only for testing
+     */
     ExternalConfigurationOverride(Map<String, String> envVariables, SystemPropertiesProvider systemPropertiesProvider) {
         this.envVariables = envVariables;
         this.systemPropertiesProvider = systemPropertiesProvider;

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/SystemPropertiesConfigProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/SystemPropertiesConfigProvider.java
@@ -17,6 +17,7 @@ package com.hazelcast.internal.config.override;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * A {@link ConfigProvider} extracting config entries from system properties.
@@ -24,18 +25,26 @@ import java.util.Map;
 class SystemPropertiesConfigProvider implements ConfigProvider {
 
     private final SystemPropertiesConfigParser systemPropertiesConfigParser;
+    private final SystemPropertiesProvider systemPropertiesProvider;
 
-    SystemPropertiesConfigProvider(SystemPropertiesConfigParser systemPropertiesConfigParser) {
+    SystemPropertiesConfigProvider(SystemPropertiesConfigParser systemPropertiesConfigParser,
+                                   SystemPropertiesProvider systemPropertiesProvider) {
         this.systemPropertiesConfigParser = systemPropertiesConfigParser;
+        this.systemPropertiesProvider = systemPropertiesProvider;
     }
 
     @Override
     public Map<String, String> properties() {
-        return Collections.unmodifiableMap(systemPropertiesConfigParser.parse(System.getProperties()));
+        return Collections.unmodifiableMap(systemPropertiesConfigParser.parse(systemPropertiesProvider.get()));
     }
 
     @Override
     public String name() {
         return "system properties";
+    }
+
+    @FunctionalInterface
+    interface SystemPropertiesProvider {
+        Properties get();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
@@ -18,8 +18,9 @@ package com.hazelcast.config;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,8 +45,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 @SuppressWarnings("checkstyle:Indentation")
-@RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class})
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ConfigTest extends HazelcastTestSupport {
 
     static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
@@ -36,7 +36,6 @@ import java.io.Writer;
 import java.util.Collections;
 import java.util.Properties;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static com.hazelcast.instance.ProtocolType.WAN;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
@@ -92,19 +91,13 @@ public class ConfigTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testExternalConfigOverrides() throws Exception {
-        String clusterName = randomName();
-        String instanceName = randomName();
+    public void testExternalConfigOverrides() {
+        String randomPropertyName = randomName();
+        System.setProperty("hz.properties." + randomPropertyName, "123");
 
-        System.setProperty("hz.cluster-name", clusterName);
+        Config cfg = Config.load();
 
-        Config cfg = withEnvironmentVariable("HZ_INSTANCENAME", instanceName)
-                .and("HZ_NETWORK_PORT_PORT", "6731")
-                .execute(Config::load);
-
-        assertEquals(clusterName, cfg.getClusterName());
-        assertEquals(instanceName, cfg.getInstanceName());
-        assertEquals(6731, cfg.getNetworkConfig().getPort());
+        assertEquals("123", cfg.getProperty(randomPropertyName));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalConfigTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalConfigTestUtils.java
@@ -21,20 +21,6 @@ import java.util.Map;
 
 class ExternalConfigTestUtils {
 
-    @SafeVarargs
-    static void runWithSystemProperties(Runnable action, Map.Entry<String, String>... entry) {
-        try {
-            for (Map.Entry<String, String> e : entry) {
-                System.setProperty(e.getKey(), e.getValue());
-            }
-            action.run();
-        } finally {
-            for (Map.Entry<String, String> e : entry) {
-                System.clearProperty(e.getKey());
-            }
-        }
-    }
-
     static <K, V> Map.Entry<K, V> entry(K key, V value) {
         return new AbstractMap.SimpleEntry<>(key, value);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalConfigTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalConfigTestUtils.java
@@ -21,15 +21,6 @@ import java.util.Map;
 
 class ExternalConfigTestUtils {
 
-    static void runWithSystemProperty(String key, String value, Runnable action) {
-        try {
-            System.setProperty(key, value);
-            action.run();
-        } finally {
-            System.clearProperty(key);
-        }
-    }
-
     @SafeVarargs
     static void runWithSystemProperties(Runnable action, Map.Entry<String, String>... entry) {
         try {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -27,39 +27,44 @@ import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import static com.hazelcast.config.RestEndpointGroup.DATA;
 import static com.hazelcast.config.RestEndpointGroup.PERSISTENCE;
-import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.runWithSystemProperty;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSupport {
 
     @Test
     public void shouldExtractConfigFromEnv() throws Exception {
         Config config = new Config();
-        withEnvironmentVariable("HZ_CLUSTERNAME", "test")
-          .and("HZ_METRICS_ENABLED", "false")
-          .and("HZ_NETWORK_JOIN_AUTODETECTION_ENABLED", "false")
-          .and("HZ_CACHE_DEFAULT_KEYTYPE_CLASSNAME", "java.lang.Object2")
-          .and("HZ_EXECUTORSERVICE_CUSTOM_POOLSIZE", "42")
-          .and("HZ_EXECUTORSERVICE_DEFAULT_STATISTICSENABLED", "false")
-          .and("HZ_DURABLEEXECUTORSERVICE_DEFAULT_CAPACITY", "42")
-          .and("HZ_SCHEDULEDEXECUTORSERVICE_DEFAULT_CAPACITY", "40")
-          .and("HZ_QUEUE_DEFAULT_MAXSIZE", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_CLUSTERNAME", "test");
+        envVariables.put("HZ_METRICS_ENABLED", "false");
+        envVariables.put("HZ_NETWORK_JOIN_AUTODETECTION_ENABLED", "false");
+        envVariables.put("HZ_CACHE_DEFAULT_KEYTYPE_CLASSNAME", "java.lang.Object2");
+        envVariables.put("HZ_EXECUTORSERVICE_CUSTOM_POOLSIZE", "42");
+        envVariables.put("HZ_EXECUTORSERVICE_DEFAULT_STATISTICSENABLED", "false");
+        envVariables.put("HZ_DURABLEEXECUTORSERVICE_DEFAULT_CAPACITY", "42");
+        envVariables.put("HZ_SCHEDULEDEXECUTORSERVICE_DEFAULT_CAPACITY", "40");
+        envVariables.put("HZ_QUEUE_DEFAULT_MAXSIZE", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("test", config.getClusterName());
         assertFalse(config.getMetricsConfig().isEnabled());
@@ -72,12 +77,14 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         assertFalse(config.getNetworkConfig().getJoin().isAutoDetectionEnabled());
     }
 
+
     @Test
     public void shouldHandleCustomPropertiesConfig() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_PROPERTIES_foo", "bar")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_PROPERTIES_foo", "bar");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("bar", config.getProperty("foo"));
     }
@@ -86,23 +93,24 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleAdvancedNetworkEndpointConfiguration() throws Exception {
         Config config = new Config();
         config.getAdvancedNetworkConfig().setClientEndpointConfig(new ServerSocketEndpointConfig()
-          .setPort(9000)
-          .setPublicAddress("172.29.1.1"));
+                .setPort(9000)
+                .setPublicAddress("172.29.1.1"));
         config.getAdvancedNetworkConfig().setMemberEndpointConfig(new ServerSocketEndpointConfig()
-          .setPort(9001)
-          .setPublicAddress("172.29.1.1"));
+                .setPort(9001)
+                .setPublicAddress("172.29.1.1"));
         config.getAdvancedNetworkConfig().setRestEndpointConfig(new RestServerEndpointConfig()
-          .setPort(9002)
-          .setPublicAddress("172.29.1.1"));
+                .setPort(9002)
+                .setPublicAddress("172.29.1.1"));
         config.getAdvancedNetworkConfig().setMemcacheEndpointConfig(new ServerSocketEndpointConfig()
-          .setPort(9003)
-          .setPublicAddress("172.29.1.1"));
+                .setPort(9003)
+                .setPublicAddress("172.29.1.1"));
 
-        withEnvironmentVariable("HZ_ADVANCEDNETWORK_CLIENTSERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.1")
-          .and("HZ_ADVANCEDNETWORK_MEMBERSERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.2")
-          .and("HZ_ADVANCEDNETWORK_RESTSERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.3")
-          .and("HZ_ADVANCEDNETWORK_MEMCACHESERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.4")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_ADVANCEDNETWORK_CLIENTSERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.1");
+        envVariables.put("HZ_ADVANCEDNETWORK_MEMBERSERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.2");
+        envVariables.put("HZ_ADVANCEDNETWORK_RESTSERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.3");
+        envVariables.put("HZ_ADVANCEDNETWORK_MEMCACHESERVERSOCKETENDPOINTCONFIG.PUBLICADDRESS", "127.0.0.4");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         ServerSocketEndpointConfig clientEndpointConfig = (ServerSocketEndpointConfig) config.getAdvancedNetworkConfig().getEndpointConfigs().get(EndpointQualifier.CLIENT);
         ServerSocketEndpointConfig memberEndpointConfig = (ServerSocketEndpointConfig) config.getAdvancedNetworkConfig().getEndpointConfigs().get(EndpointQualifier.MEMBER);
@@ -123,11 +131,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleNetworkRestApiConfig() throws Exception {
         Config config = new Config();
         config.getNetworkConfig()
-          .getRestApiConfig()
-          .disableAllGroups();
+                .getRestApiConfig()
+                .disableAllGroups();
 
-        withEnvironmentVariable("HZ_NETWORK_RESTAPI_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_NETWORK_RESTAPI_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().isEmpty());
     }
@@ -136,11 +145,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleHotRestartPersistenceConfig() throws Exception {
         Config config = new Config();
         config.getHotRestartPersistenceConfig()
-          .setEnabled(true)
-          .setParallelism(4);
+                .setEnabled(true)
+                .setParallelism(4);
 
-        withEnvironmentVariable("HZ_HOTRESTARTPERSISTENCE_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_HOTRESTARTPERSISTENCE_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getHotRestartPersistenceConfig().isEnabled());
         assertEquals(4, config.getHotRestartPersistenceConfig().getParallelism());
@@ -150,11 +160,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleUserCodeDeploymentConfig() throws Exception {
         Config config = new Config();
         config.getUserCodeDeploymentConfig()
-          .setEnabled(true)
-          .setClassCacheMode(UserCodeDeploymentConfig.ClassCacheMode.OFF);
+                .setEnabled(true)
+                .setClassCacheMode(UserCodeDeploymentConfig.ClassCacheMode.OFF);
 
-        withEnvironmentVariable("HZ_USERCODEDEPLOYMENT_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_USERCODEDEPLOYMENT_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getUserCodeDeploymentConfig().isEnabled());
         assertEquals(UserCodeDeploymentConfig.ClassCacheMode.OFF, config.getUserCodeDeploymentConfig().getClassCacheMode());
@@ -164,12 +175,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleExecutorServiceConfig() throws Exception {
         Config config = new Config();
         config.getExecutorConfig("foo1")
-          .setPoolSize(1)
-          .setStatisticsEnabled(true);
+                .setPoolSize(1)
+                .setStatisticsEnabled(true);
 
-        withEnvironmentVariable("HZ_EXECUTORSERVICE_FOO1_STATISTICSENABLED", "true")
-          .and("HZ_EXECUTORSERVICE_FOO1_QUEUECAPACITY", "17")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_EXECUTORSERVICE_FOO1_STATISTICSENABLED", "true");
+        envVariables.put("HZ_EXECUTORSERVICE_FOO1_QUEUECAPACITY", "17");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getExecutorConfig("foo1").isStatisticsEnabled());
         assertEquals(17, config.getExecutorConfig("foo1").getQueueCapacity());
@@ -180,12 +192,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleDurableExecutorServiceConfig() throws Exception {
         Config config = new Config();
         config.getDurableExecutorConfig("foo1")
-          .setPoolSize(1)
-          .setStatisticsEnabled(true);
+                .setPoolSize(1)
+                .setStatisticsEnabled(true);
 
-        withEnvironmentVariable("HZ_DURABLEEXECUTORSERVICE_FOO1_STATISTICSENABLED", "true")
-          .and("HZ_DURABLEEXECUTORSERVICE_FOO1_CAPACITY", "17")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_DURABLEEXECUTORSERVICE_FOO1_STATISTICSENABLED", "true");
+        envVariables.put("HZ_DURABLEEXECUTORSERVICE_FOO1_CAPACITY", "17");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getDurableExecutorConfig("foo1").isStatisticsEnabled());
         assertEquals(17, config.getDurableExecutorConfig("foo1").getCapacity());
@@ -196,12 +209,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleScheduledServiceConfig() throws Exception {
         Config config = new Config();
         config.getScheduledExecutorConfig("foo1")
-          .setPoolSize(1)
-          .setStatisticsEnabled(true);
+                .setPoolSize(1)
+                .setStatisticsEnabled(true);
 
-        withEnvironmentVariable("HZ_SCHEDULEDEXECUTORSERVICE_FOO1_ENABLED", "true")
-          .and("HZ_SCHEDULEDEXECUTORSERVICE_FOO1_CAPACITY", "17")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_SCHEDULEDEXECUTORSERVICE_FOO1_ENABLED", "true");
+        envVariables.put("HZ_SCHEDULEDEXECUTORSERVICE_FOO1_CAPACITY", "17");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getScheduledExecutorConfig("foo1").isStatisticsEnabled());
         assertEquals(17, config.getScheduledExecutorConfig("foo1").getCapacity());
@@ -212,12 +226,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleScheduledServiceConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getScheduledExecutorConfig("foo1")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_SCHEDULEDEXECUTORSERVICE_FOO1_MERGEPOLICY_CLASSNAME", "CustomMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_SCHEDULEDEXECUTORSERVICE_FOO1_MERGEPOLICY_CLASSNAME", "CustomMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("CustomMergePolicy", config.getScheduledExecutorConfig("foo1").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getScheduledExecutorConfig("foo1").getMergePolicyConfig().getBatchSize());
@@ -227,25 +242,27 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleCardinalityEstimatorConfig() throws Exception {
         Config config = new Config();
         config.getCardinalityEstimatorConfig("foo")
-          .setAsyncBackupCount(4);
+                .setAsyncBackupCount(4);
 
-        withEnvironmentVariable("HZ_CARDINALITYESTIMATOR_FOO_BACKUPCOUNT", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_CARDINALITYESTIMATOR_FOO_BACKUPCOUNT", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
-        assertEquals(2,  config.getCardinalityEstimatorConfig("foo").getBackupCount());
-        assertEquals(4,  config.getCardinalityEstimatorConfig("foo").getAsyncBackupCount());
+        assertEquals(2, config.getCardinalityEstimatorConfig("foo").getBackupCount());
+        assertEquals(4, config.getCardinalityEstimatorConfig("foo").getAsyncBackupCount());
     }
 
     @Test
     public void shouldHandleCardinalityEstimatorConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getCardinalityEstimatorConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_CARDINALITYESTIMATOR_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_CARDINALITYESTIMATOR_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getCardinalityEstimatorConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getCardinalityEstimatorConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -255,12 +272,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleSplitBrainProtectionConfig() throws Exception {
         Config config = new Config();
         config.getSplitBrainProtectionConfig("foo")
-          .setEnabled(true)
-          .setProtectOn(SplitBrainProtectionOn.READ);
+                .setEnabled(true)
+                .setProtectOn(SplitBrainProtectionOn.READ);
 
-        withEnvironmentVariable("HZ_SPLITBRAINPROTECTION_FOO_ENABLED", "true")
-          .and("HZ_SPLITBRAINPROTECTION_FOO_FUNCTIONCLASSNAME", "com.foo.SomeClass")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_SPLITBRAINPROTECTION_FOO_ENABLED", "true");
+        envVariables.put("HZ_SPLITBRAINPROTECTION_FOO_FUNCTIONCLASSNAME", "com.foo.SomeClass");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getSplitBrainProtectionConfig("foo").isEnabled());
         assertSame(SplitBrainProtectionOn.READ, config.getSplitBrainProtectionConfig("foo").getProtectOn());
@@ -271,11 +289,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandlePNCounterConfig() throws Exception {
         Config config = new Config();
         config.getPNCounterConfig("foo")
-          .setStatisticsEnabled(false)
-          .setReplicaCount(2);
+                .setStatisticsEnabled(false)
+                .setReplicaCount(2);
 
-        withEnvironmentVariable("HZ_PNCOUNTER_FOO_STATISTICSENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_PNCOUNTER_FOO_STATISTICSENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getPNCounterConfig("foo").isStatisticsEnabled());
         assertEquals(2, config.getPNCounterConfig("foo").getReplicaCount());
@@ -286,8 +305,9 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         Config config = new Config();
         config.getNetworkConfig().getMemcacheProtocolConfig().setEnabled(false);
 
-        withEnvironmentVariable("HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getNetworkConfig().getMemcacheProtocolConfig().isEnabled());
     }
@@ -296,11 +316,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleRingBufferConfig() throws Exception {
         Config config = new Config();
         config.getRingbufferConfig("foo")
-          .setAsyncBackupCount(2)
-          .setBackupCount(4);
+                .setAsyncBackupCount(2)
+                .setBackupCount(4);
 
-        withEnvironmentVariable("HZ_RINGBUFFER_FOO_ASYNCBACKUPCOUNT", "1")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_RINGBUFFER_FOO_ASYNCBACKUPCOUNT", "1");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(1, config.getRingbufferConfig("foo").getAsyncBackupCount());
         assertEquals(4, config.getRingbufferConfig("foo").getBackupCount());
@@ -310,12 +331,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleRingBufferConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getRingbufferConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_RINGBUFFER_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_RINGBUFFER_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getRingbufferConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getRingbufferConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -325,11 +347,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleCacheConfig() throws Exception {
         Config config = new Config();
         config.getCacheConfig("foo")
-          .setStatisticsEnabled(false)
-          .setBackupCount(4);
+                .setStatisticsEnabled(false)
+                .setBackupCount(4);
 
-        withEnvironmentVariable("HZ_CACHE_FOO_STATISTICSENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_CACHE_FOO_STATISTICSENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getCacheConfig("foo").isStatisticsEnabled());
         assertEquals(4, config.getCacheConfig("foo").getBackupCount());
@@ -339,12 +362,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleCacheConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getCacheConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_CACHE_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_CACHE_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getCacheConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getCacheConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -354,11 +378,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleFlakeIdConfig() throws Exception {
         Config config = new Config();
         config.getFlakeIdGeneratorConfig("foo")
-          .setStatisticsEnabled(false)
-          .setAllowedFutureMillis(1000);
+                .setStatisticsEnabled(false)
+                .setAllowedFutureMillis(1000);
 
-        withEnvironmentVariable("HZ_FLAKEIDGENERATOR_FOO_STATISTICSENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_FLAKEIDGENERATOR_FOO_STATISTICSENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getFlakeIdGeneratorConfig("foo").isStatisticsEnabled());
         assertEquals(1000, config.getFlakeIdGeneratorConfig("foo").getAllowedFutureMillis());
@@ -368,11 +393,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleQueueConfig() throws Exception {
         Config config = new Config();
         config.getQueueConfig("foo")
-          .setBackupCount(4)
-          .setMaxSize(10);
+                .setBackupCount(4)
+                .setMaxSize(10);
 
-        withEnvironmentVariable("HZ_QUEUE_FOO_BACKUPCOUNT", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_QUEUE_FOO_BACKUPCOUNT", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getQueueConfig("foo").getBackupCount());
         assertEquals(10, config.getQueueConfig("foo").getMaxSize());
@@ -382,12 +408,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleQueueConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getQueueConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_QUEUE_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_QUEUE_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getQueueConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getQueueConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -397,11 +424,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleListConfig() throws Exception {
         Config config = new Config();
         config.getListConfig("foo")
-          .setBackupCount(4)
-          .setMaxSize(10);
+                .setBackupCount(4)
+                .setMaxSize(10);
 
-        withEnvironmentVariable("HZ_LIST_FOO_BACKUPCOUNT", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_LIST_FOO_BACKUPCOUNT", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getListConfig("foo").getBackupCount());
         assertEquals(10, config.getListConfig("foo").getMaxSize());
@@ -411,12 +439,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleListConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getListConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_LIST_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_LIST_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getListConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getListConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -426,11 +455,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleSetConfig() throws Exception {
         Config config = new Config();
         config.getSetConfig("foo")
-          .setBackupCount(4)
-          .setMaxSize(10);
+                .setBackupCount(4)
+                .setMaxSize(10);
 
-        withEnvironmentVariable("HZ_SET_FOO_BACKUPCOUNT", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_SET_FOO_BACKUPCOUNT", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getSetConfig("foo").getBackupCount());
         assertEquals(10, config.getSetConfig("foo").getMaxSize());
@@ -440,12 +470,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleSetConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getSetConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_SET_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_SET_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getSetConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getSetConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -455,11 +486,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMapConfig() throws Exception {
         Config config = new Config();
         config.getMapConfig("foo")
-          .setBackupCount(4)
-          .setMaxIdleSeconds(100);
+                .setBackupCount(4)
+                .setMaxIdleSeconds(100);
 
-        withEnvironmentVariable("HZ_MAP_FOO_BACKUPCOUNT", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MAP_FOO_BACKUPCOUNT", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getMapConfig("foo").getBackupCount());
         assertEquals(100, config.getMapConfig("foo").getMaxIdleSeconds());
@@ -469,12 +501,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMapConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getMapConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_MAP_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MAP_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getMapConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getMapConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -484,13 +517,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMapConfigNearCache() throws Exception {
         Config config = new Config();
         NearCacheConfig nearCacheConfig = new NearCacheConfig()
-          .setMaxIdleSeconds(10)
-          .setInMemoryFormat(InMemoryFormat.NATIVE);
+                .setMaxIdleSeconds(10)
+                .setInMemoryFormat(InMemoryFormat.NATIVE);
         config.getMapConfig("foo").setNearCacheConfig(nearCacheConfig);
 
-
-        withEnvironmentVariable("HZ_MAP_FOO_NEARCACHE_MAXIDLESECONDS", "5")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MAP_FOO_NEARCACHE_MAXIDLESECONDS", "5");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(5, config.getMapConfig("foo").getNearCacheConfig().getMaxIdleSeconds());
         assertEquals(InMemoryFormat.NATIVE, config.getMapConfig("foo").getNearCacheConfig().getInMemoryFormat());
@@ -500,16 +533,17 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMapMerkleTreeConfig() throws Exception {
         Config config = new Config();
         MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig()
-          .setEnabled(false)
-          .setDepth(5);
+                .setEnabled(false)
+                .setDepth(5);
 
         config.getMapConfig("foo1")
-          .setBackupCount(4)
-          .setMerkleTreeConfig(merkleTreeConfig);
+                .setBackupCount(4)
+                .setMerkleTreeConfig(merkleTreeConfig);
 
-        withEnvironmentVariable("HZ_MAP_FOO1_BACKUPCOUNT", "2")
-          .and("HZ_MAP_FOO1_MERKLETREE_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MAP_FOO1_BACKUPCOUNT", "2");
+        envVariables.put("HZ_MAP_FOO1_MERKLETREE_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getMapConfig("foo1").getBackupCount());
         assertTrue(config.getMapConfig("foo1").getMerkleTreeConfig().isEnabled());
@@ -520,16 +554,17 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMapEventJournalConfig() throws Exception {
         Config config = new Config();
         EventJournalConfig eventJournalConfig = new EventJournalConfig()
-          .setEnabled(false)
-          .setCapacity(10);
+                .setEnabled(false)
+                .setCapacity(10);
 
         config.getMapConfig("foo1")
-          .setBackupCount(4)
-          .setEventJournalConfig(eventJournalConfig);
+                .setBackupCount(4)
+                .setEventJournalConfig(eventJournalConfig);
 
-        withEnvironmentVariable("HZ_MAP_FOO1_BACKUPCOUNT", "2")
-          .and("HZ_MAP_FOO1_EVENTJOURNAL_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MAP_FOO1_BACKUPCOUNT", "2");
+        envVariables.put("HZ_MAP_FOO1_EVENTJOURNAL_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getMapConfig("foo1").getBackupCount());
         assertTrue(config.getMapConfig("foo1").getEventJournalConfig().isEnabled());
@@ -540,12 +575,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMapMapStoreConfig() throws Exception {
         Config config = new Config();
         config.getMapConfig("foo")
-          .getMapStoreConfig()
-          .setEnabled(true)
-          .setWriteBatchSize(10);
+                .getMapStoreConfig()
+                .setEnabled(true)
+                .setWriteBatchSize(10);
 
-        withEnvironmentVariable("HZ_MAP_FOO_MAPSTORE_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MAP_FOO_MAPSTORE_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getMapConfig("foo").getMapStoreConfig().isEnabled());
         assertEquals(10, config.getMapConfig("foo").getMapStoreConfig().getWriteBatchSize());
@@ -555,11 +591,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleReplicatedMapConfig() throws Exception {
         Config config = new Config();
         config.getReplicatedMapConfig("foo")
-          .setAsyncFillup(false)
-          .setStatisticsEnabled(false);
+                .setAsyncFillup(false)
+                .setStatisticsEnabled(false);
 
-        withEnvironmentVariable("HZ_REPLICATEDMAP_FOO_ASYNCFILLUP", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_REPLICATEDMAP_FOO_ASYNCFILLUP", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getReplicatedMapConfig("foo").isAsyncFillup());
         assertFalse(config.getReplicatedMapConfig("foo").isStatisticsEnabled());
@@ -569,12 +606,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleReplicatedMapConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getReplicatedMapConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_REPLICATEDMAP_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_REPLICATEDMAP_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getReplicatedMapConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getReplicatedMapConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -584,11 +622,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMultiMapConfig() throws Exception {
         Config config = new Config();
         config.getMultiMapConfig("foo")
-          .setBackupCount(4)
-          .setBinary(false);
+                .setBackupCount(4)
+                .setBinary(false);
 
-        withEnvironmentVariable("HZ_MULTIMAP_FOO_BACKUPCOUNT", "2")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MULTIMAP_FOO_BACKUPCOUNT", "2");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals(2, config.getMultiMapConfig("foo").getBackupCount());
         assertFalse(config.getMultiMapConfig("foo").isBinary());
@@ -598,12 +637,13 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleMultiMapConfigMergePolicy() throws Exception {
         Config config = new Config();
         config.getMultiMapConfig("foo")
-          .getMergePolicyConfig()
-          .setPolicy("foo")
-          .setBatchSize(4);
+                .getMergePolicyConfig()
+                .setPolicy("foo")
+                .setBatchSize(4);
 
-        withEnvironmentVariable("HZ_MULTIMAP_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_MULTIMAP_FOO_MERGEPOLICY_CLASSNAME", "PutIfAbsentMergePolicy");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertEquals("PutIfAbsentMergePolicy", config.getMultiMapConfig("foo").getMergePolicyConfig().getPolicy());
         assertEquals(4, config.getMultiMapConfig("foo").getMergePolicyConfig().getBatchSize());
@@ -613,14 +653,15 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleAuditLogConfig() throws Exception {
         Config config = new Config();
         config.getAuditlogConfig()
-          .setEnabled(false)
-          .setFactoryClassName("com.acme.AuditlogToSyslogFactory")
-          .setProperty("host", "syslogserver.acme.com")
-          .setProperty("port", "514")
-          .setProperty("type", "tcp");
+                .setEnabled(false)
+                .setFactoryClassName("com.acme.AuditlogToSyslogFactory")
+                .setProperty("host", "syslogserver.acme.com")
+                .setProperty("port", "514")
+                .setProperty("type", "tcp");
 
-        withEnvironmentVariable("HZ_AUDITLOG_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_AUDITLOG_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
         assertTrue(config.getAuditlogConfig().isEnabled());
         assertEquals("com.acme.AuditlogToSyslogFactory", config.getAuditlogConfig().getFactoryClassName());
@@ -633,10 +674,11 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleRestApiConfig() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_NETWORK_RESTAPI_ENABLED", "true")
-          .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_DATA_ENABLED", "true")
-          .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_HOTRESTART_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_NETWORK_RESTAPI_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_DATA_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_HOTRESTART_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
         assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
@@ -646,10 +688,11 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleRestApiConfig_whenPersistenceEnabled() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_NETWORK_RESTAPI_ENABLED", "true")
-                .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_DATA_ENABLED", "true")
-                .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_PERSISTENCE_ENABLED", "true")
-                .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_NETWORK_RESTAPI_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_DATA_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_PERSISTENCE_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
         assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
@@ -660,11 +703,12 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleRestApiConfig_when_bothPersistenceAndHotRestartAreEnabled() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_NETWORK_RESTAPI_ENABLED", "true")
-                .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_DATA_ENABLED", "true")
-                .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_HOTRESTART_ENABLED", "true")
-                .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_PERSISTENCE_ENABLED", "true")
-                .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_NETWORK_RESTAPI_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_DATA_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_HOTRESTART_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_PERSISTENCE_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
         assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
         assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
@@ -674,37 +718,52 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
     public void shouldHandleEmptyLicenseKey() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_LICENSEKEY", "")
-                .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
-        assertEquals(config.getLicenseKey(), "");
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_LICENSEKEY", "");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
+        assertEquals("", config.getLicenseKey());
     }
 
     @Test
     public void shouldHandleShortLicenseKey() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_LICENSEKEY", "foo")
-                .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
-        assertEquals(config.getLicenseKey(), "foo");
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_LICENSEKEY", "foo");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
+        assertEquals("foo", config.getLicenseKey());
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void shouldHandleRestApiConfigInvalidEntry() throws Exception {
         Config config = new Config();
 
-        withEnvironmentVariable("HZ_NETWORK_RESTAPI_ENABLED", "true")
-          .and("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_FOO_ENABLED", "true")
-          .execute(() -> new ExternalConfigurationOverride().overwriteMemberConfig(config));
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_NETWORK_RESTAPI_ENABLED", "true");
+        envVariables.put("HZ_NETWORK_RESTAPI_ENDPOINTGROUPS_FOO_ENABLED", "true");
+        new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Test
     public void shouldDisallowConflictingEntries() throws Exception {
-        withEnvironmentVariable("HZ_CLUSTERNAME", "test")
-          .execute(
-            () -> runWithSystemProperty("hz.cluster-name", "test2", () -> {
-                Config config = new Config();
-                new ExternalConfigurationOverride().overwriteMemberConfig(config);
-            })
-          );
+        Map<String, String> envVariables = new HashMap<>();
+        envVariables.put("HZ_CLUSTERNAME", "test");
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.cluster-name", "test2");
+        Config config = new Config();
+        assertThatExceptionOfType(InvalidConfigurationException.class)
+                .isThrownBy(() ->
+                        new ExternalConfigurationOverride(envVariables, () -> systemProperties).overwriteMemberConfig(config)
+                ).withMessage("Discovered conflicting configuration entries");
+    }
+
+    @Test
+    public void shouldUseSystem_SystemPropertiesAsDefault() throws Exception {
+        Config config = new Config();
+        String randomPropertyName = randomString();
+        System.setProperty("hz.properties." + randomPropertyName, "123");
+        new ExternalConfigurationOverride().overwriteMemberConfig(config);
+        assertEquals("123", config.getProperty(randomPropertyName));
+        System.clearProperty(randomPropertyName);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideSystemPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideSystemPropertiesTest.java
@@ -18,94 +18,98 @@ package com.hazelcast.internal.config.override;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+import java.util.Properties;
+
 import static com.hazelcast.config.RestEndpointGroup.DATA;
 import static com.hazelcast.config.RestEndpointGroup.PERSISTENCE;
-import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.entry;
-import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.runWithSystemProperties;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class ExternalMemberConfigurationOverrideSystemPropertiesTest extends HazelcastTestSupport {
+
+    private static final Map<String, String> EMPTY_ENV_VARIABLES = emptyMap();
 
     @Test
     public void shouldExtractConfigFromSysProperties() {
-        runWithSystemProperties(() -> {
-              Config config = new Config();
-              new ExternalConfigurationOverride().overwriteMemberConfig(config);
+        Config config = new Config();
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.cluster-name", "test");
+        systemProperties.put("hz.network.join.autodetection.enabled", "false");
+        systemProperties.put("hz.executor-service.custom.pool-size", "42");
+        new ExternalConfigurationOverride(EMPTY_ENV_VARIABLES, () -> systemProperties).overwriteMemberConfig(config);
 
-              assertEquals("test", config.getClusterName());
-              assertEquals(42, config.getExecutorConfig("custom").getPoolSize());
-              assertFalse(config.getNetworkConfig().getJoin().isAutoDetectionEnabled());
-          },
-          entry("hz.cluster-name", "test"),
-          entry("hz.network.join.autodetection.enabled", "false"),
-          entry("hz.executor-service.custom.pool-size", "42"));
+        assertEquals("test", config.getClusterName());
+        assertEquals(42, config.getExecutorConfig("custom").getPoolSize());
+        assertFalse(config.getNetworkConfig().getJoin().isAutoDetectionEnabled());
     }
 
     @Test
     public void shouldHandleRestApiConfigFromSysProperties() {
-        runWithSystemProperties(() -> {
-              Config config = new Config();
-              new ExternalConfigurationOverride().overwriteMemberConfig(config);
+        Config config = new Config();
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.network.rest-api.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.DATA.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.hot_restart.enabled", "true");
 
-              assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
-              assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
-              assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
-          },
-          entry("hz.network.rest-api.enabled", "true"),
-          entry("hz.network.rest-api.endpoint-groups.DATA.enabled", "true"),
-          entry("hz.network.rest-api.endpoint-groups.hot_restart.enabled", "true"));
+        new ExternalConfigurationOverride(EMPTY_ENV_VARIABLES, () -> systemProperties).overwriteMemberConfig(config);
+
+        assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
     }
 
     @Test
     public void shouldHandleRestApiConfigFromSysProperties_whenPersistenceEnabled() {
-        runWithSystemProperties(() -> {
-                    Config config = new Config();
-                    new ExternalConfigurationOverride().overwriteMemberConfig(config);
+        Config config = new Config();
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.network.rest-api.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.DATA.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.persistence.enabled", "true");
 
-                    assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
-                    assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
-                    assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
-                },
-                entry("hz.network.rest-api.enabled", "true"),
-                entry("hz.network.rest-api.endpoint-groups.DATA.enabled", "true"),
-                entry("hz.network.rest-api.endpoint-groups.persistence.enabled", "true"));
+        new ExternalConfigurationOverride(EMPTY_ENV_VARIABLES, () -> systemProperties).overwriteMemberConfig(config);
+
+        assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
     }
 
     @Test
     public void shouldHandleRestApiConfigFromSysProperties_when_bothPersistenceAndHotRestartAreEnabled() {
-        runWithSystemProperties(() -> {
-                    Config config = new Config();
-                    new ExternalConfigurationOverride().overwriteMemberConfig(config);
+        Config config = new Config();
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.network.rest-api.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.DATA.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.hot_restart.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.persistence.enabled", "true");
 
-                    assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
-                    assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
-                    assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
-                },
-                entry("hz.network.rest-api.enabled", "true"),
-                entry("hz.network.rest-api.endpoint-groups.DATA.enabled", "true"),
-                entry("hz.network.rest-api.endpoint-groups.hot_restart.enabled", "true"),
-                entry("hz.network.rest-api.endpoint-groups.persistence.enabled", "true"));
+        new ExternalConfigurationOverride(EMPTY_ENV_VARIABLES, () -> systemProperties).overwriteMemberConfig(config);
+
+        assertTrue(config.getNetworkConfig().getRestApiConfig().isEnabled());
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(DATA));
+        assertTrue(config.getNetworkConfig().getRestApiConfig().getEnabledGroups().contains(PERSISTENCE));
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void shouldHandleRestApiConfigFromSysPropertiesInvalidEntry() {
-        runWithSystemProperties(() -> {
-              Config config = new Config();
-              new ExternalConfigurationOverride().overwriteMemberConfig(config);
-          },
-          entry("hz.network.rest-api.enabled", "true"),
-          entry("hz.network.rest-api.endpoint-groups.fooo.enabled", "true"),
-          entry("hz.network.rest-api.endpoint-groups.HOT_RESTART.enabled", "true"));
+        Config config = new Config();
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.network.rest-api.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.fooo.enabled", "true");
+        systemProperties.put("hz.network.rest-api.endpoint-groups.HOT_RESTART.enabled", "true");
+
+        new ExternalConfigurationOverride(EMPTY_ENV_VARIABLES, () -> systemProperties).overwriteMemberConfig(config);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/SystemPropertiesClientConfigParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/SystemPropertiesClientConfigParserTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.config.override;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,7 +31,7 @@ import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.ent
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SystemPropertiesClientConfigParserTest extends HazelcastTestSupport {
 
     private final SystemPropertiesConfigParser sysPropertiesConfigParser = SystemPropertiesConfigParser.client();

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/SystemPropertiesConfigProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/SystemPropertiesConfigProviderTest.java
@@ -23,8 +23,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Properties;
+
 import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.entry;
-import static com.hazelcast.internal.config.override.ExternalConfigTestUtils.runWithSystemProperty;
 import static com.hazelcast.internal.config.override.SystemPropertiesConfigParser.member;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -33,10 +34,9 @@ public class SystemPropertiesConfigProviderTest extends HazelcastTestSupport {
 
     @Test
     public void shouldParseClusternameConfigFromSystemProperties() {
-        runWithSystemProperty("hz.cluster-name", "testcluster", () -> {
-            SystemPropertiesConfigProvider provider = new SystemPropertiesConfigProvider(member());
-
-            assertContains(provider.properties().entrySet(), entry("hazelcast.cluster-name", "testcluster"));
-        });
+        Properties systemProperties = new Properties();
+        systemProperties.put("hz.cluster-name", "testcluster");
+        SystemPropertiesConfigProvider provider = new SystemPropertiesConfigProvider(member(), () -> systemProperties);
+        assertContains(provider.properties().entrySet(), entry("hazelcast.cluster-name", "testcluster"));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolverTest.java
@@ -20,13 +20,12 @@ import com.hazelcast.kubernetes.KubernetesClient.Endpoint;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.NoLogFactory;
 import com.hazelcast.spi.discovery.DiscoveryNode;
-import org.junit.Before;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,9 +33,10 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(KubernetesApiEndpointResolver.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class KubernetesApiEndpointResolverTest {
     private static final ILogger LOGGER = new NoLogFactory().getLogger("no");
     private static final String SERVICE_NAME = "serviceName";
@@ -46,14 +46,7 @@ public class KubernetesApiEndpointResolverTest {
     private static final String POD_LABEL_VALUE = "podLabelValue";
     private static final Boolean RESOLVE_NOT_READY_ADDRESSES = true;
 
-    @Mock
-    private KubernetesClient client;
-
-    @Before
-    public void setup()
-            throws Exception {
-        PowerMockito.whenNew(KubernetesClient.class).withAnyArguments().thenReturn(client);
-    }
+    private final KubernetesClient client = mock(KubernetesClient.class);
 
     @Test
     public void resolveWhenNodeInFound() {

--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRulePowerMockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRulePowerMockTest.java
@@ -26,18 +26,11 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.net.NetworkInterface;
-import java.util.ArrayList;
-import java.util.List;
-
 import static com.hazelcast.test.OverridePropertyRule.set;
-import static java.util.Collections.enumeration;
-import static java.util.Collections.list;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 /**
@@ -53,11 +46,9 @@ public class OverridePropertyRulePowerMockTest {
     @Rule
     public OverridePropertyRule overridePreferIpv4Rule = set("java.net.preferIPv4Stack", "true");
 
-    private NetworkInterface networkInterface = mock(NetworkInterface.class);
-
     @Before
     public void setUp() {
-        mockStatic(NetworkInterface.class);
+        mockStatic(OtherClass.class);
     }
 
     @Test
@@ -95,11 +86,7 @@ public class OverridePropertyRulePowerMockTest {
     }
 
     private TestClass createTestClass() throws Exception {
-        NetworkInterface networkInterface = mock(NetworkInterface.class);
-        List<NetworkInterface> networkInterfaces = new ArrayList<NetworkInterface>();
-        networkInterfaces.add(networkInterface);
-        when(NetworkInterface.getNetworkInterfaces()).thenReturn(enumeration(networkInterfaces));
-
+        when(OtherClass.getName()).thenReturn("mocked-name");
         return new TestClass();
     }
 
@@ -107,11 +94,15 @@ public class OverridePropertyRulePowerMockTest {
 
         String getProperty(String property) throws Exception {
             // assert that PowerMock is working
-            ArrayList<NetworkInterface> networkInterfaces = list(NetworkInterface.getNetworkInterfaces());
-            assertEquals(1, networkInterfaces.size());
-            assertEquals(networkInterface, networkInterfaces.get(0));
+            assertEquals("mocked-name", OtherClass.getName());
 
             return System.getProperty(property);
+        }
+    }
+
+    private static final class OtherClass {
+        static String getName() {
+            return "some-name";
         }
     }
 }


### PR DESCRIPTION
Avoided opening `java.util` module for tests on JDK17

Related to: 
- https://github.com/hazelcast/hazelcast/pull/19896
- https://hazelcast.atlassian.net/browse/HZ-687

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible