### PR TITLE
Configure Dependabot to set "Source: Internal" label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,13 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00"
+    labels:
+      - "Source: Internal"
+      - "dependencies"
     open-pull-requests-limit: 100
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"


### PR DESCRIPTION
And to process GitHub Actions as well.