### PR TITLE
Allow integer conversions for SQL dynamic params

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/math/RoundFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/math/RoundFunctionIntegrationTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.sql.impl.expression.math;
 
-import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.jet.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.ByteIntegerVal;
@@ -31,6 +29,8 @@ import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.ByteVal;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.IntegerVal;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.LongVal;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.ShortVal;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,6 +41,13 @@ import org.junit.runner.RunWith;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigDecimalVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.DoubleIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.DoubleVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.FloatIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.FloatVal;
 import static com.hazelcast.sql.SqlColumnType.BIGINT;
 import static com.hazelcast.sql.SqlColumnType.BOOLEAN;
 import static com.hazelcast.sql.SqlColumnType.DATE;
@@ -55,13 +62,6 @@ import static com.hazelcast.sql.SqlColumnType.TIMESTAMP;
 import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.SqlColumnType.TINYINT;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigDecimalVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.DoubleIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.DoubleVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.FloatIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.FloatVal;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -268,7 +268,7 @@ public class RoundFunctionIntegrationTest extends ExpressionTestSupport {
         check_2("15", "?", TINYINT, (byte) 20, (byte) -1);
         check_2("15", "?", TINYINT, (byte) 20, (short) -1);
         check_2("15", "?", TINYINT, (byte) 20, -1);
-        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, BIGINT), -1L);
+        check_2("15", "?", TINYINT, (byte) 20, -1L);
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigInteger.ONE.negate());
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigDecimal.ONE.negate());
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, VARCHAR), "-1");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/math/TruncateFunctionIntegrationTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.sql.impl.expression.math;
 
-import com.hazelcast.sql.SqlColumnType;
-import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.jet.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.ByteIntegerVal;
@@ -31,6 +29,8 @@ import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.ByteVal;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.IntegerVal;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.LongVal;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.ShortVal;
+import com.hazelcast.sql.SqlColumnType;
+import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,7 +41,13 @@ import org.junit.runner.RunWith;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import static com.hazelcast.sql.SqlColumnType.BIGINT;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.DoubleIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.FloatIntegerVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.BigDecimalVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.DoubleVal;
+import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.FloatVal;
 import static com.hazelcast.sql.SqlColumnType.BOOLEAN;
 import static com.hazelcast.sql.SqlColumnType.DATE;
 import static com.hazelcast.sql.SqlColumnType.DECIMAL;
@@ -53,13 +59,6 @@ import static com.hazelcast.sql.SqlColumnType.TIME;
 import static com.hazelcast.sql.SqlColumnType.TIMESTAMP;
 import static com.hazelcast.sql.SqlColumnType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigDecimalIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.BigIntegerIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.DoubleIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue.FloatIntegerVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.BigDecimalVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.DoubleVal;
-import static com.hazelcast.jet.sql.impl.support.expressions.ExpressionValue.FloatVal;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -241,7 +240,7 @@ public class TruncateFunctionIntegrationTest extends ExpressionTestSupport {
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, (byte) -1);
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, (short) -1);
         check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, -1);
-        checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, BIGINT), -1L);
+        check_2("15", "?", SqlColumnType.TINYINT, (byte) 10, -1L);
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigInteger.ONE.negate());
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigDecimal.ONE.negate());
         checkFailure_2("15", "?", SqlErrorCode.DATA_EXCEPTION, parameterError(0, INTEGER, VARCHAR), "-1");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/string/SubstringFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/string/SubstringFunctionIntegrationTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.jet.sql.impl.expression.string;
 
+import com.hazelcast.jet.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.jet.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.string.SubstringFunction;
@@ -179,7 +179,7 @@ public class SubstringFunctionIntegrationTest extends ExpressionTestSupport {
         checkValue0(sql2("'abcde'", "?"), VARCHAR, "bcde", (byte) 2);
         checkValue0(sql2("'abcde'", "?"), VARCHAR, "bcde", (short) 2);
         checkValue0(sql2("'abcde'", "?"), VARCHAR, "bcde", 2);
-        checkFailure0(sql2("'abcde'", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, BIGINT), 2L);
+        checkValue0(sql2("'abcde'", "?"), VARCHAR, "bcde", 2L);
         checkFailure0(sql2("'abcde'", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigInteger.ONE);
         checkFailure0(sql2("'abcde'", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigDecimal.ONE);
         checkFailure0(sql2("'abcde'", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, REAL), 2f);
@@ -225,7 +225,7 @@ public class SubstringFunctionIntegrationTest extends ExpressionTestSupport {
         checkValue0(sql3("'abcde'", "2", "?"), VARCHAR, "bc", (byte) 2);
         checkValue0(sql3("'abcde'", "2", "?"), VARCHAR, "bc", (short) 2);
         checkValue0(sql3("'abcde'", "2", "?"), VARCHAR, "bc", 2);
-        checkFailure0(sql3("'abcde'", "2", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, BIGINT), 2L);
+        checkValue0(sql3("'abcde'", "2", "?"), VARCHAR, "bc", 2L);
         checkFailure0(sql3("'abcde'", "2", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigInteger.ONE);
         checkFailure0(sql3("'abcde'", "2", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, DECIMAL), BigDecimal.ONE);
         checkFailure0(sql3("'abcde'", "2", "?"), DATA_EXCEPTION, parameterError(0, INTEGER, REAL), 2f);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/RowAssignmentTypeCoercionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/RowAssignmentTypeCoercionTest.java
@@ -312,12 +312,9 @@ public class RowAssignmentTypeCoercionTest extends SqlTestSupport {
                         .withExpectedLiteralFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type SMALLINT")
                         .withExpectedColumnFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type SMALLINT")
                         .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of BOOLEAN type, but SMALLINT was found"),
-                TestParams.passingCase(1403, SMALLINT, TINYINT, "cast(42 as smallint)", (short) 42, (byte) 42)
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of TINYINT type, but SMALLINT was found"),
+                TestParams.passingCase(1403, SMALLINT, TINYINT, "cast(42 as smallint)", (short) 42, (byte) 42),
                 TestParams.failingCase(1404, SMALLINT, TINYINT, "420", (short) 420)
-                        .withExpectedLiteralFailureRegex("Numeric overflow while converting SMALLINT to TINYINT")
-                        .withExpectedColumnFailureRegex("Numeric overflow while converting SMALLINT to TINYINT")
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of TINYINT type, but SMALLINT was found"),
+                        .withExpectedFailureRegex("Numeric overflow while converting SMALLINT to TINYINT"),
                 TestParams.passingCase(1405, SMALLINT, SMALLINT, "cast(42 as smallint)", (short) 42, (short) 42),
                 TestParams.passingCase(1406, SMALLINT, INTEGER, "cast(42 as smallint)", (short) 42, 42),
                 TestParams.passingCase(1407, SMALLINT, BIGINT, "cast(42 as smallint)", (short) 42, 42L),
@@ -355,18 +352,12 @@ public class RowAssignmentTypeCoercionTest extends SqlTestSupport {
                         .withExpectedLiteralFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type INTEGER")
                         .withExpectedColumnFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type INTEGER")
                         .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of BOOLEAN type, but INTEGER was found"),
-                TestParams.passingCase(1503, INTEGER, TINYINT, "cast(42 as integer)", 42, (byte) 42)
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of TINYINT type, but INTEGER was found"),
+                TestParams.passingCase(1503, INTEGER, TINYINT, "cast(42 as integer)", 42, (byte) 42),
                 TestParams.failingCase(1504, INTEGER, TINYINT, "42000", 42000)
-                        .withExpectedLiteralFailureRegex("Numeric overflow while converting INTEGER to TINYINT")
-                        .withExpectedColumnFailureRegex("Numeric overflow while converting INTEGER to TINYINT")
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of TINYINT type, but INTEGER was found"),
-                TestParams.passingCase(1505, INTEGER, SMALLINT, "cast(42 as integer)", 42, (short) 42)
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of SMALLINT type, but INTEGER was found"),
+                        .withExpectedFailureRegex("Numeric overflow while converting INTEGER to TINYINT"),
+                TestParams.passingCase(1505, INTEGER, SMALLINT, "cast(42 as integer)", 42, (short) 42),
                 TestParams.failingCase(1506, INTEGER, SMALLINT, "42000", 42000)
-                        .withExpectedLiteralFailureRegex("Numeric overflow while converting INTEGER to SMALLINT")
-                        .withExpectedColumnFailureRegex("Numeric overflow while converting INTEGER to SMALLINT")
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of SMALLINT type, but INTEGER was found"),
+                        .withExpectedFailureRegex("Numeric overflow while converting INTEGER to SMALLINT"),
                 TestParams.passingCase(1507, INTEGER, INTEGER, "cast(42 as integer)", 42, 42),
                 TestParams.passingCase(1508, INTEGER, BIGINT, "cast(42 as integer)", 42, 42L),
                 TestParams.passingCase(1509, INTEGER, DECIMAL, "cast(42 as integer)", 42, BigDecimal.valueOf(42)),
@@ -403,24 +394,15 @@ public class RowAssignmentTypeCoercionTest extends SqlTestSupport {
                         .withExpectedLiteralFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type BIGINT")
                         .withExpectedColumnFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type BIGINT")
                         .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of BOOLEAN type, but BIGINT was found"),
-                TestParams.passingCase(1603, BIGINT, TINYINT, "cast(42 as bigint)", 42L, (byte) 42)
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of TINYINT type, but BIGINT was found"),
+                TestParams.passingCase(1603, BIGINT, TINYINT, "cast(42 as bigint)", 42L, (byte) 42),
                 TestParams.failingCase(1604, BIGINT, TINYINT, "4200000000", 4200000000L)
-                        .withExpectedLiteralFailureRegex("Numeric overflow while converting BIGINT to TINYINT")
-                        .withExpectedColumnFailureRegex("Numeric overflow while converting BIGINT to TINYINT")
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of TINYINT type, but BIGINT was found"),
-                TestParams.passingCase(1605, BIGINT, SMALLINT, "cast(42 as bigint)", 42L, (short) 42)
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of SMALLINT type, but BIGINT was found"),
+                        .withExpectedFailureRegex("Numeric overflow while converting BIGINT to TINYINT"),
+                TestParams.passingCase(1605, BIGINT, SMALLINT, "cast(42 as bigint)", 42L, (short) 42),
                 TestParams.failingCase(1606, BIGINT, SMALLINT, "4200000000", 4200000000L)
-                        .withExpectedLiteralFailureRegex("Numeric overflow while converting BIGINT to SMALLINT")
-                        .withExpectedColumnFailureRegex("Numeric overflow while converting BIGINT to SMALLINT")
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of SMALLINT type, but BIGINT was found"),
-                TestParams.passingCase(1607, BIGINT, INTEGER, "cast(42 as bigint)", 42L, 42)
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of INTEGER type, but BIGINT was found"),
+                        .withExpectedFailureRegex("Numeric overflow while converting BIGINT to SMALLINT"),
+                TestParams.passingCase(1607, BIGINT, INTEGER, "cast(42 as bigint)", 42L, 42),
                 TestParams.failingCase(1608, BIGINT, INTEGER, "4200000000", 4200000000L)
-                        .withExpectedLiteralFailureRegex("Numeric overflow while converting BIGINT to INTEGER")
-                        .withExpectedColumnFailureRegex("Numeric overflow while converting BIGINT to INTEGER")
-                        .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of INTEGER type, but BIGINT was found"),
+                        .withExpectedFailureRegex("Numeric overflow while converting BIGINT to INTEGER"),
                 TestParams.passingCase(1609, BIGINT, BIGINT, "cast(42 as bigint)", 42L, 42L),
                 TestParams.passingCase(1610, BIGINT, DECIMAL, "cast(42 as bigint)", 42L, BigDecimal.valueOf(42)),
                 TestParams.passingCase(1611, BIGINT, REAL, "cast(42 as bigint)", 42L, 42F),
@@ -1216,6 +1198,16 @@ public class RowAssignmentTypeCoercionTest extends SqlTestSupport {
          */
         private TestParams withExpectedDynamicParameterFailureRegex(String failureRegex) {
             this.expectedDynamicParameterFailureRegex = Pattern.compile(failureRegex);
+            return this;
+        }
+
+        /**
+         * This test case is expected to fail if the source is any of literal, column
+         * or dynamic parameter.
+         */
+        private TestParams withExpectedFailureRegex(String failureRegex) {
+            this.expectedLiteralFailureRegex = this.expectedColumnFailureRegex = this.expectedDynamicParameterFailureRegex =
+                    Pattern.compile(failureRegex);
             return this;
         }
 


### PR DESCRIPTION
The rules for allowed parameter conversions were relaxed: additionally,
conversion from higher precision integer to lower precision integer is
allowed (e.g. conversion from BIGINT to TINYINT, that's `long` to
`byte`). Out-of-range error is thrown if the actual argument value
doesn't fit into the smaller integer.

The reason is that some clients don't have all equivalent integer types.
E.g. Node.js only has `long` type, if the user wanted to query an `int`
field, he can't simply pass the value, but has to cast the parameter in
the query.

Fixes #19042