### PR TITLE
Don't run Kinesis tests when Docker is not available

### DIFF
--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -74,12 +74,9 @@ public class KinesisFailureTest extends AbstractKinesisTest {
     }
 
     @BeforeClass
-    public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
-    }
-
-    @BeforeClass
     public static void beforeClass() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))
                 .withNetwork(NETWORK)
@@ -107,7 +104,9 @@ public class KinesisFailureTest extends AbstractKinesisTest {
 
     @AfterClass
     public static void afterClass() {
-        KINESIS.shutdown();
+        if (KINESIS != null) {
+            KINESIS.shutdown();
+        }
 
         if (toxiProxy != null) {
             toxiProxy.stop();

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -60,17 +60,9 @@ public class KinesisFailureTest extends AbstractKinesisTest {
     @ClassRule
     public static final Network NETWORK = Network.newNetwork();
 
-    @ClassRule
-    public static final LocalStackContainer LOCALSTACK = new LocalStackContainer(parse("localstack/localstack")
-            .withTag("0.12.3"))
-            .withNetwork(NETWORK)
-            .withServices(Service.KINESIS);
+    public static LocalStackContainer localStack;
 
-    @ClassRule
-    public static final ToxiproxyContainer TOXIPROXY = new ToxiproxyContainer(parse("shopify/toxiproxy")
-            .withTag("2.1.0"))
-            .withNetwork(NETWORK)
-            .withNetworkAliases("toxiproxy");
+    public static ToxiproxyContainer toxiProxy;
 
     private static AwsConfig AWS_CONFIG;
     private static AmazonKinesisAsync KINESIS;
@@ -88,16 +80,27 @@ public class KinesisFailureTest extends AbstractKinesisTest {
 
     @BeforeClass
     public static void beforeClass() {
+        localStack = new LocalStackContainer(parse("localstack/localstack")
+                .withTag("0.12.3"))
+                .withNetwork(NETWORK)
+                .withServices(Service.KINESIS);
+        localStack.start();
+        toxiProxy = new ToxiproxyContainer(parse("shopify/toxiproxy")
+                .withTag("2.1.0"))
+                .withNetwork(NETWORK)
+                .withNetworkAliases("toxiproxy");
+        toxiProxy.start();
+
         System.setProperty(SDKGlobalConfiguration.AWS_CBOR_DISABLE_SYSTEM_PROPERTY, "true");
         // with the jackson versions we use (2.11.x) Localstack doesn't without disabling CBOR
         // https://github.com/localstack/localstack/issues/3208
 
-        PROXY = TOXIPROXY.getProxy(LOCALSTACK, 4566);
+        PROXY = toxiProxy.getProxy(localStack, 4566);
 
         AWS_CONFIG = new AwsConfig()
                 .withEndpoint("http://" + PROXY.getContainerIpAddress() + ":" + PROXY.getProxyPort())
-                .withRegion(LOCALSTACK.getRegion())
-                .withCredentials(LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey());
+                .withRegion(localStack.getRegion())
+                .withCredentials(localStack.getAccessKey(), localStack.getSecretKey());
         KINESIS = AWS_CONFIG.buildClient();
         HELPER = new KinesisTestHelper(KINESIS, STREAM, Logger.getLogger(KinesisIntegrationTest.class));
     }
@@ -105,6 +108,13 @@ public class KinesisFailureTest extends AbstractKinesisTest {
     @AfterClass
     public static void afterClass() {
         KINESIS.shutdown();
+
+        if (toxiProxy != null) {
+            toxiProxy.stop();
+        }
+        if (localStack != null) {
+            localStack.stop();
+        }
     }
 
     @Test

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
@@ -36,7 +36,6 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
@@ -80,12 +80,9 @@ public class KinesisIntegrationTest extends AbstractKinesisTest {
     }
 
     @BeforeClass
-    public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
-    }
-
-    @BeforeClass
     public static void beforeClass() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))
                 .withServices(Service.KINESIS);
@@ -117,7 +114,9 @@ public class KinesisIntegrationTest extends AbstractKinesisTest {
 
     @AfterClass
     public static void afterClass() {
-        KINESIS.shutdown();
+        if (KINESIS != null) {
+            KINESIS.shutdown();
+        }
 
         if (localStack != null) {
             localStack.stop();


### PR DESCRIPTION
@ClassRule runs before @BeforeClass, so the containers were started
before the check for available Docker environment could skip the test.

Fixes #20025

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
