### PR TITLE
Add docker note to config error messages

### DIFF
--- a/distribution/src/bin-filemode-755/hz-cluster-admin
+++ b/distribution/src/bin-filemode-755/hz-cluster-admin
@@ -7,7 +7,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "- Change member config using JAVA API: config.getNetworkConfig().getRestApiConfig().setEnabled(true);"
     echo "- Change XML/YAML configuration property: hazelcast.network.rest-api.enabled to true"
     echo "- Add system property: -Dhz.network.rest-api.enabled=true"
-    echo "- Add environment variable property: HZ_NETWORK_RESTAPI_ENABLED=true"
+    echo "- Add environment variable property: HZ_NETWORK_RESTAPI_ENABLED=true (recommended when running container/docker image)"
     echo " A command may fail with a message like"
     echo "'REST endpoint group is not enabled - CP'."
     echo "In that case you must change the cluster's configuration to enable"
@@ -16,7 +16,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "- Change member config using JAVA API: config.getNetworkConfig().getRestApiConfig().enableGroups(RestEndpointGroup.CP);"
     echo "- Change XML/YAML configuration property: hazelcast.network.rest-api.endpoint-group CP with `enabled` set to true"
     echo "- Add system property: -Dhz.network.rest-api.endpoint-groups.cp.enabled=true"
-    echo "- Add environment variable property: HZ_NETWORK_RESTAPI_ENDPOINTGROUPS.CP.ENABLED=true"
+    echo "- Add environment variable property: HZ_NETWORK_RESTAPI_ENDPOINTGROUPS.CP.ENABLED=true (recommended when running container/docker image)"
     echo
     echo "Parameters:"
     echo "  -o, --operation    : Specifies the operation to perform, one of 'get-state', 'change-state',"

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiFilter.java
@@ -49,13 +49,14 @@ public class RestApiFilter implements TextProtocolFilter {
                 String name = restEndpointGroup.name();
                 connection.close("REST endpoint group is not enabled - " + restEndpointGroup
                         + ". To enable it, please do one of the following:\n"
-                        + "- Change member config using JAVA API: "
+                        + "  - Change member config using JAVA API: "
                         + " config.getNetworkConfig().getRestApiConfig().enableGroups(RestEndpointGroup." + name + ");\n"
-                        + "- Change XML/YAML configuration property: "
+                        + "  - Change XML/YAML configuration property: "
                         + "hazelcast.network.rest-api.endpoint-group " + name + " with `enabled` set to true\n"
-                        + "- Add system property: "
-                        + "-Dhz.network.rest-api.endpoint-groups." + name.toLowerCase() + ".enabled=true\n"
-                        + "- Add environment variable property: HZ_NETWORK_RESTAPI_ENDPOINTGROUPS." + name + ".ENABLED=true",
+                        + "  - Add system property: "
+                        + "  -Dhz.network.rest-api.endpoint-groups." + name.toLowerCase() + ".enabled=true\n"
+                        + "  - Add environment variable property: HZ_NETWORK_RESTAPI_ENDPOINTGROUPS." + name + ".ENABLED=true"
+                        + " (recommended when running container/docker image)",
                         null);
             }
         } else if (!commandLine.isEmpty()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
@@ -109,7 +109,8 @@ public class UnifiedProtocolDecoder
                             + "config.getNetworkConfig().getRestApiConfig().setEnabled(true);\n"
                             + "- Change XML/YAML configuration property: hazelcast.network.rest-api.enabled to true\n"
                             + "- Add system property: -Dhz.network.rest-api.enabled=true\n"
-                            + "- Add environment variable property: HZ_NETWORK_RESTAPI_ENABLED=true");
+                            + "- Add environment variable property: HZ_NETWORK_RESTAPI_ENABLED=true"
+                            + " (recommended when running container/docker image)");
                 }
                 initChannelForText(protocol, true);
             } else if (MemcacheTextDecoder.TEXT_PARSERS.isCommandPrefix(protocol)) {
@@ -122,7 +123,8 @@ public class UnifiedProtocolDecoder
                             + "- Change XML/YAML configuration property: "
                             + "hazelcast.network.memcache-protocol.enabled to true\n"
                             + "- Add system property: -Dhz.network.memcache-protocol.enabled=true\n"
-                            + "- Add environment variable property: HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED=true");
+                            + "- Add environment variable property: HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED=true"
+                            + " (recommended when running container/docker image)");
                 }
                 // text doesn't have a protocol; anything that isn't cluster/client protocol will be interpreted as txt.
                 initChannelForText(protocol, false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentService.java
@@ -75,7 +75,8 @@ public final class UserCodeDeploymentService implements ManagedService {
                     + "config.getUserCodeDeploymentConfig().setEnabled(true);\n"
                     + "- Change XML/YAML configuration property: Set hazelcast.user-code-deployment.enabled to true\n"
                     + "- Add system property: -Dhz.user-code-deployment.enabled=true\n"
-                    + "- Add environment variable: HZ_USERCODEDEPLOYMENT_ENABLED=true");
+                    + "- Add environment variable: HZ_USERCODEDEPLOYMENT_ENABLED=true"
+                    + " (recommended when running container/docker image)");
         }
         locator.defineClassesFromClient(classDefinitions);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -104,7 +104,8 @@ public final class Util {
             "  - Change member config using Java API: %s;\n" +
                     "  - Change XML/YAML configuration property: Set %s\n" +
                     "  - Add system property: %s\n" +
-                    "  - Add environment variable: %s";
+                    "  - Add environment variable: %s" +
+                    " (recommended when running container/docker image)";
 
     public static final String JET_IS_DISABLED_MESSAGE = "The Jet engine is disabled.\n" +
             "To enable the Jet engine on the members, please do one of the following:\n" +


### PR DESCRIPTION
Users using container/docker might be confused about Java config, Yaml
and system properties suggestions and might try e.g. to add yaml file
configuration, while the easiest for them is to set environment
property.

EE counter part done in https://github.com/hazelcast/hazelcast-enterprise/pull/4614

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
