### PR TITLE
Export com.ibm.lang.management.internal to access metrics

### DIFF
--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -39,6 +39,7 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
     JDK_OPTS="\
         --add-modules java.se \
         --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
+        --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED \
         --add-opens java.base/java.lang=ALL-UNNAMED \
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
         --add-opens java.management/sun.management=ALL-UNNAMED \

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -36,7 +36,7 @@ if NOT "%MAX_HEAP_SIZE%" == "" (
 FOR /F "tokens=* USEBACKQ" %%F IN (`CALL "%RUN_JAVA%" -cp "%HAZELCAST_HOME%\lib\hazelcast-${project.version}.jar" com.hazelcast.internal.util.JavaVersion`) DO SET JAVA_VERSION=%%F
 
 IF NOT "%JAVA_VERSION%" == "8" (
-	set JAVA_OPTS=%JAVA_OPTS% --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+	set JAVA_OPTS=%JAVA_OPTS% --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports jdk.management/com.ibm.lang.management.internal=ALL_UNNAMED
 )
 
 REM HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).

--- a/distribution/src/main/java/com/hazelcast/commandline/HazelcastServerCommandLine.java
+++ b/distribution/src/main/java/com/hazelcast/commandline/HazelcastServerCommandLine.java
@@ -206,6 +206,8 @@ public class HazelcastServerCommandLine {
             commandList.add("java.se");
             commandList.add("--add-exports");
             commandList.add("java.base/jdk.internal.ref=ALL-UNNAMED");
+            commandList.add("--add-exports");
+            commandList.add("jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED");
             commandList.add("--add-opens");
             commandList.add("java.base/java.lang=ALL-UNNAMED");
             commandList.add("--add-opens");

--- a/distribution/src/test/java/com/hazelcast/commandline/HazelcastServerCommandLineTest.java
+++ b/distribution/src/test/java/com/hazelcast/commandline/HazelcastServerCommandLineTest.java
@@ -167,7 +167,9 @@ public class HazelcastServerCommandLineTest {
         hazelcastServerCommandLine.start(null, null, null, null, null, false, false, false);
         // then
         verify(processExecutor).buildAndStart((List<String>) argThat(
-                Matchers.hasItems("--add-modules", "java.se", "--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
+                Matchers.hasItems("--add-modules", "java.se",
+                        "--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
+                        "--add-exports", "jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED",
                         "--add-opens", "java.base/java.lang=ALL-UNNAMED",
                         "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens",
                         "java.management/sun.management=ALL-UNNAMED", "--add-opens",

--- a/pom.xml
+++ b/pom.xml
@@ -1241,6 +1241,7 @@
                 <!--
                 Allow access to Operating system metrics:
                    open jdk.management/com.sun.management.internal
+                   export jdk.management/com.ibm.lang.management.internal
 
                 Avoid warnings caused by reflection in
                 SelectorOptimizer:
@@ -1260,6 +1261,7 @@
                     --add-opens java.base/java.lang=${hazelcast.module.name}
                     --add-opens java.management/sun.management=${hazelcast.module.name}
                     --add-exports java.xml/jdk.xml.internal=${hazelcast.module.name}
+                    --add-exports jdk.management/com.ibm.lang.management.internal=${hazelcast.module.name}
                     --illegal-access=deny
                 </javaModuleArgs>
             </properties>


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/20521
closes https://github.com/hazelcast/hazelcast/issues/20522

on EE: https://github.com/hazelcast/hazelcast-enterprise/pull/4658

**Issue:**
- Tests are failing on IBM semeru 16 and 17 since `com.ibm.lang.management.internal` package is not accessible.
```
java.lang.reflect.InaccessibleObjectException: Unable to make public long com.ibm.lang.management.internal.ExtendedOperatingSystemMXBeanImpl.getCommittedVirtualMemorySize() accessible: module jdk.management does not "exports com.ibm.lang.management.internal" to unnamed module
```

**Modification:**
- Exported `com.ibm.lang.management.internal` package.