### PR TITLE
Revert the Bump animal-sniffer-maven-plugin from 1.19 to 1.21 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
         <maven.dependency.plugin.version>3.2.0</maven.dependency.plugin.version>
-        <maven.animal.sniffer.plugin.version>1.21</maven.animal.sniffer.plugin.version>
+        <maven.animal.sniffer.plugin.version>1.19</maven.animal.sniffer.plugin.version>
         <maven.git.commit.id.plugin.version>4.9.10</maven.git.commit.id.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>


### PR DESCRIPTION
Reverts #20567 as it breaks Java 11+ builds
