### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Hazelcast is committed to providing our users with secure software they can rely on.
+We promptly investigate all reports of security vulnerabilities affecting Hazelcast products.
+If you believe you have found a security vulnerability, we strongly encourage you to report
+it to us immediately, and we ask your help in working with our team before disclosure in a public forum.
+This allows us to address the issue most effectively for the benefit and protection of all users.
+
+**It’s easy to submit a vulnerability report:**
+
+* If you’re a Hazelcast customer, open a support ticket and provide us with as much detail as you’re able.
+* If you are not a Hazelcast customer, please email **security@hazelcast.com**.  
+  *Note: This email address is only for reporting security vulnerabilities, not inquiries about security-related topics. Please reach out to us via one of our community channels for general security questions.*
+
+Using either method, your report will be received promptly by Hazelcast staff.
+
+### What happens to my report?
+
+Our standard process is:
+
+1. Upon receipt of your private report, Hazelcast will route it to the appropriate team for investigation.
+2. If we need additional information, we will directly and privately reach out to the person who sent the vulnerability report.
+3. We will verify the vulnerability and its fix.
+4. The security fix will be included in a new release.
+
+We greatly appreciate your partnership in helping us provide the strongest security posture for all users. Thank you.
+
+<!--
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+-->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Using either method, your report will be received promptly by Hazelcast staff.
 
 Our standard process is:
 
-1. Upon receipt of your private report, Hazelcast will route it to the appropriate team for investigation.
+1. Upon receiving your private report, Hazelcast will route it to the appropriate team for investigation.
 2. If we need additional information, we will directly and privately reach out to the person who sent the vulnerability report.
 3. We will verify the vulnerability and its fix.
 4. The security fix will be included in a new release.


### PR DESCRIPTION
Fixes #20393

This PR adds the `SECURITY.md` file recommended by GitHub to inform users about security policies.

The current content is based on https://hazelcast.com/information-security/

We could consider including info about supported versions (CC @Holmistr ). See the commented-out tail section of the new file.