### PR TITLE
implementing HZ_PARDOT_ID env var support

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -36,13 +36,13 @@ import static java.lang.Math.min;
  */
 class BuildInfoCollector implements MetricsCollector {
 
-    private static final String PARDOT_ID_ENV_VAR = "HZ_PARDOT_ID";
-
     static final int CLASSPATH_MAX_LENGTH = 100_000;
+
+    private static final String PARDOT_ID_ENV_VAR = "HZ_PARDOT_ID";
 
     private final Map<String, String> envVars;
 
-    public BuildInfoCollector(Map<String, String> envVars) {
+    BuildInfoCollector(Map<String, String> envVars) {
         this.envVars = envVars;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/BuildInfoCollector.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -35,7 +36,15 @@ import static java.lang.Math.min;
  */
 class BuildInfoCollector implements MetricsCollector {
 
+    private static final String PARDOT_ID_ENV_VAR = "HZ_PARDOT_ID";
+
     static final int CLASSPATH_MAX_LENGTH = 100_000;
+
+    private final Map<String, String> envVars;
+
+    public BuildInfoCollector(Map<String, String> envVars) {
+        this.envVars = envVars;
+    }
 
     static String formatClassPath(String classpath) {
         String[] classPathEntries = classpath.split(File.pathSeparator);
@@ -64,6 +73,10 @@ class BuildInfoCollector implements MetricsCollector {
      * {@code source} if unable to find the download ID.
      */
     private String getDownloadId() {
+        String passedByEnvVar = envVars.get(PARDOT_ID_ENV_VAR);
+        if (passedByEnvVar != null) {
+            return passedByEnvVar;
+        }
         try (InputStream is = getClass().getClassLoader()
                                         .getResourceAsStream("hazelcast-download.properties")) {
             if (is != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -51,31 +51,35 @@ public class PhoneHome {
     volatile ScheduledFuture<?> phoneHomeFuture;
     private final ILogger logger;
     private final String basePhoneHomeUrl;
-    private final HashMap<String, String> envVars;
     private final List<MetricsCollector> metricsCollectorList;
 
     public PhoneHome(Node node) {
         this(node, DEFAULT_BASE_PHONE_HOME_URL, CLOUD_INFO_COLLECTOR);
     }
 
+    /**
+     * Visible for testing.
+     */
     PhoneHome(Node node, String basePhoneHomeUrl, Map<String, String> envVars) {
         this(node, basePhoneHomeUrl, envVars, CLOUD_INFO_COLLECTOR);
     }
 
-    PhoneHome(Node node, String baseUrl, MetricsCollector... additionalCollectors) {
-        this(node, baseUrl, System.getenv(), additionalCollectors);
+    /**
+     * Visible for testing.
+     */
+    PhoneHome(Node node, String basePhoneHomeUrl, MetricsCollector... additionalCollectors) {
+        this(node, basePhoneHomeUrl, System.getenv(), additionalCollectors);
     }
 
     @SuppressWarnings("checkstyle:magicnumber")
-    PhoneHome(Node node, String baseUrl, Map<String, String> envVars, MetricsCollector... additionalCollectors) {
+    private PhoneHome(Node node, String basePhoneHomeUrl, Map<String, String> envVars, MetricsCollector... additionalCollectors) {
         hazelcastNode = node;
         logger = hazelcastNode.getLogger(PhoneHome.class);
-        basePhoneHomeUrl = baseUrl;
-        this.envVars = new HashMap<>(envVars);
+        this.basePhoneHomeUrl = basePhoneHomeUrl;
         metricsCollectorList = new ArrayList<>(additionalCollectors.length + 8);
         Collections.addAll(metricsCollectorList,
                 new RestApiMetricsCollector(),
-                new BuildInfoCollector(envVars), new ClusterInfoCollector(), new ClientInfoCollector(),
+                new BuildInfoCollector(new HashMap<>(envVars)), new ClusterInfoCollector(), new ClientInfoCollector(),
                 new MapInfoCollector(), new OSInfoCollector(), new DistributedObjectCounterCollector(),
                 new CacheInfoCollector(), new JetInfoCollector(), new CPSubsystemInfoCollector(),
                 new SqlInfoCollector());

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.internal.util.phonehome;
 
+import com.google.common.collect.ImmutableMap;
 import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -178,6 +179,13 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         node.getConfig().getMapConfig("hazelcast").setReadBackupData(true);
         parameters = phoneHome.phoneHome(true);
         assertEquals(parameters.get(PhoneHomeMetrics.MAP_COUNT_WITH_READ_ENABLED.getRequestParameterName()), "1");
+    }
+
+    @Test
+    public void pardotIdOverride_withEnvVar() {
+        PhoneHome phoneHome = new PhoneHome(node, "http://example.org", ImmutableMap.of("HZ_PARDOT_ID", "1234"));
+        Map<String, String> params = phoneHome.phoneHome(true);
+        assertEquals("1234", params.get("p"));
     }
 
     @Test


### PR DESCRIPTION
Makes the pardotId (`p`) phonehome request parameter override-able using the HZ_PARDOT_ID environment variable.

Fixes MC-1272

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
