### PR TITLE
Replace deprecaded use of hamcrest's assertThat with assertj

### DIFF
--- a/hazelcast/src/test/kotlin/com/hazelcast/jet/impl/util/KotlinReflectionUtilsTest.kt
+++ b/hazelcast/src/test/kotlin/com/hazelcast/jet/impl/util/KotlinReflectionUtilsTest.kt
@@ -3,9 +3,7 @@ package com.hazelcast.jet.impl.util
 import com.hazelcast.test.HazelcastParallelClassRunner
 import com.hazelcast.test.annotation.ParallelJVMTest
 import com.hazelcast.test.annotation.QuickTest
-import org.hamcrest.Matchers.containsInAnyOrder
-import org.hamcrest.Matchers.hasSize
-import org.junit.Assert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -20,13 +18,13 @@ class KotlinReflectionUtilsTest {
         val classes = ReflectionUtils.nestedClassesOf(OuterClass::class.java)
 
         // Then
-        assertThat(classes, hasSize(4))
-        assertThat(classes, containsInAnyOrder(
+        assertThat(classes).hasSize(4)
+        assertThat(classes).containsExactlyInAnyOrder(
                 OuterClass::class.java,
                 OuterClass.NestedClass::class.java,
                 Class.forName("com.hazelcast.jet.impl.util.KotlinReflectionUtilsTest\$OuterClass\$method\$1"),
                 Class.forName("com.hazelcast.jet.impl.util.KotlinReflectionUtilsTest\$OuterClass\$method\$lambda\$1")
-        ))
+        )
     }
 
     @Suppress("unused", "UNUSED_VARIABLE")


### PR DESCRIPTION
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
