### PR TITLE
Remove `getRegistries` API from the CompactSerializationConfig

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -391,19 +391,19 @@ public class TestClientApplicationContext {
                 .getCompactSerializationConfig();
         assertTrue(compactSerializationConfig.isEnabled());
 
-        Map<String, TriTuple<String, String, String>> namedRegistries = CompactSerializationConfigAccessor.getNamedRegistries(compactSerializationConfig);
-        assertEquals(2, namedRegistries.size());
+        Map<String, TriTuple<String, String, String>> namedRegistrations = CompactSerializationConfigAccessor.getNamedRegistrations(compactSerializationConfig);
+        assertEquals(2, namedRegistrations.size());
 
         String reflectivelySerializableClassName = DummyReflectiveSerializable.class.getName();
         TriTuple<String, String, String> reflectiveClassRegistration = TriTuple.of(reflectivelySerializableClassName, reflectivelySerializableClassName, null);
-        TriTuple<String, String, String> actualReflectiveRegistration = namedRegistries.get(reflectivelySerializableClassName);
+        TriTuple<String, String, String> actualReflectiveRegistration = namedRegistrations.get(reflectivelySerializableClassName);
         assertEquals(reflectiveClassRegistration, actualReflectiveRegistration);
 
         String compactSerializableClassName = DummyCompactSerializable.class.getName();
         String compactSerializerClassName = DummyCompactSerializer.class.getName();
         String typeName = "dummy";
         TriTuple<String, String, String> explicitClassRegistration = TriTuple.of(compactSerializableClassName, typeName, compactSerializerClassName);
-        TriTuple<String, String, String> actualExplicitRegistration = namedRegistries.get(typeName);
+        TriTuple<String, String, String> actualExplicitRegistration = namedRegistrations.get(typeName);
         assertEquals(explicitClassRegistration, actualExplicitRegistration);
     }
 

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1189,19 +1189,19 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         CompactSerializationConfig compactSerializationConfig = config.getSerializationConfig().getCompactSerializationConfig();
         assertTrue(compactSerializationConfig.isEnabled());
 
-        Map<String, TriTuple<String, String, String>> namedRegistries = CompactSerializationConfigAccessor.getNamedRegistries(compactSerializationConfig);
-        assertEquals(2, namedRegistries.size());
+        Map<String, TriTuple<String, String, String>> namedRegistrations = CompactSerializationConfigAccessor.getNamedRegistrations(compactSerializationConfig);
+        assertEquals(2, namedRegistrations.size());
 
         String reflectivelySerializableClassName = DummyReflectiveSerializable.class.getName();
         TriTuple<String, String, String> reflectiveClassRegistration = TriTuple.of(reflectivelySerializableClassName, reflectivelySerializableClassName, null);
-        TriTuple<String, String, String> actualReflectiveRegistration = namedRegistries.get(reflectivelySerializableClassName);
+        TriTuple<String, String, String> actualReflectiveRegistration = namedRegistrations.get(reflectivelySerializableClassName);
         assertEquals(reflectiveClassRegistration, actualReflectiveRegistration);
 
         String compactSerializableClassName = DummyCompactSerializable.class.getName();
         String compactSerializerClassName = DummyCompactSerializer.class.getName();
         String typeName = "dummy";
         TriTuple<String, String, String> explicitClassRegistration = TriTuple.of(compactSerializableClassName, typeName, compactSerializerClassName);
-        TriTuple<String, String, String> actualExplicitRegistration = namedRegistries.get(typeName);
+        TriTuple<String, String, String> actualExplicitRegistration = namedRegistrations.get(typeName);
         assertEquals(explicitClassRegistration, actualExplicitRegistration);
     }
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/config/ConfigFactoryTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/config/ConfigFactoryTest.java
@@ -133,7 +133,7 @@ public class ConfigFactoryTest {
         registrations.put("b", registration);
         CompactSerializationConfig config = ConfigFactory.newCompactSerializationConfig(true, registrations);
         assertThat(config.isEnabled()).isTrue();
-        assertThat(CompactSerializationConfigAccessor.getNamedRegistries(config)).isEqualTo(registrations);
+        assertThat(CompactSerializationConfigAccessor.getNamedRegistrations(config)).isEqualTo(registrations);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ConfigFactoryTest {
         registrations.put("a", registration);
         CompactSerializationConfig config = ConfigFactory.newCompactSerializationConfig(true, registrations);
         assertThat(config.isEnabled()).isTrue();
-        assertThat(CompactSerializationConfigAccessor.getNamedRegistries(config)).isEqualTo(registrations);
+        assertThat(CompactSerializationConfigAccessor.getNamedRegistrations(config)).isEqualTo(registrations);
     }
 
     private static void invalidEvictionConfig(boolean isNearCache, boolean isIMap) {

--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -316,12 +316,13 @@ public final class ClientConfigXmlGenerator {
 
         gen.open("compact-serialization", "enabled", compactSerializationConfig.isEnabled());
 
-        Map<String, TriTuple<Class, String, CompactSerializer>> registries = compactSerializationConfig.getRegistries();
+        Map<String, TriTuple<Class, String, CompactSerializer>> registrations
+                = CompactSerializationConfigAccessor.getRegistrations(compactSerializationConfig);
         Map<String, TriTuple<String, String, String>> namedRegistries
-                = CompactSerializationConfigAccessor.getNamedRegistries(compactSerializationConfig);
-        if (!MapUtil.isNullOrEmpty(registries) || !MapUtil.isNullOrEmpty(namedRegistries)) {
+                = CompactSerializationConfigAccessor.getNamedRegistrations(compactSerializationConfig);
+        if (!MapUtil.isNullOrEmpty(registrations) || !MapUtil.isNullOrEmpty(namedRegistries)) {
             gen.open("registered-classes");
-            appendRegisteredClasses(gen, registries);
+            appendRegisteredClasses(gen, registrations);
             appendNamedRegisteredClasses(gen, namedRegistries);
             gen.close();
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfig.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.serialization.compact.CompactWriter;
 import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;

--- a/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfig.java
@@ -58,25 +58,25 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 public class CompactSerializationConfig {
 
     // Package-private to access those via CompactSerializationConfigAccessor
-    final Map<String, TriTuple<String, String, String>> typeNameToNamedRegistryMap;
-    final Map<String, TriTuple<String, String, String>> classNameToNamedRegistryMap;
+    final Map<String, TriTuple<String, String, String>> typeNameToNamedRegistration;
+    final Map<String, TriTuple<String, String, String>> classNameToNamedRegistration;
+    final Map<String, TriTuple<Class, String, CompactSerializer>> typeNameToRegistration;
+    final Map<Class, TriTuple<Class, String, CompactSerializer>> classToRegistration;
 
-    private final Map<String, TriTuple<Class, String, CompactSerializer>> typeNameToRegistryMap;
-    private final Map<Class, TriTuple<Class, String, CompactSerializer>> classToRegistryMap;
     private boolean enabled;
 
     public CompactSerializationConfig() {
-        this.typeNameToRegistryMap = new ConcurrentHashMap<>();
-        this.classToRegistryMap = new ConcurrentHashMap<>();
-        this.typeNameToNamedRegistryMap = new ConcurrentHashMap<>();
-        this.classNameToNamedRegistryMap = new ConcurrentHashMap<>();
+        this.typeNameToRegistration = new ConcurrentHashMap<>();
+        this.classToRegistration = new ConcurrentHashMap<>();
+        this.typeNameToNamedRegistration = new ConcurrentHashMap<>();
+        this.classNameToNamedRegistration = new ConcurrentHashMap<>();
     }
 
     public CompactSerializationConfig(CompactSerializationConfig compactSerializationConfig) {
-        this.typeNameToRegistryMap = new ConcurrentHashMap<>(compactSerializationConfig.typeNameToRegistryMap);
-        this.classToRegistryMap = new ConcurrentHashMap<>(compactSerializationConfig.classToRegistryMap);
-        this.typeNameToNamedRegistryMap = new ConcurrentHashMap<>(compactSerializationConfig.typeNameToNamedRegistryMap);
-        this.classNameToNamedRegistryMap = new ConcurrentHashMap<>(compactSerializationConfig.classNameToNamedRegistryMap);
+        this.typeNameToRegistration = new ConcurrentHashMap<>(compactSerializationConfig.typeNameToRegistration);
+        this.classToRegistration = new ConcurrentHashMap<>(compactSerializationConfig.classToRegistration);
+        this.typeNameToNamedRegistration = new ConcurrentHashMap<>(compactSerializationConfig.typeNameToNamedRegistration);
+        this.classNameToNamedRegistration = new ConcurrentHashMap<>(compactSerializationConfig.classNameToNamedRegistration);
         this.enabled = compactSerializationConfig.enabled;
     }
 
@@ -118,38 +118,15 @@ public class CompactSerializationConfig {
         return this;
     }
 
-    @Nonnull
-    public Map<String, TriTuple<Class, String, CompactSerializer>> getRegistries() {
-        return Collections.unmodifiableMap(typeNameToRegistryMap);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CompactSerializationConfig that = (CompactSerializationConfig) o;
-        return Objects.equals(typeNameToRegistryMap, that.typeNameToRegistryMap)
-                && Objects.equals(classToRegistryMap, that.classToRegistryMap);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(typeNameToRegistryMap, classToRegistryMap);
-    }
-
     private <T> void register0(Class<T> clazz, String typeName, CompactSerializer<T> explicitSerializer) {
-        TriTuple<Class, String, CompactSerializer> registry = TriTuple.of(clazz, typeName, explicitSerializer);
-        TriTuple<Class, String, CompactSerializer> oldRegistry = typeNameToRegistryMap.putIfAbsent(typeName, registry);
-        if (oldRegistry != null) {
-            throw new InvalidConfigurationException("Already have a registry for the type name " + typeName);
+        TriTuple<Class, String, CompactSerializer> registration = TriTuple.of(clazz, typeName, explicitSerializer);
+        TriTuple<Class, String, CompactSerializer> oldRegistration = typeNameToRegistration.putIfAbsent(typeName, registration);
+        if (oldRegistration != null) {
+            throw new InvalidConfigurationException("Already have a registration for the type name " + typeName);
         }
-        oldRegistry = classToRegistryMap.putIfAbsent(clazz, registry);
-        if (oldRegistry != null) {
-            throw new InvalidConfigurationException("Already have a registry for class " + clazz);
+        oldRegistration = classToRegistration.putIfAbsent(clazz, registration);
+        if (oldRegistration != null) {
+            throw new InvalidConfigurationException("Already have a registration for class " + clazz);
         }
     }
 
@@ -176,5 +153,27 @@ public class CompactSerializationConfig {
     public CompactSerializationConfig setEnabled(boolean enabled) {
         this.enabled = enabled;
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CompactSerializationConfig that = (CompactSerializationConfig) o;
+        return enabled == that.enabled
+                && Objects.equals(typeNameToRegistration, that.typeNameToRegistration)
+                && Objects.equals(classToRegistration, that.classToRegistration)
+                && Objects.equals(typeNameToNamedRegistration, that.typeNameToNamedRegistration)
+                && Objects.equals(classNameToNamedRegistration, that.classNameToNamedRegistration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, typeNameToRegistration, classToRegistration,
+                typeNameToNamedRegistration, classNameToNamedRegistration);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CompactSerializationConfigAccessor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.util.TriTuple;
+import com.hazelcast.nio.serialization.compact.CompactSerializer;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.annotation.PrivateApi;
 
@@ -26,12 +27,15 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
  * An accessor for the package-private fields of the {@link CompactSerializationConfig}.
- *
+ * <p>
  * This is intended to be used while registering explicit and reflective serializers
  * via declarative configuration. This kind of accessor is necessary as the register
  * methods on the {@link CompactSerializationConfig} accepts concrete {@link Class}
  * or {@link com.hazelcast.nio.serialization.compact.CompactSerializer} instances
  * rather than the string representation of the fully qualified class names.
+ * <p>
+ * Also, it enables us to access registered classes using the programmatic API, without
+ * providing a public API on the {@link CompactSerializationConfig}.
  */
 @Beta
 @PrivateApi
@@ -43,49 +47,56 @@ public final class CompactSerializationConfigAccessor {
     /**
      * Registers an explicit compact serializer for the given class and type name.
      */
-     public static void registerExplicitSerializer(CompactSerializationConfig compactSerializationConfig,
-                                                   String className, String typeName,
-                                                   String serializerClassName) {
-         checkNotNull(className, "Class name cannot be null");
-         checkNotNull(typeName, "Type name cannot be null");
-         checkNotNull(serializerClassName, "Explicit serializer class name cannot be null");
-         register(compactSerializationConfig, className, typeName, serializerClassName);
-     }
+    public static void registerExplicitSerializer(CompactSerializationConfig compactSerializationConfig,
+                                                  String className, String typeName,
+                                                  String serializerClassName) {
+        checkNotNull(className, "Class name cannot be null");
+        checkNotNull(typeName, "Type name cannot be null");
+        checkNotNull(serializerClassName, "Explicit serializer class name cannot be null");
+        register(compactSerializationConfig, className, typeName, serializerClassName);
+    }
 
     /**
      * Registers a reflective compact serializer for the given class name.
      * The type name will be the same with the class name.
      */
-     public static void registerReflectiveSerializer(CompactSerializationConfig compactSerializationConfig,
-                                                     String className) {
-         checkNotNull(className, "Class name cannot be null");
-         register(compactSerializationConfig, className, className, null);
-     }
+    public static void registerReflectiveSerializer(CompactSerializationConfig compactSerializationConfig,
+                                                    String className) {
+        checkNotNull(className, "Class name cannot be null");
+        register(compactSerializationConfig, className, className, null);
+    }
 
     /**
      * Returns the map of type names to config registrations.
      */
-     public static Map<String, TriTuple<String, String, String>> getNamedRegistries(
-             CompactSerializationConfig compactSerializationConfig) {
-         return compactSerializationConfig.typeNameToNamedRegistryMap;
-     }
+    public static Map<String, TriTuple<String, String, String>> getNamedRegistrations(
+            CompactSerializationConfig compactSerializationConfig) {
+        return compactSerializationConfig.typeNameToNamedRegistration;
+    }
 
+    /**
+     * Returns the map of the type names to programmatic registrations.
+     */
+    public static Map<String, TriTuple<Class, String, CompactSerializer>> getRegistrations(
+            CompactSerializationConfig compactSerializationConfig) {
+        return compactSerializationConfig.typeNameToRegistration;
+    }
 
     private static void register(CompactSerializationConfig compactSerializationConfig,
-                                  String className, String typeName, String explicitSerializerClassName) {
-         TriTuple<String, String, String> registry = TriTuple.of(className, typeName, explicitSerializerClassName);
-         TriTuple<String, String, String> oldRegistry = compactSerializationConfig
-                 .typeNameToNamedRegistryMap
-                 .putIfAbsent(typeName, registry);
-         if (oldRegistry != null) {
-             throw new InvalidConfigurationException("Already have a registry for the type name " + typeName);
-         }
+                                 String className, String typeName, String explicitSerializerClassName) {
+        TriTuple<String, String, String> registration = TriTuple.of(className, typeName, explicitSerializerClassName);
+        TriTuple<String, String, String> oldRegistration = compactSerializationConfig
+                .typeNameToNamedRegistration
+                .putIfAbsent(typeName, registration);
+        if (oldRegistration != null) {
+            throw new InvalidConfigurationException("Already have a registration for the type name " + typeName);
+        }
 
-         oldRegistry = compactSerializationConfig
-                 .classNameToNamedRegistryMap
-                 .putIfAbsent(className, registry);
-         if (oldRegistry != null) {
-             throw new InvalidConfigurationException("Already have a registry for class name " + className);
-         }
-     }
+        oldRegistration = compactSerializationConfig
+                .classNameToNamedRegistration
+                .putIfAbsent(className, registration);
+        if (oldRegistration != null) {
+            throw new InvalidConfigurationException("Already have a registration for class name " + className);
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -535,9 +535,10 @@ public class ConfigXmlGenerator {
 
         gen.open("compact-serialization", "enabled", compactSerializationConfig.isEnabled());
 
-        Map<String, TriTuple<Class, String, CompactSerializer>> registries = compactSerializationConfig.getRegistries();
+        Map<String, TriTuple<Class, String, CompactSerializer>> registries
+                = CompactSerializationConfigAccessor.getRegistrations(compactSerializationConfig);
         Map<String, TriTuple<String, String, String>> namedRegistries
-                = CompactSerializationConfigAccessor.getNamedRegistries(compactSerializationConfig);
+                = CompactSerializationConfigAccessor.getNamedRegistrations(compactSerializationConfig);
         if (!MapUtil.isNullOrEmpty(registries) || !MapUtil.isNullOrEmpty(namedRegistries)) {
             gen.open("registered-classes");
             appendRegisteredClasses(gen, registries);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -282,21 +282,22 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     }
 
     private void registerConfiguredSerializers(CompactSerializationConfig compactSerializationConfig) {
-        Map<String, TriTuple<Class, String, CompactSerializer>> registries = compactSerializationConfig.getRegistries();
-        for (TriTuple<Class, String, CompactSerializer> registry : registries.values()) {
-            Class clazz = registry.element1;
-            String typeName = registry.element2;
-            CompactSerializer serializer = registry.element3;
+        Map<String, TriTuple<Class, String, CompactSerializer>> registrations
+                = CompactSerializationConfigAccessor.getRegistrations(compactSerializationConfig);
+        for (TriTuple<Class, String, CompactSerializer> registration : registrations.values()) {
+            Class clazz = registration.element1;
+            String typeName = registration.element2;
+            CompactSerializer serializer = registration.element3;
             serializer = serializer == null ? reflectiveSerializer : serializer;
-            CompactSerializableRegistration registration = new CompactSerializableRegistration(clazz, typeName, serializer);
-            classToRegistrationMap.put(clazz, registration);
-            typeNameToRegistrationMap.put(typeName, registration);
+            CompactSerializableRegistration serializableRegistration = new CompactSerializableRegistration(clazz, typeName, serializer);
+            classToRegistrationMap.put(clazz, serializableRegistration);
+            typeNameToRegistrationMap.put(typeName, serializableRegistration);
         }
     }
 
     private void registerConfiguredNamedSerializers(CompactSerializationConfig compactSerializationConfig) {
         Map<String, TriTuple<String, String, String>> namedRegistries
-                = CompactSerializationConfigAccessor.getNamedRegistries(compactSerializationConfig);
+                = CompactSerializationConfigAccessor.getNamedRegistrations(compactSerializationConfig);
         for (TriTuple<String, String, String> registry : namedRegistries.values()) {
             String className = registry.element1;
             String typeName = registry.element2;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -289,7 +289,8 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
             String typeName = registration.element2;
             CompactSerializer serializer = registration.element3;
             serializer = serializer == null ? reflectiveSerializer : serializer;
-            CompactSerializableRegistration serializableRegistration = new CompactSerializableRegistration(clazz, typeName, serializer);
+            CompactSerializableRegistration serializableRegistration
+                    = new CompactSerializableRegistration(clazz, typeName, serializer);
             classToRegistrationMap.put(clazz, serializableRegistration);
             typeNameToRegistrationMap.put(typeName, serializableRegistration);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -405,12 +405,16 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         // Since we don't have APIs of the form register(String) or register(String, String, String) in the
         // compact serialization config, when we read the config from XML/YAML, we store registered classes
         // in a different map.
-        Map<String, TriTuple<String, String, String>> namedRegistries = CompactSerializationConfigAccessor.getNamedRegistries(actual);
+        Map<String, TriTuple<String, String, String>> namedRegistrations
+                = CompactSerializationConfigAccessor.getNamedRegistrations(actual);
 
-        for (Map.Entry<String, TriTuple<Class, String, CompactSerializer>> entry : expected.getRegistries().entrySet()) {
+        Map<String, TriTuple<Class, String, CompactSerializer>> registrations
+                = CompactSerializationConfigAccessor.getRegistrations(actual);
+
+        for (Map.Entry<String, TriTuple<Class, String, CompactSerializer>> entry : registrations.entrySet()) {
             String key = entry.getKey();
             TriTuple<Class, String, CompactSerializer> expectedRegistration = entry.getValue();
-            TriTuple<String, String, String> actualRegistration = namedRegistries.get(key);
+            TriTuple<String, String, String> actualRegistration = namedRegistrations.get(key);
 
             assertEquals(expectedRegistration.element1.getName(), actualRegistration.element1);
             assertEquals(expectedRegistration.element2, actualRegistration.element2);

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -844,9 +844,13 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         // Since we don't have APIs of the form register(String) or register(String, String, String) in the
         // compact serialization config, when we read the config from XML/YAML, we store registered classes
         // in a different map.
-        Map<String, TriTuple<String, String, String>> namedRegistries = CompactSerializationConfigAccessor.getNamedRegistries(actual);
+        Map<String, TriTuple<String, String, String>> namedRegistries
+                = CompactSerializationConfigAccessor.getNamedRegistrations(actual);
 
-        for (Map.Entry<String, TriTuple<Class, String, CompactSerializer>> entry : expected.getRegistries().entrySet()) {
+        Map<String, TriTuple<Class, String, CompactSerializer>> registrations
+                = CompactSerializationConfigAccessor.getRegistrations(actual);
+
+        for (Map.Entry<String, TriTuple<Class, String, CompactSerializer>> entry : registrations.entrySet()) {
             String key = entry.getKey();
             TriTuple<Class, String, CompactSerializer> expectedRegistration = entry.getValue();
             TriTuple<String, String, String> actualRegistration = namedRegistries.get(key);


### PR DESCRIPTION
After an internal discussion, we have decided that it is not
useful to have a getter for the registered serializers in the
compact serialization config.

Therefore, this PR removes that API and replaces its usages
with the accessor class, we have for it.

Also, this PR replaces the word `registry` with `registration`
on some places.