### PR TITLE
SqlIndexResolutionTest passes with multiple active instances

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexResolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexResolutionTest.java
@@ -96,8 +96,7 @@ public class SqlIndexResolutionTest extends SqlIndexTestSupport {
 
     @BeforeClass
     public static void beforeClass() {
-        // TODO: https://github.com/hazelcast/hazelcast/issues/19285
-        initialize(1, null);
+        initialize(2, null);
     }
 
     @Test


### PR DESCRIPTION
During removal of IMDG SQL engine this test failed during launch with multiple HZ instances. 
Now it works fine, and this PR intended to return back to original test. 

Fixes https://github.com/hazelcast/hazelcast/issues/19285