### PR TITLE
Remove unused nanohttpd dependency

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -623,13 +623,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.nanohttpd</groupId>
-            <artifactId>nanohttpd</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${http.components.version}</version>


### PR DESCRIPTION
This PR removes the unused nanohttpd test dependency. (introduced in #14013)

Related to CVE-2020-13697
