### PR TITLE
fix leak on client message decoder

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -42,13 +42,13 @@ import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 
 /**
  * Builds {@link ClientMessage}s from byte chunks.
- *
+ * <p>
  * Fragmented messages are merged into single messages before processed.
  */
 public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer, Consumer<ClientMessage>> {
 
+    final Long2ObjectHashMap<ClientMessage> builderBySessionIdMap = new Long2ObjectHashMap<>();
     private final Connection connection;
-    private final Long2ObjectHashMap<ClientMessage> builderBySessionIdMap = new Long2ObjectHashMap<>();
     private ClientMessageReader activeReader;
 
     private boolean clientIsTrusted;
@@ -97,6 +97,7 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
                         builderBySessionIdMap.put(fragmentationId, message);
                     } else if (ClientMessage.isFlagSet(flags, END_FRAGMENT_FLAG)) {
                         ClientMessage clientMessage = mergeIntoExistingClientMessage(fragmentationId);
+                        builderBySessionIdMap.remove(fragmentationId);
                         handleMessage(clientMessage);
                     } else {
                         mergeIntoExistingClientMessage(fragmentationId);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitAndBuildTest.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.protocol;
+package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCodec;
-import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
-import com.hazelcast.client.impl.protocol.util.ClientMessageEncoder;
 import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.util.UuidUtil;
@@ -107,6 +105,7 @@ public class ClientMessageSplitAndBuildTest {
 
         assertEquals(getNumberOfFrames(clientMessage1), getNumberOfFrames(resultingMessage.get()));
         assertEquals(clientMessage1.getFrameLength(), resultingMessage.get().getFrameLength());
+        assertEquals(0, decoder.builderBySessionIdMap.size());
     }
 
     @Test
@@ -158,6 +157,7 @@ public class ClientMessageSplitAndBuildTest {
 
         assertMessageEquals(clientMessage1, actualMessage1);
         assertMessageEquals(clientMessage2, actualMessage2);
+        assertEquals(0, decoder.builderBySessionIdMap.size());
     }
 
     @Test
@@ -189,6 +189,7 @@ public class ClientMessageSplitAndBuildTest {
         decoder.onRead();
 
         assertEquals(clientMessage1.getFrameLength(), resultingMessage.get().getFrameLength());
+        assertEquals(0, decoder.builderBySessionIdMap.size());
     }
 
     private void assertMessageEquals(ClientMessage expected, ClientMessage actual) {


### PR DESCRIPTION
Fragmented messages are causing leak on the ClientMessageDecoder.

builderBySessionIdMap is populated when there is a fragmented
message but the message references are never removed back from it.

This bug prevents any version that does not have the fix work
with fragmented messages.

fixes https://github.com/hazelcast/hazelcast/issues/19820

(cherry picked from commit d0e5f8fb61d47ad92f847a3783665024b3b33561)
backport of https://github.com/hazelcast/hazelcast/pull/20051
