### PR TITLE
Improve error msg on window function type mismatch

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/aggregate/WindowUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/aggregate/WindowUtils.java
@@ -126,7 +126,7 @@ public final class WindowUtils {
                     ValidatorResource.RESOURCE.mustUseSingleOrderingColumn());
         }
 
-        // paramValue is the DESCRIPTOR call, it's operand is an SqlIdentifier having the column name
+        // `descriptor` is the DESCRIPTOR call, its operand is an SqlIdentifier having the column name
         SqlIdentifier orderingColumnIdentifier = (SqlIdentifier) descriptor.getOperandList().get(0);
         String orderingColumnName = orderingColumnIdentifier.getSimple();
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastResources.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastResources.java
@@ -44,4 +44,7 @@ public interface HazelcastResources {
 
     @Resources.BaseMessage("Cannot infer return type for {1} among {0}")
     Resources.ExInst<SqlValidatorException> cannotInferCaseResult(String types, String operator);
+
+    @Resources.BaseMessage("The descriptor column type ({0}) and the interval type ({1}) do not match")
+    Resources.ExInst<SqlValidatorException> windowFunctionTypeMismatch(String descriptorType, String intervalType);
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlImposeOrderFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlImposeOrderFunctionTest.java
@@ -33,6 +33,7 @@ import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DATE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DOUBLE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INTEGER;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INTERVAL_DAY_SECOND;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.REAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.SMALLINT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIME;
@@ -118,32 +119,32 @@ public class SqlImposeOrderFunctionTest extends SqlTestSupport {
     @SuppressWarnings("unused")
     private Object[] invalidArguments() {
         return new Object[]{
-                new Object[]{TINYINT, "INTERVAL '0.001' SECOND"},
-                new Object[]{SMALLINT, "INTERVAL '0.002' SECOND"},
-                new Object[]{INTEGER, "INTERVAL '0.003' SECOND"},
-                new Object[]{BIGINT, "INTERVAL '0.004' SECOND"},
-                new Object[]{DECIMAL, "INTERVAL '0.005' SECOND"},
-                new Object[]{DECIMAL, "6"},
-                new Object[]{REAL, "INTERVAL '0.007' SECOND"},
-                new Object[]{REAL, "8"},
-                new Object[]{DOUBLE, "INTERVAL '0.009' SECOND"},
-                new Object[]{DOUBLE, "10"},
-                new Object[]{TIME, "11"},
-                new Object[]{DATE, "12"},
-                new Object[]{TIMESTAMP, "13"},
-                new Object[]{TIMESTAMP_WITH_TIME_ZONE, "14"},
+                new Object[]{TINYINT, "INTERVAL '0.001' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{SMALLINT, "INTERVAL '0.002' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{INTEGER, "INTERVAL '0.003' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{BIGINT, "INTERVAL '0.004' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{DECIMAL, "INTERVAL '0.005' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{DECIMAL, "6", TINYINT},
+                new Object[]{REAL, "INTERVAL '0.007' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{REAL, "8", TINYINT},
+                new Object[]{DOUBLE, "INTERVAL '0.009' SECOND", INTERVAL_DAY_SECOND},
+                new Object[]{DOUBLE, "10", TINYINT},
+                new Object[]{TIME, "11", TINYINT},
+                new Object[]{DATE, "12", TINYINT},
+                new Object[]{TIMESTAMP, "13", TINYINT},
+                new Object[]{TIMESTAMP_WITH_TIME_ZONE, "14", TINYINT},
         };
     }
 
     @Test
     @Parameters(method = "invalidArguments")
-    public void test_invalidArguments(QueryDataTypeFamily orderingColumnType, String maxLag) {
+    public void test_invalidArguments(QueryDataTypeFamily orderingColumnType, String maxLag, QueryDataTypeFamily lagType) {
         String name = randomName();
         TestStreamSqlConnector.create(sqlService, name, singletonList("ts"), singletonList(orderingColumnType));
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " +
                 "TABLE(IMPOSE_ORDER(TABLE(" + name + "), DESCRIPTOR(ts), " + maxLag + "))")
-        ).hasMessageContaining("Cannot apply 'IMPOSE_ORDER' function to [ROW, COLUMN_LIST");
+        ).hasMessageContaining("The descriptor column type (" + orderingColumnType + ") and the interval type (" + lagType + ") do not match");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTumbleTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTumbleTest.java
@@ -33,6 +33,7 @@ import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DATE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DECIMAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.DOUBLE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INTEGER;
+import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INTERVAL_DAY_SECOND;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.REAL;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.SMALLINT;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIME;
@@ -113,81 +114,81 @@ public class SqlTumbleTest extends SqlTestSupport {
 
     @Test
     public void test_invalidArguments_tinyInt() {
-        checkInvalidArguments(TINYINT, "INTERVAL '0.001' SECOND");
+        checkInvalidArguments(TINYINT, "INTERVAL '0.001' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_smallInt() {
-        checkInvalidArguments(SMALLINT, "INTERVAL '0.002' SECOND");
+        checkInvalidArguments(SMALLINT, "INTERVAL '0.002' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_int() {
-        checkInvalidArguments(INTEGER, "INTERVAL '0.003' SECOND");
+        checkInvalidArguments(INTEGER, "INTERVAL '0.003' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_bigInt() {
-        checkInvalidArguments(BIGINT, "INTERVAL '0.004' SECOND");
+        checkInvalidArguments(BIGINT, "INTERVAL '0.004' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_decimal_interval() {
-        checkInvalidArguments(DECIMAL, "INTERVAL '0.005' SECOND");
+        checkInvalidArguments(DECIMAL, "INTERVAL '0.005' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_decimal_number() {
-        checkInvalidArguments(DECIMAL, "6");
+        checkInvalidArguments(DECIMAL, "6", TINYINT);
     }
 
     @Test
     public void test_invalidArguments_real_interval() {
-        checkInvalidArguments(REAL, "INTERVAL '0.007' SECOND");
+        checkInvalidArguments(REAL, "INTERVAL '0.007' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_real_number() {
-        checkInvalidArguments(REAL, "8");
+        checkInvalidArguments(REAL, "8", TINYINT);
     }
 
     @Test
     public void test_invalidArguments_double_interval() {
-        checkInvalidArguments(DOUBLE, "INTERVAL '0.009' SECOND");
+        checkInvalidArguments(DOUBLE, "INTERVAL '0.009' SECOND", INTERVAL_DAY_SECOND);
     }
 
     @Test
     public void test_invalidArguments_double_number() {
-        checkInvalidArguments(DOUBLE, "10");
+        checkInvalidArguments(DOUBLE, "10", TINYINT);
     }
 
     @Test
     public void test_invalidArguments_time() {
-        checkInvalidArguments(TIME, "11");
+        checkInvalidArguments(TIME, "11", TINYINT);
     }
 
     @Test
     public void test_invalidArguments_date() {
-        checkInvalidArguments(DATE, "12");
+        checkInvalidArguments(DATE, "12", TINYINT);
     }
 
     @Test
     public void test_invalidArguments_timestamp() {
-        checkInvalidArguments(TIMESTAMP, "13");
+        checkInvalidArguments(TIMESTAMP, "13", TINYINT);
     }
 
     @Test
     public void test_invalidArguments_timestampTz() {
-        checkInvalidArguments(TIMESTAMP_WITH_TIME_ZONE, "14");
+        checkInvalidArguments(TIMESTAMP_WITH_TIME_ZONE, "14", TINYINT);
     }
 
-    private static void checkInvalidArguments(QueryDataTypeFamily orderingColumnType, String windowSize) {
+    private static void checkInvalidArguments(QueryDataTypeFamily orderingColumnType, String windowSize, QueryDataTypeFamily windowSizeType) {
         String name = randomName();
         TestStreamSqlConnector.create(sqlService, name, singletonList("ts"), singletonList(orderingColumnType));
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " +
                 "TABLE(TUMBLE(TABLE(" + name + "), DESCRIPTOR(ts), " + windowSize + "))")
-        ).hasMessageContaining("Cannot apply 'TUMBLE' function to [ROW, COLUMN_LIST");
+        ).hasMessageContaining("The descriptor column type (" + orderingColumnType + ") and the interval type (" + windowSizeType + ") do not match");
     }
 
     @Test


### PR DESCRIPTION
The type of the column in DESCRIPTOR and the type of the interval have
to match. Previously we threw `Cannot apply 'IMPOSE_ORDER' function to
[ROW, COLUMN_LIST`, now we throw more informative, e.g. `The descriptor
column type (BIGINT) and the interval type (INTERVAL DAY SECOND) do not
match`
