### PR TITLE
Make Processor.Context available from ThreadLocal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
@@ -19,7 +19,7 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
-import com.hazelcast.jet.impl.metrics.MetricsContext;
+import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.impl.util.ProgressState;
 
 import javax.annotation.Nonnull;
@@ -41,7 +41,7 @@ public interface Tasklet extends DynamicMetricsProvider {
     }
 
     @Nullable
-    default MetricsContext getMetricsContext() {
+    default Processor.Context getProcessorContext() {
         return null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -27,7 +27,7 @@ import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.metrics.MetricTags;
-import com.hazelcast.jet.impl.metrics.MetricsImpl;
+import com.hazelcast.jet.impl.execution.init.Contexts;
 import com.hazelcast.jet.impl.util.NonCompletableFuture;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.jet.impl.util.ProgressTracker;
@@ -288,11 +288,11 @@ public class TaskletExecutionService {
             final Tasklet t = tracker.tasklet;
             currentThread().setContextClassLoader(tracker.jobClassLoader);
             IdleStrategy idlerLocal = idlerNonCooperative;
-            MetricsImpl.Container userMetricsContextContainer = MetricsImpl.container();
+            Contexts.Container userMetricsContextContainer = Contexts.container();
 
             try {
                 blockingWorkerCount.inc();
-                userMetricsContextContainer.setContext(t.getMetricsContext());
+                userMetricsContextContainer.setContext(t.getProcessorContext());
                 startedLatch.countDown();
                 t.init();
                 long idleCount = 0;
@@ -335,7 +335,7 @@ public class TaskletExecutionService {
 
         private boolean finestLogEnabled;
         private Thread myThread;
-        private MetricsImpl.Container userMetricsContextContainer;
+        private Contexts.Container userMetricsContextContainer;
 
         CooperativeWorker() {
             this.trackers = new CopyOnWriteArrayList<>();
@@ -344,7 +344,7 @@ public class TaskletExecutionService {
         @Override
         public void run() {
             myThread = currentThread();
-            userMetricsContextContainer = MetricsImpl.container();
+            userMetricsContextContainer = Contexts.container();
 
             IdleStrategy idlerLocal = idlerCooperative;
             long idleCount = 0;
@@ -384,7 +384,7 @@ public class TaskletExecutionService {
             }
             try {
                 myThread.setContextClassLoader(t.jobClassLoader);
-                userMetricsContextContainer.setContext(t.tasklet.getMetricsContext());
+                userMetricsContextContainer.setContext(t.tasklet.getProcessorContext());
                 final ProgressState result = t.tasklet.call();
                 if (result.isDone()) {
                     dismissTasklet(t);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/metrics/MetricsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/metrics/MetricsImpl.java
@@ -18,54 +18,22 @@ package com.hazelcast.jet.impl.metrics;
 
 import com.hazelcast.jet.core.metrics.Metric;
 import com.hazelcast.jet.core.metrics.Unit;
-
-import javax.annotation.Nullable;
+import com.hazelcast.jet.impl.execution.init.Contexts;
 
 public final class MetricsImpl {
-
-    private static final ThreadLocal<Container> CONTEXT = ThreadLocal.withInitial(Container::new);
 
     private MetricsImpl() {
     }
 
-    public static Container container() {
-        return CONTEXT.get();
-    }
-
     public static Metric metric(String name, Unit unit) {
-        return getContext().metric(name, unit);
+        return getMetricsContext().metric(name, unit);
     }
 
     public static Metric threadSafeMetric(String name, Unit unit) {
-        return getContext().threadSafeMetric(name, unit);
+        return getMetricsContext().threadSafeMetric(name, unit);
     }
 
-    private static MetricsContext getContext() {
-        Container container = CONTEXT.get();
-        MetricsContext context = container.getContext();
-        if (context == null) {
-            throw new RuntimeException("Thread %s has no metrics context set, this method can " +
-                    "be called only on threads executing the job's processors");
-        }
-        return context;
+    private static MetricsContext getMetricsContext() {
+        return Contexts.getCastedThreadContext().metricsContext();
     }
-
-    public static class Container {
-
-        @Nullable
-        private MetricsContext context;
-
-        Container() {
-        }
-
-        @Nullable
-        public MetricsContext getContext() {
-            return context;
-        }
-
-        public void setContext(@Nullable MetricsContext context) {
-            this.context = context;
-        }
-    }
-
 }


### PR DESCRIPTION
In the SQL module we need to access Processor context from the various
lambdas. It's a PITA to add it where supported (we have to use factories
from which we get the actual function), such as in `mapUsingContext`.
But in many places it's not supported, e.g. in `AggregateOperation`
methods.

This PR replaces the metrics context that already was in a thread local
with processor context.
