### PR TITLE
Add test and warning for duplicate Kafka topics

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -65,9 +65,9 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
     Map<TopicPartition, Integer> currentAssignment = new HashMap<>();
 
     private final Properties properties;
-    private final List<String> topics;
     private final FunctionEx<? super ConsumerRecord<K, V>, ? extends T> projectionFn;
     private final EventTimeMapper<? super T> eventTimeMapper;
+    private List<String> topics;
     private int totalParallelism;
 
     private KafkaConsumer<K, V> consumer;
@@ -105,6 +105,11 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
 
     @Override
     protected void init(@Nonnull Context context) {
+        List<String> uniqueTopics = topics.stream().distinct().collect(Collectors.toList());
+        if (uniqueTopics.size() != topics.size()) {
+            getLogger().warning("Duplicate topics found in topic list: " + topics);
+        }
+        topics = uniqueTopics;
         processorIndex = context.globalProcessorIndex();
         totalParallelism = context.totalParallelism();
         consumer = new KafkaConsumer<>(properties);

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -107,6 +107,10 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
     protected void init(@Nonnull Context context) {
         List<String> uniqueTopics = topics.stream().distinct().collect(Collectors.toList());
         if (uniqueTopics.size() != topics.size()) {
+            List<String> topics = new ArrayList<>(this.topics);
+            for (String t : uniqueTopics) {
+                topics.remove(t); // removes only first element
+            }
             getLogger().warning("Duplicate topics found in topic list: " + topics);
         }
         topics = uniqueTopics;

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -344,9 +344,10 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
         IList<Object> list = instances[0].getList("sink");
         try {
+            // Wait for all messages
             assertTrueEventually(() -> assertThat(list).hasSize(messageCount), 15);
-            sleepSeconds(1);
-            assertThat(list).hasSize(messageCount);
+            // Check there are no more messages (duplicates..)
+            assertTrueAllTheTime(() -> assertThat(list).hasSize(messageCount), 1);
         } finally {
             job.cancel();
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1174,13 +1174,16 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void assertTrueAllTheTime(AssertTask task, long durationSeconds) {
-        for (int i = 0; i < durationSeconds; i++) {
+        for (int i = 0; i <= durationSeconds; i++) {
             try {
                 task.run();
             } catch (Exception e) {
                 throw rethrow(e);
             }
-            sleepSeconds(1);
+            // Don't wait if there is not next iteration
+            if ((i + 1) <= durationSeconds) {
+                sleepSeconds(1);
+            }
         }
     }
 


### PR DESCRIPTION
Relates to #19948

The issue seems to be fixed by
https://github.com/hazelcast/hazelcast-jet/pull/2732. Before this commit
this test reliably fails. After it I couldn't reproduce it with
various different partition counts etc.

Adding the test to catch any future regressions and a log warning that
duplicate topics were specified. This usually means mis-configuration.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
