### PR TITLE
Update serialVersionUID’s of Kinesis ProcSuppliers

### DIFF
--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourcePMetaSupplier.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourcePMetaSupplier.java
@@ -38,7 +38,7 @@ import static java.util.stream.Collectors.toList;
 
 public class KinesisSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     @Nonnull
     private final AwsConfig awsConfig;

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourcePSupplier.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourcePSupplier.java
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toList;
 
 public class KinesisSourcePSupplier<T> implements ProcessorSupplier {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     @Nonnull
     private final AwsConfig awsConfig;


### PR DESCRIPTION
This PR updates `serialVersionUID`’s of the processor suppliers
of kinesis source. These classes were changed on https://github.com/hazelcast/hazelcast/pull/19914
but we forgot to update the `serialVersionUID`s of them.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

