### PR TITLE
Assert maxTotalChunkedDataInBytes when only chunked migration enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
@@ -46,10 +46,14 @@ public final class ChunkSerDeHelper {
 
     public ChunkSerDeHelper(ILogger logger, int partitionId,
                             Collection<ChunkSupplier> chunkSuppliers,
+                            boolean chunkedMigrationEnabled,
                             int maxTotalChunkedDataInBytes) {
         assert chunkSuppliers != null;
         assert logger != null;
-        assert maxTotalChunkedDataInBytes > 0 : maxTotalChunkedDataInBytes;
+
+        if (chunkedMigrationEnabled) {
+            assert maxTotalChunkedDataInBytes > 0 : maxTotalChunkedDataInBytes;
+        }
 
         this.logger = logger;
         this.partitionId = partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
@@ -50,10 +50,8 @@ public final class ChunkSerDeHelper {
                             int maxTotalChunkedDataInBytes) {
         assert chunkSuppliers != null;
         assert logger != null;
-
-        if (chunkedMigrationEnabled) {
-            assert maxTotalChunkedDataInBytes > 0 : maxTotalChunkedDataInBytes;
-        }
+        assert !chunkedMigrationEnabled || (maxTotalChunkedDataInBytes > 0)
+                : "Found maxTotalChunkedDataInBytes=" + maxTotalChunkedDataInBytes;
 
         this.logger = logger;
         this.partitionId = partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
@@ -55,12 +55,13 @@ public class ReplicaFragmentMigrationState
     public ReplicaFragmentMigrationState(Map<ServiceNamespace, long[]> namespaces,
                                          Collection<Operation> migrationOperations,
                                          Collection<ChunkSupplier> chunkSuppliers,
+                                         boolean chunkedMigrationEnabled,
                                          int maxTotalChunkedDataInBytes, ILogger logger,
                                          int partitionId) {
         this.namespaces = namespaces;
         this.migrationOperations = migrationOperations;
         this.chunkSerDeHelper = new ChunkSerDeHelper(logger, partitionId,
-                chunkSuppliers, maxTotalChunkedDataInBytes);
+                chunkSuppliers, chunkedMigrationEnabled, maxTotalChunkedDataInBytes);
     }
 
     public Map<ServiceNamespace, long[]> getNamespaceVersionMap() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -362,7 +362,8 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
         }
 
         return new ReplicaFragmentMigrationState(versions, operations,
-                suppliers, maxTotalChunkedDataInBytes, getLogger(), getPartitionId());
+                suppliers, chunkedMigrationEnabled, maxTotalChunkedDataInBytes,
+                getLogger(), getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -279,6 +279,7 @@ public class PartitionReplicaSyncRequest extends AbstractPartitionOperation
         long[] versions = versionManager.getPartitionReplicaVersions(partitionId, ns);
         PartitionReplicaSyncResponse syncResponse = new PartitionReplicaSyncResponse(operations,
                 chunkSuppliers, ns, versions,
+                isChunkedMigrationEnabled(),
                 getMaxTotalChunkedDataInBytes(),
                 getLogger(), partitionId);
         syncResponse.setPartitionId(partitionId).setReplicaIndex(replicaIndex);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
@@ -187,7 +187,8 @@ public final class PartitionReplicaSyncRequestOffloadable
 
         PartitionReplicaSyncResponse syncResponse
                 = new PartitionReplicaSyncResponse(operations, chunkSuppliers, ns,
-                versions, getMaxTotalChunkedDataInBytes(), getLogger(), partitionId);
+                versions, isChunkedMigrationEnabled(), getMaxTotalChunkedDataInBytes(),
+                getLogger(), partitionId);
 
         syncResponse.setPartitionId(partitionId)
                 .setReplicaIndex(replicaIndex);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -86,6 +86,7 @@ public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
                                         Collection<ChunkSupplier> chunkSuppliers,
                                         ServiceNamespace namespace,
                                         long[] versions,
+                                        boolean chunkedMigrationEnabled,
                                         int maxTotalChunkedDataInBytes,
                                         ILogger logger,
                                         int partitionId) {
@@ -93,7 +94,7 @@ public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
         this.namespace = namespace;
         this.versions = versions;
         this.chunkSerDeHelper = new ChunkSerDeHelper(logger, partitionId,
-                chunkSuppliers, maxTotalChunkedDataInBytes);
+                chunkSuppliers, chunkedMigrationEnabled, maxTotalChunkedDataInBytes);
     }
 
     @Override


### PR DESCRIPTION
PR should fix failing compatibility tests.

**Modification:**
Assertion will be active when chunked migration is enabled.

**Note:**
I ran compatibility tests and they are passing with this PR: http://jenkins.hazelcast.com/job/ahmet-Hazelcast-EE-pr-builder/190/