### PR TITLE
Add woodstox as dependency

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -499,6 +499,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <version>${objenesis.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <spring.version>4.3.0.RELEASE</spring.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <snakeyaml.engine.version>2.3</snakeyaml.engine.version>
+        <woodstox.version>6.2.8</woodstox.version>
 
         <!-- test dependencies -->
         <activemq-artemis.version>2.11.0</activemq-artemis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <spring.version>4.3.0.RELEASE</spring.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <snakeyaml.engine.version>2.3</snakeyaml.engine.version>
-        <woodstox.version>6.2.8</woodstox.version>
+        <woodstox.version>5.3.0</woodstox.version>
 
         <!-- test dependencies -->
         <activemq-artemis.version>2.11.0</activemq-artemis.version>


### PR DESCRIPTION
Default Java StAX API has a bug when getting position of XML nodes related to newlines.

```
<hazelcast>
</hazelcast>
  ^
  |
  |

java implementation points new line here

<hazelcast>
</hazelcast>
^
|
|

woodstox implementation points new line here (as it should be)
```

This causes dynamic configuration to fail and I couldn't catch this during testing because woodstox is used in tests. Normally adding this to EE should suffice for configuration persistence but in my opinion it's bad practice to use different XML parsers between EE and OS.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
