### PR TITLE
Fix SqlErrorTest.testTimeout failure

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorAbstractTest.java
@@ -67,17 +67,16 @@ public abstract class SqlErrorAbstractTest extends SqlTestSupport {
         return smallInstanceConfig();
     }
 
-    protected void checkTimeout(boolean useClient, int dataSetSize) {
+    protected void checkTimeout(boolean useClient) {
         // Start two instances and fill them with data
         instance1 = newHazelcastInstance(false);
         instance2 = newHazelcastInstance(true);
         client = newClient();
 
-        createMapping(instance1, MAP_NAME, long.class, long.class);
-        populate(instance1, dataSetSize);
-
         // Execute query on the instance1.
-        HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query().setTimeoutMillis(1L));
+        SqlStatement query = new SqlStatement("select v from table(generate_stream(1))")
+                .setTimeoutMillis(1L);
+        HazelcastSqlException error = assertSqlException(useClient ? client : instance1, query);
         assertTrue(error.getMessage().contains("CANCEL_FORCEFUL"));
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorClientTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorClientTest.java
@@ -88,12 +88,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
     @Test
     public void testTimeout_execute() {
-        checkTimeout(true, DEFAULT_CURSOR_BUFFER_SIZE);
-    }
-
-    @Test
-    public void testTimeout_fetch() {
-        checkTimeout(true, DEFAULT_CURSOR_BUFFER_SIZE * 4);
+        checkTimeout(true);
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorTest.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.jet.sql.SqlTestSupport.awaitSingleRunningJob;
-import static com.hazelcast.sql.SqlStatement.DEFAULT_CURSOR_BUFFER_SIZE;
 import static junit.framework.TestCase.assertEquals;
 
 /**
@@ -42,7 +40,7 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
 
     @Test
     public void testTimeout() {
-        checkTimeout(false, DEFAULT_CURSOR_BUFFER_SIZE);
+        checkTimeout(false);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlStatement.java
@@ -32,10 +32,16 @@ import java.util.Objects;
  * Changes to properties do not affect the behavior of already running statements.
  */
 public final class SqlStatement {
-    /** Value for the timeout that is not set. */
+    /**
+     * Value for the timeout that is not set. The value of {@link
+     * SqlConfig#setStatementTimeoutMillis} will be used.
+     */
     public static final long TIMEOUT_NOT_SET = -1;
 
-    /** Value for the timeout that is disabled. */
+    /**
+     * Value for the timeout that is disabled, meaning there's no time limit to
+     * run a query.
+     */
     public static final long TIMEOUT_DISABLED = 0;
 
     /** Default timeout. */


### PR DESCRIPTION
The test used a batch source and a timeout of 1ms. It could happen that the
query completes under 1ms, in which case the test fails. It's easy to reproduce
in the original code by increasing the timeout.

The fix is to use a streaming source. I also removed the `testTimeout_fetch()`
method because it's not simple to implement and there's no difference in code -
it's communicated to the caller when iterating the SqlResult on the member, and
that's the same code handling both `execute` and `fetch` client messages.

Fixes #20011
