### PR TITLE
Correct typo on the `readArrayOfTimestamp*` method names

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -351,24 +351,24 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
     }
 
     @Override
-    public LocalDateTime[] readArrayOfTimetamp(@Nonnull String fieldName) {
+    public LocalDateTime[] readArrayOfTimestamp(@Nonnull String fieldName) {
         return getArrayOfTimestamp(fieldName);
     }
 
     @Nullable
     @Override
-    public LocalDateTime[] readArrayOfTimetamp(@Nonnull String fieldName, @Nullable LocalDateTime[] defaultValue) {
+    public LocalDateTime[] readArrayOfTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime[] defaultValue) {
         return isFieldExists(fieldName, ARRAY_OF_TIMESTAMP) ? getArrayOfTimestamp(fieldName) : defaultValue;
     }
 
     @Override
-    public OffsetDateTime[] readArrayOfTimetampWithTimezone(@Nonnull String fieldName) {
+    public OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName) {
         return getArrayOfTimestampWithTimezone(fieldName);
     }
 
     @Nullable
     @Override
-    public OffsetDateTime[] readArrayOfTimetampWithTimezone(@Nonnull String fieldName,
+    public OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName,
                                                              @Nullable OffsetDateTime[] defaultValue) {
         return isFieldExists(fieldName, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE)
                 ? getArrayOfTimestampWithTimezone(fieldName) : defaultValue;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -489,14 +489,14 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                 } else if (LocalDateTime.class.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_TIMESTAMP)) {
-                            field.set(o, reader.readArrayOfTimetamp(name));
+                            field.set(o, reader.readArrayOfTimestamp(name));
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfTimestamp(name, (LocalDateTime[]) field.get(o));
                 } else if (OffsetDateTime.class.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE)) {
-                            field.set(o, reader.readArrayOfTimetampWithTimezone(name));
+                            field.set(o, reader.readArrayOfTimestampWithTimezone(name));
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfTimestampWithTimezone(name, (OffsetDateTime[]) field.get(o));

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -654,7 +654,7 @@ public interface CompactReader {
      *                                         with the one defined in the schema.
      */
     @Nullable
-    LocalDateTime[] readArrayOfTimetamp(@Nonnull String fieldName);
+    LocalDateTime[] readArrayOfTimestamp(@Nonnull String fieldName);
 
     /**
      * Reads an array of timestamps consisting of date and time or returns the default value.
@@ -666,7 +666,7 @@ public interface CompactReader {
      * @return the value or the default value of the field.
      */
     @Nullable
-    LocalDateTime[] readArrayOfTimetamp(@Nonnull String fieldName, @Nullable LocalDateTime[] defaultValue);
+    LocalDateTime[] readArrayOfTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime[] defaultValue);
 
     /**
      * Reads an array of timestamps with timezone consisting of date, time and timezone offset.
@@ -678,7 +678,7 @@ public interface CompactReader {
      *                                         with the one defined in the schema.
      */
     @Nullable
-    OffsetDateTime[] readArrayOfTimetampWithTimezone(@Nonnull String fieldName);
+    OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName);
 
     /**
      * Reads an array of timestamps with timezone consisting of date, time and timezone offset or returns the default value.
@@ -690,7 +690,7 @@ public interface CompactReader {
      * @return the value or the default value of the field.
      */
     @Nullable
-    OffsetDateTime[] readArrayOfTimetampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime[] defaultValue);
+    OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime[] defaultValue);
 
     /**
      * Reads an array of compact objects.


### PR DESCRIPTION
The `s` character was missing from the word `timestamp` in the
`readArrayOfTimestamp*` methods in the `CompactReader` interface.

This PR corrects that typo.