### PR TITLE
Remove instance-tracking config from config template

### DIFF
--- a/hazelcast/src/main/config-template/hazelcast-assembly.xml
+++ b/hazelcast/src/main/config-template/hazelcast-assembly.xml
@@ -455,10 +455,6 @@
         <collection-frequency-seconds>5</collection-frequency-seconds>
     </metrics>
 
-    <instance-tracking enabled="false">
-
-    </instance-tracking>
-
     <sql>
         <statement-timeout-millis>0</statement-timeout-millis>
     </sql>

--- a/hazelcast/src/main/config-template/hazelcast-assembly.yaml
+++ b/hazelcast/src/main/config-template/hazelcast-assembly.yaml
@@ -743,9 +743,6 @@ hazelcast:
     # 'hazelcast.metrics.collection.frequency' system property.
     collection-frequency-seconds: 5
 
-  instance-tracking:
-    enabled: false
-
   sql:
     # Sets the timeout in milliseconds that is applied to SQL statements
     # without an explicit timeout. It is possible to set a timeout through the


### PR DESCRIPTION
Instance tracking is disabled by default for normal build, but for NLC
build it is enabled. Having it in the default config template (used in
zip, Docker and elsewhere) disables it also for the NLC build.

Removing the config from the template is simplest fix, compared to
creating another configuration file for the NLC build.

This is rather exotic feature, so we don't need this snippet in the
default configs, however it is still present in the full example
configs.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4349

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
