### PR TITLE
Prevent the thread of ConsoleTest from leaking

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/console/DefaultLineReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/DefaultLineReader.java
@@ -20,10 +20,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * A {@link LineReader} implementation.
@@ -38,39 +34,11 @@ class DefaultLineReader implements LineReader {
 
     @Override
     public String readLine() throws Exception {
-        return interruptableReadLine(in);
+        return in.readLine();
     }
 
     @Override
     public void close() throws IOException {
         in.close();
-    }
-
-    private String interruptableReadLine(BufferedReader reader)
-            throws InterruptedException, IOException {
-        @SuppressWarnings("checkstyle:magicnumber")
-        final long parkDurationInMs = 100;
-        Pattern pattern = Pattern.compile("\\R");
-        boolean interrupted = false;
-        int chr;
-        StringBuilder result = new StringBuilder();
-        Matcher matcher = pattern.matcher(result.toString());
-        while (!interrupted && !matcher.find()) {
-            if (reader.ready()) {
-                chr = reader.read();
-                result.append((char) chr);
-                matcher = pattern.matcher(result.toString());
-            } else {
-                // when input buffer is not ready, wait
-                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(parkDurationInMs));
-            }
-            interrupted = Thread.interrupted();
-        }
-
-        if (interrupted) {
-            throw new InterruptedException();
-        }
-
-        return result.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/console/LineReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/LineReader.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.console;
 
+import java.io.Closeable;
+
 /**
  * Reads a line of input.
  */
-public interface LineReader {
+public interface LineReader extends Closeable {
 
     String readLine() throws Exception;
 }

--- a/hazelcast/src/test/java/com/hazelcast/console/ConsoleAppTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/console/ConsoleAppTest.java
@@ -47,6 +47,8 @@ public class ConsoleAppTest extends HazelcastTestSupport {
 
     private static ByteArrayOutputStream baos;
     private static PrintStream printStream;
+    private ConsoleApp consoleApp;
+    private HazelcastInstance hz;
 
     @BeforeClass
     public static void beforeClass() {
@@ -60,12 +62,13 @@ public class ConsoleAppTest extends HazelcastTestSupport {
 
     @Before
     public void before() {
+        hz = createHazelcastInstance();
+        consoleApp = new ConsoleApp(hz, printStream);
         resetSystemOut();
     }
 
     @Test
     public void executeOnKey() {
-        ConsoleApp consoleApp = new ConsoleApp(createHazelcastInstance(), printStream);
         for (int i = 0; i < 100; i++) {
             consoleApp.handleCommand(String.format("executeOnKey message%d key%d", i, i));
             assertTextInSystemOut("message" + i);
@@ -77,10 +80,7 @@ public class ConsoleAppTest extends HazelcastTestSupport {
      */
     @Test
     public void mapPut() {
-        HazelcastInstance hz = createHazelcastInstance();
         IMap<String, String> map = hz.getMap("default");
-
-        ConsoleApp consoleApp = new ConsoleApp(hz, printStream);
         assertEquals("Unexpected map size", 0, map.size());
 
         consoleApp.handleCommand("m.put putTestKey testValue");
@@ -100,8 +100,6 @@ public class ConsoleAppTest extends HazelcastTestSupport {
      */
     @Test
     public void mapRemove() {
-        HazelcastInstance hz = createHazelcastInstance();
-        ConsoleApp consoleApp = new ConsoleApp(hz, printStream);
         IMap<String, String> map = hz.getMap("default");
         map.put("a", "valueOfA");
         map.put("b", "valueOfB");
@@ -117,8 +115,6 @@ public class ConsoleAppTest extends HazelcastTestSupport {
      */
     @Test
     public void mapDelete() {
-        HazelcastInstance hz = createHazelcastInstance();
-        ConsoleApp consoleApp = new ConsoleApp(hz, printStream);
         IMap<String, String> map = hz.getMap("default");
         map.put("a", "valueOfA");
         map.put("b", "valueOfB");
@@ -134,8 +130,6 @@ public class ConsoleAppTest extends HazelcastTestSupport {
      */
     @Test
     public void mapGet() {
-        HazelcastInstance hz = createHazelcastInstance();
-        ConsoleApp consoleApp = new ConsoleApp(hz, printStream);
         hz.<String, String>getMap("default").put("testGetKey", "testGetValue");
         consoleApp.handleCommand("m.get testGetKey");
         assertTextInSystemOut("testGetValue");
@@ -146,8 +140,6 @@ public class ConsoleAppTest extends HazelcastTestSupport {
      */
     @Test
     public void mapPutMany() {
-        HazelcastInstance hz = createHazelcastInstance();
-        ConsoleApp consoleApp = new ConsoleApp(hz, printStream);
         IMap<String, ?> map = hz.getMap("default");
         consoleApp.handleCommand("m.putmany 100 8 1000");
         assertEquals("Unexpected map size", 100, map.size());
@@ -159,9 +151,9 @@ public class ConsoleAppTest extends HazelcastTestSupport {
     }
 
     /**
-     * Asserts that given substring in in standard output buffer. Calling this method resets the buffer.
+     * Asserts that given substring in standard output buffer. Calling this method resets the buffer.
      *
-     * @param substring
+     * @param substring a substring that asserted to be in stdout buffer
      */
     private void assertTextInSystemOut(String substring) {
         assertThat(resetSystemOut(), CoreMatchers.containsString(substring));

--- a/hazelcast/src/test/java/com/hazelcast/console/ConsoleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/console/ConsoleTest.java
@@ -127,7 +127,7 @@ public class ConsoleTest {
                         terminated);
             }
         } finally {
-            if (pipeIn != null){
+            if (pipeIn != null) {
                 pipeIn.close();
             }
             if (pipeOut != null) {


### PR DESCRIPTION
The `ConsoleApp.main(null)` task created here https://github.com/hazelcast/hazelcast/blob/2b21917d243de30cf1477c2480ca817991721598/hazelcast/src/test/java/com/hazelcast/console/ConsoleTest.java#L88-L96 was getting blocked on https://github.com/hazelcast/hazelcast/blob/2b21917d243de30cf1477c2480ca817991721598/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java#L170 and didn't complete although we shutdown the thread pool. This blocking call was stemmed from `BufferReader#readLine` method and it doesn't respond the interrupt calls. At the end of the test, I write
 a line to `Sys.in` where it is listening so that it completes 

Fixes https://github.com/hazelcast/hazelcast/issues/20680

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

