### PR TITLE
Bump log4j2.version from 2.15.0 to 2.17.0 [4.2.4]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
         <log4j.version>1.2.17</log4j.version>
 
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
         <jackson.version>2.12.1</jackson.version>


### PR DESCRIPTION
Bump log4j2.version from 2.15.0 to 2.17.0
