### PR TITLE
Fix SqlResultImplTest

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlResultImplTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlResultImplTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class SqlResultImplTest extends SqlTestSupport {
 


### PR DESCRIPTION
The tests in this class used a shared cluster, but used
`HazelcastParallelClassRunner`, which made them used in parallel. The stack
trace shows that the `@After` method of `when_closed_then_iteratorFails`
unexpectedly cancelled the job used by
`when_hasNextInterrupted_then_interrupted`, which caused the test failure.

Fixes #20453