### PR TITLE
Fix performance of JmxPublisher

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/jmx/JmxPublisher.java
@@ -168,7 +168,7 @@ public class JmxPublisher implements MetricsPublisher {
     }
 
     // package-visible for test
-    @SuppressWarnings({"checkstyle:BooleanExpressionComplexity", "checkstyle:CyclomaticComplexity"})
+    @SuppressWarnings("checkstyle:BooleanExpressionComplexity")
     static String escapeObjectNameValue(String name) {
         if (!shouldEscapeObjectNameValue(name)) {
             return name;
@@ -192,6 +192,7 @@ public class JmxPublisher implements MetricsPublisher {
         return builder.toString();
     }
 
+    @SuppressWarnings("checkstyle:BooleanExpressionComplexity")
     private static boolean shouldEscapeObjectNameValue(String name) {
         for (int i = 0; i < name.length(); i++) {
             char ch = name.charAt(i);


### PR DESCRIPTION
Removing the code that was wasting CPU cycles. Using String.replace compiles RegEx every time it is used. Found during some SQL engine benchmark. 

![image](https://user-images.githubusercontent.com/57556371/149360518-2b9aeb89-0152-4f67-b18e-a06884c98a97.png)