### PR TITLE
Decrease log level for ExecutionNotFoundException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -43,6 +43,7 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import java.util.logging.Level;
 
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
@@ -208,8 +209,8 @@ class MasterSnapshotContext {
                 if (response instanceof Throwable) {
                     // If the member doesn't know the execution, it might have completed normally or exceptionally.
                     // If normally, we ignore it, if exceptionally, we'll also fail the snapshot. To know, we have
-                    // to look at the result of the StartExecutionOperation, which might not yet arrive. We'll collect
-                    // all the responses to an array and we'll wait for them later.
+                    // to look at the result of the StartExecutionOperation, which might not have arrived yet. We'll collect
+                    // all the responses to an array, and we'll wait for them later.
                     if (response instanceof ExecutionNotFoundException) {
                         missingResponses.add(mc.startOperationResponses().get(entry.getKey().getAddress()));
                         continue;
@@ -368,7 +369,9 @@ class MasterSnapshotContext {
 
             for (Entry<MemberInfo, Object> response : responses) {
                 if (response.getValue() instanceof Throwable) {
-                    logger.warning(SnapshotPhase2Operation.class.getSimpleName() + " for snapshot " + snapshotId + " in "
+                    logger.log(
+                            response.getValue() instanceof ExecutionNotFoundException ? Level.FINE : Level.WARNING,
+                            SnapshotPhase2Operation.class.getSimpleName() + " for snapshot " + snapshotId + " in "
                             + mc.jobIdString() + " failed on member: " + response, (Throwable) response.getValue());
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/ExecutionNotFoundException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/exception/ExecutionNotFoundException.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.exception;
 
 import com.hazelcast.jet.JetException;
+import com.hazelcast.spi.exception.SilentException;
 
 import static com.hazelcast.jet.Util.idToString;
 
@@ -24,7 +25,7 @@ import static com.hazelcast.jet.Util.idToString;
  * Thrown in response to operations sent from the coordinator, if the
  * target doesn't know the execution.
  */
-public class ExecutionNotFoundException extends JetException {
+public class ExecutionNotFoundException extends JetException implements SilentException {
 
     private static final long serialVersionUID = 1L;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/SilentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/SilentException.java
@@ -22,7 +22,8 @@ import com.hazelcast.spi.impl.operationservice.Operation;
  * Marker interface for exceptions.
  *
  * When an exception is marked with this interface then
- * it won't be logged by {@link Operation#logError(Throwable)}
+ * it won't be logged by {@link Operation#logError(Throwable)} on the
+ * callee side.
  *
  * It's intended to be used for exceptions which are part of a flow,
  * for example {@link com.hazelcast.durableexecutor.StaleTaskIdException}


### PR DESCRIPTION
The `ExecutionNotFoundException` after phase2 is normal and can be
ignored, let's decrease its log level to FINE, log other exceptions on
WARNING level.

Fixes #19840
