### PR TITLE
Forbid view replacement with non-equal projection

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -474,8 +474,12 @@ public class PlanExecutor {
      * but existing way is better than nothing...
      */
     private static void checkProjectsCompatibility(View original, View replacement) {
+        List<String> originalNames = replacement.viewColumnNames();
         List<QueryDataType> originalTypes = original.viewColumnTypes();
+
+        List<String> replacementNames = original.viewColumnNames();
         List<QueryDataType> replacementTypes = replacement.viewColumnTypes();
+
         if (originalTypes.size() != replacementTypes.size()) {
             throw QueryException.error(
                     String.format("Can't replace view %s: incompatible projection size. "
@@ -494,9 +498,21 @@ public class PlanExecutor {
                                         + "Original view type: %s, replacement view type %s",
                                 replacement.name(),
                                 i,
-                                originalTypes.get(i).toString(),
-                                replacementTypes.get(i).toString()
+                                originalTypes.get(i).getTypeFamily().getPublicType().toString(),
+                                replacementTypes.get(i).getTypeFamily().getPublicType().toString()
                         )
+                );
+            }
+
+            if (!replacementNames.get(i).equals(originalNames.get(i))) {
+                throw QueryException.error(
+                        String.format("Can't replace view %s: incompatible column names. "
+                                        + "Original view name: %s, replacement view name %s",
+                                replacement.name(),
+                                i,
+                                originalNames.get(i),
+                                replacementNames.get(i)
+                                )
                 );
             }
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -152,6 +152,10 @@ public class TableResolverImpl implements TableResolver {
         }
     }
 
+    public View getView(String name) {
+        return tableStorage.getView(name);
+    }
+
     public void removeView(String name, boolean ifExists) {
         if (tableStorage.removeView(name) == null && !ifExists) {
             throw QueryException.error("View does not exist: " + name);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
@@ -86,7 +86,7 @@ public class TablesStorage {
 
     View getView(String name) {
         Object obj = storage().get(name);
-        if (obj != null && obj instanceof View) {
+        if (obj instanceof View) {
             return (View) obj;
         }
         return null;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
@@ -84,6 +84,14 @@ public class TablesStorage {
         return (Mapping) storage().remove(name);
     }
 
+    View getView(String name) {
+        Object obj = storage().get(name);
+        if (obj != null && obj instanceof View) {
+            return (View) obj;
+        }
+        return null;
+    }
+
     View removeView(String name) {
         return (View) storage().remove(name);
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlExpandViewTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlExpandViewTest.java
@@ -138,16 +138,16 @@ public class SqlExpandViewTest extends SqlTestSupport {
                 .hasMessageContaining("DML operations not supported for views");
     }
 
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/20032")
+    //    @Ignore("https://github.com/hazelcast/hazelcast/issues/20032")
     @Test
     public void test_referencedViewChanged() {
         // We create a view v2 as reading from v1, and then change v1.
         // This should be reflected when querying v2 later.
         instance().getSql().execute("CREATE VIEW v1 AS SELECT __key FROM " + MAP_NAME);
         instance().getSql().execute("CREATE VIEW v2 AS SELECT __key FROM v1");
-        instance().getSql().execute("CREATE or replace VIEW v1 AS SELECT 'key=' || __key __key FROM " + MAP_NAME);
-
-        assertRowsAnyOrder("select * from v2", rows(1, "key=1"));
+        assertThatThrownBy(() -> instance().getSql().execute(
+                "CREATE or REPLACE VIEW v1 AS SELECT 'key=' || __key __key FROM " + MAP_NAME)
+        ).hasMessageContaining("Can't replace view v1");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlExpandViewTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlExpandViewTest.java
@@ -146,8 +146,13 @@ public class SqlExpandViewTest extends SqlTestSupport {
         instance().getSql().execute("CREATE VIEW v1 AS SELECT __key FROM " + MAP_NAME);
         instance().getSql().execute("CREATE VIEW v2 AS SELECT __key FROM v1");
         assertThatThrownBy(() -> instance().getSql().execute(
-                "CREATE or REPLACE VIEW v1 AS SELECT 'key=' || __key __key FROM " + MAP_NAME)
-        ).hasMessageContaining("Can't replace view v1");
+                "CREATE or REPLACE VIEW v1 AS SELECT 'key=' || __key __key FROM " + MAP_NAME))
+                .hasMessageContaining("Can't replace view v1")
+                .hasMessageContaining("Original view type: INTEGER, replacement view type VARCHAR");
+
+        assertThatThrownBy(() -> instance().getSql().execute(
+                "CREATE or REPLACE VIEW v1 AS SELECT __key AS a FROM " + MAP_NAME)
+        ).hasMessageContaining("Can't replace view v1").hasMessageContaining("incompatible column names");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/CreateViewStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/CreateViewStatementTest.java
@@ -81,12 +81,14 @@ public class CreateViewStatementTest extends SqlTestSupport {
         assertThat(((View) viewStorage.get("v")).query()).isEqualTo("SELECT \"map\".\"__key\", \"map\".\"this\"" + LE
                 + "FROM \"hazelcast\".\"public\".\"map\" AS \"map\"");
 
-        sql = "CREATE OR REPLACE VIEW v AS SELECT this FROM map";
+        createMapping("map2", Integer.class, Integer.class);
+
+        sql = "CREATE OR REPLACE VIEW v AS SELECT * FROM map2";
         instance().getSql().execute(sql);
 
         assertThat(viewStorage.get("v")).isInstanceOf(View.class);
-        assertThat(((View) viewStorage.get("v")).query()).isEqualTo("SELECT \"map\".\"this\"" + LE
-                + "FROM \"hazelcast\".\"public\".\"map\" AS \"map\"");
+        assertThat(((View) viewStorage.get("v")).query()).isEqualTo("SELECT \"map2\".\"__key\", \"map2\".\"this\"" + LE
+                + "FROM \"hazelcast\".\"public\".\"map2\" AS \"map2\"");
     }
 
     @Test


### PR DESCRIPTION
Forbid view replacement with incompatible projection to avoid additional complexity during dependent view processing.
This fix still doesn't cover replacement with DROP & CREATE VIEW, which is way more complex solution, planned for 5.2.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible