### PR TITLE
Fix the issue on deserialization of kinesis source [HZ-815]

### DIFF
--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/KinesisSources.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/KinesisSources.java
@@ -327,6 +327,9 @@ public final class KinesisSources {
     }
 
     private static class DefaultProjection<T> implements BiFunctionEx<Record, Shard, T> {
+
+        private static final long serialVersionUID = 1L;
+
         @Override
         public T applyEx(Record record, Shard shard) {
             return (T) entry(record.getPartitionKey(), toArray(record));

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/KinesisSources.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/KinesisSources.java
@@ -166,7 +166,9 @@ public final class KinesisSources {
 
         private Builder(@Nonnull String stream) {
             this.stream = stream;
-            this.projectionFn = (record, shard) -> (T) entry(record.getPartitionKey(), toArray(record, shard));
+            // Don't use lambda here since serialization/deserialization of the lambda gets corrupted
+            // after relocating aws classes
+            this.projectionFn = new DefaultProjection<>();
         }
 
         /**
@@ -322,8 +324,15 @@ public final class KinesisSources {
                     eventTimePolicy -> new KinesisSourcePMetaSupplier<T>(awsConfig, stream, retryStrategy,
                             initialShardIterators, eventTimePolicy, projectionFn));
         }
+    }
 
-        private static byte[] toArray(Record record, Shard shard) {
+    private static class DefaultProjection<T> implements BiFunctionEx<Record, Shard, T> {
+        @Override
+        public T applyEx(Record record, Shard shard) {
+            return (T) entry(record.getPartitionKey(), toArray(record));
+        }
+
+        private static byte[] toArray(Record record) {
             ByteBuffer buffer = record.getData();
             int position = buffer.position();
             int limit = buffer.limit();
@@ -334,5 +343,4 @@ public final class KinesisSources {
             }
         }
     }
-
 }


### PR DESCRIPTION
The default `projectionFn` lambda, https://github.com/hazelcast/hazelcast/blob/master/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/KinesisSources.java#L169, was getting corrupted after relocating the
`com.amazonaws.services.kinesis.model.Record`, `com.amazonaws.services.kinesis.model.Shard`
 classes during shading. I have extracted that lambda to a class so the relocator can also
properly relocate its parameters.

Fixes #20351

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
