### PR TITLE
Align HazelcastProperties#get with Properties#getProperty

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -92,13 +92,18 @@ public class HazelcastProperties {
 
     /**
      * Returns the value for the given key.
+     * If this {@code HazelcastProperties} object is initialized with a
+     * "compromised" {@link Properties} object (ie one where keys/values of types
+     * other than {@code String} have been inserted), then {@code get} on {@code String} keys
+     * mapped to non-{@code String} values will return {@code null},
+     * similarly to {@link Properties#getProperty(String)}.
      *
      * @param key the key
      * @return the value for the given key, or {@code null} if no value is found
      * @throws NullPointerException if key is {@code null}
      */
     public String get(String key) {
-        return (String) properties.get(key);
+        return properties.getProperty(key);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
@@ -93,6 +93,17 @@ public class HazelcastPropertiesTest {
     }
 
     @Test
+    public void testGet_whenValueNotString() {
+        // given a "compromised" Properties object
+        Properties props = new Properties();
+        props.put("key", 1);
+
+        // HazelcastProperties.get returns null
+        HazelcastProperties hzProperties = new HazelcastProperties(props);
+        assertNull(hzProperties.get("key"));
+    }
+
+    @Test
     public void testGet_whenFunctionAvailable_andNoOtherSettings() {
         Properties props = new Properties();
         HazelcastProperty p = new HazelcastProperty("key", new Function<HazelcastProperties, Integer>() {


### PR DESCRIPTION
When a HazelcastProperties object is initialized with a compromised
Properties object (ie one containing keys/values other than Strings),
calling HazelcastProperties#get(String) may result in a
ClassCastException (when value is not a String).
This PR aligns behaviour of HazelcastProperties#get with Properties#get:
when a non-String value is mapped to given key, then return null
instead of throwing a ClassCastException.

backport of #20634 to `4.0.z` branch