### PR TITLE
Fix mock server stuff

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -54,11 +54,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class FirewallingServer
         implements Server, Consumer<Packet> {
 
+    public final Server delegate;
     private final ScheduledExecutorService scheduledExecutor
             = newSingleThreadScheduledExecutor(new ThreadFactoryImpl("FirewallingConnectionManager"));
     private final Set<Address> blockedAddresses = newSetFromMap(new ConcurrentHashMap<>());
 
-    private final Server delegate;
     private final Consumer<Packet> packetConsumer;
     private final AtomicReference<ServerConnectionManager> connectionManagerRef = new AtomicReference<>(null);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
@@ -60,10 +60,10 @@ import static java.util.Collections.singletonMap;
 
 class MockServer implements Server {
 
+    final ConcurrentMap<UUID, MockServerConnection> connectionMap = new ConcurrentHashMap<>(10);
     private static final int RETRY_NUMBER = 5;
     private static final int DELAY_FACTOR = 100;
 
-    private final ConcurrentMap<UUID, MockServerConnection> connectionMap = new ConcurrentHashMap<>(10);
     private final TestNodeRegistry nodeRegistry;
     private final LocalAddressRegistry addressRegistry;
     private final Node node;
@@ -124,6 +124,9 @@ class MockServer implements Server {
 
         @Override
         public MockServerConnection getOrConnect(@Nonnull Address address, int stream) {
+            if (server.nodeRegistry.uuidOf(address) == null) {
+                return null;
+            }
             MockServerConnection conn = server.connectionMap.get(server.nodeRegistry.uuidOf(address));
             if (conn != null && conn.isAlive()) {
                 return conn;


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->
Hot fix for mock server connection management.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
