### PR TITLE
Rename className to typeName in SchemaWriter and GenericRecordBuilder

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SampleMetadataResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SampleMetadataResolverTest.java
@@ -158,7 +158,7 @@ public class SampleMetadataResolverTest {
     public void test_compact() {
         SerializationConfig serializationConfig = new SerializationConfig();
         serializationConfig.getCompactSerializationConfig().setEnabled(true)
-                .register(CompactClass.class, "class-name", new CompactClass.CompactClassSerializer());
+                .register(CompactClass.class, "type-name", new CompactClass.CompactClassSerializer());
         InternalSerializationService ss = new DefaultSerializationServiceBuilder()
                 .setSchemaService(CompactTestUtil.createInMemorySchemaService())
                 .setConfig(serializationConfig)
@@ -170,7 +170,7 @@ public class SampleMetadataResolverTest {
         );
         assertThat(metadata.options()).containsExactly(
                 entry(key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT, COMPACT_FORMAT),
-                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "class-name")
+                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "type-name")
         );
 
         metadata = SampleMetadataResolver.resolve(ss, ss.toData(new CompactClass(1)), key);
@@ -179,7 +179,7 @@ public class SampleMetadataResolverTest {
         );
         assertThat(metadata.options()).containsExactly(
                 entry(key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT, COMPACT_FORMAT),
-                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "class-name")
+                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "type-name")
         );
     }
 
@@ -192,22 +192,22 @@ public class SampleMetadataResolverTest {
                 .setConfig(serializationConfig)
                 .build();
 
-        Metadata metadata = SampleMetadataResolver.resolve(ss, GenericRecordBuilder.compact("class-name").setInt32("field", 1).build(), key);
+        Metadata metadata = SampleMetadataResolver.resolve(ss, GenericRecordBuilder.compact("type-name").setInt32("field", 1).build(), key);
         assertThat(metadata.fields()).containsExactly(
                 new MappingField("field", QueryDataType.INT, (key ? KEY : VALUE) + ".field")
         );
         assertThat(metadata.options()).containsExactly(
                 entry(key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT, COMPACT_FORMAT),
-                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "class-name")
+                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "type-name")
         );
 
-        metadata = SampleMetadataResolver.resolve(ss, ss.toData(GenericRecordBuilder.compact("class-name").setInt32("field", 1).build()), key);
+        metadata = SampleMetadataResolver.resolve(ss, ss.toData(GenericRecordBuilder.compact("type-name").setInt32("field", 1).build()), key);
         assertThat(metadata.fields()).containsExactly(
                 new MappingField("field", QueryDataType.INT, (key ? KEY : VALUE) + ".field")
         );
         assertThat(metadata.options()).containsExactly(
                 entry(key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT, COMPACT_FORMAT),
-                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "class-name")
+                entry(key ? OPTION_KEY_COMPACT_TYPE_NAME : OPTION_VALUE_COMPACT_TYPE_NAME, "type-name")
         );
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecordBuilder.java
@@ -35,8 +35,8 @@ public class DeserializedGenericRecordBuilder extends AbstractGenericRecordBuild
     private final TreeMap<String, Object> objects = new TreeMap<>();
     private final SchemaWriter schemaWriter;
 
-    public DeserializedGenericRecordBuilder(String className) {
-        schemaWriter = new SchemaWriter(className);
+    public DeserializedGenericRecordBuilder(String typeName) {
+        schemaWriter = new SchemaWriter(typeName);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
@@ -36,17 +36,17 @@ import java.util.TreeMap;
 public final class SchemaWriter implements CompactWriter {
 
     private final TreeMap<String, FieldDescriptor> fieldDefinitionMap = new TreeMap<>(Comparator.naturalOrder());
-    private final String className;
+    private final String typeName;
 
-    public SchemaWriter(String className) {
-        this.className = className;
+    public SchemaWriter(String typeName) {
+        this.typeName = typeName;
     }
 
     /**
      * Builds the schema from the written fields and returns it.
      */
     public Schema build() {
-        return new Schema(className, fieldDefinitionMap);
+        return new Schema(typeName, fieldDefinitionMap);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
@@ -62,8 +62,8 @@ interface GenericRecordBuilder {
      */
     @Beta
     @Nonnull
-    static GenericRecordBuilder compact(String className) {
-        return new DeserializedGenericRecordBuilder(className);
+    static GenericRecordBuilder compact(String typeName) {
+        return new DeserializedGenericRecordBuilder(typeName);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -393,7 +393,7 @@ public class CompactStreamSerializerTest {
             employeeDTOS[j] = new EmployeeDTO(20 + j, j * 100);
         }
 
-        SchemaWriter writer = new SchemaWriter("className");
+        SchemaWriter writer = new SchemaWriter("typeName");
 
         ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer();
         EmployerDTO employerDTO = new EmployerDTO("nbss", 40, HIRING, ids, employeeDTO, employeeDTOS);
@@ -424,7 +424,7 @@ public class CompactStreamSerializerTest {
     public void testFieldOrderFixedSize() throws IOException {
         EmployeeDTO employeeDTO = new EmployeeDTO(30, 102310312);
 
-        SchemaWriter writer = new SchemaWriter("className");
+        SchemaWriter writer = new SchemaWriter("typeName");
 
         ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer();
         reflectiveCompactSerializer.write(writer, employeeDTO);
@@ -453,7 +453,7 @@ public class CompactStreamSerializerTest {
     public void testSchemaEvolution_GenericRecord() {
         SerializationService serializationService = createSerializationService();
 
-        GenericRecordBuilder builder = compact("fooBarClassName");
+        GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);
         builder.setInt64("bar", 1231L);
         GenericRecord expectedGenericRecord = builder.build();
@@ -462,7 +462,7 @@ public class CompactStreamSerializerTest {
 
         SerializationService serializationService2 = createSerializationService();
 
-        GenericRecordBuilder builder2 = compact("fooBarClassName");
+        GenericRecordBuilder builder2 = compact("fooBarTypeName");
         builder2.setInt32("foo", 1);
         builder2.setInt64("bar", 1231L);
         builder2.setString("foobar", "new field");

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactWithSchemaStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactWithSchemaStreamSerializerTest.java
@@ -45,7 +45,7 @@ public class CompactWithSchemaStreamSerializerTest {
     public void testReadAsGenericRecord() throws IOException {
         SerializationService serializationService = createSerializationService();
 
-        GenericRecord expected = compact("fooBarClassName")
+        GenericRecord expected = compact("fooBarTypeName")
                 .setInt32("foo", 1)
                 .setInt64("bar", 1231L)
                 .setGenericRecord("nested",
@@ -76,7 +76,7 @@ public class CompactWithSchemaStreamSerializerTest {
     public void testFromGenericRecord() {
         SerializationService serializationService = createSerializationService();
 
-        GenericRecord expected = compact("fooBarClassName")
+        GenericRecord expected = compact("fooBarTypeName")
                 .setInt32("foo", 1)
                 .setInt64("bar", 1231L)
                 .setGenericRecord("nested",

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -99,7 +99,7 @@ public class GenericRecordTest {
     public void testCloneObjectConvertedFromData() {
         SerializationService serializationService = createSerializationService();
 
-        GenericRecordBuilder builder = compact("fooBarClassName");
+        GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);
         assertTrue(trySetAndGetMessage("foo", 5, builder).startsWith("Field can only be written once"));
         builder.setInt64("bar", 1231L);
@@ -133,7 +133,7 @@ public class GenericRecordTest {
 
     @Test
     public void testCloneObjectCreatedViaAPI() {
-        GenericRecordBuilder builder = compact("fooBarClassName");
+        GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);
         assertTrue(trySetAndGetMessage("foo", 5, builder).startsWith("Field can only be written once"));
         builder.setInt64("bar", 1231L);
@@ -155,7 +155,7 @@ public class GenericRecordTest {
     public void testBuildFromObjectConvertedFromData() {
         SerializationService serializationService = createSerializationService();
 
-        GenericRecordBuilder builder = compact("fooBarClassName");
+        GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);
         assertTrue(trySetAndGetMessage("foo", 5, builder).startsWith("Field can only be written once"));
         builder.setInt64("bar", 1231L);
@@ -182,7 +182,7 @@ public class GenericRecordTest {
 
     @Test
     public void testBuildFromObjectCreatedViaAPI() {
-        GenericRecordBuilder builder = compact("fooBarClassName");
+        GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);
         assertTrue(trySetAndGetMessage("foo", 5, builder).startsWith("Field can only be written once"));
         builder.setInt64("bar", 1231L);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprintTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprintTest.java
@@ -38,7 +38,7 @@ public class RabinFingerprintTest {
 
     @Test
     public void testRabinFingerprintIsConsistentWithWrittenData() throws IOException {
-        SchemaWriter writer = new SchemaWriter("className");
+        SchemaWriter writer = new SchemaWriter("typeName");
         writer.addField(new FieldDescriptor("a", FieldKind.BOOLEAN));
         writer.addField(new FieldDescriptor("b", FieldKind.ARRAY_OF_BOOLEAN));
         writer.addField(new FieldDescriptor("c", FieldKind.TIMESTAMP_WITH_TIMEZONE));


### PR DESCRIPTION
This PR renames className to typeName in SchemaWriter and GenericRecordBuilder.compact() since they are not classNames but typeNames. Also updates some tests to reflect the changes. 

Breaking changes (renaming an argument's name should **not be a breaking change**, right?):
- none

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
