### PR TITLE
Upgrade log4j2 to 2.15.0 [4.1.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
         <log4j.version>1.2.17</log4j.version>
 
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
         <jackson.version>2.11.2</jackson.version>


### PR DESCRIPTION
Backport #20144.

http://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228