### PR TITLE
Fix getAllConnections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -131,8 +131,8 @@ public class TcpServerConnectionManager extends TcpServerConnectionManagerBase
     public List<ServerConnection> getAllConnections(@Nonnull Address address) {
         UUID uuid = addressRegistry.uuidOf(address);
         return uuid != null
-                ? Arrays.stream(planes).map(plane -> plane.getConnection(uuid)).filter(x -> x != null)
-                .collect(Collectors.toList())
+                ? connections.stream().filter(connection -> connection.getRemoteUuid().equals(uuid))
+                                      .collect(Collectors.toList())
                 : Collections.emptyList();
     }
 


### PR DESCRIPTION
In order for `getAllConnections` to work properly in cases where there
are duplicate connections. Now, we're iterating over all connection set
instead of only iterating the planes.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

