### PR TITLE
Improve cleanup of QueryResultRegistry

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -355,6 +355,9 @@ public class PlanExecutor {
         try {
             Job job = jet.newLightJob(jobId, plan.getDag(), jobConfig);
             job.getFuture().whenComplete((r, t) -> {
+                // make sure the queryResultProducer is cleaned up after the job completes. This normally
+                // takes effect when the job fails before the QRP is removed by the RootResultConsumerSink
+                resultRegistry.remove(jobId);
                 if (t != null) {
                     int errorCode = findQueryExceptionCode(t);
                     String errorMessage = findQueryExceptionMessage(t);


### PR DESCRIPTION
We pass the `QueryResultProducer` to the sink processor by storing it in
`QueryResultRegistry`. Normally it is removed from the registry when the
`RootResultConsumerSink.init()` is called, or in a `catch` block, when something
went wrong with the submission. However, this didn't cover all cases. For
example, if the `InitExecutionOperation` failed before initializing the
`RootResultConsumerSink`, it would leak.

This commit adds one more cleanup point - when the job future completes. Tho job
submission mechanism is quite reliable. It could still leak if the job gets
stuck, in which client also the job proxy will report the job as running.

Possibly fixes #20052, we need to re-run, I couldn't reproduce it or reason
about it from the code.