### PR TITLE
Add mising JavaDoc in the authentication configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/AbstractClusterLoginConfig.java
@@ -21,6 +21,11 @@ import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import java.util.Objects;
 import java.util.Properties;
 
+/**
+ * Common configuration shared by authentication modules provided out-of-the box in Hazelcast.
+ *
+ * @param <T> self type used in the fluent API
+ */
 public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginConfig<T>> implements AuthenticationConfig {
 
     private Boolean skipIdentity;
@@ -31,6 +36,9 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         return skipIdentity;
     }
 
+    /**
+     * Allows skipping identity (name) assignment during the authentication.
+     */
     public T setSkipIdentity(Boolean skipIdentity) {
         this.skipIdentity = skipIdentity;
         return self();
@@ -40,6 +48,9 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         return skipEndpoint;
     }
 
+    /**
+     * Allows skipping address assignment of authenticated user/service.
+     */
     public T setSkipEndpoint(Boolean skipEndpoint) {
         this.skipEndpoint = skipEndpoint;
         return self();
@@ -49,6 +60,10 @@ public abstract class AbstractClusterLoginConfig<T extends AbstractClusterLoginC
         return skipRole;
     }
 
+    /**
+     * Allows skipping role assignment during authentication. Setting this value to {@code true} might speed-up authentication
+     * between cluster members (member-to-member). The roles only need to be assigned in client-to-member authentications.
+     */
     public T setSkipRole(Boolean skipRole) {
         this.skipRole = skipRole;
         return self();

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosAuthenticationConfig.java
@@ -22,6 +22,9 @@ import java.util.Properties;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 
+/**
+ * Typed authentication configuration for Kerberos tickets verification.
+ */
 public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<KerberosAuthenticationConfig> {
 
     private Boolean relaxFlagsCheck;
@@ -35,6 +38,10 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return relaxFlagsCheck;
     }
 
+    /**
+     * Allows disabling some of the checks on incoming token (e.g. passes authentication even if the mutual authentication is
+     * required by the token).
+     */
     public KerberosAuthenticationConfig setRelaxFlagsCheck(Boolean relaxFlagsCheck) {
         this.relaxFlagsCheck = relaxFlagsCheck;
         return this;
@@ -44,6 +51,10 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return securityRealm;
     }
 
+    /**
+     * Allows cutting off the Kerberos realm part from authenticated name. When set to {@code true}, the {@code '@REALM'} part
+     * is removed from the name (e.g. {@code jduke@ACME.COM} becomes {@code jduke}).
+     */
     public KerberosAuthenticationConfig setUseNameWithoutRealm(Boolean useNameWithoutRealm) {
         this.useNameWithoutRealm = useNameWithoutRealm;
         return this;
@@ -53,6 +64,10 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return useNameWithoutRealm;
     }
 
+    /**
+     * References Security realm name in Hazelcast configuration. The realm's authentication configuration (when defined) will
+     * be used to fill the user object with Kerberos credentials (e.g. KeyTab entry).
+     */
     public KerberosAuthenticationConfig setSecurityRealm(String securityRealm) {
         this.securityRealm = securityRealm;
         return this;
@@ -62,6 +77,10 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return ldapAuthenticationConfig;
     }
 
+    /**
+     * Allows specifying LDAP authentication configuration which is then used after the Kerberos authentication successfully
+     * finishes.
+     */
     public KerberosAuthenticationConfig setLdapAuthenticationConfig(LdapAuthenticationConfig ldapAuthenticationConfig) {
         this.ldapAuthenticationConfig = ldapAuthenticationConfig;
         return this;
@@ -71,6 +90,13 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return keytabFile;
     }
 
+    /**
+     * Allows (together with the {@link #setPrincipal(String)}) simplification of security realm configuration. For basic
+     * scenarios you don't need to use {@link #setSecurityRealm(String)}, but you can instead define directly kerberos principal
+     * name and keytab file path with credentials for given principal.
+     * <p>
+     * This configuration is only used when there is no {@code securityRealm} configured.
+     */
     public KerberosAuthenticationConfig setKeytabFile(String keytabFile) {
         this.keytabFile = keytabFile;
         return this;
@@ -80,6 +106,13 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return principal;
     }
 
+    /**
+     * Allows (together with the {@link #setKeytabFile(String)}) simplification of security realm configuration. For basic
+     * scenarios you don't need to use {@link #setSecurityRealm(String)}, but you can instead define directly kerberos principal
+     * name and keytab file path with credentials for given principal.
+     * <p>
+     * This configuration is only used when there is no {@code securityRealm} configured.
+     */
     public KerberosAuthenticationConfig setPrincipal(String principal) {
         this.principal = principal;
         return this;
@@ -138,20 +171,16 @@ public class KerberosAuthenticationConfig extends AbstractClusterLoginConfig<Ker
         return Objects.equals(ldapAuthenticationConfig, other.ldapAuthenticationConfig)
                 && Objects.equals(relaxFlagsCheck, other.relaxFlagsCheck)
                 && Objects.equals(useNameWithoutRealm, other.useNameWithoutRealm)
-                && Objects.equals(keytabFile, other.keytabFile)
-                && Objects.equals(principal, other.principal)
+                && Objects.equals(keytabFile, other.keytabFile) && Objects.equals(principal, other.principal)
                 && Objects.equals(securityRealm, other.securityRealm);
     }
 
     @Override
     public String toString() {
         return "KerberosAuthenticationConfig [relaxFlagsCheck=" + relaxFlagsCheck + ", securityRealm=" + securityRealm
-                + ", useNameWithoutRealm=" + useNameWithoutRealm
-                + ", ldapAuthenticationConfig=" + ldapAuthenticationConfig
-                + ", keytabFile=" + keytabFile
-                + ", principal=" + principal
-                + ", getSkipIdentity()=" + getSkipIdentity() + ", getSkipEndpoint()=" + getSkipEndpoint() + ", getSkipRole()="
-                + getSkipRole() + "]";
+                + ", useNameWithoutRealm=" + useNameWithoutRealm + ", ldapAuthenticationConfig=" + ldapAuthenticationConfig
+                + ", keytabFile=" + keytabFile + ", principal=" + principal + ", getSkipIdentity()=" + getSkipIdentity()
+                + ", getSkipEndpoint()=" + getSkipEndpoint() + ", getSkipRole()=" + getSkipRole() + "]";
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
@@ -24,6 +24,10 @@ import com.hazelcast.security.ICredentialsFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * This class configures the Kerberos identity. Based on this configuration, service tickets are retrieved from Kerberos KDC
+ * (Key Distribution Center).
+ */
 public class KerberosIdentityConfig implements IdentityConfig {
 
     private final CredentialsFactoryConfig factoryConfig = new CredentialsFactoryConfig(
@@ -33,6 +37,10 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return factoryConfig.getProperties().getProperty("spn");
     }
 
+    /**
+     * Allows to configure static service principal name (SPN). It's meant for usecases where all members share a single
+     * Kerberos identity.
+     */
     public KerberosIdentityConfig setSpn(String spn) {
         factoryConfig.getProperties().setProperty("spn", spn);
         return this;
@@ -42,6 +50,11 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return factoryConfig.getProperties().getProperty("serviceNamePrefix");
     }
 
+    /**
+     * Defines prefix of the Service Principal name. It's default value is {@code "hz/"}. By default the member's principal name
+     * (for which this credentials factory asks the service ticket) is in form "[servicePrefix][memberIpAddress]@[REALM]" (e.g.
+     * "hz/192.168.1.1@ACME.COM").
+     */
     public KerberosIdentityConfig setServiceNamePrefix(String serviceNamePrefix) {
         factoryConfig.getProperties().setProperty("serviceNamePrefix", serviceNamePrefix);
         return this;
@@ -51,6 +64,9 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return factoryConfig.getProperties().getProperty("realm");
     }
 
+    /**
+     * Defines Kerberos realm name (e.g. "ACME.COM").
+     */
     public KerberosIdentityConfig setRealm(String realm) {
         factoryConfig.getProperties().setProperty("realm", realm);
         return this;
@@ -60,6 +76,13 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return factoryConfig.getProperties().getProperty("keytabFile");
     }
 
+    /**
+     * Allows (together with the {@link #setPrincipal(String)}) simplification of security realm configuration. For basic
+     * scenarios you don't need to use {@link #setSecurityRealm(String)}, but you can instead define directly kerberos principal
+     * name and keytab file path with credentials for given principal.
+     * <p>
+     * This configuration is only used when there is no {@code securityRealm} configured.
+     */
     public KerberosIdentityConfig setKeytabFile(String keytabFile) {
         factoryConfig.getProperties().setProperty("keytabFile", keytabFile);
         return this;
@@ -69,6 +92,13 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return factoryConfig.getProperties().getProperty("principal");
     }
 
+    /**
+     * Allows (together with the {@link #setKeytabFile(String)}) simplification of security realm configuration. For basic
+     * scenarios you don't need to use {@link #setSecurityRealm(String)}, but you can instead define directly kerberos principal
+     * name and keytab file path with credentials for given principal.
+     * <p>
+     * This configuration is only used when there is no {@code securityRealm} configured.
+     */
     public KerberosIdentityConfig setPrincipal(String principal) {
         factoryConfig.getProperties().setProperty("principal", principal);
         return this;
@@ -78,6 +108,10 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return factoryConfig.getProperties().getProperty("securityRealm");
     }
 
+    /**
+     * Configures a reference to Security realm name in Hazelcast configuration. The realm's authentication configuration (when
+     * defined) is used to populate the user object with Kerberos credentials (e.g. TGT).
+     */
     public KerberosIdentityConfig setSecurityRealm(String securityRealm) {
         factoryConfig.getProperties().setProperty("securityRealm", securityRealm);
         return this;
@@ -89,6 +123,12 @@ public class KerberosIdentityConfig implements IdentityConfig {
         return strVal != null ? Boolean.parseBoolean(strVal) : null;
     }
 
+    /**
+     * Allows using fully qualified domain name instead of IP address when the SPN is constructed from a prefix and realm name.
+     * For instance, when set {@code true}, the SPN {@code "hz/192.168.1.1@ACME.COM"} could become
+     * {@code "hz/member1.acme.com@ACME.COM"} (given the reverse DNS lookup for 192.168.1.1 returns the "member1.acme.com"
+     * hostname).
+     */
     public KerberosIdentityConfig setUseCanonicalHostname(Boolean useCanonicalHostname) {
         Properties props = factoryConfig.getProperties();
         if (useCanonicalHostname != null) {
@@ -132,13 +172,9 @@ public class KerberosIdentityConfig implements IdentityConfig {
 
     @Override
     public String toString() {
-        return "KerberosIdentityConfig [spn=" + getSpn() + ", serviceNamePrefix=" + getServiceNamePrefix()
-                + ", realm=" + getRealm()
-                + ", securityRealm=" + getSecurityRealm()
-                + ", principal=" + getPrincipal()
-                + ", keytabFile=" + getKeytabFile()
-                + ", useCanonicalHostname=" + getUseCanonicalHostname()
-                + "]";
+        return "KerberosIdentityConfig [spn=" + getSpn() + ", serviceNamePrefix=" + getServiceNamePrefix() + ", realm="
+                + getRealm() + ", securityRealm=" + getSecurityRealm() + ", principal=" + getPrincipal() + ", keytabFile="
+                + getKeytabFile() + ", useCanonicalHostname=" + getUseCanonicalHostname() + "]";
     }
 
 }


### PR DESCRIPTION
The PR adds missing JavaDoc to authentication configuration classes.