### PR TITLE
Move checkstyle plugin run from validate to process-sources phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
                 <version>${maven.checkstyle.plugin.version}</version>
                 <executions>
                     <execution>
-                        <phase>validate</phase>
+                        <phase>process-sources</phase>
                         <goals>
                             <goal>checkstyle</goal>
                         </goals>


### PR DESCRIPTION
This PR fixes the doubled checkstyle plugin execution by moving it from the `validate` phase to an earlier one.

I'm not sure which plugin is causing the trouble in our case, but the problem seems to be lifecycle forking in a plugin we use.
It's described in this comment: https://github.com/fabric8io/docker-maven-plugin/issues/567#issuecomment-249639945