### PR TITLE
Update grpc & protobuf versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <avro.version>1.11.0</avro.version>
         <aws.sdk.version>1.12.120</aws.sdk.version>
         <classgraph.version>4.8.138</classgraph.version>
-        <grpc.version>1.34.0</grpc.version>
+        <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
         <hadoop.version>3.3.1</hadoop.version>
         <jackson.version>2.12.1</jackson.version>
@@ -117,7 +117,7 @@
         <parquet.version>1.12.0</parquet.version>
         <picocli.version>4.4.0</picocli.version>
         <prometheus.version>0.14.0</prometheus.version>
-        <protobuf.version>3.13.0</protobuf.version>
+        <protobuf.version>3.19.2</protobuf.version>
         <scala.version>2.12</scala.version>
         <slf4j.version>1.7.32</slf4j.version>
         <spring.version>4.3.0.RELEASE</spring.version>


### PR DESCRIPTION
Newer versions of these dependencies
include binaries for `aarch64` architecture.
Fixes the build of `hazelcast-jet-grpc`
and `hazelcast-jet-protobuf` on Apple M1*
CPUs.

Fixes #20310