### PR TITLE
Add timeout values for HTTP calls in GCP and Azure discovery

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategyFactory.java
@@ -105,6 +105,9 @@ public class AzureDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
 
     static boolean isEndpointAvailable(String url) {
         return !RestClient.create(url)
+                .withConnectTimeoutSeconds(1)
+                .withReadTimeoutSeconds(1)
+                .withRetries(1)
                 .withHeader("Metadata", "True")
                 .get()
                 .getBody()

--- a/hazelcast/src/main/java/com/hazelcast/gcp/GcpDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/gcp/GcpDiscoveryStrategyFactory.java
@@ -117,6 +117,9 @@ public class GcpDiscoveryStrategyFactory
 
     static boolean isEndpointAvailable(String url) {
         return !RestClient.create(url)
+                .withConnectTimeoutSeconds(1)
+                .withReadTimeoutSeconds(1)
+                .withRetries(1)
                 .withHeader("Metadata-Flavor", "Google")
                 .get()
                 .getBody()


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Auto discovery HTTP calls for GCP and Azure did not have timeout values set resulting the client hanging forever. This PR fixes the issue.

Fixes #20384

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
