### PR TITLE
Revert "Make Compact format little endian"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InputOutputFactory.java
@@ -36,13 +36,7 @@ public interface InputOutputFactory {
                                       InternalSerializationService service,
                                       boolean isCompatibility);
 
-    BufferObjectDataInput createInput(byte[] buffer,
-                                      InternalSerializationService service,
-                                      boolean isCompatibility, ByteOrder byteOrder);
-
     BufferObjectDataOutput createOutput(int size, InternalSerializationService service);
-
-    BufferObjectDataOutput createOutput(int size, InternalSerializationService service, ByteOrder byteOrder);
 
     ByteOrder getByteOrder();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -83,15 +83,11 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     BufferObjectDataInput createObjectDataInput(byte[] data);
 
-    BufferObjectDataInput createObjectDataInput(byte[] data, ByteOrder byteOrder);
-
     BufferObjectDataInput createObjectDataInput(byte[] data, int offset);
 
     BufferObjectDataInput createObjectDataInput(Data data);
 
     BufferObjectDataOutput createObjectDataOutput(int size);
-
-    BufferObjectDataOutput createObjectDataOutput(ByteOrder byteOrder);
 
     BufferObjectDataOutput createObjectDataOutput();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -123,9 +123,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         CompactSerializationConfig compactSerializationCfg = builder.compactSerializationConfig == null
                 ? new CompactSerializationConfig() : builder.compactSerializationConfig;
         compactStreamSerializer = new CompactStreamSerializer(compactSerializationCfg,
-                managedContext, builder.schemaService, classLoader,
-                bytes -> createObjectDataInput(bytes, ByteOrder.LITTLE_ENDIAN),
-                () -> createObjectDataOutput(ByteOrder.LITTLE_ENDIAN));
+                managedContext, builder.schemaService, classLoader, this::createObjectDataInput, this::createObjectDataOutput);
         this.compactWithSchemaSerializerAdapter = new CompactWithSchemaStreamSerializerAdapter(compactStreamSerializer);
         this.compactSerializerAdapter = new CompactStreamSerializerAdapter(compactStreamSerializer);
     }
@@ -389,11 +387,6 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     @Override
-    public final BufferObjectDataInput createObjectDataInput(byte[] data, ByteOrder byteOrder) {
-        return inputOutputFactory.createInput(data, this, isCompatibility, byteOrder);
-    }
-
-    @Override
     public final BufferObjectDataInput createObjectDataInput(byte[] data, int offset) {
         return inputOutputFactory.createInput(data, offset, this, isCompatibility);
     }
@@ -406,11 +399,6 @@ public abstract class AbstractSerializationService implements InternalSerializat
     @Override
     public final BufferObjectDataOutput createObjectDataOutput(int size) {
         return inputOutputFactory.createOutput(size, this);
-    }
-
-    @Override
-    public final BufferObjectDataOutput createObjectDataOutput(ByteOrder byteOrder) {
-        return inputOutputFactory.createOutput(outputBufferSize, this, byteOrder);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
@@ -55,18 +55,7 @@ final class ByteArrayInputOutputFactory implements InputOutputFactory {
     }
 
     @Override
-    public BufferObjectDataInput createInput(byte[] buffer, InternalSerializationService service,
-                                             boolean isCompatibility, ByteOrder byteOrder) {
-        return new ByteArrayObjectDataInput(buffer, service, byteOrder, isCompatibility);
-    }
-
-    @Override
     public BufferObjectDataOutput createOutput(int size, InternalSerializationService service) {
-        return new ByteArrayObjectDataOutput(size, service, byteOrder);
-    }
-
-    @Override
-    public BufferObjectDataOutput createOutput(int size, InternalSerializationService service, ByteOrder byteOrder) {
         return new ByteArrayObjectDataOutput(size, service, byteOrder);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeInputOutputFactory.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.serialization.InputOutputFactory;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.serialization.InputOutputFactory;
-import com.hazelcast.internal.serialization.InternalSerializationService;
 
 import java.nio.ByteOrder;
 
@@ -49,31 +49,8 @@ final class UnsafeInputOutputFactory implements InputOutputFactory {
     }
 
     @Override
-    public BufferObjectDataInput createInput(byte[] buffer, InternalSerializationService service,
-                                             boolean isCompatibility, ByteOrder byteOrder) {
-        //if explicitly selected byte order is same as nativeOrder we can use unsafe.
-        //otherwise we fallback to safe one
-        if (byteOrder == ByteOrder.nativeOrder()) {
-            return new UnsafeObjectDataInput(buffer, 0, service, isCompatibility);
-        } else {
-            return new ByteArrayObjectDataInput(buffer, 0, service, byteOrder, isCompatibility);
-        }
-    }
-
-    @Override
     public BufferObjectDataOutput createOutput(int size, InternalSerializationService service) {
         return new UnsafeObjectDataOutput(size, service);
-    }
-
-    @Override
-    public BufferObjectDataOutput createOutput(int size, InternalSerializationService service, ByteOrder byteOrder) {
-        //if explicitly selected byte order is same as nativeOrder we can use unsafe.
-        //otherwise we fallback to safe one
-        if (byteOrder == ByteOrder.nativeOrder()) {
-            return new UnsafeObjectDataOutput(size, service);
-        } else {
-            return new ByteArrayObjectDataOutput(size, service, byteOrder);
-        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -155,11 +155,6 @@ public class SamplingSerializationService implements InternalSerializationServic
     }
 
     @Override
-    public BufferObjectDataInput createObjectDataInput(byte[] data, ByteOrder byteOrder) {
-        return delegate.createObjectDataInput(data, byteOrder);
-    }
-
-    @Override
     public BufferObjectDataInput createObjectDataInput(byte[] data, int offset) {
         return delegate.createObjectDataInput(data, offset);
     }
@@ -172,11 +167,6 @@ public class SamplingSerializationService implements InternalSerializationServic
     @Override
     public BufferObjectDataOutput createObjectDataOutput(int size) {
         return delegate.createObjectDataOutput(size);
-    }
-
-    @Override
-    public BufferObjectDataOutput createObjectDataOutput(ByteOrder byteOrder) {
-        return createObjectDataOutput(byteOrder);
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 796d4703f78a9ad09d48a7a5db442c178c02ccdd.

Little endian for compact was not implemented properly. After seeing that properly implementing it will infect lots of code, we decided not to change the behaviour for compact only. Compact will work as all the existing serializers work. They respect the endianness setting in the SerializationConfig. 