### PR TITLE
Optimize retainAndGetNamespaces() (#19462)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -68,7 +68,7 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
         Collection<FragmentedMigrationAwareService> services
                 = nodeEngine.getServices(FragmentedMigrationAwareService.class);
 
-        Collection<ServiceNamespace> namespaces = new LinkedList<>();
+        Collection<ServiceNamespace> namespaces = new HashSet<>();
         for (FragmentedMigrationAwareService service : services) {
             Collection<ServiceNamespace> serviceNamespaces = service.getAllServiceNamespaces(event);
             if (serviceNamespaces != null) {


### PR DESCRIPTION
During unrelated profiling, this method seems particularly slow. We used
`LinkedList` for a collection which was later used as an argument to
`HashMap.retainAll()`. The implementation iterates the map and executes
`contains()` on the `LinkedList` for each map entry. I don't know the
runtime size of the collection, but it's slow. This PR replaces the
`LinkedList` with a `HashSet`.

(cherry picked from commit bcfd51f52592f6fadf939b5d933ce9a0c1fef3c3)

backport of #19462 to `4.2.z`