### PR TITLE
Fix the typo in the `GenericRecordBuilder` API

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/CompactUpsertTarget.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/CompactUpsertTarget.java
@@ -68,7 +68,7 @@ class CompactUpsertTarget implements UpsertTarget {
             case NULLABLE_INT8:
                 return value -> builder.setNullableInt8(path, (Byte) value);
             case NULLABLE_INT16:
-                return value -> builder.setNullableint16(path, (Short) value);
+                return value -> builder.setNullableInt16(path, (Short) value);
             case NULLABLE_INT32:
                 return value -> builder.setNullableInt32(path, (Integer) value);
             case NULLABLE_INT64:

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -254,7 +254,7 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
 
     @Nonnull
     @Override
-    public GenericRecordBuilder setNullableint16(@Nonnull String fieldName, @Nullable Short value) {
+    public GenericRecordBuilder setNullableInt16(@Nonnull String fieldName, @Nullable Short value) {
         return write(fieldName, value, FieldKind.NULLABLE_INT16);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
@@ -198,7 +198,7 @@ public class SerializingGenericRecordBuilder implements GenericRecordBuilder {
 
     @Nonnull
     @Override
-    public GenericRecordBuilder setNullableint16(@Nonnull String fieldName, @Nullable Short value) {
+    public GenericRecordBuilder setNullableInt16(@Nonnull String fieldName, @Nullable Short value) {
         checkIfAlreadyWritten(fieldName);
         defaultCompactWriter.writeNullableInt16(fieldName, value);
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
@@ -248,7 +248,7 @@ public class SerializingGenericRecordCloner implements GenericRecordBuilder {
 
     @Nonnull
     @Override
-    public GenericRecordBuilder setNullableint16(@Nonnull String fieldName, @Nullable Short value) {
+    public GenericRecordBuilder setNullableInt16(@Nonnull String fieldName, @Nullable Short value) {
         checkTypeWithSchema(schema, fieldName, FieldKind.NULLABLE_INT16);
         if (fields.putIfAbsent(fieldName, () -> cw.writeNullableInt16(fieldName, value)) != null) {
             throw new HazelcastSerializationException("Field can only be written once");

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -164,7 +164,7 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
 
     @Nonnull
     @Override
-    public GenericRecordBuilder setNullableint16(@Nonnull String fieldName, @Nullable Short value) {
+    public GenericRecordBuilder setNullableInt16(@Nonnull String fieldName, @Nullable Short value) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
@@ -252,7 +252,7 @@ interface GenericRecordBuilder {
      *                                         {@link GenericRecord#cloneWithBuilder()}.
      */
     @Nonnull
-    GenericRecordBuilder setNullableint16(@Nonnull String fieldName, @Nullable Short value);
+    GenericRecordBuilder setNullableInt16(@Nonnull String fieldName, @Nullable Short value);
 
     /**
      * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -104,7 +104,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         GenericRecordBuilder builder = compact("test");
         builder.setNullableBoolean("boolean", true);
         builder.setNullableInt8("byte", (byte) 4);
-        builder.setNullableint16("short", (short) 6);
+        builder.setNullableInt16("short", (short) 6);
         builder.setNullableInt32("int", 8);
         builder.setNullableInt64("long", 4444L);
         builder.setNullableFloat32("float", 8321.321F);
@@ -152,7 +152,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         GenericRecordBuilder builder = compact("test");
         builder.setNullableBoolean("boolean", null);
         builder.setNullableInt8("byte", null);
-        builder.setNullableint16("short", null);
+        builder.setNullableInt16("short", null);
         builder.setNullableInt32("int", null);
         builder.setNullableInt64("long", null);
         builder.setNullableFloat32("float", null);
@@ -200,7 +200,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         GenericRecordBuilder builder = compact(PrimitiveObject.class.getName());
         builder.setNullableBoolean("boolean_", true);
         builder.setNullableInt8("byte_", (byte) 2);
-        builder.setNullableint16("short_", (short) 4);
+        builder.setNullableInt16("short_", (short) 4);
         builder.setNullableInt32("int_", 8);
         builder.setNullableInt64("long_", 4444L);
         builder.setNullableFloat32("float_", 8321.321F);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -90,7 +90,7 @@ public final class CompactTestUtil {
                 .setTimestampWithTimezone("offsetDateTime", mainDTO.offsetDateTime)
                 .setNullableInt8("nullable_b", mainDTO.b)
                 .setNullableBoolean("nullable_bool", mainDTO.bool)
-                .setNullableint16("nullable_s", mainDTO.s)
+                .setNullableInt16("nullable_s", mainDTO.s)
                 .setNullableInt32("nullable_i", mainDTO.i)
                 .setNullableInt64("nullable_l", mainDTO.l)
                 .setNullableFloat32("nullable_f", mainDTO.f)

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordTest.java
@@ -46,7 +46,7 @@ public class GenericRecordTest {
 
         assertThrows(UnsupportedOperationException.class, () -> builder.setNullableBoolean("name", null));
         assertThrows(UnsupportedOperationException.class, () -> builder.setNullableInt8("name", null));
-        assertThrows(UnsupportedOperationException.class, () -> builder.setNullableint16("name", null));
+        assertThrows(UnsupportedOperationException.class, () -> builder.setNullableInt16("name", null));
         assertThrows(UnsupportedOperationException.class, () -> builder.setNullableInt32("name", null));
         assertThrows(UnsupportedOperationException.class, () -> builder.setNullableInt64("name", null));
         assertThrows(UnsupportedOperationException.class, () -> builder.setNullableFloat32("name", null));


### PR DESCRIPTION
The name of the method was misspelled as `setNullableint16`, instead
of `setNullableInt16`.

This PR fixes that problem.