### PR TITLE
Remove modulepath-tests from root project modules [HZ-691]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,6 +1269,7 @@
                 <property>
                     <name>!quick</name>
                 </property>
+                <jdk>[9,)</jdk>
             </activation>
             <modules>
                 <module>modulepath-tests</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1261,9 +1261,6 @@
                     --illegal-access=deny
                 </javaModuleArgs>
             </properties>
-            <modules>
-                <module>modulepath-tests</module>
-            </modules>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1264,6 +1264,13 @@
         </profile>
 
         <profile>
+            <id>modulepath-tests</id>
+            <modules>
+                <module>modulepath-tests</module>
+            </modules>
+        </profile>
+
+        <profile>
             <!-- same as default build (excludes Nightly & Slow tests), outputs serialized objects to a blob -->
             <!-- for compatibility testing -->
             <id>generate-compatibility-samples</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1265,6 +1265,11 @@
 
         <profile>
             <id>modulepath-tests</id>
+            <activation>
+                <property>
+                    <name>!quick</name>
+                </property>
+            </activation>
             <modules>
                 <module>modulepath-tests</module>
             </modules>


### PR DESCRIPTION
`modulepath-tests` requires hazelcast java module which we create as an automatic one (by setting `Automatic-Module-Name` in `manifest.mf`). On JDK17 it results in the compilation error when running `mvn clean compile` on the root module:
```
Caused by: org.apache.maven.plugin.compiler.CompilationFailureException: Compilation failure
.../hazelcast/modulepath-tests/src/main/java/module-info.java:[18,27] module not found: com.hazelcast.core
```
So in order to make it work we need to build main jar file and then run the module tests.

Solution would be to remove `modulepath-tests` from child modules of the root module and run them separately (as we already do in the pr-builder job) or avoid `mvn clean compile`. 

To not hurt developer experience, we decided to add `modulepath-tests` to child modules only when `modulepath-tests` profile is enabled.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
