### PR TITLE
Add predefined CompactSerializer implementations for Character type

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
+import com.hazelcast.internal.serialization.impl.compact.boxed.CharacterCompactSerializer;
 import com.hazelcast.internal.util.TriTuple;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -80,6 +81,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
         this.isEnabled = compactSerializationConfig.isEnabled();
         registerConfiguredSerializers(compactSerializationConfig);
         registerConfiguredNamedSerializers(compactSerializationConfig);
+        registerDefaultSerializers();
     }
 
     /**
@@ -284,6 +286,13 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
             classToRegistrationMap.put(clazz, serializableRegistration);
             typeNameToRegistrationMap.put(typeName, serializableRegistration);
         }
+    }
+
+    private void registerDefaultSerializers() {
+        CompactSerializableRegistration r = new CompactSerializableRegistration(
+          Character.class, Character.class.getName(), new CharacterCompactSerializer());
+        classToRegistrationMap.put(r.getClazz(), r);
+        typeNameToRegistrationMap.put(r.getTypeName(), r);
     }
 
     private void registerConfiguredNamedSerializers(CompactSerializationConfig compactSerializationConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/boxed/CharacterCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/boxed/CharacterCompactSerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl.compact.boxed;
+
+import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactSerializer;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
+
+import javax.annotation.Nonnull;
+
+public class CharacterCompactSerializer implements CompactSerializer<Character> {
+
+    private static final String FIELD_NAME = "character";
+
+    @Nonnull
+    @Override
+    public Character read(@Nonnull CompactReader in) {
+        return (char) in.readInt32(FIELD_NAME);
+    }
+
+    @Override
+    public void write(@Nonnull CompactWriter out, @Nonnull Character object) {
+        out.writeInt32(FIELD_NAME, object);
+    }
+}


### PR DESCRIPTION
Added predefined serializers for `Character` type to avoid problems caused while attempting serialization of a class with `Character` field:

> Exception in thread "main" java.lang.StackOverflowError
	at java.base/java.lang.String.compareTo(String.java:133)
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:52)
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:47)
	at java.base/java.util.TreeMap.getEntryUsingComparator(TreeMap.java:374)
	at java.base/java.util.TreeMap.getEntry(TreeMap.java:344)
	at java.base/java.util.TreeMap.get(TreeMap.java:279)

