### PR TITLE
Update elasticsearch 6 dependency to the latest patch release

### DIFF
--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -75,11 +75,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <!--
-            Supports Elastic server 6.8.17 and higher
-            because of security vulnerabilities see #2906
-            -->
-            <version>6.8.17</version>
+            <version>6.8.23</version>
         </dependency>
 
         <!-- TEST -->

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -30,7 +30,7 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 
 public final class ElasticSupport {
 
-    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:6.8.17")
+    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:6.8.23")
             .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
     public static final int PORT = 9200;
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <maven.os.plugin.version>1.6.2</maven.os.plugin.version>
         <maven.protobuf.plugin.version>0.6.1</maven.protobuf.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
-        <owasp.dependency-check.version>6.5.2</owasp.dependency-check.version>
+        <owasp.dependency-check.version>6.5.3</owasp.dependency-check.version>
         <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
         <codehause.license.plugin.version>2.0.0</codehause.license.plugin.version>
 


### PR DESCRIPTION
This PR updates the elasticsearch 6 client dependency to the latest patch release (see [release notes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/es-release-notes.html))

It relates to #20022 (which is a false positive finding from the OWASP scanner).

The PR also updates the OWASP dependency checker to the latest patch version.