### PR TITLE
Implement missing delegate methods

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/FirewallingServer.java
@@ -80,7 +80,6 @@ public class FirewallingServer
         return delegate.getConnections();
     }
 
-
     @Override
     public void addConnectionListener(ConnectionListener listener) {
         delegate.addConnectionListener(listener);
@@ -271,6 +270,10 @@ public class FirewallingServer
             return delegate.getConnections();
         }
 
+        @Override
+        public int connectionCount() {
+            return delegate.connectionCount();
+        }
 
         @Override
         public ServerConnection get(@Nonnull Address address, int streamId) {
@@ -295,6 +298,12 @@ public class FirewallingServer
         @Override
         public synchronized ServerConnection getOrConnect(@Nonnull Address address, int streamId) {
             return wrap(delegate.getOrConnect(address, streamId));
+        }
+
+        @Override
+        public boolean blockOnConnect(Address address,
+                                      long timeoutMillis, int streamId) throws InterruptedException {
+            return delegate.blockOnConnect(address, timeoutMillis, streamId);
         }
 
         @Override


### PR DESCRIPTION
stumbled upon during test failure investigations...

**Modification:**
Added missing delegate methods, otherwise default methods was being called. 