### PR TITLE
Add run-lts-compilers PR trigger phrase to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ trigger the build using special comments. These are the phrases you may
 see used in the comments on your PR:
 
 * `run-lab-run` - run the default PR builder
+* `run-lts-compilers` - compiles the sources with JDK 11 and JDK 17 (without running tests)
 * `run-ee-tests` - run tests from hazelcast-enterprise with this PR
 * `run-windows` - run the tests on a Windows machine (HighFive is not supported here)
 * `run-with-jdk17` - run the tests with JDK 17


### PR DESCRIPTION
Add `run-lts-compilers` trigger to the README. It executes the http://jenkins.hazelcast.com/job/Hazelcast-pr-compiler/ job.