### PR TITLE
Fix SqlErrorTest.testCancel failure

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorAbstractTest.java
@@ -122,14 +122,10 @@ public abstract class SqlErrorAbstractTest extends SqlTestSupport {
         instance1 = newHazelcastInstance(true);
         client = newClient();
 
-        createMapping(instance1, MAP_NAME, long.class, long.class);
-        IMap<Long, Long> map = instance1.getMap(MAP_NAME);
-        map.put(1L, 1L);
-        map.put(2L, 2L);
-
         HazelcastInstance target = useClient ? client : instance1;
 
-        try (SqlResult res = target.getSql().execute(query().setCursorBufferSize(1))) {
+        try (SqlResult res = target.getSql().execute("select * from table(generate_stream(1))")) {
+            sleepSeconds(1);
             res.close();
 
             try {


### PR DESCRIPTION
It was a test issue. The SqlResult is automatically closed when the backing job
completes (for member cursors) or when all rows are fetched (for client cursor).
A close from the client after that is ignored.

A sleep inserted before `res.close()` reproduced the issue (only for member,
because for client the fetch size was set to 1 and the client would never have
fetched all rows at that point).

Fixed by replacing the query with a streaming one.

Fixes #20336