### PR TITLE
[5.0.1-BETA-1] Fix mock connection management

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -54,11 +54,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class FirewallingServer
         implements Server, Consumer<Packet> {
 
+    public final Server delegate;
     private final ScheduledExecutorService scheduledExecutor
             = newSingleThreadScheduledExecutor(new ThreadFactoryImpl("FirewallingConnectionManager"));
     private final Set<Address> blockedAddresses = newSetFromMap(new ConcurrentHashMap<>());
 
-    private final Server delegate;
     private final Consumer<Packet> packetConsumer;
     private final AtomicReference<ServerConnectionManager> connectionManagerRef = new AtomicReference<>(null);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
@@ -60,10 +60,10 @@ import static java.util.Collections.singletonMap;
 
 class MockServer implements Server {
 
+    final ConcurrentMap<UUID, MockServerConnection> connectionMap = new ConcurrentHashMap<>(10);
     private static final int RETRY_NUMBER = 5;
     private static final int DELAY_FACTOR = 100;
 
-    private final ConcurrentMap<UUID, MockServerConnection> connectionMap = new ConcurrentHashMap<>(10);
     private final TestNodeRegistry nodeRegistry;
     private final LocalAddressRegistry addressRegistry;
     private final Node node;
@@ -124,6 +124,9 @@ class MockServer implements Server {
 
         @Override
         public MockServerConnection getOrConnect(@Nonnull Address address, int stream) {
+            if (server.nodeRegistry.uuidOf(address) == null) {
+                return null;
+            }
             MockServerConnection conn = server.connectionMap.get(server.nodeRegistry.uuidOf(address));
             if (conn != null && conn.isAlive()) {
                 return conn;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -190,19 +190,20 @@ public class MockServerConnection implements ServerConnection {
         }
 
         if (localConnection != null) {
-            assert localNodeEngine != null;
-            Server server = localNodeEngine.getNode().getServer();
-            // this is a member-to-member connection
-            if (server instanceof FirewallingServer) {
-                (((MockServer) ((FirewallingServer) server).delegate)).connectionMap.remove(remoteUuid);
-            } else if (server instanceof MockServer) {
-                ((MockServer) server).connectionMap.remove(remoteUuid);
-            }
             localConnection.close(msg, cause);
         }
 
         if (lifecycleListener != null) {
             lifecycleListener.onConnectionClose(this, cause, false);
+        }
+
+        assert localNodeEngine != null;
+        Server server = localNodeEngine.getNode().getServer();
+        // this is a member-to-member connection
+        if (server instanceof FirewallingServer) {
+            (((MockServer) ((FirewallingServer) server).delegate)).connectionMap.remove(remoteUuid);
+        } else if (server instanceof MockServer) {
+            ((MockServer) server).connectionMap.remove(remoteUuid);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -183,11 +183,6 @@ public class MockServerConnection implements ServerConnection {
         if (!alive.compareAndSet(true, false)) {
             return;
         }
-        if (localNodeEngine != null) {
-            localNodeEngine.getNode()
-                    .getLocalAddressRegistry()
-                    .tryRemoveRegistration(remoteUuid, remoteAddress);
-        }
 
         if (localConnection != null) {
             localConnection.close(msg, cause);
@@ -198,6 +193,9 @@ public class MockServerConnection implements ServerConnection {
         }
 
         if (localNodeEngine != null) {
+            localNodeEngine.getNode()
+                    .getLocalAddressRegistry()
+                    .tryRemoveRegistration(remoteUuid, remoteAddress);
             Server server = localNodeEngine.getNode().getServer();
             // this is a member-to-member connection
             if (server instanceof FirewallingServer) {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -27,7 +27,6 @@ import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.nio.PacketIOHelper;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import org.mockito.Mock;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -197,13 +197,14 @@ public class MockServerConnection implements ServerConnection {
             lifecycleListener.onConnectionClose(this, cause, false);
         }
 
-        assert localNodeEngine != null;
-        Server server = localNodeEngine.getNode().getServer();
-        // this is a member-to-member connection
-        if (server instanceof FirewallingServer) {
-            (((MockServer) ((FirewallingServer) server).delegate)).connectionMap.remove(remoteUuid);
-        } else if (server instanceof MockServer) {
-            ((MockServer) server).connectionMap.remove(remoteUuid);
+        if (localNodeEngine != null) {
+            Server server = localNodeEngine.getNode().getServer();
+            // this is a member-to-member connection
+            if (server instanceof FirewallingServer) {
+                (((MockServer) ((FirewallingServer) server).delegate)).connectionMap.remove(remoteUuid);
+            } else if (server instanceof MockServer) {
+                ((MockServer) server).connectionMap.remove(remoteUuid);
+            }
         }
     }
 


### PR DESCRIPTION
Backport of #20352 

Hot fix for failing mock server connection management.

Related to: #20014

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
