### PR TITLE
[HZ-875] Fix MembershipFailureTest#slave_receives_member_list_from_non_master

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -21,9 +21,14 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigAccessor;
+import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.OperationService;
+import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
@@ -333,15 +338,17 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void slave_receives_member_list_from_non_master() {
+    public void slave_receives_member_list_from_non_master() throws InterruptedException {
         String infiniteTimeout = Integer.toString(Integer.MAX_VALUE);
         Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), infiniteTimeout)
                 .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        CountDownLatch latchSlave2 = new CountDownLatch(1);
+        CountDownLatch latchSlave3 = new CountDownLatch(1);
 
         HazelcastInstance master = newHazelcastInstance(config);
         HazelcastInstance slave1 = newHazelcastInstance(config);
-        HazelcastInstance slave2 = newHazelcastInstance(config);
-        HazelcastInstance slave3 = newHazelcastInstance(config);
+        HazelcastInstance slave2 = newHazelcastInstance(getConfigWithLatchService(latchSlave2));
+        HazelcastInstance slave3 = newHazelcastInstance(getConfigWithLatchService(latchSlave3));
 
         assertClusterSize(4, master, slave3);
         assertClusterSizeEventually(4, slave1, slave2);
@@ -350,6 +357,15 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         dropOperationsFrom(slave1, F_ID, singletonList(HEARTBEAT));
         dropOperationsFrom(slave2, F_ID, singletonList(HEARTBEAT));
         dropOperationsFrom(slave3, F_ID, singletonList(HEARTBEAT));
+
+        // To make sure that there is not pending/remaining heartbeat operations left in slave2
+        // and slave3, we're sending new urgent operations to these members that will be processed
+        // after those remaining heartbeats and then waiting for them to be processed.
+        OperationService operationService = getNode(master).getNodeEngine().getOperationService();
+        operationService.send(new UrgentOperationAwaitOn(), getNode(slave2).address);
+        operationService.send(new UrgentOperationAwaitOn(), getNode(slave3).address);
+        latchSlave2.await();
+        latchSlave3.await();
 
         suspectMember(slave2, master);
         suspectMember(slave2, slave1);
@@ -896,5 +912,45 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
     Collection<HazelcastInstance> getAllHazelcastInstances() {
         return factory.getAllHazelcastInstances();
+    }
+
+    private static class LatchService {
+        static final String SERVICE_NAME = "latch-service";
+
+        final CountDownLatch latch;
+
+        private LatchService(CountDownLatch latch) {
+            this.latch = latch;
+        }
+    }
+
+    private static class UrgentOperationAwaitOn extends Operation implements UrgentSystemOperation {
+        @Override
+        public void run() throws Exception {
+            LatchService service = getService();
+            service.latch.countDown();
+            getLogger().info("Count down on latch");
+        }
+
+        @Override
+        public String getServiceName() {
+            return LatchService.SERVICE_NAME;
+        }
+
+        @Override
+        public boolean returnsResponse(){
+            return false;
+        }
+    }
+
+    private Config getConfigWithLatchService(CountDownLatch latch) {
+        String infiniteTimeout = Integer.toString(Integer.MAX_VALUE);
+        Config config = smallInstanceConfig().setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), infiniteTimeout)
+                .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        LatchService latchService = new LatchService(latch);
+        ServiceConfig serviceConfig = new ServiceConfig().setEnabled(true)
+                .setName(LatchService.SERVICE_NAME).setImplementation(latchService);
+        ConfigAccessor.getServicesConfig(config).addServiceConfig(serviceConfig);
+        return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -69,6 +69,7 @@ import static com.hazelcast.spi.properties.ClusterProperty.MERGE_NEXT_RUN_DELAY_
 import static com.hazelcast.spi.properties.ClusterProperty.PARTIAL_MEMBER_DISCONNECTION_RESOLUTION_HEARTBEAT_COUNT;
 import static com.hazelcast.test.Accessors.getAddress;
 import static com.hazelcast.test.Accessors.getNode;
+import static com.hazelcast.test.Accessors.getOperationService;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
 import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
@@ -361,10 +362,10 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         // To make sure that there is not pending/remaining heartbeat operations left in slave2
         // and slave3, we're sending new urgent operations to these members that will be processed
         // after those remaining heartbeats and then waiting for them to be processed.
-        OperationService masterOperationService = getNode(master).getNodeEngine().getOperationService();
+        OperationService masterOperationService = getOperationService(master);
         masterOperationService.send(new UrgentOperationAwaitOn(), getNode(slave2).address);
         masterOperationService.send(new UrgentOperationAwaitOn(), getNode(slave3).address);
-        OperationService slave1OperationService = getNode(slave1).getNodeEngine().getOperationService();
+        OperationService slave1OperationService = getOperationService(slave1);
         slave1OperationService.send(new UrgentOperationAwaitOn(), getNode(slave2).address);
         slave1OperationService.send(new UrgentOperationAwaitOn(), getNode(slave3).address);
 


### PR DESCRIPTION
The failing reason for the test is described here: https://github.com/hazelcast/hazelcast/issues/20553#issuecomment-1027832486. 
Formerly, we had a race condition between the blocking of heartbeat
packets and member suspicion processes in this test. Fixed the issue by
waiting for the completion of heartbeat packets processing. This
synchronization based on the fact that urgent operations are processed
in the receiving order on a member with default configuration which has
only 1 priority thread and only single connection used while sending these
packets.

Btw, I detected that this retry mechanism breaks our assumptions: https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServer.java#L339-L342. 
Even after we add the drop filter, heartbeat packets can be sent via connection
with this way, so we can't say that latest heartbeat message has sent before our
urgent operations.
Apart from that, the urgent ops can also be scheduled to run on normal generic
threads. I could solve this by setting the generic thread count to 1 and the priority
generic thread count to 0, but I couldn't know how to block the packet retry.


Fixes https://github.com/hazelcast/hazelcast/issues/20553

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
