### PR TITLE
Enhance error message when multiple discovery strategies are enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
@@ -173,41 +173,44 @@ class ClusterDiscoveryServiceBuilder {
                                                     boolean gcpDiscoveryEnabled, boolean azureDiscoveryEnabled,
                                                     boolean kubernetesDiscoveryEnabled, boolean eurekaDiscoveryEnabled,
                                                     boolean discoverySpiEnabled, boolean hazelcastCloudEnabled) {
+        List<String> enabledDiscoveries = new ArrayList<>();
         int count = 0;
         if (addressListProvided) {
             count++;
+            enabledDiscoveries.add("cluster members given explicitly");
         }
         if (awsDiscoveryEnabled) {
             count++;
+            enabledDiscoveries.add("AWS discovery");
         }
         if (gcpDiscoveryEnabled) {
             count++;
+            enabledDiscoveries.add("GCP discovery");
         }
         if (azureDiscoveryEnabled) {
             count++;
+            enabledDiscoveries.add("Azure discovery");
         }
         if (kubernetesDiscoveryEnabled) {
             count++;
+            enabledDiscoveries.add("Kubernetes discovery");
         }
         if (eurekaDiscoveryEnabled) {
             count++;
+            enabledDiscoveries.add("Eureka discovery");
         }
         if (discoverySpiEnabled) {
             count++;
+            enabledDiscoveries.add("Discovery SPI");
         }
         if (hazelcastCloudEnabled) {
             count++;
+            enabledDiscoveries.add("Hazelcast Cloud");
         }
         if (count > 1) {
             throw new IllegalStateException("Only one discovery method can be enabled at a time. "
-                    + "cluster members given explicitly : " + addressListProvided
-                    + ", aws discovery: " + awsDiscoveryEnabled
-                    + ", gcp discovery: " + gcpDiscoveryEnabled
-                    + ", azure discovery: " + azureDiscoveryEnabled
-                    + ", kubernetes discovery: " + kubernetesDiscoveryEnabled
-                    + ", eureka discovery: " + eurekaDiscoveryEnabled
-                    + ", discovery spi enabled : " + discoverySpiEnabled
-                    + ", hazelcast.cloud enabled : " + hazelcastCloudEnabled);
+                    + "Keep only one of the following method enabled by removing the others from the configuration, "
+                    + "or setting enabled to 'false': " + String.join(",", enabledDiscoveries));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.config;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
@@ -218,35 +220,47 @@ public class JoinConfig {
      */
     @SuppressWarnings("checkstyle:npathcomplexity")
     public void verify() {
+        List<String> enabledDiscoveries = new ArrayList<>();
         int countEnabled = 0;
         if (getTcpIpConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("TCP/IP");
         }
         if (getMulticastConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("Multicast");
         }
         if (getAwsConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("AWS discovery");
         }
         if (getGcpConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("GCP discovery");
         }
         if (getAzureConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("Azure discovery");
         }
         if (getKubernetesConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("Kubernetes discovery");
         }
         if (getEurekaConfig().isEnabled()) {
             countEnabled++;
+            enabledDiscoveries.add("Eureka discovery");
         }
 
         Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryConfig.getDiscoveryStrategyConfigs();
-        countEnabled += discoveryStrategyConfigs.size();
+        if (!discoveryStrategyConfigs.isEmpty()) {
+            countEnabled++;
+            enabledDiscoveries.add("Discovery SPI");
+        }
 
         if (countEnabled > 1) {
-            throw new InvalidConfigurationException("Multiple join configuration cannot be enabled at the same time. Enable only "
-                    + "one of: TCP/IP, Multicast, AWS, GCP, Azure, Kubernetes, Eureka, or Discovery Strategy");
+            throw new InvalidConfigurationException("Only one discovery method can be enabled at a time. "
+                    + "Keep only one of the following method enabled by removing the others from the configuration, "
+                    + "or setting enabled to 'false': " + String.join(", ", enabledDiscoveries));
         }
     }
 


### PR DESCRIPTION
Based on feedback here: https://groups.google.com/g/hazelcast/c/QBXjo2HFNe4/m/O5R8_UzfBAAJ

Unifying the error message for both client and member and make it more "call to action". Also, displaying only those options that are really enabled to guide the user even more.