### PR TITLE
Remove persistence-file dynamic config option

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -36,8 +36,6 @@ import com.hazelcast.config.CompactSerializationConfig;
 import com.hazelcast.config.CompactSerializationConfigAccessor;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConsistencyCheckStrategy;
-import com.hazelcast.config.IntegrityCheckerConfig;
-import com.hazelcast.config.LocalDeviceConfig;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.DiskTierConfig;
@@ -58,11 +56,13 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.InstanceTrackingConfig;
+import com.hazelcast.config.IntegrityCheckerConfig;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.KubernetesConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.LocalDeviceConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
@@ -1395,14 +1395,12 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     @Test
     public void testDynamicConfiguration() {
         boolean persistenceEnabled = false;
-        File persistenceFile = new File("/mnt/persistence-file");
         File backupDir = new File("/mnt/backup-dir");
         int backupCount = 7;
 
         DynamicConfigurationConfig dynamicConfigurationConfig = config.getDynamicConfigurationConfig();
 
         assertEquals(persistenceEnabled, dynamicConfigurationConfig.isPersistenceEnabled());
-        assertEquals(persistenceFile, dynamicConfigurationConfig.getPersistenceFile());
         assertEquals(backupDir, dynamicConfigurationConfig.getBackupDir());
         assertEquals(backupCount, dynamicConfigurationConfig.getBackupCount());
     }

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -1085,7 +1085,6 @@
 
             <hz:dynamic-configuration>
                 <hz:persistence-enabled>false</hz:persistence-enabled>
-                <hz:persistence-file>/mnt/persistence-file</hz:persistence-file>
                 <hz:backup-dir>/mnt/backup-dir</hz:backup-dir>
                 <hz:backup-count>7</hz:backup-count>
             </hz:dynamic-configuration>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -440,8 +440,6 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     if (persistenceEnabled) {
                         throw new InvalidConfigurationException("Dynamic Configuration Persistence isn't available for Spring.");
                     }
-                } else if ("persistence-file".equals(name)) {
-                    dynamicConfigBuilder.addPropertyValue("persistenceFile", getTextContent(n));
                 } else if ("backup-dir".equals(name)) {
                     dynamicConfigBuilder.addPropertyValue("backupDir", getTextContent(n));
                 } else if ("backup-count".equals(name)) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.1.xsd
@@ -4730,20 +4730,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="persistence-file" type="xs:string" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>
-                        Path for dynamic configuration persistence file. Dynamic changes will be
-                        persisted into this file. If not set, configuration file that was used to
-                        start Hazelcast (root configuration) will be used. If set, this file (the
-                        file specified in the persistence-file path) will be used for persisting
-                        dynamic changes instead of root configuration file. User should also do
-                        the following two: Create an XML or YAML file specified in this path and
-                        import this XML or YAML file to the root configuration. Path can be an
-                        absolute or relative path to the node startup directory.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
             <xs:element name="backup-dir" type="xs:string" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -901,10 +901,6 @@ public class ConfigXmlGenerator {
         gen.open("dynamic-configuration")
                 .node("persistence-enabled", dynamicConfigurationConfig.isPersistenceEnabled());
 
-        if (dynamicConfigurationConfig.getPersistenceFile() != null) {
-            gen.node("persistence-file", dynamicConfigurationConfig.getPersistenceFile().getAbsolutePath());
-        }
-
         if (dynamicConfigurationConfig.getBackupDir() != null) {
             gen.node("backup-dir", dynamicConfigurationConfig.getBackupDir().getAbsolutePath());
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/DynamicConfigurationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DynamicConfigurationConfig.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Objects;
 
@@ -42,7 +41,6 @@ public class DynamicConfigurationConfig {
     public static final int DEFAULT_BACKUP_COUNT = 5;
 
     private boolean persistenceEnabled;
-    private File persistenceFile;
     private File backupDir = new File(DEFAULT_BACKUP_DIR);
     private int backupCount = DEFAULT_BACKUP_COUNT;
 
@@ -64,35 +62,6 @@ public class DynamicConfigurationConfig {
     @Nonnull
     public DynamicConfigurationConfig setPersistenceEnabled(boolean persistenceEnabled) {
         this.persistenceEnabled = persistenceEnabled;
-        return this;
-    }
-
-    /**
-     * Returns persistence file where Dynamic Configuration changes are persisted.
-     * Note that if you set this file to something other than root declarative
-     * configuration (hazelcast.xml for example) you must import into the root
-     * declarative configuration manually.
-     *
-     * @return persistenceFile
-     */
-    @Nullable
-    public File getPersistenceFile() {
-        return persistenceFile;
-    }
-
-    /**
-     * Sets persistence file where Dynamic Configuration changes are persisted.
-     * Note that if you set this file to something other than root declarative
-     * configuration (hazelcast.xml for example) you must import into the root
-     * declarative configuration manually. If set to null, then root config is
-     * used.
-     *
-     * @param persistenceFile can be absolute path or relative path to the node startup directory
-     * @return DynamicConfigurationConfig
-     */
-    @Nonnull
-    public DynamicConfigurationConfig setPersistenceFile(@Nullable File persistenceFile) {
-        this.persistenceFile = persistenceFile;
         return this;
     }
 
@@ -151,14 +120,12 @@ public class DynamicConfigurationConfig {
         DynamicConfigurationConfig that = (DynamicConfigurationConfig) o;
         return persistenceEnabled == that.persistenceEnabled
                 && backupCount == that.backupCount
-                && Objects.equals(persistenceFile, that.persistenceFile)
                 && Objects.equals(backupDir, that.backupDir);
     }
 
     @Override
     public int hashCode() {
         int result = (persistenceEnabled ? 1 : 0);
-        result = 31 * result + (persistenceFile != null ? persistenceFile.hashCode() : 0);
         result = 31 * result + (backupDir != null ? backupDir.hashCode() : 0);
         result = 31 * result + backupCount;
         return result;
@@ -168,7 +135,6 @@ public class DynamicConfigurationConfig {
     public String toString() {
         return "DynamicConfigurationConfig{"
                 + "persistenceEnabled=" + persistenceEnabled
-                + ", persistenceFile=" + persistenceFile
                 + ", backupDir=" + backupDir
                 + ", backupCount=" + backupCount
                 + '}';

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -498,8 +498,6 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             String name = cleanNodeName(n);
             if (matches("persistence-enabled", name)) {
                 dynamicConfigurationConfig.setPersistenceEnabled(parseBoolean(getTextContent(n)));
-            } else if (matches("persistence-file", name)) {
-                dynamicConfigurationConfig.setPersistenceFile(new File(getTextContent(n)).getAbsoluteFile());
             } else if (matches("backup-dir", name)) {
                 dynamicConfigurationConfig.setBackupDir(new File(getTextContent(n)).getAbsoluteFile());
             } else if (matches("backup-count", name)) {

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.json
@@ -3781,10 +3781,6 @@
           "type": "boolean",
           "description": "True if dynamic configuration persistence is enabled."
         },
-        "persistence-file": {
-          "type": "string",
-          "description": "Path for dynamic configuration persistence file. Dynamic changes will be persisted into this file. If not set, configuration file that was used to start Hazelcast (root configuration) will be used. If set, this file (the file specified in the persistence-file path) will be used for persisting dynamic changes instead of root configuration file. User should also do the following two: Create an XML or YAML file specified in this path and import this XML or YAML file to the root configuration. Path can be an absolute or relative path to the node startup directory."
-        },
         "backup-dir": {
           "type": "string",
           "description": "Directory for dynamic configuration persistence file backups. Each new backup will be created inside this directory. Can be an absolute or relative path to the node startup directory. If not set, new folder will be created at the node startup directory."

--- a/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.1.xsd
@@ -4193,20 +4193,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="persistence-file" type="xs:string" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>
-                        Path for dynamic configuration persistence file. Dynamic changes will be
-                        persisted into this file. If not set, configuration file that was used to
-                        start Hazelcast (root configuration) will be used. If set, this file (the
-                        file specified in the persistence-file path) will be used for persisting
-                        dynamic changes instead of root configuration file. User should also do
-                        the following two: Create an XML or YAML file specified in this path and
-                        import this XML or YAML file to the root configuration. Path can be an
-                        absolute or relative path to the node startup directory.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
             <xs:element name="backup-dir" type="xs:string" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2775,15 +2775,6 @@
         It has the following sub-elements:
         * <persistence-enabled>:
             True if dynamic configuration persistence is enabled.
-        * <persistence-file>:
-            Path for dynamic configuration persistence file. Dynamic changes will be
-            persisted into this file. If not set, configuration file that was used to
-            start Hazelcast (root configuration) will be used. If set, this file (the
-            file specified in the persistence-file path) will be used for persisting
-            dynamic changes instead of root configuration file. User should also do
-            the following two: Create an XML or YAML file specified in this path and
-            import this XML or YAML file to the root configuration. Path can be an
-            absolute or relative path to the node startup directory.
         * <backup-dir>:
             Directory for dynamic configuration persistence file backups.
             Each new backup will be created inside this directory.
@@ -2794,7 +2785,6 @@
     -->
         <dynamic-configuration>
             <persistence-enabled>true</persistence-enabled>
-            <persistence-file>/mnt/dynamic/persistence-file.xml</persistence-file>
             <backup-dir>/mnt/dynamic/backup-dir</backup-dir>
             <backup-count>7</backup-count>
         </dynamic-configuration>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2712,15 +2712,6 @@ hazelcast:
   # It has the following sub-elements:
   # * "persistence-enabled":
   #     True if dynamic configuration persistence is enabled.
-  # * "persistence-file":
-  #     Path for dynamic configuration persistence file. Dynamic changes will be
-  #     persisted into this file. If not set, configuration file that was used to
-  #     start Hazelcast (root configuration) will be used. If set, this file (the
-  #     file specified in the persistence-file path) will be used for persisting
-  #     dynamic changes instead of root configuration file. User should also do
-  #     the following two: Create an XML or YAML file specified in this path and
-  #     import this XML or YAML file to the root configuration. Path can be an
-  #     absolute or relative path to the node startup directory.
   # * "backup-dir":
   #     Directory for dynamic configuration persistence file backups.
   #     Each new backup will be created inside this directory.
@@ -2731,7 +2722,6 @@ hazelcast:
 
   dynamic-configuration:
     persistence-enabled: true
-    persistence-file: /mnt/dynamic/persistence-file.xml
     backup-dir: /mnt/dynamic/backup-dir
     backup-count: 7
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -391,7 +391,6 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
     public void testDynamicConfigurationConfig() {
         DynamicConfigurationConfig dynamicConfigurationConfig = new DynamicConfigurationConfig()
                 .setPersistenceEnabled(true)
-                .setPersistenceFile(new File("persistence-file").getAbsoluteFile())
                 .setBackupDir(new File("backup-dir").getAbsoluteFile())
                 .setBackupCount(7);
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3144,14 +3144,12 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testDynamicConfig() {
         boolean persistenceEnabled = true;
-        String persistenceFile = "/mnt/dynamic-configuration/persistence-file";
         String backupDir = "/mnt/dynamic-configuration/backup-dir";
         int backupCount = 7;
 
         String xml = HAZELCAST_START_TAG
                 + "<dynamic-configuration>"
                 + "    <persistence-enabled>" + persistenceEnabled + "</persistence-enabled>"
-                + "    <persistence-file>" + persistenceFile + "</persistence-file>"
                 + "    <backup-dir>" + backupDir + "</backup-dir>"
                 + "    <backup-count>" + backupCount + "</backup-count>"
                 + "</dynamic-configuration>\n"
@@ -3161,7 +3159,6 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         DynamicConfigurationConfig dynamicConfigurationConfig = config.getDynamicConfigurationConfig();
 
         assertEquals(persistenceEnabled, dynamicConfigurationConfig.isPersistenceEnabled());
-        assertEquals(new File(persistenceFile).getAbsolutePath(), dynamicConfigurationConfig.getPersistenceFile().getAbsolutePath());
         assertEquals(new File(backupDir).getAbsolutePath(), dynamicConfigurationConfig.getBackupDir().getAbsolutePath());
         assertEquals(backupCount, dynamicConfigurationConfig.getBackupCount());
 
@@ -3175,7 +3172,6 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         dynamicConfigurationConfig = config.getDynamicConfigurationConfig();
 
         assertEquals(persistenceEnabled, dynamicConfigurationConfig.isPersistenceEnabled());
-        assertNull(dynamicConfigurationConfig.getPersistenceFile());
         assertEquals(new File(DEFAULT_BACKUP_DIR).getAbsolutePath(), dynamicConfigurationConfig.getBackupDir().getAbsolutePath());
         assertEquals(DEFAULT_BACKUP_COUNT, dynamicConfigurationConfig.getBackupCount());
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3150,7 +3150,6 @@ public class YamlConfigBuilderTest
     @Test
     public void testDynamicConfig() {
         boolean persistenceEnabled = true;
-        String persistenceFile = "/mnt/dynamic-configuration/persistence-file";
         String backupDir = "/mnt/dynamic-configuration/backup-dir";
         int backupCount = 7;
 
@@ -3158,7 +3157,6 @@ public class YamlConfigBuilderTest
                 + "hazelcast:\n"
                 + "  dynamic-configuration:\n"
                 + "    persistence-enabled: " +  persistenceEnabled + "\n"
-                + "    persistence-file: " + persistenceFile + "\n"
                 + "    backup-dir: " + backupDir + "\n"
                 + "    backup-count: " + backupCount + "\n";
 
@@ -3166,7 +3164,6 @@ public class YamlConfigBuilderTest
         DynamicConfigurationConfig dynamicConfigurationConfig = config.getDynamicConfigurationConfig();
 
         assertEquals(persistenceEnabled, dynamicConfigurationConfig.isPersistenceEnabled());
-        assertEquals(new File(persistenceFile).getAbsolutePath(), dynamicConfigurationConfig.getPersistenceFile().getAbsolutePath());
         assertEquals(new File(backupDir).getAbsolutePath(), dynamicConfigurationConfig.getBackupDir().getAbsolutePath());
         assertEquals(backupCount, dynamicConfigurationConfig.getBackupCount());
 
@@ -3179,7 +3176,6 @@ public class YamlConfigBuilderTest
         dynamicConfigurationConfig = config.getDynamicConfigurationConfig();
 
         assertEquals(persistenceEnabled, dynamicConfigurationConfig.isPersistenceEnabled());
-        assertNull(dynamicConfigurationConfig.getPersistenceFile());
         assertEquals(new File(DEFAULT_BACKUP_DIR).getAbsolutePath(), dynamicConfigurationConfig.getBackupDir().getAbsolutePath());
         assertEquals(DEFAULT_BACKUP_COUNT, dynamicConfigurationConfig.getBackupCount());
     }

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/dynamic-configuration/success.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/dynamic-configuration/success.json
@@ -3,7 +3,6 @@
     "hazelcast": {
       "dynamic-configuration":{
         "persistence-enabled": true,
-        "persistence-file": "/mnt/persistence-file",
         "backup-dir": "mnt/backup-dir",
         "backup-count": 7
       }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -997,7 +997,6 @@
 
     <dynamic-configuration>
         <persistence-enabled>true</persistence-enabled>
-        <persistence-file>/mnt/persistence-file</persistence-file>
         <backup-dir>/mnt/backup-dir</backup-dir>
         <backup-count>7</backup-count>
     </dynamic-configuration>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -939,7 +939,6 @@ hazelcast:
 
   dynamic-configuration:
     persistence-enabled: true
-    persistence-file: /mnt/persistence-file
     backup-dir: /mnt/backup-dir
     backup-count: 7
 


### PR DESCRIPTION
It was not part of the original requirements and complicates
config persistence from user and technical perspective.

EE PR https://github.com/hazelcast/hazelcast-enterprise/pull/4760