### PR TITLE
Fix typo in CompactReader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -230,13 +230,13 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
     }
 
     @Override
-    public byte[] readArrayOInt(@Nonnull String fieldName) {
+    public byte[] readArrayOfInt8(@Nonnull String fieldName) {
         return getArrayOfInt8(fieldName);
     }
 
     @Nullable
     @Override
-    public byte[] readArrayOInt(@Nonnull String fieldName, @Nullable byte[] defaultValue) {
+    public byte[] readArrayOfInt8(@Nonnull String fieldName, @Nullable byte[] defaultValue) {
         return isFieldExists(fieldName, ARRAY_OF_INT8) ? getArrayOfInt8(fieldName) : defaultValue;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -370,7 +370,7 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                 } else if (Byte.TYPE.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8)) {
-                            field.set(o, reader.readArrayOInt(name));
+                            field.set(o, reader.readArrayOfInt8(name));
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfInt8(name, (byte[]) field.get(o));

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -414,7 +414,7 @@ public interface CompactReader {
      *                                         with the one defined in the schema.
      */
     @Nullable
-    byte[] readArrayOInt(@Nonnull String fieldName);
+    byte[] readArrayOfInt8(@Nonnull String fieldName);
 
     /**
      * Reads an array of 8-bit two's complement signed integers or returns the default value.
@@ -426,7 +426,7 @@ public interface CompactReader {
      * @return the value or the default value of the field.
      */
     @Nullable
-    byte[] readArrayOInt(@Nonnull String fieldName, @Nullable byte[] defaultValue);
+    byte[] readArrayOfInt8(@Nonnull String fieldName, @Nullable byte[] defaultValue);
 
     /**
      * Reads an array of 16-bit two's complement signed integers.


### PR DESCRIPTION
Fixes a typo in compact reader

Breaking changes (list specific methods/types/messages):
- none (compact is beta)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
