### PR TITLE
Use patched libraries from Red Hat Maven GA repo for some vulnerable dependencies

### DIFF
--- a/extensions/hadoop-dist/files-azure/pom.xml
+++ b/extensions/hadoop-dist/files-azure/pom.xml
@@ -53,29 +53,4 @@
             <version>${hadoop.version}</version>
         </dependency>
     </dependencies>
-
-    <!-- The following part of the POM is related to handling CVE-2019-10172 in jackson-mapper-asl version
-        1.9.13 (dependency of hadoop-azure 3.3.1) -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>1.9.13.redhat-00007</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <repositories>
-        <repository>
-            <id>redhat-ga</id>
-            <url>https://maven.repository.redhat.com/ga/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/extensions/hadoop-dist/files-azure/pom.xml
+++ b/extensions/hadoop-dist/files-azure/pom.xml
@@ -53,4 +53,29 @@
             <version>${hadoop.version}</version>
         </dependency>
     </dependencies>
+
+    <!-- The following part of the POM is related to handling CVE-2019-10172 in jackson-mapper-asl version
+        1.9.13 (dependency of hadoop-azure 3.3.1) -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>1.9.13.redhat-00007</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>redhat-ga</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -582,7 +582,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/owasp-check-suppressions.xml
+++ b/owasp-check-suppressions.xml
@@ -35,4 +35,12 @@
        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/avatica\-core@.*$</packageUrl>
        <cpe>cpe:/a:apache:calcite</cpe>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The Hazelcast fork of JsonSurfer is based on top of original JsonSurfer version v1.6.3.
+       See https://github.com/hazelcast/JsonSurfer/
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.hazelcast\.jsurfer/.*$</packageUrl>
+       <cve>CVE-2016-10750</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <guava.version>30.1.1-jre</guava.version>
         <hadoop.version>3.3.1</hadoop.version>
         <jackson.version>2.12.1</jackson.version>
+        <jackson.mapper.asl.version>1.9.13.redhat-00007</jackson.mapper.asl.version>
         <jline.version>3.19.0</jline.version>
         <jms.api.version>2.0.1</jms.api.version>
         <json-surfer.version>1.0-SNAPSHOT</json-surfer.version>
@@ -1665,6 +1666,21 @@
                 <artifactId>antlr4-runtime</artifactId>
                 <version>${antlr4.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>${jackson.mapper.asl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+                <version>${jackson.mapper.asl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
             <!--
             The following are test dependencies, they are not in the final distribution.
             We put them there for the dependency convergence task to succeed.
@@ -1738,16 +1754,6 @@
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>1.9.13.redhat-00007</version>
-            </dependency>
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
         <kafka.version>2.2.2</kafka.version>
         <kotlin.version>1.5.32</kotlin.version>
-        <log4j.version>1.2.17</log4j.version>
+        <log4j.version>1.2.17.redhat-3</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <mysql.connector.version>8.0.20</mysql.connector.version>
         <netty.version>4.1.63.Final</netty.version>
@@ -1372,6 +1372,17 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <!-- Red Hat Maven repository provides patches for several vulnerable libraries (dependencies) which are not patched in the Maven Central repository. -->
+        <repository>
+            <id>redhat-ga</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <dependencyManagement>
@@ -1727,6 +1738,16 @@
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>1.9.13.redhat-00007</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixes #19575.

This PR updates the `jackson-mapper-asl` vulnerable `hadoop-azure` dependency and vulnerable `log4j` dependency of  `hazelcast-sql`.

Addresses CVE-2019-10172, CVE-2019-17571

### jackson-mapper-asl: `diff  1.9.13 1.9.13.redhat-00007`

```patch
diff -urN 1.9.13/META-INF/MANIFEST.MF 1.9.13.redhat-00007/META-INF/MANIFEST.MF
--- 1.9.13/META-INF/MANIFEST.MF	2013-07-14 21:03:42.000000000 +0200
+++ 1.9.13.redhat-00007/META-INF/MANIFEST.MF	2020-03-10 10:45:10.000000000 +0100
@@ -1,4 +1,11 @@
 Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.8.2
-Created-By: 1.7.0_10-ea-b16 (Oracle Corporation)
+Created-By: 1.8.0_121-b13 (Oracle Corporation)
+Built-By: PNC-Builder-0.4.0
+Implementation-Title: Data mapper for Jackson JSON processor
+Implementation-Version: 1.9.13.redhat-00007
+Implementation-Vendor: http://fasterxml.com
+Specification-Title: Data mapper for Jackson JSON processor
+Specification-Version: 1.9.13.redhat-00007
+Specification-Vendor: http://fasterxml.com
 
diff -urN 1.9.13/org/codehaus/jackson/map/ext/DOMDeserializer.java 1.9.13.redhat-00007/org/codehaus/jackson/map/ext/DOMDeserializer.java
--- 1.9.13/org/codehaus/jackson/map/ext/DOMDeserializer.java	2012-02-16 22:10:56.000000000 +0100
+++ 1.9.13.redhat-00007/org/codehaus/jackson/map/ext/DOMDeserializer.java	2020-03-10 10:43:48.000000000 +0100
@@ -22,6 +22,27 @@
         _parserFactory = DocumentBuilderFactory.newInstance();
         // yup, only cave men do XML without recognizing namespaces...
         _parserFactory.setNamespaceAware(true);
+
+        /* CVE-2016-3720 */
+        // [databind#1279]: make sure external entities NOT expanded by default
+        _parserFactory.setExpandEntityReferences(false);
+        // ... and in general, aim for "safety"
+        try {
+            _parserFactory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+        } catch(Exception pce) {
+            // not much point to do anything; could log but...
+        } catch (Error e) {
+            // 14-Jul-2016, tatu: Not sure how or why, but during code coverage runs
+            //   (via Cobertura) we get `java.lang.AbstractMethodError` so... ignore that too
+        }
+        // [databind#2589] add two more settings just in case
+        try {
+            _parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (Throwable t) { } // as per previous one, nothing much to do
+        try {
+            _parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (Throwable t) { } // as per previous one, nothing much to do
+
     }
 
     protected DOMDeserializer(Class<T> cls) { super(cls); }
diff -urN 1.9.13/org/codehaus/jackson/map/jsontype/impl/TypeDeserializerBase.java 1.9.13.redhat-00007/org/codehaus/jackson/map/jsontype/impl/TypeDeserializerBase.java
--- 1.9.13/org/codehaus/jackson/map/jsontype/impl/TypeDeserializerBase.java	2012-02-16 22:10:58.000000000 +0100
+++ 1.9.13.redhat-00007/org/codehaus/jackson/map/jsontype/impl/TypeDeserializerBase.java	2020-03-10 10:43:48.000000000 +0100
@@ -110,7 +110,26 @@
         synchronized (_deserializers) {
             deser = _deserializers.get(typeId);
             if (deser == null) {
-                JavaType type = _idResolver.typeFromId(typeId);
+                // BZ-1507389 and CVEs related to polymorphic deserialization
+                // the check is done after discovering type name from given json (wrapper array,
+                // wrapper object, ...) and before an attempt to locate the class and its
+                // instantiation
+                // without polymorphic deserialization the check should not be done even with
+                // default (empty) whitelist
+                JavaType type = null;
+                if (_idResolver.getMechanism() == JsonTypeInfo.Id.CLASS) {
+                    // check without mapping before idResolver attempts to load the class
+                    checkLegalTypes(ctxt.getParser(), typeId);
+                    // map the class after checking
+                    type = _idResolver.typeFromId(typeId);
+                } else {
+                    // map the name to class before checking
+                    type = _idResolver.typeFromId(typeId);
+                    if (type != null) {
+                        checkLegalTypes(ctxt.getParser(), type.getRawClass().getName());
+                    }
+                }
+
                 if (type == null) {
                     // As per [JACKSON-614], use the default impl if no type id available:
                     if (_defaultImpl == null) {
diff -urN 1.9.13/org/codehaus/jackson/map/TypeDeserializer.java 1.9.13.redhat-00007/org/codehaus/jackson/map/TypeDeserializer.java
--- 1.9.13/org/codehaus/jackson/map/TypeDeserializer.java	2012-02-16 22:11:00.000000000 +0100
+++ 1.9.13.redhat-00007/org/codehaus/jackson/map/TypeDeserializer.java	2020-03-10 10:43:48.000000000 +0100
@@ -1,6 +1,11 @@
 package org.codehaus.jackson.map;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import org.codehaus.jackson.*;
 import org.codehaus.jackson.annotate.JsonTypeInfo.As;
@@ -23,6 +28,20 @@
  */
 public abstract class TypeDeserializer
 {
+    /**
+     * Set of allowed packages for bean deserialization.
+     */
+    protected final static Set<String> ALLOW_DESER_PACKAGES;
+
+    static {
+        String strlist = System.getProperty("jackson.deserialization.whitelist.packages");
+        Set<String> s = new HashSet<String>();
+        if (strlist != null) {
+            s = new HashSet<String>(Arrays.asList(strlist.split(",")));
+        }
+        ALLOW_DESER_PACKAGES = Collections.unmodifiableSet(s);
+    }
+
     /*
     /**********************************************************
     /* Introspection
@@ -113,5 +132,51 @@
     public abstract Object deserializeTypedFromAny(JsonParser jp, DeserializationContext ctxt)
         throws IOException, JsonProcessingException;
 
+    /**
+     * <p>BZ-1507389 and CVEs related to polymorphic deserialization</p>
+     * <p>Check if given type is whitelisted without loading it's class to prevent possible
+     * exploit with {@code static} blocks.</p>
+     * @param parser
+     * @param typeId
+     * @throws JsonMappingException
+     */
+    protected static void checkLegalTypes(JsonParser parser, String typeId)
+            throws JsonMappingException {
+
+        if (typeId == null || "".equals(typeId)) {
+            return;
+        }
+
+        // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2
+        // decompose arrays
+        while (typeId.charAt(0) == '[') {
+            typeId = typeId.substring(1);
+            if (!typeId.isEmpty() && typeId.charAt(0) == 'L') {
+                typeId = typeId.substring(1);
+            }
+            // we don't have to skip last ';' because of startsWith()
+        }
+        if (typeId.length() == 1) {
+            // base type B C D F I J S Z
+            return;
+        }
+
+        Iterator<String> iter = ALLOW_DESER_PACKAGES.iterator();
+
+        boolean pass = false;
+
+        while (iter.hasNext()) {
+            if (typeId.startsWith(iter.next())) {
+                pass = true;
+                break;
+            }
+        }
+
+        if (!pass) {
+            throw new JsonMappingException(
+                    String.format("Illegal type (%s) to deserialize: prevented for security reasons", typeId));
+        }
+    }
+
 }

```

### log4j: `diff  1.2.17 1.2.17.redhat-3`
```patch
diff -urN log4j-1.2.17/META-INF/MANIFEST.MF log4j-1.2.17.redhat-3/META-INF/MANIFEST.MF
--- log4j-1.2.17/META-INF/MANIFEST.MF	2012-05-06 13:01:46.000000000 +0200
+++ log4j-1.2.17.redhat-3/META-INF/MANIFEST.MF	2017-08-24 10:41:46.000000000 +0200
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Archiver-Version: Plexus Archiver
 Created-By: Apache Maven
-Built-By: cy
-Build-Jdk: 1.6.0_23
+Built-By: mockbuild
+Build-Jdk: 1.8.0_141
 
diff -urN log4j-1.2.17/org/apache/log4j/FilteredObjectInputStream.java log4j-1.2.17.redhat-3/org/apache/log4j/FilteredObjectInputStream.java
--- log4j-1.2.17/org/apache/log4j/FilteredObjectInputStream.java	1970-01-01 01:00:00.000000000 +0100
+++ log4j-1.2.17.redhat-3/org/apache/log4j/FilteredObjectInputStream.java	2017-08-24 10:39:54.000000000 +0200
@@ -0,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.log4j;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Extended ObjectInputStream that only allows certain classes to be deserialized.
+ *
+ * Backported from 2.8.2
+ */
+public class FilteredObjectInputStream extends ObjectInputStream {
+
+    private static final List REQUIRED_JAVA_CLASSES = Arrays.asList(new String[] {
+        // Types of non-trainsient fields of LoggingEvent
+        "java.lang.String",
+        "java.util.Hashtable",
+        // ThrowableInformation
+        "[Ljava.lang.String;"
+    });
+
+    private final Collection allowedClasses;
+
+    public FilteredObjectInputStream(final InputStream in, final Collection allowedClasses) throws IOException {
+        super(in);
+        this.allowedClasses = allowedClasses;
+    }
+
+    protected Class resolveClass(final ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        String name = desc.getName();
+        if (!(isAllowedByDefault(name) || allowedClasses.contains(name))) {
+            throw new InvalidObjectException("Class is not allowed for deserialization: " + name);
+        }
+        return super.resolveClass(desc);
+    }
+
+    private static boolean isAllowedByDefault(final String name) {
+        return name.startsWith("org.apache.log4j.") ||
+            name.startsWith("[Lorg.apache.log4j.") ||
+            REQUIRED_JAVA_CLASSES.contains(name);
+    }
+
+}
diff -urN log4j-1.2.17/org/apache/log4j/net/SocketNode.java log4j-1.2.17.redhat-3/org/apache/log4j/net/SocketNode.java
--- log4j-1.2.17/org/apache/log4j/net/SocketNode.java	2012-05-06 13:00:24.000000000 +0200
+++ log4j-1.2.17.redhat-3/org/apache/log4j/net/SocketNode.java	2017-08-24 10:39:54.000000000 +0200
@@ -22,6 +22,10 @@
 import java.io.InterruptedIOException;
 import java.io.ObjectInputStream;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.log4j.FilteredObjectInputStream;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggerRepository;
@@ -53,8 +57,9 @@
     this.socket = socket;
     this.hierarchy = hierarchy;
     try {
-      ois = new ObjectInputStream(
-                         new BufferedInputStream(socket.getInputStream()));
+      ois = new FilteredObjectInputStream(
+                         new BufferedInputStream(socket.getInputStream()),
+                         getAllowedClasses());
     } catch(InterruptedIOException e) {
       Thread.currentThread().interrupt();
       logger.error("Could not open ObjectInputStream to "+socket, e);
@@ -65,6 +70,14 @@
     }
   }
 
+  private Collection getAllowedClasses() {
+      Collection allowedClasses = new ArrayList();
+      String property = System.getProperty("org.apache.log4j.net.allowedClasses");
+      if (property != null)
+          allowedClasses.addAll(Arrays.asList(property.split(",")));
+      return allowedClasses;
+  }
+
   //public
   //void finalize() {
   //System.err.println("-------------------------Finalize called");
```