### PR TITLE
Fix mock connection management

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
@@ -236,7 +236,7 @@ class MockServer implements Server {
             if (!connection.isAlive()) {
                 return false;
             }
-
+            connection.setRemoteUuid(remoteUuid);
             connection.setLifecycleListener(lifecycleListener);
             server.connectionMap.put(remoteUuid, connection);
             LinkedAddresses addressesToRegister = LinkedAddresses.getResolvedAddresses(remoteAddress);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java
@@ -167,8 +167,9 @@ class MockServer implements Server {
             UUID remoteMemberUuid = targetNode.getThisUuid();
 
 
-            // Create a unidirectional connection pair that is split into
-            // two distinct connection.
+            // Create a unidirectional connection that is split into
+            // two distinct connection objects (one for the local member
+            // side and the other for the remote member side)
             // These two connections below are only used for sending
             // packets from the local member to the remote member.
 
@@ -184,8 +185,8 @@ class MockServer implements Server {
                     node.getServer().getConnectionManager(EndpointQualifier.MEMBER)
             );
 
-            // This connection is only used to receive packets from the connection
-            // created above.
+            // This connection is only used to receive packets on the remote member
+            // which are sent from the local member's connection created above.
             // Since this connection is not registered in the connection map of remote
             // member's connection server, when the remote member intends to send a
             // packet to this local member, it won't have access to this connection,

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -47,7 +47,7 @@ public class MockServerConnection implements ServerConnection {
     protected final NodeEngineImpl localNodeEngine;
     protected final NodeEngineImpl remoteNodeEngine;
 
-    volatile MockServerConnection localConnection;
+    volatile MockServerConnection otherConnection;
 
     private volatile ConnectionLifecycleListener lifecycleListener;
 
@@ -56,7 +56,7 @@ public class MockServerConnection implements ServerConnection {
     private final Address remoteAddress;
 
     private final UUID localUuid;
-    private UUID remoteUuid;
+    private final UUID remoteUuid;
 
     private final ServerConnectionManager connectionManager;
 
@@ -167,7 +167,7 @@ public class MockServerConnection implements ServerConnection {
         } while (!writeDone);
 
         assertNotNull(newPacket);
-        newPacket.setConn(localConnection);
+        newPacket.setConn(otherConnection);
         return newPacket;
     }
 
@@ -184,25 +184,12 @@ public class MockServerConnection implements ServerConnection {
             return;
         }
 
-        if (localConnection != null) {
-            localConnection.close(msg, cause);
+        if (otherConnection != null) {
+            otherConnection.close(msg, cause);
         }
 
         if (lifecycleListener != null) {
             lifecycleListener.onConnectionClose(this, cause, false);
-        }
-
-        if (localNodeEngine != null) {
-            localNodeEngine.getNode()
-                    .getLocalAddressRegistry()
-                    .tryRemoveRegistration(remoteUuid, remoteAddress);
-            Server server = localNodeEngine.getNode().getServer();
-            // this is a member-to-member connection
-            if (server instanceof FirewallingServer) {
-                (((MockServer) ((FirewallingServer) server).delegate)).connectionMap.remove(remoteUuid);
-            } else if (server instanceof MockServer) {
-                ((MockServer) server).connectionMap.remove(remoteUuid);
-            }
         }
     }
 
@@ -237,7 +224,6 @@ public class MockServerConnection implements ServerConnection {
 
     @Override
     public void setRemoteUuid(UUID remoteUuid) {
-        this.remoteUuid = remoteUuid;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -54,7 +54,7 @@ public class MockServerConnection implements ServerConnection {
     private final Address remoteAddress;
 
     private final UUID localUuid;
-    private final UUID remoteUuid;
+    private volatile UUID remoteUuid;
 
     private final ServerConnectionManager connectionManager;
 
@@ -222,6 +222,7 @@ public class MockServerConnection implements ServerConnection {
 
     @Override
     public void setRemoteUuid(UUID remoteUuid) {
+        this.remoteUuid = remoteUuid;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -20,8 +20,6 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.internal.nio.ConnectionLifecycleListener;
 import com.hazelcast.internal.nio.ConnectionType;
-import com.hazelcast.internal.server.FirewallingServer;
-import com.hazelcast.internal.server.Server;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.nio.PacketIOHelper;


### PR DESCRIPTION
This PR fixes the issues related to the hostname PR changes on the
mock connection manager. This caused the connections to the old members
not to be removed in the WAN tests which shutdowns and starts the cluster.
The main cause was that I changed (in the hostname PR) the used address
incorrectly in the place that we close the other side of connections (I was
mistakenly closing the connection on the same side again instead of the other
side.) 
https://github.com/ufukyilmaz/hazelcast/blob/54013fe5f4fd2c48401fd3a229c6f47df59cd131/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java#L364. I fixed that and then
cleaned up the code a bit.
Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/4551 and possibly
others

Octopus runs: 
https://jenkins.hazelcast.com/job/Hazelcast-EE-octopus-pr-builder/510
https://jenkins.hazelcast.com/job/Hazelcast-EE-octopus-pr-builder/511 -> Similar test failures reported before in https://github.com/hazelcast/hazelcast-enterprise/issues/4270, https://github.com/hazelcast/hazelcast-enterprise/issues/4475)
http://jenkins.hazelcast.com/job/Hazelcast-EE-octopus-pr-builder/512/
Repeated runs of `MapWanSyncAPITest`: http://jenkins.hazelcast.com/job/ufuk-test-runner/52/console (200 min run no failure)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

