### PR TITLE
Fix NPE in getAllConnections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/Connection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/Connection.java
@@ -97,8 +97,15 @@ public interface Connection {
 
     /**
      * Gets the {@link UUID} of the other side of this connection.
-     * It can be null if the other side of connection is not hz
-     * member or client (e.g. REST client)
+     * The remote UUID of the connection set is not immediately
+     * available after the connection is created.
+     * For the member connections, it's set during the
+     * {@link com.hazelcast.internal.cluster.impl.MemberHandshake} processing
+     * For the client connections, it's set after client
+     * authentication is performed.
+     * If the other side of connection is not Hazelcast member or
+     * native client (when the other side of connection is MEMCACHED
+     * or REST client), this method always returns null.
      * @return the uuid of the remote endpoint of the connection.
      */
     @Nullable

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/ServerConnectionManager.java
@@ -134,12 +134,15 @@ public interface ServerConnectionManager
     ServerConnection get(@Nonnull Address address, int streamId);
 
     /**
-     * Gets all the connections for a given address on all planes. If
-     * there is no connection exist on any plane, it returns an
-     * empty list.
+     * Returns all the registered connections that belong to the given address.
+     * Note that this method doesn't return the member connections whose
+     * {@link com.hazelcast.internal.cluster.impl.MemberHandshake} aren't
+     * processed yet and the client connections whose authentications aren't
+     * yet completed. If there is no registered connection exists for the given
+     * address, it returns an empty list.
      *
      * @param address the address of connections
-     * @return the list of connections to the given address or an
+     * @return the list of connections that belong to the given address or an
      * empty list if one doesn't exist
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -133,10 +134,8 @@ public class TcpServerConnectionManager extends TcpServerConnectionManagerBase
         // we don't keep all duplicates on the planes, we need to iterate over
         // connections set which stores all active connections.
         return instanceUuid != null
-                ? connections.stream().filter(connection -> {
-                    UUID remoteUuid = connection.getRemoteUuid();
-                    return remoteUuid != null && remoteUuid.equals(instanceUuid);
-                }).collect(Collectors.toList())
+                ? connections.stream().filter(connection -> Objects.equals(instanceUuid, connection.getRemoteUuid()))
+                                      .collect(Collectors.toList())
                 : Collections.emptyList();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -128,13 +128,15 @@ public class TcpServerConnectionManager extends TcpServerConnectionManagerBase
     @Override
     @Nonnull
     public List<ServerConnection> getAllConnections(@Nonnull Address address) {
-        UUID uuid = addressRegistry.uuidOf(address);
+        UUID instanceUuid = addressRegistry.uuidOf(address);
         // Because duplicate connections can be established on the planes and
         // we don't keep all duplicates on the planes, we need to iterate over
         // connections set which stores all active connections.
-        return uuid != null
-                ? connections.stream().filter(connection -> connection.getRemoteUuid().equals(uuid))
-                                      .collect(Collectors.toList())
+        return instanceUuid != null
+                ? connections.stream().filter(connection -> {
+                    UUID remoteUuid = connection.getRemoteUuid();
+                    return remoteUuid != null && remoteUuid.equals(instanceUuid);
+                }).collect(Collectors.toList())
                 : Collections.emptyList();
     }
 


### PR DESCRIPTION
In this commit: https://github.com/hazelcast/hazelcast/commit/0a077a0b79bbc8309c5e994696f6a89f1c77569c, I missed the fact that the `remoteUUID` of some of the connections being iterated on the
 `connection` set may be null 🤦 . This PR fixes this NPE issue. 


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible