### PR TITLE
Mark BITMAP options as non-required for CREATE INDEX query

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -100,6 +100,8 @@ import static java.util.Collections.singletonList;
 
 public class PlanExecutor {
     private static final String LE = System.lineSeparator();
+    private static final String DEFAULT_UNIQUE_KEY = "__key";
+    private static final String DEFAULT_UNIQUE_KEY_TRANSFORMATION = "OBJECT";
 
     private final TableResolverImpl catalog;
     private final HazelcastInstance hazelcastInstance;
@@ -143,8 +145,16 @@ public class PlanExecutor {
 
         if (plan.indexType().equals(IndexType.BITMAP)) {
             Map<String, String> options = plan.options();
+
             String uniqueKey = options.get(UNIQUE_KEY);
+            if (uniqueKey == null) {
+                uniqueKey = DEFAULT_UNIQUE_KEY;
+            }
+
             String uniqueKeyTransform = options.get(UNIQUE_KEY_TRANSFORMATION);
+            if (uniqueKeyTransform == null) {
+                uniqueKeyTransform = DEFAULT_UNIQUE_KEY_TRANSFORMATION;
+            }
 
             BitmapIndexOptions bitmapIndexOptions = new BitmapIndexOptions();
             bitmapIndexOptions.setUniqueKey(uniqueKey);
@@ -153,8 +163,8 @@ public class PlanExecutor {
             indexConfig.setBitmapIndexOptions(bitmapIndexOptions);
         }
 
-        // The `addIndex()` call does nothing, if an index with the same name already exists. Even if its config
-        // is different.
+        // The `addIndex()` call does nothing, if an index with the same name already exists.
+        // Even if its config is different.
         hazelcastInstance.getMap(plan.mapName()).addIndex(indexConfig);
 
         return UpdateSqlResultImpl.createUpdateCountResult(0);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/ParserResource.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/ParserResource.java
@@ -46,9 +46,6 @@ public interface ParserResource {
     @BaseMessage("Option ''{0}'' specified more than once")
     ExInst<SqlValidatorException> duplicateOption(String optionName);
 
-    @BaseMessage("Required option missing: {0}")
-    ExInst<SqlValidatorException> missingOption(String optionName);
-
     @BaseMessage("Mapping does not exist: {0}")
     ExInst<SqlValidatorException> droppedMappingDoesNotExist(String mappingName);
 
@@ -60,10 +57,6 @@ public interface ParserResource {
 
     @BaseMessage("Unknown option for {0} index: {1}")
     ExInst<SqlValidatorException> unsupportedIndexType(String indexType, String option);
-
-    @BaseMessage("Can't create BITMAP index: " +
-            "BITMAP index requires 'unique_key' and 'unique_key_transformation' options")
-    ExInst<SqlValidatorException> bitmapIndexConfigEmpty();
 
     @BaseMessage("Unsupported value for {0}: {1}")
     ExInst<SqlValidatorException> processingGuaranteeBadValue(String key, String value);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateIndex.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateIndex.java
@@ -189,10 +189,6 @@ public class SqlCreateIndex extends SqlCreate {
                     options().keySet().iterator().next()));
         }
 
-        if (indexType.equals(IndexType.BITMAP) && options.getList().isEmpty()) {
-            throw validator.newValidationError(type, RESOURCE.bitmapIndexConfigEmpty());
-        }
-
         Set<String> optionNames = new HashSet<>();
 
         for (SqlNode option : options.getList()) {
@@ -200,14 +196,6 @@ public class SqlCreateIndex extends SqlCreate {
             if (!optionNames.add(name)) {
                 throw validator.newValidationError(option, RESOURCE.duplicateOption(name));
             }
-        }
-
-        if (indexType.equals(IndexType.BITMAP) && !optionNames.contains(UNIQUE_KEY)) {
-            throw validator.newValidationError(options, RESOURCE.missingOption(UNIQUE_KEY));
-        }
-
-        if (indexType.equals(IndexType.BITMAP) && !optionNames.contains(UNIQUE_KEY_TRANSFORMATION)) {
-            throw validator.newValidationError(options, RESOURCE.missingOption(UNIQUE_KEY_TRANSFORMATION));
         }
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlCreateIndexTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlCreateIndexTest.java
@@ -96,6 +96,18 @@ public class SqlCreateIndexTest extends OptimizerTestSupport {
         assertThat(mapContainer(map).getIndexes().getIndex(MAP_NAME)).isNull();
 
         String indexName = SqlTestSupport.randomName();
+        String sql = "CREATE INDEX IF NOT EXISTS " + indexName + " ON " + MAP_NAME + " (__key) TYPE BITMAP; ";
+
+        instance().getSql().execute(sql);
+
+        assertThat(mapContainer(map).getIndexes().getIndex(indexName)).isNotNull();
+    }
+
+    @Test
+    public void when_bitmapIndexWithOptionCreated_then_succeeds() {
+        assertThat(mapContainer(map).getIndexes().getIndex(MAP_NAME)).isNull();
+
+        String indexName = SqlTestSupport.randomName();
         String sql = "CREATE INDEX IF NOT EXISTS " + indexName + " ON " + MAP_NAME + " (__key) TYPE BITMAP " +
                 "OPTIONS ('unique_key' = '__key' , 'unique_key_transformation' = 'OBJECT'); ";
 
@@ -171,21 +183,6 @@ public class SqlCreateIndexTest extends OptimizerTestSupport {
     }
 
     @Test
-    public void when_indexCreatedWithMissingOptions_then_throws() {
-        String sql1 = "CREATE INDEX IF NOT EXISTS idx ON " + MAP_NAME + " (__key) TYPE BITMAP " +
-                "OPTIONS ('unique_key' = '__key')";
-
-        assertThatThrownBy(() -> instance().getSql().execute(sql1))
-                .hasMessageContaining("Required option missing: unique_key_transformation");
-
-        String sql2 = "CREATE INDEX IF NOT EXISTS idx ON " + MAP_NAME + " (__key) TYPE BITMAP " +
-                "OPTIONS ('unique_key_transformation' = 'RAW')";
-
-        assertThatThrownBy(() -> instance().getSql().execute(sql2))
-                .hasMessageContaining("Required option missing: unique_key");
-    }
-
-    @Test
     public void when_hashOrSortedIndexCreatedWithOptions_then_throws() {
         String sql1 = "CREATE INDEX IF NOT EXISTS idx ON " + MAP_NAME + " (this) TYPE HASH OPTIONS ('a' = '1')";
         assertThatThrownBy(() -> instance().getSql().execute(sql1))
@@ -194,13 +191,6 @@ public class SqlCreateIndexTest extends OptimizerTestSupport {
         String sql2 = "CREATE INDEX IF NOT EXISTS idx2 ON " + MAP_NAME + " (this) TYPE SORTED OPTIONS ('a' = '1')";
         assertThatThrownBy(() -> instance().getSql().execute(sql2))
                 .hasMessageContaining("Unknown option for SORTED index: a");
-    }
-
-    @Test
-    public void when_bitmapIndexCreatedWithoutOptions_then_throws() {
-        String sql = "CREATE INDEX IF NOT EXISTS idx ON " + MAP_NAME + " (this) TYPE BITMAP";
-        assertThatThrownBy(() -> instance().getSql().execute(sql))
-                .hasMessageContaining("BITMAP index requires unique_key and unique_key_transformation options");
     }
 
     private void checkPlan(boolean withIndex, boolean sorted, String sql) {


### PR DESCRIPTION
During documentation PR review (https://github.com/hazelcast/hz-docs/pull/330) small mistake in our logic was found: 

`CREATE INDEX` call with `BITMAP` index passed treated `unique_key` and `unique_key_transformation` as required options, what is wrong. 
This PR introduces a fix which make `unique_key` and `unique_key_transformation` options ... optional :)
If  `unique_key` and `unique_key_transformation` options were not specified in query, the default values are provided:
- `unique_key = "__key"`
-  `unique_key_transformation = OBJECT` 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible