### PR TITLE
Remove leftover comments in CompactReader methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -259,9 +259,6 @@ public interface CompactReader {
     /**
      * Reads a time consisting of hour, minute, second, and nano seconds
      * or returns the default value.
-     * <p>
-     * This method may only return {@code null}, if the {@code defaultValue}
-     * is {@code null}.
      *
      * @param fieldName    name of the field.
      * @param defaultValue default value to return if the field with the given name
@@ -286,9 +283,6 @@ public interface CompactReader {
 
     /**
      * Reads a date consisting of year, month, and day or returns the default value.
-     * <p>
-     * This method may only return {@code null}, if the {@code defaultValue}
-     * is {@code null}.
      *
      * @param fieldName    name of the field.
      * @param defaultValue default value to return if the field with the given name
@@ -313,9 +307,6 @@ public interface CompactReader {
 
     /**
      * Reads a timestamp consisting of date and time or returns the default value.
-     * <p>
-     * This method may only return {@code null}, if the {@code defaultValue}
-     * is {@code null}.
      *
      * @param fieldName    name of the field.
      * @param defaultValue default value to return if the field with the given name
@@ -341,9 +332,6 @@ public interface CompactReader {
     /**
      * Reads a timestamp with timezone consisting of date, time and timezone offset
      * or returns the default value.
-     * <p>
-     * This method may only return {@code null}, if the {@code defaultValue}
-     * is {@code null}.
      *
      * @param fieldName    name of the field.
      * @param defaultValue default value to return if the field with the given name


### PR DESCRIPTION
Remove leftover comments in CompactReader methods


Breaking changes (list specific methods/types/messages):

none

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
