### PR TITLE
Fix performance of SqlPage.getColumnValueForClient

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListMultiFrameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListMultiFrameCodec.java
@@ -18,8 +18,8 @@ package com.hazelcast.client.impl.protocol.codec.builtin;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -68,7 +68,7 @@ public final class ListMultiFrameCodec {
 
     public static <T> List<T> decode(ClientMessage.ForwardFrameIterator iterator,
                                      Function<ClientMessage.ForwardFrameIterator, T> decodeFunction) {
-        List<T> result = new LinkedList<>();
+        List<T> result = new ArrayList<>();
         //begin frame, list
         iterator.next();
         while (!nextFrameIsDataStructureEndFrame(iterator)) {
@@ -81,7 +81,7 @@ public final class ListMultiFrameCodec {
 
     public static <T> List<T> decodeContainsNullable(ClientMessage.ForwardFrameIterator iterator,
                                                      Function<ClientMessage.ForwardFrameIterator, T> decodeFunction) {
-        List<T> result = new LinkedList<>();
+        List<T> result = new ArrayList<>();
         //begin frame, list
         iterator.next();
         while (!nextFrameIsDataStructureEndFrame(iterator)) {


### PR DESCRIPTION
Changing the ```List``` implementation from ```LinkedList``` to ```ArrayList```. This part of code has an impact on ```com/hazelcast/sql/impl/client/SqlPage.getColumnValueForClient``` method. The SQL ```select(*)``` benchmark on the client machine profiling result (wall-clock mode):

![image](https://user-images.githubusercontent.com/57556371/149744117-cbe90082-a5b0-4a13-8831-5343941adc21.png)

The rigth part of the flame graph is:

![image](https://user-images.githubusercontent.com/57556371/149744300-ec3b95a0-e88c-46a3-bf98-42101ce20e3e.png)

The other parts are:
- deserialization (that s optional)
- waiting for a cluster to repond

After switching the implementation:

![image](https://user-images.githubusercontent.com/57556371/149744487-0afc9667-9a3d-4347-a0d1-92efa2827e55.png)

In terms of the benchmark it speeds up:
- over 5% with deserializion on client's side
- over 10% with no deserialization