### PR TITLE
Fix mapping of Map fields in SQL (forward-port of #20256)

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlFilterProjectTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlFilterProjectTest.java
@@ -624,7 +624,7 @@ public class SqlFilterProjectTest extends SqlTestSupport {
         SqlResult result = sqlService.execute("SELECT * FROM t");
 
         assertThat(result.updateCount()).isEqualTo(-1);
-        assertThat(result.getRowMetadata().getColumnCount()).isEqualTo(14);
+        assertThat(result.getRowMetadata().getColumnCount()).isEqualTo(15);
         assertThat(result.getRowMetadata().getColumn(0).getName()).isEqualTo("string");
         assertThat(result.getRowMetadata().getColumn(0).getType()).isEqualTo(SqlColumnType.VARCHAR);
         assertThat(result.getRowMetadata().getColumn(1).getName()).isEqualTo("boolean");
@@ -651,8 +651,10 @@ public class SqlFilterProjectTest extends SqlTestSupport {
         assertThat(result.getRowMetadata().getColumn(11).getType()).isEqualTo(SqlColumnType.TIMESTAMP);
         assertThat(result.getRowMetadata().getColumn(12).getName()).isEqualTo("timestampTz");
         assertThat(result.getRowMetadata().getColumn(12).getType()).isEqualTo(SqlColumnType.TIMESTAMP_WITH_TIME_ZONE);
-        assertThat(result.getRowMetadata().getColumn(13).getName()).isEqualTo("object");
+        assertThat(result.getRowMetadata().getColumn(13).getName()).isEqualTo("map");
         assertThat(result.getRowMetadata().getColumn(13).getType()).isEqualTo(SqlColumnType.OBJECT);
+        assertThat(result.getRowMetadata().getColumn(14).getName()).isEqualTo("object");
+        assertThat(result.getRowMetadata().getColumn(14).getType()).isEqualTo(SqlColumnType.OBJECT);
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/SqlAggregateTest_TypeCoercion.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/SqlAggregateTest_TypeCoercion.java
@@ -54,7 +54,7 @@ public class SqlAggregateTest_TypeCoercion extends SqlTestSupport {
         assertRowsAnyOrder(
                 "SELECT " + allFields + " " +
                         "FROM t " +
-                        "GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14",
+                        "GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15",
                 singletonList(TestAllTypesSqlConnector.ALL_TYPES_ROW));
     }
 
@@ -68,7 +68,7 @@ public class SqlAggregateTest_TypeCoercion extends SqlTestSupport {
                         allFields +
                         ", count(null) " +
                         "from allTypesTable",
-                Collections.singleton(new Row(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 0L, 0L)));
+                Collections.singleton(new Row(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 0L, 0L)));
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -224,6 +224,7 @@ public class SqlAvroTest extends SqlTestSupport {
                 + ", \"date\" DATE"
                 + ", \"timestamp\" TIMESTAMP"
                 + ", timestampTz TIMESTAMP WITH TIME ZONE"
+                + ", map OBJECT"
                 + ", object OBJECT"
                 + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
                 + "OPTIONS ( "
@@ -254,6 +255,7 @@ public class SqlAvroTest extends SqlTestSupport {
                         LocalDate.of(2020, 4, 15),
                         LocalDateTime.of(2020, 4, 15, 12, 23, 34, 1_000_000),
                         OffsetDateTime.of(2020, 4, 15, 12, 23, 34, 200_000_000, UTC),
+                        "{42=43}", // object values are stored as strings in avro format
                         null
                 ))
         );

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
@@ -188,6 +188,7 @@ public class SqlJsonTest extends SqlTestSupport {
                 + ", \"date\" DATE"
                 + ", \"timestamp\" TIMESTAMP"
                 + ", timestampTz TIMESTAMP WITH TIME ZONE"
+                + ", map OBJECT"
                 + ", object OBJECT"
                 + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
                 + "OPTIONS ( "
@@ -217,6 +218,7 @@ public class SqlJsonTest extends SqlTestSupport {
                         LocalDate.of(2020, 4, 15),
                         LocalDateTime.of(2020, 4, 15, 12, 23, 34, 1_000_000),
                         OffsetDateTime.of(2020, 4, 15, 12, 23, 34, 200_000_000, UTC),
+                        ImmutableMap.of("42", 43), // JSON serializer stores maps as JSON objects, the key is converted to a string
                         null
                 ))
         );

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPojoTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPojoTest.java
@@ -209,7 +209,8 @@ public class SqlPojoTest extends SqlTestSupport {
                 + ", object"
                 + ") SELECT "
                 + "CAST(1 AS INT)"
-                + ", f.*"
+                + ", string, \"boolean\", byte, short, \"int\", long, \"float\", \"double\", \"decimal\", " +
+                "\"time\", \"date\", \"timestamp\", timestampTz, \"object\""
                 + " FROM " + from + " f"
         );
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlJsonTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlJsonTest.java
@@ -165,6 +165,7 @@ public class SqlJsonTest extends SqlTestSupport {
                 + ", \"timestamp\" TIMESTAMP"
                 + ", timestampTz TIMESTAMP WITH TIME ZONE"
                 + ", object OBJECT"
+                + ", map OBJECT"
                 + ") TYPE " + IMapSqlConnector.TYPE_NAME + ' '
                 + "OPTIONS ("
                 + '\'' + OPTION_KEY_FORMAT + "'='" + JSON_FLAT_FORMAT + '\''
@@ -191,6 +192,7 @@ public class SqlJsonTest extends SqlTestSupport {
                         LocalDate.of(2020, 4, 15),
                         LocalDateTime.of(2020, 4, 15, 12, 23, 34, 1_000_000),
                         OffsetDateTime.of(2020, 4, 15, 12, 23, 34, 200_000_000, UTC),
+                        "{42=43}", // map converted to a string in JSON format
                         null
                 ))
         );

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPortableTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPortableTest.java
@@ -394,7 +394,10 @@ public class SqlPortableTest extends SqlTestSupport {
                 + ")"
         );
 
-        sqlService.execute("SINK INTO " + to + " SELECT 13, 'a', f.* FROM " + from + " f");
+        sqlService.execute("SINK INTO " + to + " " +
+                "SELECT 13, 'a', string, \"boolean\", byte, short, \"int\", long, \"float\", \"double\", \"decimal\", " +
+                "\"time\", \"date\", \"timestamp\", timestampTz, \"object\" " +
+                "FROM " + from + " f");
 
         InternalGenericRecord valueRecord = serializationService
                 .readAsInternalGenericRecord(randomEntryFrom(to).getValue());

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/model/AllTypesValue.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/model/AllTypesValue.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.jet.sql.impl.connector.map.model;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -27,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.time.Instant.ofEpochMilli;
@@ -57,6 +60,7 @@ public final class AllTypesValue implements Serializable {
     private Instant instant;
     private ZonedDateTime zonedDateTime;
     private OffsetDateTime offsetDateTime;
+    private Map<Integer, Integer> map;
     private Object object;
 
     public AllTypesValue() {
@@ -67,7 +71,7 @@ public final class AllTypesValue implements Serializable {
                          long long0, float float0, double double0, BigDecimal bigDecimal, BigInteger bigInteger,
                          LocalTime localTime, LocalDate localDate, LocalDateTime localDateTime, Date date,
                          GregorianCalendar calendar, Instant instant, ZonedDateTime zonedDateTime,
-                         OffsetDateTime offsetDateTime, Object object
+                         OffsetDateTime offsetDateTime, Map<Integer, Integer> map, Object object
     ) {
         this.string = string;
         this.character0 = character0;
@@ -88,6 +92,7 @@ public final class AllTypesValue implements Serializable {
         this.instant = instant;
         this.zonedDateTime = zonedDateTime;
         this.offsetDateTime = offsetDateTime;
+        this.map = map;
         this.object = object;
     }
 
@@ -112,6 +117,7 @@ public final class AllTypesValue implements Serializable {
                 ofEpochMilli(1586953414200L),
                 ZonedDateTime.of(2020, 4, 15, 12, 23, 34, 200_000_000, UTC),
                 OffsetDateTime.of(2020, 4, 15, 12, 23, 34, 200_000_000, UTC),
+                ImmutableMap.of(42, 43),
                 null
         );
     }
@@ -268,6 +274,14 @@ public final class AllTypesValue implements Serializable {
         this.offsetDateTime = offsetDateTime;
     }
 
+    public Map<Integer, Integer> getMap() {
+        return map;
+    }
+
+    public void setMap(Map<Integer, Integer> map) {
+        this.map = map;
+    }
+
     public Object getObject() {
         return object;
     }
@@ -298,6 +312,7 @@ public final class AllTypesValue implements Serializable {
                 ", instant=" + instant +
                 ", zonedDateTime=" + zonedDateTime +
                 ", offsetDateTime=" + offsetDateTime +
+                ", map=" + map +
                 ", object=" + object +
                 '}';
     }
@@ -330,6 +345,7 @@ public final class AllTypesValue implements Serializable {
                 Objects.equals(instant, that.instant) &&
                 Objects.equals(zonedDateTime, that.zonedDateTime) &&
                 Objects.equals(offsetDateTime, that.offsetDateTime) &&
+                Objects.equals(map, that.map) &&
                 Objects.equals(object, that.object);
     }
 
@@ -354,6 +370,7 @@ public final class AllTypesValue implements Serializable {
                 instant,
                 zonedDateTime,
                 offsetDateTime,
+                map,
                 object
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.connector.test;
 
+import com.google.common.collect.ImmutableMap;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
@@ -77,6 +78,7 @@ public class TestAllTypesSqlConnector implements SqlConnector {
             new MappingField("date", QueryDataType.DATE),
             new MappingField("timestamp", QueryDataType.TIMESTAMP),
             new MappingField("timestampTz", QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME),
+            new MappingField("map", QueryDataType.OBJECT),
             new MappingField("object", QueryDataType.OBJECT)
     );
 
@@ -96,6 +98,7 @@ public class TestAllTypesSqlConnector implements SqlConnector {
             LocalDate.of(2020, 4, 15),
             LocalDateTime.of(2020, 4, 15, 12, 23, 34, 1_000_000),
             OffsetDateTime.of(2020, 4, 15, 12, 23, 34, 200_000_000, UTC),
+            ImmutableMap.of(42, 43),
             null
     };
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/type/QueryDataTypeUtils.java
@@ -253,6 +253,7 @@ public final class QueryDataTypeUtils {
                 }
 
             case OBJECT:
+            case MAP:
                 return OBJECT;
 
             case NULL:


### PR DESCRIPTION
The type of the column in DESCRIPTOR and the type of the interval have
to match. Previously we threw `Cannot apply 'IMPOSE_ORDER' function to
[ROW, COLUMN_LIST`, now we throw more informative, e.g. `The descriptor
column type (BIGINT) and the interval type (INTERVAL DAY SECOND) do not
match`

Fixes: https://github.com/hazelcast/hazelcast/issues/20217
Forward-port of: https://github.com/hazelcast/hazelcast/pull/20256