### PR TITLE
Make SqlResult iterator's hasNext() method interruptable

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlResultImplTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlResultImplTest.java
@@ -17,30 +17,59 @@
 package com.hazelcast.jet.sql.impl;
 
 import com.hazelcast.function.ConsumerEx;
-import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.sql.SqlTestSupport;
+import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SqlResultImplTest extends JetTestSupport {
+public class SqlResultImplTest extends SqlTestSupport {
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(1, null);
+    }
 
     @Test
     // test for https://github.com/hazelcast/hazelcast-jet/issues/2697
     public void when_closed_then_iteratorFails() {
-        SqlResult sqlResult = createHazelcastInstance().getSql().execute("select * from table(generate_stream(1))");
+        SqlResult sqlResult = instance().getSql().execute("select * from table(generate_stream(1))");
         sqlResult.close();
         Iterator<SqlRow> iterator = sqlResult.iterator();
         assertThatThrownBy(() -> iterator.forEachRemaining(ConsumerEx.noop()));
+    }
+
+    @Test
+    public void when_hasNextInterrupted_then_interrupted() {
+        // this query is a continuous one, but never returns any rows (all are filtered out)
+        SqlResult sqlResult = instance().getSql().execute("select * from table(generate_stream(1)) where v < 0");
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread t = new Thread(() -> {
+            try {
+                sqlResult.iterator().hasNext();
+            } catch (HazelcastSqlException e) {
+                if (e.getCause() instanceof RuntimeException
+                        && e.getCause().getCause() instanceof InterruptedException) {
+                    interrupted.set(true);
+                }
+            }
+        });
+        t.start();
+        t.interrupt();
+        assertTrueEventually(() -> assertTrue(interrupted.get()));
     }
 }


### PR DESCRIPTION
Related to #19943. This PR doesn't fix the issue, it will only cause
that the test will not time out, but will throw a different error.