### PR TITLE
Re-enable javadoc check for Jet package

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -117,12 +117,19 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <!-- Only for methods on public APIs we agreed to have JavaDoc. -->
-        <!-- TODO: figure out how to do that -->
-        <!--<module name="JavadocMethod">-->
-        <!--<property name="scope" value="public"/>-->
-        <!--<property name="allowMissingParamTags" value="true"/>-->
-        <!--</module>-->
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="validateThrows" value="false"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+        </module>
         <module name="JavadocType">
+            <property name="scope" value="public"/>
+        </module>
+        <module name="MissingJavadocType">
             <property name="scope" value="public"/>
         </module>
         <module name="JavadocVariable">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -421,6 +421,13 @@
     <suppress checks="MethodLength" files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]"/>
 
     <suppress checks="Javadoc|Name|MagicNumber|VisibilityModifier" files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]hazelcast[\\/]jet"/>
-
     <suppress checks="" files="target[\\/]generated-sources"/>
+
+    <!-- Exclude JavadocMethod everywhere but Jet package - means Jet package will be checked -->
+    <suppress checks="JavadocMethod|MissingJavadocMethod" files="^(?!.*([\\/]src[\\/](main|test)[\\/]java[\\/]com[\\/]hazelcast[\\/]jet).*)"/>
+
+    <suppress checks="JavadocMethod" files="JetException\.java"/>
+    <suppress checks="JavadocMethod" files="RestartableException\.java"/>
+    <suppress checks="JavadocMethod" files="JobNotFoundException\.java"/>
+
 </suppressions>

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -33,7 +33,9 @@ import static com.tngtech.archunit.lang.conditions.ArchConditions.beStatic;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.haveRawType;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
-
+/**
+ * Common {@link ArchRule} for Hazelcast tests
+ */
 public final class ArchUnitRules {
     /**
      * ArchUnit rule checking that Serializable classes have a valid serialVersionUID

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ModuleImportOptions.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ModuleImportOptions.java
@@ -21,6 +21,9 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
+/**
+ * Predefined {@link ImportOption}s
+ */
 public final class ModuleImportOptions {
 
     private ModuleImportOptions() {

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/FinalRemovalAgent.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/FinalRemovalAgent.java
@@ -34,6 +34,11 @@ import java.util.Set;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
+/**
+ * Agent that removes final modifier on configured classes and methods
+ * so that they can be proxied, mocked or subclassed.
+ * For compatibility testing.
+ */
 public final class FinalRemovalAgent {
 
     // Class name -> List<final method names> to be processed for

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -84,6 +84,9 @@ import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+/**
+ * Picocli implementation of the {@code hz-cli} command
+ */
 @SuppressWarnings({
         "unused",
         "MismatchedQueryAndUpdateOfCollection",
@@ -619,7 +622,7 @@ public class HazelcastCommandLine implements Runnable {
         }
     }
 
-    public static class HazelcastVersionProvider implements IVersionProvider {
+    static class HazelcastVersionProvider implements IVersionProvider {
 
         @Override
         public String[] getVersion() {
@@ -632,7 +635,7 @@ public class HazelcastCommandLine implements Runnable {
         }
     }
 
-    public static class Verbosity {
+    static class Verbosity {
 
         @Option(names = {"-v", "--verbosity"},
                 description = {"Show verbose logs and full stack trace of errors"},
@@ -645,7 +648,7 @@ public class HazelcastCommandLine implements Runnable {
         }
     }
 
-    public static class TargetsMixin {
+    static class TargetsMixin {
 
         @Option(names = {"-t", "--targets"},
                 description = "The cluster name and addresses to use if you want to connect to a "

--- a/hazelcast/src/main/java/com/hazelcast/client/console/SqlConsole.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/SqlConsole.java
@@ -59,6 +59,9 @@ import static com.hazelcast.internal.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.internal.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.internal.util.StringUtil.trim;
 
+/**
+ * SqlConsole based on jline library to execute SQL queries from command line
+ */
 @SuppressWarnings({
         "checkstyle:CyclomaticComplexity",
         "checkstyle:MethodLength",

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -21,6 +21,9 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 
+/**
+ * Abstract class for all config builders containing common functionality
+ */
 public class AbstractConfigBuilder {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/KerberosIdentityConfig.java
@@ -147,7 +147,7 @@ public class KerberosIdentityConfig implements IdentityConfig {
     @Override
     public IdentityConfig copy() {
         return new KerberosIdentityConfig().setRealm(getRealm()).setSecurityRealm(getSecurityRealm())
-                .setServiceNamePrefix(getServiceNamePrefix()).setSpn(getSpn());
+                                           .setServiceNamePrefix(getServiceNamePrefix()).setSpn(getSpn());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/ResourceType.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/ResourceType.java
@@ -60,6 +60,9 @@ public enum ResourceType {
         this.id = id;
     }
 
+    /**
+     * Returns the integer identifier of the ResourceType
+     */
     public int getId() {
         return id;
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
@@ -219,6 +219,9 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
         return maxProcessorAccumulatedRecords;
     }
 
+    /**
+     * Sets the maximum number of accumulated records in a processor
+     */
     public void setMaxProcessorAccumulatedRecords(long maxProcessorAccumulatedRecords) {
         this.maxProcessorAccumulatedRecords = maxProcessorAccumulatedRecords;
     }
@@ -256,6 +259,9 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
         return classLoader;
     }
 
+    /**
+     * Sets the processor classloader
+     */
     @Nonnull
     public TestProcessorMetaSupplierContext setClassLoader(ClassLoader classLoader) {
         this.classLoader = classLoader;

--- a/hazelcast/src/main/java/com/hazelcast/jet/function/RunnableEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/function/RunnableEx.java
@@ -21,8 +21,17 @@ import java.io.Serializable;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 
 
+/**
+ * {@code Serializable} variant of {@link Runnable java.lang.Runnable}
+ * which declares checked exception.
+ */
 @FunctionalInterface
 public interface RunnableEx extends Runnable, Serializable {
+
+    /**
+     * Exception-declaring version of {@link Runnable#run()}.
+     * @throws Exception in case of any exceptional case
+     */
     void runEx() throws Exception;
 
     @Override
@@ -34,6 +43,9 @@ public interface RunnableEx extends Runnable, Serializable {
         }
     }
 
+    /**
+     * No-op Runnable
+     */
     static RunnableEx noop() {
         return () -> {
         };

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointSlicesProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointSlicesProvider.java
@@ -32,7 +32,7 @@ import static com.hazelcast.kubernetes.KubernetesApiProvider.convertToString;
 import static com.hazelcast.kubernetes.KubernetesClient.Endpoint;
 import static com.hazelcast.kubernetes.KubernetesClient.EndpointAddress;
 
-public class KubernetesApiEndpointSlicesProvider
+class KubernetesApiEndpointSlicesProvider
         implements KubernetesApiProvider {
 
     public String getEndpointsByServiceLabelUrlString() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
@@ -44,6 +44,9 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Simple RestClient for communication with the cloud APIs
+ */
 public final class RestClient {
 
     /**
@@ -247,6 +250,9 @@ public final class RestClient {
         return scanner.next();
     }
 
+    /**
+     * Response to a HTTP call
+     */
     public static class Response {
 
         private final int code;


### PR DESCRIPTION
Jet had stricter rules on javadoc.

This commit enables (Missing)JavadocType and (Missing)JavadocMethod.
for the Jet package (plus few places where it's not specifically excluded by 
IMDG exclusions) and fixes several places where the javadoc was missing.

Fixes #18616

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
