### PR TITLE
Remove ParallelJVMTest from JobSubmissionSlownessRegressionTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -46,7 +46,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SlowTest.class, IgnoredForCoverage.class, ParallelJVMTest.class})
+@Category({SlowTest.class, IgnoredForCoverage.class})
 public final class JobSubmissionSlownessRegressionTest extends JetTestSupport {
 
     private static final int DURATION_SECS = 10;

--- a/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.test.IgnoredForCoverage;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
The test submits as many jobs as it can during a period of time. If
other CPU intensive tests run at the same time this will inevitably
reduce the rate, causing the test to fail.

It is still possible that other jobs on the machine may affect the test,
but it is less likely.

Fixes #19658
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
