### PR TITLE
Add utility method to collect service namespaces

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -18,14 +18,14 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.internal.eviction.ExpirationManager;
+import com.hazelcast.internal.partition.impl.NameSpaceUtil;
+import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
@@ -192,21 +192,19 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
     }
 
     public Collection<ServiceNamespace> getNamespaces(Predicate<CacheConfig> predicate, int replicaIndex) {
-        if (recordStores.isEmpty()) {
-            return Collections.emptyList();
-        }
+        return NameSpaceUtil.getAllNamespaces(recordStores,
+                new NameSpaceUtil.ServiceQuestioner<ICacheRecordStore>() {
+                    @Override
+                    public boolean test(ICacheRecordStore recordStore) {
+                        CacheConfig cacheConfig = recordStore.getConfig();
+                        return recordStore.getConfig().getTotalBackupCount() < replicaIndex
+                                || !predicate.test(cacheConfig);
+                    }
 
-        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
-        for (ICacheRecordStore recordStore : recordStores.values()) {
-            CacheConfig cacheConfig = recordStore.getConfig();
-            if (recordStore.getConfig().getTotalBackupCount() >= replicaIndex
-                && predicate.test(cacheConfig)) {
-                if (namespaces == Collections.EMPTY_LIST) {
-                    namespaces = new LinkedList<>();
-                }
-                namespaces.add(recordStore.getObjectNamespace());
-            }
-        }
-        return namespaces;
+                    @Override
+                    public ObjectNamespace apply(ICacheRecordStore recordStore) {
+                        return recordStore.getObjectNamespace();
+                    }
+                });
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.internal.eviction.ExpirationManager;
 import com.hazelcast.internal.partition.impl.NameSpaceUtil;
-import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
@@ -193,18 +192,10 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
 
     public Collection<ServiceNamespace> getNamespaces(Predicate<CacheConfig> predicate, int replicaIndex) {
         return NameSpaceUtil.getAllNamespaces(recordStores,
-                new NameSpaceUtil.ServiceQuestioner<ICacheRecordStore>() {
-                    @Override
-                    public boolean test(ICacheRecordStore recordStore) {
-                        CacheConfig cacheConfig = recordStore.getConfig();
-                        return recordStore.getConfig().getTotalBackupCount() < replicaIndex
-                                || !predicate.test(cacheConfig);
-                    }
-
-                    @Override
-                    public ObjectNamespace apply(ICacheRecordStore recordStore) {
-                        return recordStore.getObjectNamespace();
-                    }
-                });
+                recordStore -> {
+                    CacheConfig cacheConfig = recordStore.getConfig();
+                    return recordStore.getConfig().getTotalBackupCount() < replicaIndex
+                            || !predicate.test(cacheConfig);
+                }, ICacheRecordStore::getObjectNamespace);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -194,8 +194,8 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
         return NameSpaceUtil.getAllNamespaces(recordStores,
                 recordStore -> {
                     CacheConfig cacheConfig = recordStore.getConfig();
-                    return recordStore.getConfig().getTotalBackupCount() < replicaIndex
-                            || !predicate.test(cacheConfig);
+                    return recordStore.getConfig().getTotalBackupCount() >= replicaIndex
+                            && predicate.test(cacheConfig);
                 }, ICacheRecordStore::getObjectNamespace);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.locksupport;
 
+import com.hazelcast.internal.partition.impl.NameSpaceUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
@@ -29,7 +30,6 @@ import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -106,23 +106,17 @@ public final class LockStoreContainer {
     }
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
-        if (lockStores.isEmpty()) {
-            return Collections.EMPTY_LIST;
-        }
+        return NameSpaceUtil.getAllNamespaces(lockStores,
+                new NameSpaceUtil.ServiceQuestioner<LockStoreImpl>() {
+                    @Override
+                    public boolean test(LockStoreImpl lockStore) {
+                        return lockStore.getTotalBackupCount() < replicaIndex;
+                    }
 
-        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
-        for (LockStoreImpl lockStore : lockStores.values()) {
-            if (lockStore.getTotalBackupCount() < replicaIndex) {
-                continue;
-            }
-
-            if (namespaces == Collections.EMPTY_LIST) {
-                namespaces = new LinkedList<>();
-            }
-
-            namespaces.add(lockStore.getNamespace());
-        }
-
-        return namespaces;
+                    @Override
+                    public ObjectNamespace apply(LockStoreImpl lockStore) {
+                        return lockStore.getNamespace();
+                    }
+                });
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
@@ -107,7 +107,7 @@ public final class LockStoreContainer {
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
         return NameSpaceUtil.getAllNamespaces(lockStores,
-                lockStore -> lockStore.getTotalBackupCount() < replicaIndex,
+                lockStore -> lockStore.getTotalBackupCount() >= replicaIndex,
                 LockStoreImpl::getNamespace);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreContainer.java
@@ -107,16 +107,7 @@ public final class LockStoreContainer {
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
         return NameSpaceUtil.getAllNamespaces(lockStores,
-                new NameSpaceUtil.ServiceQuestioner<LockStoreImpl>() {
-                    @Override
-                    public boolean test(LockStoreImpl lockStore) {
-                        return lockStore.getTotalBackupCount() < replicaIndex;
-                    }
-
-                    @Override
-                    public ObjectNamespace apply(LockStoreImpl lockStore) {
-                        return lockStore.getNamespace();
-                    }
-                });
+                lockStore -> lockStore.getTotalBackupCount() < replicaIndex,
+                LockStoreImpl::getNamespace);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
@@ -38,18 +38,19 @@ public final class NameSpaceUtil {
     }
 
     public static <T> Collection<ServiceNamespace> getAllNamespaces(Map<?, T> containers,
-                                                                    ServiceQuestioner<T> function) {
+                                                                    Predicate<T> containerFilter,
+                                                                    Function<T, ObjectNamespace> toNamespace) {
         if (MapUtil.isNullOrEmpty(containers)) {
             return Collections.emptySet();
         }
 
         Collection<ServiceNamespace> collection = Collections.emptySet();
         for (T container : containers.values()) {
-            if (function.test(container)) {
+            if (containerFilter.test(container)) {
                 continue;
             }
 
-            ObjectNamespace namespace = function.apply(container);
+            ObjectNamespace namespace = toNamespace.apply(container);
 
             if (collection.isEmpty()) {
                 collection = singleton(namespace);
@@ -67,20 +68,5 @@ public final class NameSpaceUtil {
         }
 
         return collection;
-    }
-
-    /**
-     * Questions services with 2 questions:
-     * <p>
-     * <lu>
-     * <li>Which containers must be collected?</li>
-     * <li>What is your ObjectNamespace?</li>
-     * </lu>
-     *
-     * @param <T> type of containers
-     */
-    public interface ServiceQuestioner<T>
-            extends Predicate<T>, Function<T, ObjectNamespace> {
-
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
@@ -37,6 +37,13 @@ public final class NameSpaceUtil {
     private NameSpaceUtil() {
     }
 
+    /**
+     * @param containers      collection of all containers in a partition
+     * @param containerFilter allows only matching containers
+     * @param toNamespace     returns {@link ObjectNamespace} for a container
+     *
+     * @return all service namespaces after functions are applied
+     */
     public static <T> Collection<ServiceNamespace> getAllNamespaces(Map<?, T> containers,
                                                                     Predicate<T> containerFilter,
                                                                     Function<T, ObjectNamespace> toNamespace) {
@@ -46,7 +53,7 @@ public final class NameSpaceUtil {
 
         Collection<ServiceNamespace> collection = Collections.emptySet();
         for (T container : containers.values()) {
-            if (containerFilter.test(container)) {
+            if (!containerFilter.test(container)) {
                 continue;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.impl;
+
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.internal.util.MapUtil;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.Collections.singleton;
+
+/**
+ * Helper class for retrieving ServiceNamespace objects.
+ */
+public final class NameSpaceUtil {
+
+    private NameSpaceUtil() {
+    }
+
+    public static <T> Collection<ServiceNamespace> getAllNamespaces(Map<?, T> containers,
+                                                                    ServiceQuestioner<T> function) {
+        if (MapUtil.isNullOrEmpty(containers)) {
+            return Collections.emptySet();
+        }
+
+        Collection<ServiceNamespace> collection = Collections.emptySet();
+        for (T container : containers.values()) {
+            if (function.test(container)) {
+                continue;
+            }
+
+            ObjectNamespace namespace = function.apply(container);
+
+            if (collection.isEmpty()) {
+                collection = singleton(namespace);
+                continue;
+            }
+
+            if (collection.size() == 1) {
+                // previous is an immutable singleton set
+                collection = new HashSet<>(collection);
+                collection.add(namespace);
+                continue;
+            }
+
+            collection.add(namespace);
+        }
+
+        return collection;
+    }
+
+    /**
+     * Questions services with 2 questions:
+     * <p>
+     * <lu>
+     * <li>Which containers must be collected?</li>
+     * <li>What is your ObjectNamespace?</li>
+     * </lu>
+     *
+     * @param <T> type of containers
+     */
+    public interface ServiceQuestioner<T>
+            extends Predicate<T>, Function<T, ObjectNamespace> {
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -132,8 +132,7 @@ public class PartitionContainer {
         return NameSpaceUtil.getAllNamespaces(maps, recordStore -> {
             MapContainer mapContainer = recordStore.getMapContainer();
             MapConfig mapConfig = mapContainer.getMapConfig();
-            return mapConfig.getTotalBackupCount() < replicaIndex
-                    || !predicate.test(mapConfig);
+            return mapConfig.getTotalBackupCount() >= replicaIndex && predicate.test(mapConfig);
         }, recordStore -> recordStore.getMapContainer().getObjectNamespace());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.eviction.ExpirationManager;
 import com.hazelcast.internal.locksupport.LockSupportService;
 import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.partition.impl.NameSpaceUtil;
 import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.ConcurrencyUtil;
@@ -38,7 +39,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
@@ -129,27 +129,22 @@ public class PartitionContainer {
     }
 
     public Collection<ServiceNamespace> getNamespaces(Predicate<MapConfig> predicate, int replicaIndex) {
-        if (maps.isEmpty()) {
-            return Collections.emptyList();
-        }
+        return NameSpaceUtil.getAllNamespaces(maps,
+                new NameSpaceUtil.ServiceQuestioner<RecordStore>() {
+                    @Override
+                    public boolean test(RecordStore recordStore) {
+                        MapContainer mapContainer = recordStore.getMapContainer();
+                        MapConfig mapConfig = mapContainer.getMapConfig();
 
-        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
-        for (RecordStore recordStore : maps.values()) {
-            MapContainer mapContainer = recordStore.getMapContainer();
-            MapConfig mapConfig = mapContainer.getMapConfig();
+                        return mapConfig.getTotalBackupCount() < replicaIndex
+                                || !predicate.test(mapConfig);
+                    }
 
-            if (mapConfig.getTotalBackupCount() < replicaIndex
-                    || !predicate.test(mapConfig)) {
-                continue;
-            }
-
-            if (namespaces == Collections.EMPTY_LIST) {
-                namespaces = new LinkedList<>();
-            }
-            namespaces.add(mapContainer.getObjectNamespace());
-        }
-
-        return namespaces;
+                    @Override
+                    public ObjectNamespace apply(RecordStore recordStore) {
+                        return recordStore.getMapContainer().getObjectNamespace();
+                    }
+                });
     }
 
     public int getPartitionId() {
@@ -161,7 +156,8 @@ public class PartitionContainer {
     }
 
     public RecordStore getRecordStore(String name) {
-        return ConcurrencyUtil.getOrPutSynchronized(maps, name, contextMutexFactory, recordStoreConstructor);
+        return ConcurrencyUtil.getOrPutSynchronized(maps, name,
+                contextMutexFactory, recordStoreConstructor);
     }
 
     public RecordStore getRecordStore(String name, boolean skipLoadingOnCreate) {
@@ -170,7 +166,8 @@ public class PartitionContainer {
     }
 
     public RecordStore getRecordStoreForHotRestart(String name) {
-        return ConcurrencyUtil.getOrPutSynchronized(maps, name, contextMutexFactory, recordStoreConstructorForHotRestart);
+        return ConcurrencyUtil.getOrPutSynchronized(maps, name,
+                contextMutexFactory, recordStoreConstructorForHotRestart);
     }
 
     @Nullable
@@ -179,9 +176,12 @@ public class PartitionContainer {
     }
 
     public void destroyMap(MapContainer mapContainer) {
-        // Mark map container destroyed before the underlying data structures are destroyed. We need this to ensure that every
-        // reader that observed non-destroyed state may use previously read data. E.g. if the reader returned only Key1 it
-        // is guaranteed that it hadn't missed Key2 because it was destroyed earlier.
+        // Mark map container destroyed before the underlying
+        // data structures are destroyed. We need this to
+        // ensure that every reader that observed non-destroyed
+        // state may use previously read data. E.g. if the
+        // reader returned only Key1 it is guaranteed that it
+        // hadn't missed Key2 because it was destroyed earlier.
         mapContainer.onBeforeDestroy();
 
         String name = mapContainer.getName();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -129,22 +129,12 @@ public class PartitionContainer {
     }
 
     public Collection<ServiceNamespace> getNamespaces(Predicate<MapConfig> predicate, int replicaIndex) {
-        return NameSpaceUtil.getAllNamespaces(maps,
-                new NameSpaceUtil.ServiceQuestioner<RecordStore>() {
-                    @Override
-                    public boolean test(RecordStore recordStore) {
-                        MapContainer mapContainer = recordStore.getMapContainer();
-                        MapConfig mapConfig = mapContainer.getMapConfig();
-
-                        return mapConfig.getTotalBackupCount() < replicaIndex
-                                || !predicate.test(mapConfig);
-                    }
-
-                    @Override
-                    public ObjectNamespace apply(RecordStore recordStore) {
-                        return recordStore.getMapContainer().getObjectNamespace();
-                    }
-                });
+        return NameSpaceUtil.getAllNamespaces(maps, recordStore -> {
+            MapContainer mapContainer = recordStore.getMapContainer();
+            MapConfig mapConfig = mapContainer.getMapConfig();
+            return mapConfig.getTotalBackupCount() < replicaIndex
+                    || !predicate.test(mapConfig);
+        }, recordStore -> recordStore.getMapContainer().getObjectNamespace());
     }
 
     public int getPartitionId() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -19,7 +19,6 @@ package com.hazelcast.multimap.impl;
 import com.hazelcast.internal.locksupport.LockSupportService;
 import com.hazelcast.internal.partition.impl.NameSpaceUtil;
 import com.hazelcast.internal.services.DistributedObjectNamespace;
-import com.hazelcast.internal.services.ObjectNamespace;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ConstructorFunction;
@@ -82,17 +81,8 @@ public class MultiMapPartitionContainer {
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
         return NameSpaceUtil.getAllNamespaces(containerMap,
-                new NameSpaceUtil.ServiceQuestioner<MultiMapContainer>() {
-            @Override
-            public boolean test(MultiMapContainer container) {
-                return container.getConfig().getTotalBackupCount() < replicaIndex;
-            }
-
-            @Override
-            public ObjectNamespace apply(MultiMapContainer container) {
-                return container.getObjectNamespace();
-            }
-        });
+                container -> container.getConfig().getTotalBackupCount() < replicaIndex,
+                MultiMapContainer::getObjectNamespace);
     }
 
     void destroyMultiMap(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -81,7 +81,7 @@ public class MultiMapPartitionContainer {
 
     public Collection<ServiceNamespace> getAllNamespaces(int replicaIndex) {
         return NameSpaceUtil.getAllNamespaces(containerMap,
-                container -> container.getConfig().getTotalBackupCount() < replicaIndex,
+                container -> container.getConfig().getTotalBackupCount() >= replicaIndex,
                 MultiMapContainer::getObjectNamespace);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -307,7 +307,7 @@ public class RingbufferService implements ManagedService, RemoteService, Chunked
         Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
 
         return NameSpaceUtil.getAllNamespaces(partitionContainers,
-                container -> container.getConfig().getTotalBackupCount() < event.getReplicaIndex(),
+                container -> container.getConfig().getTotalBackupCount() >= event.getReplicaIndex(),
                 RingbufferContainer::getNamespace);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.partition.ChunkedMigrationAwareService;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
+import com.hazelcast.internal.partition.impl.NameSpaceUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.services.DistributedObjectNamespace;
@@ -34,7 +35,6 @@ import com.hazelcast.internal.services.SplitBrainHandlerService;
 import com.hazelcast.internal.services.SplitBrainProtectionAwareService;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ContextMutexFactory;
-import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.ringbuffer.impl.operations.MergeOperation;
 import com.hazelcast.ringbuffer.impl.operations.ReplicationOperation;
@@ -49,10 +49,8 @@ import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -308,21 +306,18 @@ public class RingbufferService implements ManagedService, RemoteService, Chunked
         int partitionId = event.getPartitionId();
         Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
 
-        if (MapUtil.isNullOrEmpty(partitionContainers)) {
-            return Collections.EMPTY_LIST;
-        }
+        return NameSpaceUtil.getAllNamespaces(partitionContainers,
+                new NameSpaceUtil.ServiceQuestioner<RingbufferContainer>() {
+                    @Override
+                    public boolean test(RingbufferContainer container) {
+                        return container.getConfig().getTotalBackupCount() < event.getReplicaIndex();
+                    }
 
-        Collection<ServiceNamespace> namespaces = Collections.EMPTY_LIST;
-        for (RingbufferContainer container : partitionContainers.values()) {
-            if (container.getConfig().getTotalBackupCount() < event.getReplicaIndex()) {
-                continue;
-            }
-            if (namespaces == Collections.EMPTY_LIST) {
-                namespaces = new LinkedList<>();
-            }
-            namespaces.add(container.getNamespace());
-        }
-        return namespaces;
+                    @Override
+                    public ObjectNamespace apply(RingbufferContainer container) {
+                        return container.getNamespace();
+                    }
+                });
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -307,17 +307,8 @@ public class RingbufferService implements ManagedService, RemoteService, Chunked
         Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
 
         return NameSpaceUtil.getAllNamespaces(partitionContainers,
-                new NameSpaceUtil.ServiceQuestioner<RingbufferContainer>() {
-                    @Override
-                    public boolean test(RingbufferContainer container) {
-                        return container.getConfig().getTotalBackupCount() < event.getReplicaIndex();
-                    }
-
-                    @Override
-                    public ObjectNamespace apply(RingbufferContainer container) {
-                        return container.getNamespace();
-                    }
-                });
+                container -> container.getConfig().getTotalBackupCount() < event.getReplicaIndex(),
+                RingbufferContainer::getNamespace);
     }
 
     @Override


### PR DESCRIPTION
**Modifications:**
- add utility method to use for the same functionality
- use `set` type since we have many `retainAll` method calls on collections