### PR TITLE
Removing eager deserialization of JSON in SQL/JET

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/extract/HazelcastJsonQueryTarget.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/extract/HazelcastJsonQueryTarget.java
@@ -46,9 +46,10 @@ class HazelcastJsonQueryTarget implements QueryTarget {
     @Override
     public void setTarget(Object target, Data targetData) {
         if (target == null && targetData != null) {
-            target = serializationService.toObject(targetData);
+            this.target = targetData;
+        } else {
+            this.target = target;
         }
-        this.target = target;
     }
 
     @Override


### PR DESCRIPTION
The ```HazelcastJsonQueryTarget``` deserialized a whole JSON object from ```HeapData``` in the constructor:

![image](https://user-images.githubusercontent.com/57556371/152365295-9699f030-ef24-4f83-bcff-d36e35e52162.png)

Benchmark before/after:
![image](https://user-images.githubusercontent.com/57556371/152365793-9bb23509-e2ab-4729-8fad-eb00c55af1a6.png)
