### PR TITLE
Support jar: scheme in JCache URI config [HZ-821]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
@@ -91,6 +91,7 @@ public abstract class AbstractHazelcastCachingProvider implements CachingProvide
         supportedSchemes.add("file");
         supportedSchemes.add("http");
         supportedSchemes.add("https");
+        supportedSchemes.add("jar");
         SUPPORTED_SCHEMES = unmodifiableSet(supportedSchemes);
     }
 
@@ -265,7 +266,7 @@ public abstract class AbstractHazelcastCachingProvider implements CachingProvide
         URL configURL;
         if ("classpath".equals(scheme)) {
             configURL = classLoader.getResource(location.getRawSchemeSpecificPart());
-        } else if ("file".equals(scheme) || "http".equals(scheme) || "https".equals(scheme)) {
+        } else if ("file".equals(scheme) || "http".equals(scheme) || "https".equals(scheme) || "jar".equals(scheme)) {
             configURL = location.toURL();
         } else {
             throw new URISyntaxException(location.toString(), "Unsupported protocol in configuration location URL");

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.HazelcastCachingProvider;
-import com.hazelcast.cache.impl.HazelcastServerCacheManager;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -17,8 +17,10 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;
 import com.hazelcast.client.cache.jsr.JsrClientTestUtil;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.CacheConfig;
@@ -29,6 +31,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.JarUtil;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -40,6 +43,7 @@ import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -49,6 +53,8 @@ import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.TestEnvironment.isSolaris;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -100,6 +106,23 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
         cacheManager.close();
 
         assertEquals(0, HazelcastClient.getAllHazelcastClients().size());
+    }
+
+    @Test
+    public void cacheCacheManagerByLocationJarFileTest() throws Exception {
+        File jcacheConfigFile = File.createTempFile("jcache_config_", ".jar");
+        JarUtil.createJarFile(
+                "src/test/resources/",
+                newArrayList("hazelcast-client-c1.xml"),
+                jcacheConfigFile.getAbsolutePath()
+        );
+
+        URI uri = new URI("jar:file:" + jcacheConfigFile.getAbsolutePath() + "!/hazelcast-client-c1.xml");
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager(uri, null, new Properties());
+        assertThat(cacheManager).isNotNull();
+
+        HazelcastClientCacheManager clientCacheManager = cacheManager.unwrap(HazelcastClientCacheManager.class);
+        assertThat(clientCacheManager.getHazelcastInstance().getName()).isEqualTo("client-cluster1");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.jsr.JsrTestUtil;
@@ -28,9 +29,11 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.JarUtil;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
@@ -51,6 +54,7 @@ import javax.cache.integration.CacheLoaderException;
 import javax.cache.integration.CacheWriter;
 import javax.cache.integration.CacheWriterException;
 import javax.cache.spi.CachingProvider;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -65,6 +69,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -354,6 +360,23 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
         Cache<Integer, String> testCache = cacheManager.getCache("testCache", Integer.class, String.class);
         assertNotNull(testCache);
+    }
+
+    @Test
+    public void cacheCacheManagerByLocationJarFileTest() throws Exception {
+        File jcacheConfigFile = File.createTempFile("jcache_config_", ".jar");
+        JarUtil.createJarFile(
+                "src/test/resources/",
+                newArrayList("test-hazelcast-jcache.xml"),
+                jcacheConfigFile.getAbsolutePath()
+        );
+
+        URI uri = new URI("jar:file:" + jcacheConfigFile.getAbsolutePath() + "!/test-hazelcast-jcache.xml");
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager(uri, null, new Properties());
+        assertThat(cacheManager).isNotNull();
+
+        HazelcastServerCacheManager serverCacheManager = cacheManager.unwrap(HazelcastServerCacheManager.class);
+        assertThat(serverCacheManager.getHazelcastInstance().getName()).isEqualTo("test-hazelcast-jcache");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
-import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/resources/hazelcast-client-c1.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-c1.xml
@@ -20,6 +20,7 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.1.xsd">
 
+    <instance-name>client-cluster1</instance-name>
     <cluster-name>cluster1</cluster-name>
 
     <network>


### PR DESCRIPTION
This solves 2 similar issues both reported in #17051:

- config stored inside packaged Spring Boot application, where the URI
is e.g. `jar:file:/.../app.jar!/BOOT-INF/classes!/hazelcast.xml`

- config stored inside a jar nested in Spring Boot application jar,
where the URI is e.g.
`jar:file:/.../app.jar!/BOOT-INF/lib/nested.jar!/hazelcast.xml`

Fixes #17051

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible