### PR TITLE
Fix iterator visibility

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapChunkSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapChunkSupplier.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.internal.partition.ChunkSupplier;
+import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.map.impl.operation.MapChunk;
+import com.hazelcast.map.impl.operation.MapChunkContext;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Once instance created per map during migration.
+ */
+class MapChunkSupplier implements ChunkSupplier {
+
+    protected final MapChunkContext context;
+
+    protected BooleanSupplier isEndOfChunk;
+
+    private final int partitionId;
+    private final int replicaIndex;
+    private final MapServiceContext mapServiceContext;
+
+    // written by 1 but read by multiple threads
+    private volatile int chunkNumber;
+
+    MapChunkSupplier(MapServiceContext mapServiceContext, ServiceNamespace namespace,
+                     int partitionId, int replicaIndex) {
+        this.mapServiceContext = mapServiceContext;
+        this.replicaIndex = replicaIndex;
+        this.partitionId = partitionId;
+        this.context = createMapChunkContext(mapServiceContext, namespace, partitionId);
+    }
+
+    // overridden in EE
+    protected MapChunkContext createMapChunkContext(MapServiceContext mapServiceContext,
+                                                    ServiceNamespace namespace, int partitionId) {
+        return new MapChunkContext(mapServiceContext, partitionId, namespace);
+    }
+
+    // overridden in EE
+    protected Operation createChunkOperation(int chunkNumber) {
+        return new MapChunk(context, chunkNumber, isEndOfChunk);
+    }
+
+    @Override
+    public final void signalEndOfChunkWith(BooleanSupplier isEndOfChunk) {
+        this.isEndOfChunk = isEndOfChunk;
+    }
+
+    @Override
+    public final Operation next() {
+        assert isEndOfChunk != null : "isEndOfChunk must be set before";
+
+        chunkNumber++;
+        return createChunkOperation(chunkNumber)
+                .setPartitionId(partitionId)
+                .setReplicaIndex(replicaIndex)
+                .setServiceName(MapService.SERVICE_NAME)
+                .setNodeEngine(mapServiceContext.getNodeEngine());
+    }
+
+    @Override
+    public final boolean hasNext() {
+        if (chunkNumber == 0) {
+            // First chunk must be sent regardless of map has data
+            // because in first chunk we also migrate metadata.
+            return true;
+        }
+        return context.hasMoreChunks();
+    }
+
+    @Override
+    public final String toString() {
+        return getClass().getSimpleName()
+                + '{'
+                + "partitionId=" + partitionId
+                + ", chunkNumber=" + chunkNumber
+                + ", mapName=" + context.getMapName()
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -18,6 +18,8 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.internal.partition.ChunkSupplier;
+import com.hazelcast.internal.partition.ChunkSuppliers;
 import com.hazelcast.internal.partition.ChunkedMigrationAwareService;
 import com.hazelcast.internal.partition.MigrationEndpoint;
 import com.hazelcast.internal.partition.OffloadedReplicationPreparation;
@@ -28,16 +30,12 @@ import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.map.impl.operation.MapChunk;
-import com.hazelcast.map.impl.operation.MapChunkContext;
 import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.internal.partition.ChunkSupplier;
-import com.hazelcast.internal.partition.ChunkSuppliers;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
@@ -48,7 +46,6 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import static com.hazelcast.config.CacheDeserializedValues.NEVER;
@@ -154,61 +151,11 @@ class MapMigrationAwareService
                                           Collection<ServiceNamespace> namespaces) {
         List<ChunkSupplier> chain = new ArrayList<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
-            chain.add(new MapChunkSupplier(namespace, event.getPartitionId(),
-                    event.getReplicaIndex()));
+            chain.add(new MapChunkSupplier(mapServiceContext, namespace,
+                    event.getPartitionId(), event.getReplicaIndex()));
         }
 
         return ChunkSuppliers.newChainedChunkSupplier(chain);
-    }
-
-    private final class MapChunkSupplier implements ChunkSupplier {
-
-        private final int partitionId;
-        private final int replicaIndex;
-        private final MapChunkContext context;
-
-        private int chunkNumber;
-        private BooleanSupplier isEndOfChunk;
-
-        private MapChunkSupplier(ServiceNamespace namespace, int partitionId, int replicaIndex) {
-            this.replicaIndex = replicaIndex;
-            this.context = new MapChunkContext(mapServiceContext, partitionId, namespace);
-            this.partitionId = partitionId;
-        }
-
-        @Override
-        public void signalEndOfChunkWith(BooleanSupplier isEndOfChunk) {
-            this.isEndOfChunk = isEndOfChunk;
-        }
-
-        @Override
-        public Operation next() {
-            chunkNumber++;
-            return new MapChunk(context, chunkNumber, isEndOfChunk)
-                    .setPartitionId(partitionId)
-                    .setReplicaIndex(replicaIndex)
-                    .setServiceName(MapService.SERVICE_NAME)
-                    .setNodeEngine(mapServiceContext.getNodeEngine());
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (chunkNumber == 0) {
-                // First chunk must be sent regardless of map has data
-                // because in first chunk we also migrate metadata.
-                return true;
-            }
-            return context.hasMoreChunks();
-        }
-
-        @Override
-        public String toString() {
-            return "MapChunkSupplier{"
-                    + "partitionId=" + partitionId
-                    + ", chunkNumber=" + chunkNumber
-                    + ", mapName=" + context.getMapName()
-                    + '}';
-        }
     }
 
     boolean assertAllKnownNamespaces(Collection<ServiceNamespace> namespaces) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunk.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunk.java
@@ -73,6 +73,7 @@ import static com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntries.n
 /**
  * Represents a chunk of migrated data per map.
  * <p>
+ *
  * @see #writeChunk
  */
 @SuppressWarnings("checkstyle:MethodCount")
@@ -116,7 +117,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
     }
 
     @Override
-    public void run() throws Exception {
+    public final void run() throws Exception {
         RecordStore recordStore = getRecordStore(mapName);
 
         if (firstChunk) {
@@ -142,13 +143,13 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
     }
 
     @Override
-    public void beforeRun() {
+    public final void beforeRun() {
         RecordStore recordStore = getRecordStore(mapName);
         recordStore.beforeOperation();
     }
 
     @Override
-    public void afterRunFinal() {
+    public final void afterRunFinal() {
         RecordStore recordStore = getRecordStore(mapName);
         recordStore.afterOperation();
     }
@@ -305,7 +306,6 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
                 .getMapConfig().getEvictionConfig();
         return mapContainer.getEvictor() != Evictor.NULL_EVICTOR
                 && evictionConfig.getMaxSizePolicy() == PER_NODE;
-
     }
 
     private void applyNearCacheState(RecordStore recordStore) {
@@ -386,7 +386,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
+    protected final void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
 
         out.writeBoolean(firstChunk);
@@ -416,7 +416,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
         writeNearCacheState(out);
     }
 
-    public void writeNearCacheState(ObjectDataOutput out) throws IOException {
+    public final void writeNearCacheState(ObjectDataOutput out) throws IOException {
         MetaDataGenerator metaData = getPartitionMetaDataGenerator(context.getRecordStore());
         int partitionId = context.getPartitionId();
         UUID partitionUuid = metaData.getOrCreateUuid(partitionId);
@@ -432,7 +432,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
         out.writeLong(currentSequence);
     }
 
-    public void readNearCacheState(ObjectDataInput in) throws IOException {
+    public final void readNearCacheState(ObjectDataInput in) throws IOException {
         boolean nullUuid = in.readBoolean();
         partitionUuid = nullUuid ? null : new UUID(in.readLong(), in.readLong());
         currentSequence = in.readLong();
@@ -501,7 +501,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
      * If number of written bytes exceeds chunk limit, it stops writing.
      * Next key-values pairs are written in subsequent chunks later.
      */
-    protected void writeChunk(ObjectDataOutput out, MapChunkContext context) throws IOException {
+    protected final void writeChunk(ObjectDataOutput out, MapChunkContext context) throws IOException {
         SerializationService ss = context.getSerializationService();
         long recordCount = 0;
 
@@ -532,7 +532,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
+    protected final void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
 
         this.firstChunk = in.readBoolean();
@@ -545,8 +545,7 @@ public class MapChunk extends Operation implements IdentifiedDataSerializable {
         this.lastChunk = in.readBoolean();
     }
 
-    protected void readMetadata(ObjectDataInput in)
-            throws IOException {
+    protected void readMetadata(ObjectDataInput in) throws IOException {
         this.mapIndexInfo = in.readObject();
         this.loaded = in.readBoolean();
         this.stats = new LocalRecordStoreStatsImpl();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunkContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunkContext.java
@@ -42,8 +42,6 @@ import java.util.Set;
 
 public class MapChunkContext {
 
-    protected Iterator<Map.Entry<Data, Record>> iterator;
-
     private final int partitionId;
     private final String mapName;
     private final SerializationService ss;
@@ -53,6 +51,7 @@ public class MapChunkContext {
     private final LocalMapStatsImpl mapStats;
 
     private ServiceNamespace serviceNamespace;
+    private Iterator<Map.Entry<Data, Record>> iterator;
 
     public MapChunkContext(MapServiceContext mapServiceContext,
                            int partitionId, ServiceNamespace namespaces) {
@@ -64,6 +63,7 @@ public class MapChunkContext {
         this.expirySystem = recordStore.getExpirySystem();
         this.ss = mapServiceContext.getNodeEngine().getSerializationService();
         this.mapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(mapName);
+        setIterator(recordStore.iterator());
     }
 
     public ILogger getLogger(String className) {
@@ -74,7 +74,6 @@ public class MapChunkContext {
     private RecordStore getRecordStore(String mapName) {
         return mapServiceContext.getRecordStore(partitionId, mapName, true);
     }
-
     public boolean hasMoreChunks() {
         beforeOperation();
         try {
@@ -93,6 +92,10 @@ public class MapChunkContext {
             iterator = recordStore.iterator();
         }
         return iterator;
+    }
+
+    protected void setIterator(Iterator<Map.Entry<Data, Record>> iterator) {
+        this.iterator = iterator;
     }
 
     public RecordStore getRecordStore() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
@@ -60,7 +60,7 @@ public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
         this.mapReplicationOperation = mapReplicationOperation;
     }
 
-    void prepare(PartitionContainer container, Collection<ServiceNamespace> namespaces, int replicaIndex) {
+    void prepare(PartitionContainer container, Collection<ServiceNamespace> namespaces) {
         MapService mapService = container.getMapService();
 
         MetaDataGenerator metaData = getPartitionMetaDataGenerator(mapService);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -62,7 +62,7 @@ public class MapReplicationOperation extends Operation
 
         this.mapNearCacheStateHolder = new MapNearCacheStateHolder();
         this.mapNearCacheStateHolder.setMapReplicationOperation(this);
-        this.mapNearCacheStateHolder.prepare(container, namespaces, replicaIndex);
+        this.mapNearCacheStateHolder.prepare(container, namespaces);
     }
 
     @Override
@@ -74,7 +74,8 @@ public class MapReplicationOperation extends Operation
                 mapNearCacheStateHolder.applyState();
             }
         } catch (Throwable e) {
-            getLogger().severe("map replication operation failed for partitionId=" + getPartitionId(), e);
+            getLogger().severe("map replication operation failed for partitionId="
+                    + getPartitionId(), e);
 
             disposePartition();
 


### PR DESCRIPTION
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/4606

**Issue:**
This line checks if there is still any chunk to send: https://github.com/hazelcast/hazelcast/blob/a872b65cfe691e7babad6c7bc9b3b7c1976ef85d/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java#L310
The issue is about iterator's usage, in the line above we are checking remaining chunks by using iterator and this checking can happen outside of a partition thread.

**Modifications:**
- This is the main fix which sets volatile reference to force visibility:https://github.com/hazelcast/hazelcast/pull/20506/files#diff-8c96de91401a3b71473a7937218591a8a55baf50043a88e8bcf0fe2e8428c7a4R403. The reason of setting iterator again is to make internal state of the iterator also visible. Making only reference volatile is not sufficient in this case. By re-setting iterator, we're doing a volatile write to make all state before it visible for other threads.

- Other changes are refactoring to share common functionality. Goal of this refactoring is not to repeat same fix in multiple places. 


