### PR TITLE
Throw an unsupported exception when calling addWanReplicationConfig method on DynamicConfiguration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -345,7 +345,7 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public Config addWanReplicationConfig(WanReplicationConfig wanReplicationConfig) {
-        return super.addWanReplicationConfig(wanReplicationConfig);
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -862,7 +862,7 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addWanReplicationConfig(WanReplicationConfig wanReplicationConfig) {
-        return staticConfig.addWanReplicationConfig(wanReplicationConfig);
+        throw new UnsupportedOperationException("Unsupported operation");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -60,6 +60,7 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.TopicConfig;
+import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
@@ -121,6 +122,12 @@ public class DynamicConfigTest extends HazelcastTestSupport {
 
     protected HazelcastInstance getDriver() {
         return members[members.length - 1];
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAddWanReplicationConfigIsNotSupported() {
+        WanReplicationConfig wanReplicationConfig = new WanReplicationConfig();
+        getDriver().getConfig().addWanReplicationConfig(wanReplicationConfig);
     }
 
     @Test


### PR DESCRIPTION
Dynamic configuration works only for adding new data structure configuration; so some of the add*Config don’t really add the configuration.
As a result, a user wouldn't know that invoking `hazelcastInstance.getConfig().addWanReplicationConfig(...)` does effectively nothing.

This PR fixes `ClientDynamicClusterConfig#addWanReplicationConfig` and `DynamicConfigurationAwareConfig#addWanReplicationConfig` behaviour by throwing `UnsupportedOperationException`.

Related issue: #20437
