### PR TITLE
Do not collect metrics for expected exception: AssumptionViolatedException

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
@@ -19,6 +19,7 @@ package com.hazelcast.test.metrics;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.MetricsPublisher;
 import com.hazelcast.internal.util.StringUtil;
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -60,6 +61,8 @@ public class MetricsRule implements TestRule {
             public void evaluate() throws Throwable {
                 try {
                     base.evaluate();
+                } catch (AssumptionViolatedException e) {
+                    // represents expected exceptions, no need to tale an action.
                 } catch (Throwable t) {
                     StringBuilder sb = new StringBuilder();
                     publishers.forEach((instanceName, publisher) -> publisher.dumpRecordings(instanceName, sb));

--- a/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/metrics/MetricsRule.java
@@ -62,7 +62,7 @@ public class MetricsRule implements TestRule {
                 try {
                     base.evaluate();
                 } catch (AssumptionViolatedException e) {
-                    // represents expected exceptions, no need to tale an action.
+                    // represents expected exceptions, no need to take an action.
                 } catch (Throwable t) {
                     StringBuilder sb = new StringBuilder();
                     publishers.forEach((instanceName, publisher) -> publisher.dumpRecordings(instanceName, sb));


### PR DESCRIPTION
was causing unnecessary 10 seconds waiting in metrics-rule.

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/4570