### PR TITLE
Fix SuspendExecutionOnFailureTest assertions

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
@@ -192,8 +192,8 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
 
         counterMap.put("key", false);
         job.resume();
-        // sinkMap is an idempotent sink, so even we're using at-least-once, no key will be duplicated, so the
-        // must contain expected number of items.
+        // sinkMap is an idempotent sink, so even though we're using at-least-once, no key will be duplicated, so it
+        // must contain the expected number of items.
         assertTrueEventually(() -> assertEquals(numItems, sinkMap.size()));
         assertTrueEventually(() -> assertEquals(JobStatus.RUNNING, job.getStatus()));
 


### PR DESCRIPTION
I think the assertion on line 192 was wrong. If a vertex fails after a
certain item, there's no guarantee that a downstream vertex already
processed all previous items. The test failed rarely because the source
emits items one by one with 5ms delay, so it was very likely that all
items were sunk, but if there was some hiccup, it could fail.

Fixes #19836
