### PR TITLE
Convert `finalPosition` to a local variable in the `CompactInternalGenericRecord`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -91,7 +91,6 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private final OffsetReader offsetReader;
     private final Schema schema;
     private final BufferObjectDataInput in;
-    private final int finalPosition;
     private final int dataStartPosition;
     private final int variableOffsetsPosition;
     private final CompactStreamSerializer serializer;
@@ -107,6 +106,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
         this.associatedClass = associatedClass;
         this.schemaIncludedInBinary = schemaIncludedInBinary;
         try {
+            int finalPosition;
             int numberOfVariableLengthFields = schema.getNumberOfVariableSizeFields();
             if (numberOfVariableLengthFields != 0) {
                 int dataLength = in.readInt();


### PR DESCRIPTION
The `finalPosition` field was not used anywhere apart from the constructor.
Hence, this PR converts that to a local variable.