### PR TITLE
Fix jet security tests on EE side

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -249,7 +249,7 @@ public class DefaultNodeExtension implements NodeExtension {
         if (jetServiceBackend != null) {
             systemLogger.info("Jet is enabled");
             // Configure the internal distributed objects.
-            jetServiceBackend.configureJetInternalObjects(node);
+            jetServiceBackend.configureJetInternalObjects(node.config.getStaticConfig(), node.getProperties());
         } else {
             systemLogger.info(JET_IS_DISABLED_MESSAGE);
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -332,30 +332,6 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         return taskletExecutionService;
     }
 
-    public void configureJetInternalObjects(Node node) {
-        Config config = node.config.getStaticConfig();
-        JetConfig jetConfig = config.getJetConfig();
-
-        MapConfig internalMapConfig = new MapConfig(INTERNAL_JET_OBJECTS_PREFIX + '*')
-                .setBackupCount(jetConfig.getBackupCount())
-                // we query creationTime of resources maps
-                .setStatisticsEnabled(true);
-
-        internalMapConfig.getMergePolicyConfig().setPolicy(DiscardMergePolicy.class.getName());
-
-        MapConfig resultsMapConfig = new MapConfig(internalMapConfig)
-                .setName(JOB_RESULTS_MAP_NAME)
-                .setTimeToLiveSeconds(node.getProperties().getSeconds(JOB_RESULTS_TTL_SECONDS));
-
-        MapConfig metricsMapConfig = new MapConfig(internalMapConfig)
-                .setName(JOB_METRICS_MAP_NAME)
-                .setTimeToLiveSeconds(node.getProperties().getSeconds(JOB_RESULTS_TTL_SECONDS));
-
-        config.addMapConfig(internalMapConfig)
-                .addMapConfig(resultsMapConfig)
-                .addMapConfig(metricsMapConfig);
-    }
-
     public void beforeClusterStateChange(ClusterState requestedState) {
         if (requestedState == PASSIVE) {
             try {


### PR DESCRIPTION
Removed the leftover method which is accidentally added
on https://github.com/hazelcast/hazelcast/commit/91d1f16a4bb1693ae5e092a8afe57ee4cf3a657d.
Using method not overridden by this EE was causing problems.

Fixes jet security tests failing on EE side.



Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
