### PR TITLE
Rename ARRAY_OF_BOOLEANS to ARRAY_OF_BOOLEAN in the FieldKind

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldOperations.java
@@ -61,7 +61,7 @@ public final class FieldOperations {
                 stringBuilder.append(record.getBoolean(fieldName));
             }
         };
-        ALL[FieldKind.ARRAY_OF_BOOLEANS.getId()] = new FieldKindBasedOperations() {
+        ALL[FieldKind.ARRAY_OF_BOOLEAN.getId()] = new FieldKindBasedOperations() {
             @Override
             public Object readObject(GenericRecord genericRecord, String fieldName) {
                 return genericRecord.getArrayOfBoolean(fieldName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -141,7 +141,7 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setArrayOfBoolean(@Nonnull String fieldName, @Nullable boolean[] value) {
-        return write(fieldName, value, FieldKind.ARRAY_OF_BOOLEANS);
+        return write(fieldName, value, FieldKind.ARRAY_OF_BOOLEAN);
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -50,7 +50,7 @@ import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.NUL
 import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.SHORT_OFFSET_READER;
 import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.SHORT_OFFSET_READER_RANGE;
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
@@ -414,7 +414,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
         FieldDescriptor fd = getFieldDefinition(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
-            case ARRAY_OF_BOOLEANS:
+            case ARRAY_OF_BOOLEAN:
                 return getVariableSize(fd, CompactInternalGenericRecord::readBooleanBits);
             case ARRAY_OF_NULLABLE_BOOLEAN:
                 return getNullableArrayAsPrimitiveArray(fd, ObjectDataInput::readBooleanArray, "Boolean");
@@ -691,8 +691,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
         FieldDescriptor fd = getFieldDefinition(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
-            case ARRAY_OF_BOOLEANS:
-                return getVariableSize(fieldName, ARRAY_OF_BOOLEANS, CompactInternalGenericRecord::readBooleanBitsAsNullables);
+            case ARRAY_OF_BOOLEAN:
+                return getVariableSize(fieldName, ARRAY_OF_BOOLEAN, CompactInternalGenericRecord::readBooleanBitsAsNullables);
             case ARRAY_OF_NULLABLE_BOOLEAN:
                 return getArrayOfVariableSize(fieldName, ARRAY_OF_NULLABLE_BOOLEAN,
                         Boolean[]::new, ObjectDataInput::readBoolean);
@@ -904,7 +904,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     public Boolean getBooleanFromArray(@Nonnull String fieldName, int index) {
-        int position = readVariableSizeFieldPosition(fieldName, ARRAY_OF_BOOLEANS);
+        int position = readVariableSizeFieldPosition(fieldName, ARRAY_OF_BOOLEAN);
         if (position == NULL_OFFSET) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
@@ -248,7 +248,7 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
     @Nullable
     @Override
     public boolean[] readArrayOfBoolean(@Nonnull String fieldName, @Nullable boolean[] defaultValue) {
-        return isFieldExists(fieldName, ARRAY_OF_BOOLEANS) ? getArrayOfBoolean(fieldName) : defaultValue;
+        return isFieldExists(fieldName, ARRAY_OF_BOOLEAN) ? getArrayOfBoolean(fieldName) : defaultValue;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
@@ -39,7 +39,7 @@ import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.BYTE_OFFSET_READER_RANGE;
 import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.SHORT_OFFSET_READER_RANGE;
 import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.INT8;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
 import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
@@ -300,7 +300,7 @@ public class DefaultCompactWriter implements CompactWriter {
 
     @Override
     public void writeArrayOfBoolean(@Nonnull String fieldName, @Nullable boolean[] values) {
-        writeVariableSizeField(fieldName, ARRAY_OF_BOOLEANS, values, DefaultCompactWriter::writeBooleanBits);
+        writeVariableSizeField(fieldName, ARRAY_OF_BOOLEAN, values, DefaultCompactWriter::writeBooleanBits);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -34,7 +34,7 @@ import java.util.TreeMap;
 
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.exceptionForUnexpectedNullValue;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.exceptionForUnexpectedNullValueInArray;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
@@ -206,7 +206,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     @Override
     @Nullable
     public boolean[] getArrayOfBoolean(@Nonnull String fieldName) {
-        FieldKind fieldKind = check(fieldName, ARRAY_OF_BOOLEANS, ARRAY_OF_NULLABLE_BOOLEAN);
+        FieldKind fieldKind = check(fieldName, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN);
         if (fieldKind == ARRAY_OF_NULLABLE_BOOLEAN) {
             Boolean[] array = (Boolean[]) objects.get(fieldName);
             boolean[] result = new boolean[array.length];
@@ -422,8 +422,8 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     @Nullable
     @Override
     public Boolean[] getArrayOfNullableBoolean(@Nonnull String fieldName) {
-        FieldKind fieldKind = check(fieldName, ARRAY_OF_BOOLEANS, ARRAY_OF_NULLABLE_BOOLEAN);
-        if (fieldKind == ARRAY_OF_BOOLEANS) {
+        FieldKind fieldKind = check(fieldName, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN);
+        if (fieldKind == ARRAY_OF_BOOLEAN) {
             boolean[] array = (boolean[]) objects.get(fieldName);
             Boolean[] result = new Boolean[array.length];
             Arrays.setAll(result, i -> array[i]);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.internal.nio.InstanceCreationUtil.createNewInstance;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEANS;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
@@ -362,7 +362,7 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                 Class<?> componentType = type.getComponentType();
                 if (Boolean.TYPE.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
-                        if (fieldExists(schema, name, ARRAY_OF_BOOLEANS, ARRAY_OF_NULLABLE_BOOLEAN)) {
+                        if (fieldExists(schema, name, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN)) {
                             field.set(o, reader.readArrayOfBoolean(name));
                         }
                     };
@@ -411,7 +411,7 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                     writers[index] = (w, o) -> w.writeArrayOfFloat64(name, (double[]) field.get(o));
                 } else if (Boolean.class.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
-                        if (fieldExists(schema, name, ARRAY_OF_BOOLEANS, ARRAY_OF_NULLABLE_BOOLEAN)) {
+                        if (fieldExists(schema, name, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN)) {
                             field.set(o, reader.readArrayOfNullableBoolean(name));
                         }
                     };

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
@@ -133,7 +133,7 @@ public final class SchemaWriter implements CompactWriter {
 
     @Override
     public void writeArrayOfBoolean(@Nonnull String fieldName, @Nullable boolean[] values) {
-        addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_BOOLEANS));
+        addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_BOOLEAN));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
@@ -339,7 +339,7 @@ public class SerializingGenericRecordCloner implements GenericRecordBuilder {
     @Override
     @Nonnull
     public GenericRecordBuilder setArrayOfBoolean(@Nonnull String fieldName, @Nullable boolean[] value) {
-        checkTypeWithSchema(schema, fieldName, FieldKind.ARRAY_OF_BOOLEANS);
+        checkTypeWithSchema(schema, fieldName, FieldKind.ARRAY_OF_BOOLEAN);
         if (fields.putIfAbsent(fieldName, () -> cw.writeArrayOfBoolean(fieldName, value)) != null) {
             throw new HazelcastSerializationException("Field can only be written once");
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/FieldTypeToFieldKind.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/FieldTypeToFieldKind.java
@@ -58,7 +58,7 @@ public final class FieldTypeToFieldKind {
             case BYTE_ARRAY:
                 return FieldKind.ARRAY_OF_INT8;
             case BOOLEAN_ARRAY:
-                return FieldKind.ARRAY_OF_BOOLEANS;
+                return FieldKind.ARRAY_OF_BOOLEAN;
             case CHAR_ARRAY:
                 return FieldKind.ARRAY_OF_CHAR;
             case SHORT_ARRAY:

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldKind.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldKind.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.annotation.Beta;
 public enum FieldKind {
 
     BOOLEAN(0),
-    ARRAY_OF_BOOLEANS(1),
+    ARRAY_OF_BOOLEAN(1),
     INT8(2),
     ARRAY_OF_INT8(3),
     CHAR(4),

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/EnumCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/EnumCompatibilityTest.java
@@ -136,7 +136,7 @@ public class EnumCompatibilityTest {
         // Used in FieldDescriptorCodec
         Map<FieldKind, Integer> mappings = new HashMap<>();
         mappings.put(FieldKind.BOOLEAN, 0);
-        mappings.put(FieldKind.ARRAY_OF_BOOLEANS, 1);
+        mappings.put(FieldKind.ARRAY_OF_BOOLEAN, 1);
         mappings.put(FieldKind.INT8, 2);
         mappings.put(FieldKind.ARRAY_OF_INT8, 3);
         mappings.put(FieldKind.CHAR, 4);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprintTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprintTest.java
@@ -40,7 +40,7 @@ public class RabinFingerprintTest {
     public void testRabinFingerprintIsConsistentWithWrittenData() throws IOException {
         SchemaWriter writer = new SchemaWriter("className");
         writer.addField(new FieldDescriptor("a", FieldKind.BOOLEAN));
-        writer.addField(new FieldDescriptor("b", FieldKind.ARRAY_OF_BOOLEANS));
+        writer.addField(new FieldDescriptor("b", FieldKind.ARRAY_OF_BOOLEAN));
         writer.addField(new FieldDescriptor("c", FieldKind.TIMESTAMP_WITH_TIMEZONE));
         Schema schema = writer.build();
 


### PR DESCRIPTION
We recently decided to drop the `s` suffix from the `ARRAY_OF_XXX` enum
members.

However, it seems that we forgot to change the name of the `ARRAY_OF_BOOLEANS`.

This PR makes the name of that enum member consistent with others.