### PR TITLE
[HZ-889] Prevent unnecesary warnings in LDAP login module

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
@@ -242,7 +242,11 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
         Properties props = super.initLoginModuleProperties();
         setIfConfigured(props, Context.PROVIDER_URL, url);
         setIfConfigured(props, "java.naming.ldap.factory.socket", socketFactoryClassName);
-        props.setProperty("parseDN", String.valueOf(parseDn));
+        // HZ-889 Prevent warnings logged in BasicLdapLoginModule.verifyOptions(), the parseDn is not nullable in this config
+        // class so we don't know if it was configured explicitly
+        if (LdapRoleMappingMode.ATTRIBUTE == roleMappingMode) {
+            props.setProperty("parseDN", String.valueOf(parseDn));
+        }
         setIfConfigured(props, "roleContext", roleContext);
         setIfConfigured(props, "roleFilter", roleFilter);
         setIfConfigured(props, "roleMappingAttribute", roleMappingAttribute);


### PR DESCRIPTION
This PR prevents passing `parseDN` attribute from Hazelcast `LdapAuthenticationConfig` to LDAP login modules (EE) when it's not necessary. It fixes unnecessary WARN messages in the log. E.g.

```
2022-02-04 18:39:01 WARN LdapLoginModule:89 - Login module option parseDN is not supported when roleMappingMode==direct. It's only supported in following mapping mode(s): [attribute]
```
