### PR TITLE
Add dedicated compact serializers for char and char[] types

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -227,6 +227,13 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                     }
                 };
                 writers[index] = (w, o) -> w.writeInt32(name, field.getInt(o));
+            } else if (Character.TYPE.equals(type)) {
+                readers[index] = (reader, schema, o) -> {
+                    if (fieldExists(schema, name, INT32, NULLABLE_INT32)) {
+                        field.setChar(o, (char) reader.readInt32(name));
+                    }
+                };
+                writers[index] = (w, o) -> w.writeInt32(name, field.getChar(o));
             } else if (Long.TYPE.equals(type)) {
                 readers[index] = (reader, schema, o) -> {
                     if (fieldExists(schema, name, INT64, NULLABLE_INT64)) {
@@ -381,6 +388,13 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfInt16(name, (short[]) field.get(o));
+                } else if (Character.TYPE.equals(componentType)) {
+                    readers[index] = (reader, schema, o) -> {
+                        if (fieldExists(schema, name, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32)) {
+                            field.set(o, intsAsCharArray(reader.readArrayOfInt32(name)));
+                        }
+                    };
+                    writers[index] = (w, o) -> w.writeArrayOfInt32(name, charsAsIntArray((char[]) field.get(o)));
                 } else if (Integer.TYPE.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32)) {
@@ -534,6 +548,30 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
 
         writersCache.put(clazz, writers);
         readersCache.put(clazz, readers);
+    }
+
+    private int[] charsAsIntArray(char[] values) {
+        if (values == null) {
+            return null;
+        } else {
+            int[] ints = new int[values.length];
+            for (int i = 0; i < values.length; i++) {
+                ints[i] = values[i];
+            }
+            return ints;
+        }
+    }
+
+    private char[] intsAsCharArray(int[] values) {
+        if (values == null) {
+            return null;
+        } else {
+            char[] chars = new char[values.length];
+            for (int i = 0; i < values.length; i++) {
+                chars[i] = (char) values[i];
+            }
+            return chars;
+        }
     }
 
     private String[] enumsAsStrings(Enum[] values) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -31,7 +31,9 @@ import com.hazelcast.nio.serialization.compact.CompactWriter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import example.serialization.ArraysDTO;
 import example.serialization.BitsDTO;
+import example.serialization.BoxedPrimitivesDTO;
 import example.serialization.EmployeeDTO;
 import example.serialization.EmployeeDTOSerializer;
 import example.serialization.EmployerDTO;
@@ -263,6 +265,32 @@ public class CompactStreamSerializerTest {
         Data data = serializationService.toData(employeeDTO);
         EmployeeDTO object = serializationService.toObject(data);
         assertEquals(employeeDTO, object);
+    }
+
+    @Test
+    public void testPrimitiveArraysDefaultSerialization() {
+        SerializationService serializationService = createSerializationService();
+        ArraysDTO raw = new ArraysDTO("bytes".getBytes(),
+          "chars".toCharArray(),
+          new float[] {1.2f},
+          new double[]{1.2d},
+          new boolean[] {false},
+          new long[] {1L},
+          new short[]{(short) 1},
+          new int[]{1});
+        Data data = serializationService.toData(raw);
+        ArraysDTO deserialized = serializationService.toObject(data);
+        assertEquals(raw, deserialized);
+    }
+
+    @Test
+    public void testBoxedTypesDefaultSerialization() {
+        SerializationService serializationService = createSerializationService();
+        BoxedPrimitivesDTO raw = new BoxedPrimitivesDTO(
+          Byte.valueOf("1"), 'c', 1.2f, 1.2, false, 15L, (short) 1, 2);
+        Data data = serializationService.toData(raw);
+        BoxedPrimitivesDTO deserialized = serializationService.toObject(data);
+        assertEquals(raw, deserialized);
     }
 
     @Test

--- a/hazelcast/src/test/java/example/serialization/ArraysDTO.java
+++ b/hazelcast/src/test/java/example/serialization/ArraysDTO.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import java.util.Arrays;
+
+public class ArraysDTO {
+    private byte[] b1;
+    private char[] c1;
+    private float[] f1;
+    private double[] d1;
+    private boolean[] bool1;
+    private long[] l1;
+    private short[] s1;
+    private int[] i1;
+
+    public ArraysDTO() {
+    }
+
+    public ArraysDTO(byte[] b1,
+              char[] c1,
+              float[] f1,
+              double[] d1,
+              boolean[] bool1,
+              long[] l1,
+              short[] s1,
+              int[] i1) {
+        this.b1 = b1;
+        this.c1 = c1;
+        this.f1 = f1;
+        this.d1 = d1;
+        this.bool1 = bool1;
+        this.l1 = l1;
+        this.s1 = s1;
+        this.i1 = i1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArraysDTO arraysDTO = (ArraysDTO) o;
+        return Arrays.equals(b1, arraysDTO.b1)
+          && Arrays.equals(c1, arraysDTO.c1)
+          && Arrays.equals(f1, arraysDTO.f1)
+          && Arrays.equals(d1, arraysDTO.d1)
+          && Arrays.equals(bool1, arraysDTO.bool1)
+          && Arrays.equals(l1, arraysDTO.l1)
+          && Arrays.equals(s1, arraysDTO.s1)
+          && Arrays.equals(i1, arraysDTO.i1);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(b1);
+        result = 31 * result + Arrays.hashCode(c1);
+        result = 31 * result + Arrays.hashCode(f1);
+        result = 31 * result + Arrays.hashCode(d1);
+        result = 31 * result + Arrays.hashCode(bool1);
+        result = 31 * result + Arrays.hashCode(l1);
+        result = 31 * result + Arrays.hashCode(s1);
+        result = 31 * result + Arrays.hashCode(i1);
+        return result;
+    }
+}

--- a/hazelcast/src/test/java/example/serialization/BoxedPrimitivesDTO.java
+++ b/hazelcast/src/test/java/example/serialization/BoxedPrimitivesDTO.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import java.util.Objects;
+
+public class BoxedPrimitivesDTO {
+    private Byte b1;
+    private Character c1;
+    private Float f1;
+    private Double d1;
+    private Boolean bool1;
+    private Long l1;
+    private Short s1;
+    private Integer i1;
+
+    public BoxedPrimitivesDTO() {
+    }
+
+    public BoxedPrimitivesDTO(
+      Byte b1,
+      Character c1,
+      Float f1,
+      Double d1,
+      Boolean bool1,
+      Long l1,
+      Short s1,
+      Integer i1) {
+        this.b1 = b1;
+        this.c1 = c1;
+        this.f1 = f1;
+        this.d1 = d1;
+        this.bool1 = bool1;
+        this.l1 = l1;
+        this.s1 = s1;
+        this.i1 = i1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BoxedPrimitivesDTO that = (BoxedPrimitivesDTO) o;
+        return Objects.equals(b1, that.b1)
+          && Objects.equals(c1, that.c1)
+          && Objects.equals(f1, that.f1)
+          && Objects.equals(d1, that.d1)
+          && Objects.equals(bool1, that.bool1)
+          && Objects.equals(l1, that.l1)
+          && Objects.equals(s1, that.s1)
+          && Objects.equals(i1, that.i1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(b1, c1, f1, d1, bool1, l1, s1, i1);
+    }
+}


### PR DESCRIPTION
Without the branch covering `Character.TYPE`, the recursive serialization never terminates resulting in a `StackOverFlowError`:

> Exception in thread "main" java.lang.StackOverflowError
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:52)
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:47)
	at java.base/java.util.TreeMap.getEntryUsingComparator(TreeMap.java:374)
	at java.base/java.util.TreeMap.getEntry(TreeMap.java:344)
	at java.base/java.util.TreeMap.get(TreeMap.java:279)
	at com.hazelcast.internal.serialization.impl.compact.Schema.getField(Schema.java:142)
	at com.hazelcast.internal.serialization.impl.compact.DefaultCompactWriter.checkFieldDefinition(DefaultCompactWriter.java:416)
	at com.hazelcast.internal.serialization.impl.compact.DefaultCompactWriter.setPosition(DefaultCompactWriter.java:403)