### PR TITLE
Fix covariant return types and bump animal-sniffer-maven-plugin version

### DIFF
--- a/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sinks.java
+++ b/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sinks.java
@@ -32,6 +32,9 @@ import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import static com.hazelcast.internal.util.JVMUtil.upcast;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -197,7 +200,7 @@ public final class S3Sinks {
             int newCapacity = (int) (minimumLength * BUFFER_SCALE);
             ByteBuffer newBuffer = ByteBuffer.allocateDirect(newCapacity);
             if (buffer != null) {
-                buffer.flip();
+                upcast(buffer).flip();
                 newBuffer.put(buffer);
             }
             buffer = newBuffer;
@@ -223,7 +226,7 @@ public final class S3Sinks {
 
         private void flushBuffer(boolean isLastPart) {
             if (buffer.position() > 0) {
-                buffer.flip();
+                upcast(buffer).flip();
                 UploadPartRequest req = UploadPartRequest
                         .builder()
                         .bucket(bucketName)
@@ -235,7 +238,7 @@ public final class S3Sinks {
                 String eTag = s3Client.uploadPart(req, RequestBody.fromByteBuffer(buffer)).eTag();
                 completedParts.add(CompletedPart.builder().partNumber(partNumber).eTag(eTag).build());
                 partNumber++;
-                buffer.clear();
+                upcast(buffer).clear();
             }
 
             if (isLastPart) {

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -68,32 +68,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${maven.animal.sniffer.plugin.version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                    <ignores>
-                        <ignore>java.lang.invoke.MethodHandle</ignore>
-                        <ignore>sun.misc.Unsafe</ignore>
-                    </ignores>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>source-java8-check</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>${maven.source.plugin.version}</version>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public final class ClientMessageReader {
 
@@ -87,9 +88,9 @@ public final class ClientMessageReader {
                 sumUntrustedMessageLength += frameLength;
             }
 
-            src.position(src.position() + Bits.INT_SIZE_IN_BYTES);
+            upcast(src).position(src.position() + Bits.INT_SIZE_IN_BYTES);
             int flags = Bits.readShortL(src, src.position()) & INT_MASK;
-            src.position(src.position() + Bits.SHORT_SIZE_IN_BYTES);
+            upcast(src).position(src.position() + Bits.SHORT_SIZE_IN_BYTES);
 
             int size = frameLength - SIZE_OF_FRAME_LENGTH_AND_FLAGS;
             byte[] bytes = new byte[size];

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageWriter.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class ClientMessageWriter {
 
@@ -57,14 +58,14 @@ public class ClientMessageWriter {
         if (writeOffset == -1) {
             if (bytesWritable >= SIZE_OF_FRAME_LENGTH_AND_FLAGS) {
                 Bits.writeIntL(dst, dst.position(), frameContentLength + SIZE_OF_FRAME_LENGTH_AND_FLAGS);
-                dst.position(dst.position() + Bits.INT_SIZE_IN_BYTES);
+                upcast(dst).position(dst.position() + Bits.INT_SIZE_IN_BYTES);
 
                 if (isLastFrame) {
                     Bits.writeShortL(dst, dst.position(), (short) (frame.flags | IS_FINAL_FLAG));
                 } else {
                     Bits.writeShortL(dst, dst.position(), (short) frame.flags);
                 }
-                dst.position(dst.position() + Bits.SHORT_SIZE_IN_BYTES);
+                upcast(dst).position(dst.position() + Bits.SHORT_SIZE_IN_BYTES);
                 writeOffset = 0;
             } else {
                 return false;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -39,6 +39,7 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.FRAGMENTATION_ID_
 import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * Builds {@link ClientMessage}s from byte chunks.
@@ -73,7 +74,7 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
 
     @Override
     public HandlerStatus onRead() {
-        src.flip();
+        upcast(src).flip();
         try {
             while (src.hasRemaining()) {
                 boolean trusted = isEndpointTrusted();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoder.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * A {@link OutboundHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
@@ -64,7 +65,7 @@ public class ClientMessageEncoder extends OutboundHandler<Supplier<ClientMessage
                 }
             }
         } finally {
-            dst.flip();
+            upcast(dst).flip();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class BulkGetCommand extends AbstractTextCommand {
 
@@ -61,6 +62,6 @@ public class BulkGetCommand extends AbstractTextCommand {
             byteBuffer.put(bytes);
         }
         byteBuffer.put(TextCommandConstants.END);
-        byteBuffer.flip();
+        upcast(byteBuffer).flip();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
@@ -27,6 +27,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.SERVER_ERROR;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_SERVER;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class ErrorCommand extends AbstractTextCommand {
@@ -58,7 +59,7 @@ public class ErrorCommand extends AbstractTextCommand {
             response.put(msg);
         }
         response.put(TextCommandConstants.RETURN);
-        response.flip();
+        upcast(response).flip();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -20,6 +20,8 @@ import com.hazelcast.internal.ascii.AbstractTextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.nio.IOUtil;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
+
 import java.nio.ByteBuffer;
 
 public class SetCommand extends AbstractTextCommand {
@@ -49,7 +51,7 @@ public class SetCommand extends AbstractTextCommand {
             while (src.hasRemaining()) {
                 char c = (char) src.get();
                 if (c == '\n') {
-                    bbValue.flip();
+                    upcast(bbValue).flip();
                     return true;
                 }
             }
@@ -62,7 +64,7 @@ public class SetCommand extends AbstractTextCommand {
             int n = Math.min(cb.remaining(), bbValue.remaining());
             if (n > 0) {
                 cb.get(bbValue.array(), bbValue.position(), n);
-                bbValue.position(bbValue.position() + n);
+                upcast(bbValue).position(bbValue.position() + n);
             }
         } else {
             IOUtil.copyToHeapBuffer(cb, bbValue);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class StatsCommand extends AbstractTextCommand {
@@ -78,7 +79,7 @@ public class StatsCommand extends AbstractTextCommand {
         putLong(DECR_HITS, stats.getDecrHits());
         putLong(DECR_MISSES, stats.getDecrMisses());
         response.put(TextCommandConstants.END);
-        response.flip();
+        upcast(response).flip();
     }
 
     private void putInt(byte[] name, int value) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -34,6 +34,7 @@ import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_404;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_500;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_503;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 @SuppressFBWarnings({"EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT"})
@@ -159,7 +160,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
             }
         }
         response.put(TextCommandConstants.RETURN);
-        response.flip();
+        upcast(response).flip();
         setStatusCode(statusCode.code);
     }
 
@@ -217,7 +218,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
         if (value != null) {
             response.put(value);
         }
-        response.flip();
+        upcast(response).flip();
         setStatusCode(statusCode.code);
     }
 
@@ -261,7 +262,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
         if (value != null) {
             response.put(value);
         }
-        response.flip();
+        upcast(response).flip();
         setStatusCode(statusCode.code);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_100;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class HttpPostCommand extends HttpCommand {
@@ -74,7 +75,7 @@ public class HttpPostCommand extends HttpCommand {
         }
         if (complete) {
             if (data != null) {
-                data.flip();
+                upcast(data).flip();
             }
         }
         return complete;
@@ -146,7 +147,7 @@ public class HttpPostCommand extends HttpCommand {
         if (b == CARRIAGE_RETURN) {
             readLF(cb);
         } else {
-            cb.position(cb.position() - 1);
+            upcast(cb).position(cb.position() - 1);
         }
     }
 
@@ -169,7 +170,7 @@ public class HttpPostCommand extends HttpCommand {
         } else {
             result = StringUtil.bytesToString(bb.array(), 0, bb.position());
         }
-        bb.clear();
+        upcast(bb).clear();
         return result;
     }
 
@@ -223,7 +224,7 @@ public class HttpPostCommand extends HttpCommand {
         int capacity = lineBuffer.capacity() << 1;
 
         ByteBuffer newBuffer = ByteBuffer.allocate(capacity);
-        lineBuffer.flip();
+        upcast(lineBuffer).flip();
         newBuffer.put(lineBuffer);
         lineBuffer = newBuffer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -47,6 +47,7 @@ import static com.hazelcast.internal.nio.IOUtil.getPath;
 import static com.hazelcast.internal.nio.IOUtil.readFullyOrNothing;
 import static com.hazelcast.internal.nio.IOUtil.rename;
 import static com.hazelcast.internal.nio.IOUtil.toFileName;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.nio.ByteBuffer.allocate;
@@ -276,18 +277,18 @@ public class NearCachePreloader<K> {
             return;
         }
         fos.write(buf.array());
-        buf.position(0);
+        upcast(buf).position(0);
     }
 
     private void flushLocalBuffer(FileChannel outChannel) throws IOException {
         if (buf.position() == 0) {
             return;
         }
-        buf.flip();
+        upcast(buf).flip();
         while (buf.hasRemaining()) {
             outChannel.write(buf);
         }
-        buf.clear();
+        upcast(buf).clear();
     }
 
     private static String getFilename(String directory, String nearCacheName) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundHandler.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import static com.hazelcast.internal.networking.ChannelOption.DIRECT_BUF;
 import static com.hazelcast.internal.networking.ChannelOption.SO_SNDBUF;
 import static com.hazelcast.internal.nio.IOUtil.newByteBuffer;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * The {@link OutboundHandler} is a {@link ChannelHandler} for outbound
@@ -119,7 +120,7 @@ public abstract class OutboundHandler<S, D> extends ChannelHandler<OutboundHandl
         if (bytes != null) {
             buffer.put(bytes);
         }
-        buffer.flip();
+        upcast(buffer).flip();
         dst = (D) buffer;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -74,6 +74,7 @@ import static com.hazelcast.internal.networking.ChannelOption.TCP_NODELAY;
 import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.String.format;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
@@ -97,7 +98,7 @@ public final class IOUtil {
         if (bb.hasRemaining()) {
             bb.compact();
         } else {
-            bb.clear();
+            upcast(bb).clear();
         }
     }
 
@@ -336,8 +337,8 @@ public final class IOUtil {
                 int srcPosition = src.position();
                 int destPosition = dst.position();
                 System.arraycopy(src.array(), srcPosition, dst.array(), destPosition, n);
-                src.position(srcPosition + n);
-                dst.position(destPosition + n);
+                upcast(src).position(srcPosition + n);
+                upcast(dst).position(destPosition + n);
             }
         }
         return n;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
@@ -36,6 +36,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
@@ -83,7 +84,7 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
     @Override
     public HandlerStatus onRead() throws Exception {
-        src.flip();
+        upcast(src).flip();
         try {
             while (src.hasRemaining()) {
                 doRead(src);
@@ -146,14 +147,14 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
         }
 
         ByteBuffer newBuffer = ByteBuffer.allocate(capacity);
-        commandLineBuffer.flip();
+        upcast(commandLineBuffer).flip();
         newBuffer.put(commandLineBuffer);
         commandLineBuffer = newBuffer;
     }
 
     private void reset() {
         command = null;
-        commandLineBuffer.clear();
+        upcast(commandLineBuffer).clear();
         commandLineRead = false;
     }
 
@@ -167,7 +168,7 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
         } else {
             result = StringUtil.bytesToString(bb.array(), 0, bb.position());
         }
-        bb.clear();
+        upcast(bb).clear();
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextEncoder.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class TextEncoder extends OutboundHandler<Supplier<TextCommand>, ByteBuffer> {
     public static final String TEXT_ENCODER = "textencoder";
@@ -96,7 +97,7 @@ public class TextEncoder extends OutboundHandler<Supplier<TextCommand>, ByteBuff
                 }
             }
         } finally {
-            dst.flip();
+            upcast(dst).flip();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -24,6 +24,8 @@ import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.query.impl.getters.JsonPathCursor;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationThread;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.ByteBuffer;
@@ -105,7 +107,7 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
         UTF8Reader(BufferObjectDataInput input) {
             byte[] data = obtainBytes(input);
             inputBuffer = ByteBuffer.wrap(data);
-            inputBuffer.position(input.position());
+            upcast(inputBuffer).position(input.position());
             decoder = Thread.currentThread() instanceof OperationThread
                     ? DECODER_THREAD_LOCAL.get()
                     : StandardCharsets.UTF_8.newDecoder();

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -29,6 +29,7 @@ import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
@@ -81,7 +82,7 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
 
             return CLEAN;
         } finally {
-            dst.flip();
+            upcast(dst).flip();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketDecoder.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Packet.FLAG_URGENT;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * The {@link InboundHandler} for member to member communication.
@@ -56,7 +57,7 @@ public class PacketDecoder extends InboundHandlerWithCounters<ByteBuffer, Consum
 
     @Override
     public HandlerStatus onRead() throws Exception {
-        src.flip();
+        upcast(src).flip();
         try {
             while (src.hasRemaining()) {
                 Packet packet = packetReader.readFrom(src);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketEncoder.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * A {@link OutboundHandler} that for member to member communication.
@@ -73,7 +74,7 @@ public class PacketEncoder extends OutboundHandler<Supplier<Packet>, ByteBuffer>
                 }
             }
         } finally {
-            dst.flip();
+            upcast(dst).flip();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
@@ -29,6 +29,7 @@ import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.Protocols.UNEXPECTED_PROTOCOL;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.bytesToString;
 
 /**
@@ -95,7 +96,7 @@ public class SingleProtocolDecoder
 
     @Override
     public HandlerStatus onRead() {
-        src.flip();
+        upcast(src).flip();
 
         try {
             if (src.remaining() < PROTOCOL_LENGTH) {
@@ -113,7 +114,7 @@ public class SingleProtocolDecoder
                     // previous handler may get stuck in a DIRTY loop even if the
                     // channel closes. We observed this behavior in TLSDecoder
                     // before.
-                    src.position(src.limit());
+                    upcast(src).position(src.limit());
                 }
                 return CLEAN;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -27,6 +27,7 @@ import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.Protocols.UNEXPECTED_PROTOCOL;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 /**
@@ -87,7 +88,7 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
 
             return CLEAN;
         } finally {
-            dst.flip();
+            upcast(dst).flip();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TextHandshakeDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TextHandshakeDecoder.java
@@ -21,6 +21,8 @@ import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.nio.ascii.MemcacheTextDecoder;
 import com.hazelcast.internal.nio.ascii.RestApiTextDecoder;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
+
 import java.nio.ByteBuffer;
 
 public class TextHandshakeDecoder
@@ -58,7 +60,7 @@ public class TextHandshakeDecoder
         // we need to restore whatever is read
         ByteBuffer src = this.src;
         ByteBuffer dst = (ByteBuffer) inboundHandlers[0].src();
-        src.flip();
+        upcast(src).flip();
         dst.put(src);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
@@ -47,6 +47,7 @@ import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
 import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.bytesToString;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_RECEIVE_BUFFER_SIZE;
@@ -80,7 +81,7 @@ public class UnifiedProtocolDecoder
 
     @Override
     public HandlerStatus onRead() throws Exception {
-        src.flip();
+        upcast(src).flip();
 
         try {
             if (src.remaining() < PROTOCOL_LENGTH) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolEncoder.java
@@ -36,6 +36,7 @@ import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.ascii.TextEncoder.TEXT_ENCODER;
 import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_SEND_BUFFER_SIZE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SEND_BUFFER_SIZE;
@@ -127,7 +128,7 @@ public class UnifiedProtocolEncoder
 
             return CLEAN;
         } finally {
-            dst.flip();
+            upcast(dst).flip();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
@@ -22,6 +22,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeDataSupport;
 import java.lang.management.ManagementFactory;
+import java.nio.Buffer;
 
 import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE;
 import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE_AVAILABLE;
@@ -110,6 +111,36 @@ public final class JVMUtil {
         } while (totalBegin != totalEnd);
 
         return used;
+    }
+
+    /**
+     * Explicit cast to {@link Buffer} parent buffer type. It resolves issues with covariant return types in Java 9+ for
+     * {@link java.nio.ByteBuffer} and {@link java.nio.CharBuffer}. Explicit casting resolves the NoSuchMethodErrors (e.g
+     * java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer) when the project is compiled with newer
+     * Java version and run on Java 8.
+     * <p/>
+     * <a href="https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html">Java 8</a> doesn't provide override the
+     * following Buffer methods in subclasses:
+     *
+     * <pre>
+     * Buffer clear​()
+     * Buffer flip​()
+     * Buffer limit​(int newLimit)
+     * Buffer mark​()
+     * Buffer position​(int newPosition)
+     * Buffer reset​()
+     * Buffer rewind​()
+     * </pre>
+     *
+     * <a href="https://docs.oracle.com/javase/9/docs/api/java/nio/ByteBuffer.html">Java 9</a> introduces the overrides in child
+     * classes (e.g the ByteBuffer), but the return type is the specialized one and not the abstract {@link Buffer}. So the code
+     * compiled with newer Java is not working on Java 8 unless a workaround with explicit casting is used.
+     *
+     * @param buf buffer to cast to the abstract {@link Buffer} parent type
+     * @return the provided buffer
+     */
+    public static Buffer upcast(Buffer buf) {
+        return buf;
     }
 
     // not private for testing

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
@@ -32,6 +32,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.concurrent.locks.LockSupport;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -72,8 +73,8 @@ public final class StreamSocketP extends AbstractProcessor {
             LockSupport.parkNanos(MILLISECONDS.toNanos(1));
         }
         getLogger().info("Connected to socket " + hostAndPort());
-        byteBuffer.limit(0);
-        charBuffer.limit(0);
+        upcast(byteBuffer).limit(0);
+        upcast(charBuffer).limit(0);
     }
 
     @Override
@@ -97,10 +98,10 @@ public final class StreamSocketP extends AbstractProcessor {
             return;
         }
         socketDone = socketChannel.read(byteBuffer) < 0;
-        byteBuffer.flip();
-        charBuffer.clear();
+        upcast(byteBuffer).flip();
+        upcast(charBuffer).clear();
         charsetDecoder.decode(byteBuffer, charBuffer, socketDone);
-        charBuffer.flip();
+        upcast(charBuffer).flip();
         byteBuffer.compact();
         assert byteBuffer.position() < MAX_BYTES_PER_CHAR - 1 : "position=" + byteBuffer.position();
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/IMapOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/IMapOutputStream.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.Math.min;
 
 public class IMapOutputStream extends OutputStream {
@@ -98,6 +99,6 @@ public class IMapOutputStream extends OutputStream {
             throw new IOException("Writing to chunked IMap failed: " + e, e);
         }
         currentChunkIndex++;
-        currentChunk.clear();
+        upcast(currentChunk).clear();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
         <maven.dependency.plugin.version>3.2.0</maven.dependency.plugin.version>
-        <maven.animal.sniffer.plugin.version>1.19</maven.animal.sniffer.plugin.version>
+        <maven.animal.sniffer.plugin.version>1.21</maven.animal.sniffer.plugin.version>
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
@@ -556,6 +556,31 @@
                         <configuration>
                             <outputFile>${project.build.outputDirectory}/META-INF/attribution.txt</outputFile>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>${maven.animal.sniffer.plugin.version}</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java18</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                    <ignores>
+                        <ignore>java.lang.invoke.MethodHandle</ignore>
+                        <ignore>sun.misc.Unsafe</ignore>
+                    </ignores>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>source-java8-check</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Replaces #20603 

This PR fixes issues with covariant return types when using `Buffer` methods in child classes. A new method `JVMUtil.upcast()` is added to explicitly cast the argument to the abstract Buffer parent class.

The new animal-sniffer plugin version allows identifying these types of issues.