### PR TITLE
[HZ-818] Allow member rejoin when first arrangement not done

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -714,7 +714,7 @@ public class ClusterJoinManager {
                 || previousMembersMap.contains(memberUuid)
                 // or it is a known missing member
                 || clusterService.getMembershipManager().isMissingMember(address, memberUuid))
-                && (node.getPartitionService().getLeftMemberSnapshot(memberUuid) != null);
+                && node.getPartitionService().hasLeftMemberSnapshotOrPartitionsUninitialized(memberUuid);
     }
 
     private boolean checkIfUsingAnExistingMemberUuid(JoinMessage joinMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -138,4 +138,11 @@ public interface InternalPartitionService extends IPartitionService, ManagedServ
 
     @Nullable
     PartitionTableView getLeftMemberSnapshot(UUID uuid);
+
+    /**
+     * @param uuid a member UUID
+     * @return {@code true} if partitions are uninitialized or a partition assignments
+     *         snapshot exists for the given member UUID, otherwise {@code false}.
+     */
+    boolean hasLeftMemberSnapshotOrPartitionsUninitialized(UUID uuid);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -1240,6 +1240,14 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         return partitionStateManager.getSnapshot(uuid);
     }
 
+    @Override
+    public boolean hasLeftMemberSnapshotOrPartitionsUninitialized(UUID uuid) {
+        // - if first arrangement isn't done yet, always allow rejoin
+        // - otherwise, check if a partition assignments snapshot is
+        // available for the given uuid
+        return !partitionStateManager.isInitialized() || partitionStateManager.getSnapshot(uuid) != null;
+    }
+
     /**
      * Returns true only if local member is the last known master by
      * {@code InternalPartitionServiceImpl}.


### PR DESCRIPTION
The previous condition to determine if a member is
rejoining the cluster (having a persistent identity)
would only consider if a partition assignments snapshot
exists for that member UUID (meaning that the member
previously left the cluster unexpectedly). If partition
arrangement was not yet done at the time the member
left, there is no snapshot, so it is not recognized as
a rejoining member. If, however, at the time of
rejoining partition arrangement is not yet done, then it
should be admitted as a rejoining member, without having
to perform a force start.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4568

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
