### PR TITLE
Send compact schemas urgently during cluster changes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientSchemaService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientSchemaService.java
@@ -104,6 +104,6 @@ public class ClientSchemaService implements SchemaService {
         }
         ClientMessage clientMessage = ClientSendAllSchemasCodec.encodeRequest(new ArrayList<>(schemas.values()));
         ClientInvocation invocation = new ClientInvocation(client, clientMessage, SERVICE_NAME);
-        invocation.invoke().joinInternal();
+        invocation.invokeUrgent().joinInternal();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/CompactFormatIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/CompactFormatIntegrationTest.java
@@ -199,9 +199,10 @@ public abstract class CompactFormatIntegrationTest extends HazelcastTestSupport 
 
         restartCluster();
 
-        IMap<Integer, EmployeeDTO> map2 = instance2.getMap("test");
-        map2.put(1, employeeDTO);
-        assertEquals(employeeDTO, map2.get(1));
+        map.put(1, employeeDTO);
+        assertEquals(employeeDTO, map.get(1));
+        // Perform a query to make sure that the schema is available on the cluster
+        assertEquals(1, map.values(Predicates.sql("age == 30")).size());
     }
 
     protected abstract void restartCluster();


### PR DESCRIPTION
We send the compact schemas we have on the client to the new cluster
we connect while the client is in the `CONNECTED_TO_CLUSTER` state.

During that state, normal invocations are not allowed, as the client
has not finished sending its state to the cluster.

So, in the remote operations we do during that state, we have to
invoke them as urgently, otherwise they won't be allowed to run.

However, we were not doing that in the `ClientSchemaService#sendAllSchemas`
method, which is part of the data the client must send to the cluster.

This PR fixes that problem.

We had a test(`testClusterRestart`) where we were checking the cluster restart
case, but the test was using a different client after the restart. The first
client was desperately retrying sending state to the cluster but failing to
do so.

I have also fixed the test by using the same client instance.