### PR TITLE
Bump log4j2.version from 2.15.0 to 2.17.0 [4.1.8]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
         <log4j.version>1.2.17</log4j.version>
 
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
         <jackson.version>2.11.2</jackson.version>


### PR DESCRIPTION
Bumps `log4j2.version` from 2.16.0 to 2.17.0.

Updates `log4j-api` from 2.16.0 to 2.17.0

Updates `log4j-core` from 2.16.0 to 2.17.0

Updates `log4j-slf4j-impl` from 2.13.2 to 2.17.0

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:development
  update-type: version-update:semver-minor
- dependency-name: org.apache.logging.log4j:log4j-slf4j-impl
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit ca8ad71b166a06ce51fe93fe6ce340d719dcc0fd)
