### PR TITLE
Don't skip the new split resulting from a MissingPartitionException

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -164,7 +164,7 @@ final class MapIndexScanP extends AbstractProcessor {
                     split.peek();
                 } catch (MissingPartitionException e) {
                     splits.addAll(splitOnMigration(split));
-                    splits.remove(i);
+                    splits.remove(i--);
                     continue;
                 }
                 if (split.currentRow == null) {


### PR DESCRIPTION
Fixes issue in this comment:
https://github.com/hazelcast/hazelcast/issues/19885#issuecomment-987649060

The assertion on line 187 is broken in this scenario:
- there's only 1 split
- we receive MissingPartitionException
- `splitOnMigration()` doesn't split the old split into two, but only into one (can happen if, for example, we don't yet have updated partition information)
- since there was only 1 split and after `splitOnMigration` there's
  still only one split, we finish the iteration, `extremeIndex` will
  remain -1, but `splits` won't be empty.

Same will happen if there's more than one split and all are in this situation.

The fix is to decrement `i` after removing the old split so that in the
next iteration we look at the newly-added split.

Doesn't fix other causes reported in #19885.