### PR TITLE
Set config file if loaded from the classpath and file exists

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -82,7 +82,6 @@ import static com.hazelcast.config.LocalDeviceConfig.DEFAULT_DEVICE_NAME;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
-import static com.hazelcast.internal.config.XmlConfigLocator.DEFAULT_CONFIG_NAME;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -242,10 +242,15 @@ public class Config {
         return cfg;
     }
 
+    // configurationFile must be set correctly because dynamic
+    // configuration persistence depends on this field. If this is
+    // absent, hazelcast instance may fail to find a file to persist.
     private static void setConfigurationFileFromUrl(Config cfg) {
         if (cfg.getConfigurationFile() == null && cfg.getConfigurationUrl() != null) {
             File configFile = new File(cfg.getConfigurationUrl().getPath());
-            if (configFile.exists() && !configFile.getName().equals(DEFAULT_CONFIG_NAME)) {
+
+            // Only set configurationFile if the config actually exist on the filesystem.
+            if (configFile.exists()) {
                 cfg.setConfigurationFile(configFile);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -82,6 +82,7 @@ import static com.hazelcast.config.LocalDeviceConfig.DEFAULT_DEVICE_NAME;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER_CONFIG;
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.validateSuffixInSystemProperty;
+import static com.hazelcast.internal.config.XmlConfigLocator.DEFAULT_CONFIG_NAME;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
@@ -237,7 +238,17 @@ public class Config {
         cfg = new ExternalConfigurationOverride().overwriteMemberConfig(cfg);
         PersistenceAndHotRestartPersistenceMerger
                 .merge(cfg.getHotRestartPersistenceConfig(), cfg.getPersistenceConfig());
+        setConfigurationFileFromUrl(cfg);
         return cfg;
+    }
+
+    private static void setConfigurationFileFromUrl(Config cfg) {
+        if (cfg.getConfigurationFile() == null && cfg.getConfigurationUrl() != null) {
+            File configFile = new File(cfg.getConfigurationUrl().getPath());
+            if (configFile.exists() && !configFile.getName().equals(DEFAULT_CONFIG_NAME)) {
+                cfg.setConfigurationFile(configFile);
+            }
+        }
     }
 
     private static Config loadFromFile(Properties properties) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -127,6 +127,7 @@ import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProper
 import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties.PRODUCT;
 import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties.START_TIMESTAMP;
 import static com.hazelcast.config.InstanceTrackingConfig.InstanceTrackingProperties.VERSION;
+import static com.hazelcast.internal.config.XmlConfigLocator.DEFAULT_CONFIG_NAME;
 import static com.hazelcast.internal.util.InstanceTrackingUtil.writeInstanceTrackingFile;
 import static com.hazelcast.jet.impl.util.Util.JET_IS_DISABLED_MESSAGE;
 import static com.hazelcast.jet.impl.util.Util.checkJetIsEnabled;
@@ -217,6 +218,12 @@ public class DefaultNodeExtension implements NodeExtension, JetPacketConsumer {
                 throw new InvalidConfigurationException(
                         "Dynamic Configuration Persistence is enabled but config file couldn't be found."
                                 + " This is probably because declarative configuration isn't used."
+                );
+            }
+
+            if (config.getConfigurationFile().getName().equals(DEFAULT_CONFIG_NAME)) {
+                throw new InvalidConfigurationException(
+                        "Please don't use default configuration with Dynamic Configuration Persistence."
                 );
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
@@ -158,6 +158,10 @@ public abstract class AbstractConfigLocator {
             LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
+            File file = new File(url.getPath());
+            if (file.exists()) {
+                configurationFile = file;
+            }
             in = resolveResourceAsStream(configFileName);
             if (in == null) {
                 throw new HazelcastException(String.format("Could not load '%s' from the classpath", configFileName));

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
@@ -158,10 +158,6 @@ public abstract class AbstractConfigLocator {
             LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
-
-            // configurationFile must be set correctly because dynamic
-            // configuration persistence depends on this field. If this is
-            // absent, hazelcast instance may fail to find a file to persist.
             File file = new File(url.getPath());
             if (file.exists()) {
                 configurationFile = file;
@@ -316,14 +312,14 @@ public abstract class AbstractConfigLocator {
     private URL resolveResourceUrl(String configFileName) {
         URL resource = Config.class.getClassLoader().getResource(configFileName);
         return resource != null
-                ? resource
-                : Thread.currentThread().getContextClassLoader().getResource(configFileName);
+          ? resource
+          : Thread.currentThread().getContextClassLoader().getResource(configFileName);
     }
 
     private InputStream resolveResourceAsStream(String configFileName) {
         InputStream resource = Config.class.getClassLoader().getResourceAsStream(configFileName);
         return resource != null
-                ? resource
-                : Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
+          ? resource
+          : Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
@@ -158,6 +158,10 @@ public abstract class AbstractConfigLocator {
             LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
+
+            // configurationFile must be set correctly because dynamic
+            // configuration persistence depends on this field. If this is
+            // absent, hazelcast instance may fail to find a file to persist.
             File file = new File(url.getPath());
             if (file.exists()) {
                 configurationFile = file;
@@ -312,14 +316,14 @@ public abstract class AbstractConfigLocator {
     private URL resolveResourceUrl(String configFileName) {
         URL resource = Config.class.getClassLoader().getResource(configFileName);
         return resource != null
-          ? resource
-          : Thread.currentThread().getContextClassLoader().getResource(configFileName);
+                ? resource
+                : Thread.currentThread().getContextClassLoader().getResource(configFileName);
     }
 
     private InputStream resolveResourceAsStream(String configFileName) {
         InputStream resource = Config.class.getClassLoader().getResourceAsStream(configFileName);
         return resource != null
-          ? resource
-          : Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
+                ? resource
+                : Thread.currentThread().getContextClassLoader().getResourceAsStream(configFileName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractConfigLocator.java
@@ -158,10 +158,6 @@ public abstract class AbstractConfigLocator {
             LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
-            File file = new File(url.getPath());
-            if (file.exists()) {
-                configurationFile = file;
-            }
             in = resolveResourceAsStream(configFileName);
             if (in == null) {
                 throw new HazelcastException(String.format("Could not load '%s' from the classpath", configFileName));

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/XmlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/XmlConfigLocator.java
@@ -32,6 +32,8 @@ import static com.hazelcast.internal.config.DeclarativeConfigUtil.XML_ACCEPTED_S
  */
 public class XmlConfigLocator extends AbstractConfigLocator {
 
+    public static final String DEFAULT_CONFIG_NAME = "hazelcast-default.xml";
+
     @Override
     public boolean locateFromSystemProperty() {
         return loadFromSystemProperty(SYSPROP_MEMBER_CONFIG, XML_ACCEPTED_SUFFIXES);
@@ -54,7 +56,7 @@ public class XmlConfigLocator extends AbstractConfigLocator {
 
     @Override
     public boolean locateDefault() {
-        loadDefaultConfigurationFromClasspath("hazelcast-default.xml");
+        loadDefaultConfigurationFromClasspath(DEFAULT_CONFIG_NAME);
         return true;
     }
 }


### PR DESCRIPTION
If user adds a file config under resources folder and starts a hazelcast instance, configFile field won't be set. This PR aims to change that.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
