### PR TITLE
Thread-safe Map/Cache replication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
@@ -43,8 +43,8 @@ import static java.util.Collections.emptyList;
  */
 public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
 
-    private UUID partitionUuid;
-    private List<Object> cacheNameSequencePairs = emptyList();
+    private volatile UUID partitionUuid;
+    private volatile List<Object> cacheNameSequencePairs = emptyList();
     private Operation cacheReplicationOperation;
 
     public CacheNearCacheStateHolder() {
@@ -61,14 +61,15 @@ public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
         int partitionId = segment.getPartitionId();
         partitionUuid = metaData.getOrCreateUuid(partitionId);
 
-        cacheNameSequencePairs = new ArrayList(namespaces.size());
+        List<Object> nameSeqPairs = new ArrayList<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
             ObjectNamespace ns = (ObjectNamespace) namespace;
             String cacheName = ns.getObjectName();
 
-            cacheNameSequencePairs.add(cacheName);
-            cacheNameSequencePairs.add(metaData.currentSequence(cacheName, partitionId));
+            nameSeqPairs.add(cacheName);
+            nameSeqPairs.add(metaData.currentSequence(cacheName, partitionId));
         }
+        cacheNameSequencePairs = nameSeqPairs;
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator(ICacheService cacheService) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -505,8 +505,8 @@ public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K,
     public int hashCode() {
         int result = cacheLoaderFactory != null ? cacheLoaderFactory.hashCode() : 0;
         result = 31 * result + listenerConfigurations.hashCode();
-        result = 31 * result + keyType.hashCode();
-        result = 31 * result + valueType.hashCode();
+        result = keyType == null ? result : 31 * result + keyType.hashCode();
+        result = valueType == null ? result : 31 * result + valueType.hashCode();
         result = 31 * result + (cacheWriterFactory != null ? cacheWriterFactory.hashCode() : 0);
         result = 31 * result + (expiryPolicyFactory != null ? expiryPolicyFactory.hashCode() : 0);
         result = 31 * result + (isReadThrough ? 1 : 0);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
@@ -43,9 +43,8 @@ import static java.util.Collections.EMPTY_LIST;
  */
 public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
 
-    // keep this `protected`, extended in another context
-    protected UUID partitionUuid;
-    protected List<Object> mapNameSequencePairs = EMPTY_LIST;
+    protected volatile UUID partitionUuid;
+    protected volatile List<Object> mapNameSequencePairs = EMPTY_LIST;
 
     private MapReplicationOperation mapReplicationOperation;
 
@@ -68,17 +67,15 @@ public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
         int partitionId = container.getPartitionId();
         partitionUuid = metaData.getOrCreateUuid(partitionId);
 
+        List<Object> nameSeqPairs = new ArrayList<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
-            if (mapNameSequencePairs == EMPTY_LIST) {
-                mapNameSequencePairs = new ArrayList(namespaces.size());
-            }
-
             ObjectNamespace mapNamespace = (ObjectNamespace) namespace;
             String mapName = mapNamespace.getObjectName();
 
-            mapNameSequencePairs.add(mapName);
-            mapNameSequencePairs.add(metaData.currentSequence(mapName, partitionId));
+            nameSeqPairs.add(mapName);
+            nameSeqPairs.add(metaData.currentSequence(mapName, partitionId));
         }
+        mapNameSequencePairs = nameSeqPairs;
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator(MapService mapService) {

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -96,6 +96,12 @@ public class CacheConfigTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testHashCode() {
+        CacheConfig cacheConfig = new CacheConfig();
+        assertTrue(cacheConfig.hashCode() != 0);
+    }
+
+    @Test
     public void testCacheConfigLoaderWriterXml() throws Exception {
         Config config = new XmlConfigBuilder(configUrl2).build();
 


### PR DESCRIPTION
Map/CacheNearCacheStateHolder fields may be populated from one thread,
then serialized from another thread. This is the case with differential
sync, where prepare is invoked from generic thread, then data are
serialized from partition thread.

Also includes a fix for AbstractCacheConfig#hashCode that should
take into account keyType and valueType are nullable.

Forward port of #20164 implementing @fbarotov 's [comment](https://github.com/hazelcast/hazelcast/pull/20164/files#r769567337)

EE PR https://github.com/hazelcast/hazelcast-enterprise/pull/4762