### PR TITLE
[TSTORE] Pass partitionId to RecordFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -48,6 +48,7 @@ import com.hazelcast.map.impl.query.QueryEntryFactory;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.ObjectRecordFactory;
 import com.hazelcast.map.impl.record.RecordFactory;
+import com.hazelcast.map.impl.record.RecordFactoryAttributes;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.query.impl.Index;
@@ -103,7 +104,7 @@ public class MapContainer {
     protected final InternalSerializationService serializationService;
     protected final Function<Object, Data> toDataFunction = new ObjectToData();
     protected final InterceptorRegistry interceptorRegistry = new InterceptorRegistry();
-    protected final ConstructorFunction<Void, RecordFactory> recordFactoryConstructor;
+    protected final ConstructorFunction<RecordFactoryAttributes, RecordFactory> recordFactoryConstructor;
     /**
      * Holds number of registered {@link InvalidationListener} from clients.
      */
@@ -250,7 +251,8 @@ public class MapContainer {
     }
 
     // overridden in different context
-    ConstructorFunction<Void, RecordFactory> createRecordFactoryConstructor(final SerializationService serializationService) {
+    ConstructorFunction<RecordFactoryAttributes, RecordFactory> createRecordFactoryConstructor(
+            final SerializationService serializationService) {
         return anyArg -> {
             switch (mapConfig.getInMemoryFormat()) {
                 case BINARY:
@@ -406,7 +408,7 @@ public class MapContainer {
         return toDataFunction;
     }
 
-    public ConstructorFunction<Void, RecordFactory> getRecordFactoryConstructor() {
+    public ConstructorFunction<RecordFactoryAttributes, RecordFactory> getRecordFactoryConstructor() {
         return recordFactoryConstructor;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordFactoryAttributes.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordFactoryAttributes.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.record;
+
+import com.hazelcast.internal.util.ConstructorFunction;
+
+/**
+ * A set of attributes to pass to the {@link ConstructorFunction} that it needs
+ * or may need to use for creating the {@link RecordFactory}.
+ */
+@FunctionalInterface
+public interface RecordFactoryAttributes {
+    /**
+     * Returns the id of the partition on which the given record is to be created.
+     *
+     * @return the partition id
+     */
+    int getPartitionId();
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -73,7 +73,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         this.serializationService = nodeEngine.getSerializationService();
         this.inMemoryFormat = mapContainer.getMapConfig().getInMemoryFormat();
-        this.recordFactory = mapContainer.getRecordFactoryConstructor().createNew(null);
+        this.recordFactory = mapContainer.getRecordFactoryConstructor().createNew(() -> partitionId);
         this.valueComparator = mapServiceContext.getValueComparatorOf(inMemoryFormat);
         this.mapStoreContext = mapContainer.getMapStoreContext();
         this.mapDataStore = mapStoreContext.getMapStoreManager().getMapDataStore(name, partitionId);


### PR DESCRIPTION
For tiered store receiving the partition id is necessary to allow
allocating the memory block backing the record in a partitioned manner.
This change introduces `RecordFactoryAttributes`, which yet contains only
the partition id, but later can be extended with other attributes. This 
`RecordFactoryAttributes` is passed to the `RecordFactory` to allow it
accessing the partition-related components of the tiered store 
implementation.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4496
Depends on https://github.com/hazelcast/hazelcast-enterprise/pull/4468