### PR TITLE
Fix possible NPE in JetConsoleLogHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/JetConsoleLogHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/JetConsoleLogHandler.java
@@ -80,6 +80,9 @@ public class JetConsoleLogHandler extends StreamHandler {
         }
 
         private static String abbreviateLoggerName(String name) {
+            if (name == null) {
+                return "null";
+            }
             return name.replaceAll("\\B\\w+\\.", ".");
         }
 


### PR DESCRIPTION
`java.util.logging.LogRecord.getLoggerName()` can, according to its javadoc,
return null. We need to deal with that gracefully.

Reported as (probably) unrelated issue in
https://stackoverflow.com/q/71029711/952135