### PR TITLE
Fix type-inference compilation failure at JDK 17

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -156,7 +156,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
                 .map(conn -> (NioChannel) ((TcpServerConnection) conn).getChannel())
                 .flatMap(channel -> Stream.of(channel.inboundPipeline(), channel.outboundPipeline()))
                 .collect(Collectors.groupingBy(MigratablePipeline::owner,
-                        Collectors.toMap(Function.identity(), MigratablePipeline::load)));
+                        Collectors.toMap(Function.<MigratablePipeline>identity(), MigratablePipeline::load)));
     }
 
     private StringBuilder debug(HazelcastInstance hz,


### PR DESCRIPTION
Added explicit type parameter to fix type-inference compilation failure at JDK 17