### PR TITLE
Fixing tasklet complete performance

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -44,6 +44,7 @@ import static com.hazelcast.map.impl.OwnedEntryCostEstimatorFactory.createMapSiz
  */
 public class StorageImpl<R extends Record> implements Storage<Data, R> {
 
+    public static final int ADDITIONAL_ENTRIES_CAPACITY = 20;
     private final StorageSCHM<R> records;
     private final SerializationService serializationService;
     private final InMemoryFormat inMemoryFormat;
@@ -157,7 +158,7 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
 
     @Override
     public MapEntriesWithCursor fetchEntries(IterationPointer[] pointers, int size) {
-        List<Map.Entry<Data, R>> entries = new ArrayList<>(size);
+        List<Map.Entry<Data, R>> entries = new ArrayList<>(size + ADDITIONAL_ENTRIES_CAPACITY);
         IterationPointer[] newPointers = records.fetchEntries(pointers, size, entries);
         List<Map.Entry<Data, Data>> entriesData = new ArrayList<>(entries.size());
         for (Map.Entry<Data, R> entry : entries) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -43,8 +43,8 @@ import static com.hazelcast.map.impl.OwnedEntryCostEstimatorFactory.createMapSiz
  * @param <R> the value type to be put in this storage.
  */
 public class StorageImpl<R extends Record> implements Storage<Data, R> {
+    private static final int ADDITIONAL_ENTRIES_CAPACITY = 20;
 
-    public static final int ADDITIONAL_ENTRIES_CAPACITY = 20;
     private final StorageSCHM<R> records;
     private final SerializationService serializationService;
     private final InMemoryFormat inMemoryFormat;


### PR DESCRIPTION
The issue is that the method ```com.hazelcast.internal.util.SampleableConcurrentHashMap#fetchEntries``` can add to ```ArrayList``` ```at least {@code size} keys```, so the initial size is not enough from time to time. It is visible in benchamrk profiling output:

![image](https://user-images.githubusercontent.com/57556371/151770802-8330065a-d88b-4114-b860-4d9592dfa746.png)

The purple method is ```ArrayList.grow```.

The additional capacity ```20``` was chosen by looking at the list capacity after the ```fetch``` ended.