### PR TITLE
Handle CURSOR arguments

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastCallBinding.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastCallBinding.java
@@ -95,6 +95,8 @@ public class HazelcastCallBinding extends SqlCallBinding {
                 typeName = calciteType.getSqlTypeName().toString();
             } else if (calciteType.getSqlTypeName() == SqlTypeName.SYMBOL) {
                 typeName = "SYMBOL";
+            } else if (calciteType.getSqlTypeName() == SqlTypeName.CURSOR) {
+                typeName = "CURSOR";
             } else {
                 QueryDataType hazelcastType = HazelcastTypeUtils.toHazelcastType(calciteType);
                 if (hazelcastType.getTypeFamily().getPublicType() != null) {


### PR DESCRIPTION
If an argument to a function is CURSOR, we failed to generate a correct error message. Before:
```
Unexpected SQL type: CURSOR
```
After:
```
Cannot apply 'TUMBLE' function to [CURSOR, COLUMN_LIST, INTERVAL_MINUTE] (consider adding an explicit CAST)
```