### PR TITLE
Use patched htrace-core4 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1374,6 +1374,17 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>hazelcast-security</id>
+            <name>Thirdparty security fixes</name>
+            <url>https://repository.hazelcast.com/security-maven/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
         <!-- Red Hat Maven repository provides patches for several vulnerable libraries (dependencies) which are not patched in the Maven Central repository. -->
         <repository>
             <id>redhat-ga</id>
@@ -1585,6 +1596,11 @@
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.connector.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.htrace</groupId>
+                <artifactId>htrace-core4</artifactId>
+                <version>4.2.0-incubating.hazelcast-1</version>
             </dependency>
             <!-- NOTE: httpcore and httpclient versions are not in sync -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1600,7 +1600,7 @@
             <dependency>
                 <groupId>org.apache.htrace</groupId>
                 <artifactId>htrace-core4</artifactId>
-                <version>4.2.0-incubating.hazelcast-1</version>
+                <version>4.2.0-incubating.hazelcast-2</version>
             </dependency>
             <!-- NOTE: httpcore and httpclient versions are not in sync -->
             <dependency>


### PR DESCRIPTION
Fixes #19573

This PR explicitly defines the `htrace-core4` dependency version to avoid having vulnerable jackson-databind library on the classpath. 

Sources of the patched module:
https://github.com/hazelcast/thirdparty-security-fixes/tree/org.apache.htrace_htrace-core4_4.2.0-incubating-v4.2.0-incubating.hazelcast-1/org.apache.htrace_htrace-core4_4.2.0-incubating