### PR TITLE
Fix javadoc in distribution module HZ-625

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -157,6 +157,25 @@
                     </rules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+                            <excludes>
+                                <exclude>.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/distribution/src/main/java/com/hazelcast/commandline/HazelcastServerCommandLine.java
+++ b/distribution/src/main/java/com/hazelcast/commandline/HazelcastServerCommandLine.java
@@ -49,7 +49,7 @@ import static picocli.CommandLine.Option;
  */
 @Command(name = "hz", description = "Utility for the Hazelcast operations." + "%n%n"
         + "Global options are:%n", versionProvider = VersionProvider.class, mixinStandardHelpOptions = true, sortOptions = false)
-class HazelcastServerCommandLine {
+public class HazelcastServerCommandLine {
 
     static final String CLASSPATH_SEPARATOR = ":";
     static final int MIN_JAVA_VERSION_FOR_MODULAR_OPTIONS = 9;


### PR DESCRIPTION
Fixes release error:

```
07:57:30  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.3.1:jar (attach-javadocs) on project hazelcast-distribution: MavenReportException: Error while generating Javadoc: 
07:57:30  [ERROR] Exit code: 1 - javadoc: error - No public or protected classes found to document.
07:57:30  [ERROR] 
07:57:30  [ERROR] Command line was: /usr/local/openjdk-8/jre/../bin/javadoc -J-Xmx1024m @options @packages
```

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible