### PR TITLE
Simplify and rename core SqlTestSupport

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TablesStorageTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TablesStorageTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.sql.impl.schema.Mapping;
 import com.hazelcast.sql.impl.schema.view.View;
+import com.hazelcast.test.Accessors;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -26,7 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static com.hazelcast.sql.impl.SqlTestSupport.nodeEngine;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +43,7 @@ public class TablesStorageTest extends SimpleTestInClusterSupport {
 
     @Before
     public void before() {
-        storage = new TablesStorage(nodeEngine(instance()));
+        storage = new TablesStorage(Accessors.getNodeEngineImpl(instance()));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlMetadataTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.sql;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlRowImpl;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.row.HeapRow;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlMetadataTest extends SqlTestSupport {
+public class SqlMetadataTest extends CoreSqlTestSupport {
     @Test
     public void testColumnMetadata() {
         SqlColumnMetadata column = new SqlColumnMetadata("a", SqlColumnType.INTEGER, true);

--- a/hazelcast/src/test/java/com/hazelcast/sql/SqlStatementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/SqlStatementTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql;
 
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlStatementTest extends SqlTestSupport {
+public class SqlStatementTest extends CoreSqlTestSupport {
 
     private static final String SQL = "sql";
 

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/CoreSqlTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/CoreSqlTestSupport.java
@@ -16,12 +16,9 @@
 
 package com.hazelcast.sql.impl;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.OverridePropertyRule;
 import org.junit.ClassRule;
@@ -33,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Helper test classes.
  */
-public class SqlTestSupport extends HazelcastTestSupport {
+public class CoreSqlTestSupport extends HazelcastTestSupport {
 
     @ClassRule
     public static OverridePropertyRule enableJetRule = OverridePropertyRule.set("hz.jet.enabled", "true");
@@ -54,12 +51,6 @@ public class SqlTestSupport extends HazelcastTestSupport {
         }
     }
 
-    public static <T> T serialize(Object original) {
-        InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
-
-        return ss.toObject(ss.toData(original));
-    }
-
     public static <T> T serializeAndCheck(Object original, int expectedClassId) {
         assertTrue(original instanceof IdentifiedDataSerializable);
 
@@ -68,10 +59,8 @@ public class SqlTestSupport extends HazelcastTestSupport {
         assertEquals(SqlDataSerializerHook.F_ID, original0.getFactoryId());
         assertEquals(expectedClassId, original0.getClassId());
 
-        return serialize(original);
-    }
+        InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
 
-    public static NodeEngineImpl nodeEngine(HazelcastInstance instance) {
-        return Accessors.getNodeEngineImpl(instance);
+        return ss.toObject(ss.toData(original));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryIdTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNotEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class QueryIdTest extends SqlTestSupport {
+public class QueryIdTest extends CoreSqlTestSupport {
     @Test
     public void testIds() {
         UUID memberId = UUID.randomUUID();

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/QueryUtilsTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -49,7 +50,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class QueryUtilsTest extends SqlTestSupport {
+public class QueryUtilsTest extends CoreSqlTestSupport {
 
     private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
 
@@ -62,7 +63,7 @@ public class QueryUtilsTest extends SqlTestSupport {
     public void testVersionMismatch() {
         HazelcastInstance member = factory.newHazelcastInstance();
 
-        NodeEngine nodeEngine = nodeEngine(member);
+        NodeEngine nodeEngine = Accessors.getNodeEngineImpl(member);
         String memberId = nodeEngine.getLocalMember().getUuid().toString();
         String memberVersion = nodeEngine.getLocalMember().getVersion().toString();
 
@@ -84,7 +85,7 @@ public class QueryUtilsTest extends SqlTestSupport {
 
         member.getCluster().changeClusterState(ClusterState.FROZEN);
 
-        Map<UUID, PartitionIdSet> map = QueryUtils.createPartitionMap(nodeEngine(member), null, false);
+        Map<UUID, PartitionIdSet> map = QueryUtils.createPartitionMap(Accessors.getNodeEngineImpl(member), null, false);
 
         assertTrue(map.isEmpty());
     }
@@ -96,7 +97,7 @@ public class QueryUtilsTest extends SqlTestSupport {
         member.getCluster().changeClusterState(ClusterState.FROZEN);
 
         try {
-            QueryUtils.createPartitionMap(nodeEngine(member), null, true);
+            QueryUtils.createPartitionMap(Accessors.getNodeEngineImpl(member), null, true);
 
             fail("Must fail");
         } catch (QueryException e) {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/UpdateSqlResultImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/UpdateSqlResultImplTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
-public class UpdateSqlResultImplTest extends SqlTestSupport {
+public class UpdateSqlResultImplTest extends CoreSqlTestSupport {
 
     @Test
     public void test_updateCountResult() {

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/GenericQueryTargetTest.java
@@ -23,11 +23,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.LazyTarget;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.SqlErrorCode;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class GenericQueryTargetTest extends SqlTestSupport {
+public class GenericQueryTargetTest extends CoreSqlTestSupport {
     @Test
     public void testTargetDescriptor() {
         serializeAndCheck(new GenericQueryTargetDescriptor(), SqlDataSerializerHook.TARGET_DESCRIPTOR_GENERIC);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/QueryPathTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/extract/QueryPathTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.sql.impl.extract;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class QueryPathTest extends SqlTestSupport {
+public class QueryPathTest extends CoreSqlTestSupport {
     @Test
     public void testPathResolution() {
         // Top fields.

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/PlanNodeSchemaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/plan/node/PlanNodeSchemaTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.plan.node;
 
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class PlanNodeSchemaTest extends SqlTestSupport {
+public class PlanNodeSchemaTest extends CoreSqlTestSupport {
     @Test
     public void testSingleSchema() {
         QueryDataType type0 = QueryDataType.VARCHAR;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/row/EmptyRowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/row/EmptyRowTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.sql.impl.row;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class EmptyRowTest extends SqlTestSupport {
+public class EmptyRowTest extends CoreSqlTestSupport {
     @Test
     public void testEmptyRow() {
         EmptyRow row = EmptyRow.INSTANCE;

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/row/HeapRowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/row/HeapRowTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.sql.impl.row;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlCustomClass;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class HeapRowTest extends SqlTestSupport {
+public class HeapRowTest extends CoreSqlTestSupport {
     @Test
     public void testHeapRow() {
         Object[] values = new Object[2];

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/MapTableFieldTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/MapTableFieldTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.sql.impl.schema.map;
 
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class MapTableFieldTest extends SqlTestSupport {
+public class MapTableFieldTest extends CoreSqlTestSupport {
     @Test
     public void testContent() {
         MapTableField field = new MapTableField("name", QueryDataType.INT, false, QueryPath.KEY_PATH);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/MapTableIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/MapTableIndexTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.sql.impl.schema.map;
 
 import com.hazelcast.config.IndexType;
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class MapTableIndexTest extends SqlTestSupport {
+public class MapTableIndexTest extends CoreSqlTestSupport {
     @Test
     public void testContent() {
         MapTableIndex index = new MapTableIndex("index", SORTED, 1, singletonList(1), singletonList(INT));

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapPlanObjectKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapPlanObjectKeyTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.sql.impl.SqlTestSupport;
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.extract.GenericQueryTargetDescriptor;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.extract.QueryTarget;
@@ -45,7 +45,7 @@ import static java.util.Collections.singletonList;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class PartitionedMapPlanObjectKeyTest extends SqlTestSupport {
+public class PartitionedMapPlanObjectKeyTest extends CoreSqlTestSupport {
     @Test
     public void test_partitioned() {
         String schema1 = "schema1";

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.sql.impl.type;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlCustomClass;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.sql.impl.type.converter.BigDecimalConverter;
 import com.hazelcast.sql.impl.type.converter.BigIntegerConverter;
 import com.hazelcast.sql.impl.type.converter.BooleanConverter;
@@ -66,7 +66,7 @@ import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class QueryDataTypeTest extends SqlTestSupport {
+public class QueryDataTypeTest extends CoreSqlTestSupport {
     @Test
     public void testDefaultTypes() {
         checkType(QueryDataType.VARCHAR, StringConverter.INSTANCE);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/SqlDaySecondIntervalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/SqlDaySecondIntervalTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.sql.impl.type;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlDaySecondIntervalTest extends SqlTestSupport {
+public class SqlDaySecondIntervalTest extends CoreSqlTestSupport {
     @Test
     public void testEquals() {
         SqlDaySecondInterval value = new SqlDaySecondInterval(1);

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/type/SqlYearMonthIntervalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/type/SqlYearMonthIntervalTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.sql.impl.type;
 
+import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.sql.impl.SqlTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlYearMonthIntervalTest extends SqlTestSupport {
+public class SqlYearMonthIntervalTest extends CoreSqlTestSupport {
     @Test
     public void testEquals() {
         SqlYearMonthInterval value = new SqlYearMonthInterval(1);


### PR DESCRIPTION
Not entirely, but fixes #19240. We cannot remove it fully because we
can't move the other SqlTestSupport to core module, so I only eliminated
some of the methods.