### PR TITLE
Fix hanging HzStartTest

### DIFF
--- a/distribution/src/bin-filemode-755/hz
+++ b/distribution/src/bin-filemode-755/hz
@@ -93,7 +93,7 @@ do
   fi
 done
 
-HZ_CMD="${JAVA} -cp ${CLASSPATH} ${JAVA_OPTS_ARRAY[@]} com.hazelcast.commandline.HazelcastServerCommandLine"
+HZ_CMD="exec ${JAVA} -cp ${CLASSPATH} ${JAVA_OPTS_ARRAY[@]} com.hazelcast.commandline.HazelcastServerCommandLine"
 
 echo "########################################"
 echo "# JAVA=$JAVA"

--- a/distribution/src/bin-filemode-755/hz-start
+++ b/distribution/src/bin-filemode-755/hz-start
@@ -25,4 +25,4 @@ findScriptDir
 
 echo Warning: "$0" is deprecated. Please use "hz start" instead.
 
-"$SCRIPT_DIR"/hz start "$@"
+exec "$SCRIPT_DIR"/hz start "$@"

--- a/distribution/src/main/java/com/hazelcast/commandline/ProcessExecutor.java
+++ b/distribution/src/main/java/com/hazelcast/commandline/ProcessExecutor.java
@@ -39,6 +39,9 @@ class ProcessExecutor {
         processBuilder.environment().putAll(environment);
         Process process = processBuilder.start();
         if (!daemon) {
+            // Register shutdown hook so when something kills us we destroy the Hazelcast process
+            Runtime.getRuntime().addShutdownHook(new Thread(process::destroy));
+
             process.waitFor();
         }
     }


### PR DESCRIPTION
The Hazelcast process wasn't being killed correctly and in combination
with java.lang.ProcessBuilder#inheritIO the JVM running the test was
hanging at shut down (the test passed correctly).

There were 2 issues causing improper shutdown:

 - the scripts `hz`/`hz-start` were not using exec command which replaces
current shell process with the command, this resulted in killing the
shell, but that doesn't immediatelly kill the `HazelcastServerCommandLine`
process.  Using exec means we kill the `HazelcastServerCommandLine`
directly.

 - similarly the `HazelcastServerCommandLine` starts a new process
(`HazelcastMemberStarter`) and when it is killed it doesn't automatically
kill the new process. Added shutdown hook so the process is killed in
normal scenario (it won't be killed correclty if `kill -9` is used, but
we can't do anything about that).

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4425

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
