### PR TITLE
Thread-safe cache replication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
@@ -33,6 +33,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,8 +44,8 @@ import static java.util.Collections.emptyList;
  */
 public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
 
-    private UUID partitionUuid;
-    private List<Object> cacheNameSequencePairs = emptyList();
+    private volatile UUID partitionUuid;
+    private volatile List<Object> cacheNameSequencePairs = emptyList();
     private Operation cacheReplicationOperation;
 
     public CacheNearCacheStateHolder() {
@@ -61,7 +62,7 @@ public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
         int partitionId = segment.getPartitionId();
         partitionUuid = metaData.getOrCreateUuid(partitionId);
 
-        cacheNameSequencePairs = new ArrayList(namespaces.size());
+        cacheNameSequencePairs = Collections.synchronizedList(new ArrayList(namespaces.size()));
         for (ServiceNamespace namespace : namespaces) {
             ObjectNamespace ns = (ObjectNamespace) namespace;
             String cacheName = ns.getObjectName();
@@ -115,7 +116,7 @@ public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
         partitionUuid = nullUuid ? null : new UUID(in.readLong(), in.readLong());
 
         int size = in.readInt();
-        cacheNameSequencePairs = new ArrayList(size);
+        cacheNameSequencePairs = Collections.synchronizedList(new ArrayList(size));
         for (int i = 0; i < size; i++) {
             cacheNameSequencePairs.add(in.readObject());
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -505,8 +505,8 @@ public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K,
     public int hashCode() {
         int result = cacheLoaderFactory != null ? cacheLoaderFactory.hashCode() : 0;
         result = 31 * result + listenerConfigurations.hashCode();
-        result = 31 * result + keyType.hashCode();
-        result = 31 * result + valueType.hashCode();
+        result = keyType == null ? result : 31 * result + keyType.hashCode();
+        result = valueType == null ? result : 31 * result + valueType.hashCode();
         result = 31 * result + (cacheWriterFactory != null ? cacheWriterFactory.hashCode() : 0);
         result = 31 * result + (expiryPolicyFactory != null ? expiryPolicyFactory.hashCode() : 0);
         result = 31 * result + (isReadThrough ? 1 : 0);

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -91,6 +91,12 @@ public class CacheConfigTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testHashCode() {
+        CacheConfig cacheConfig = new CacheConfig();
+        assertTrue(cacheConfig.hashCode() != 0);
+    }
+
+    @Test
     public void testCacheConfigLoaderWriterXml() throws Exception {
         Config config = new XmlConfigBuilder(configUrl2).build();
 


### PR DESCRIPTION
* Thread-safe cache replication

Enterprise cache replication operation
(for migration or anti-entropy) may be
prepared on a generic operation thread,
then serialized on a partition thread.
Data structures populated during preparation
must be thread safe.

* Add null check for key/valueType in cache config hashCode

keyType & valueType can be null when a cache config
is not yet resolved (ie key/value class names
have not yet been resolved to classes).

Backport of: #20164 to `5.0.z`
