### PR TITLE
[HZ-907] Protect MulticastDiscoveryStrategy against Java deserialization attacks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 import com.hazelcast.spi.discovery.multicast.impl.MulticastDiscoveryReceiver;
 import com.hazelcast.spi.discovery.multicast.impl.MulticastDiscoverySender;
+import com.hazelcast.spi.discovery.multicast.impl.MulticastDiscoverySerializationHelper;
 import com.hazelcast.spi.discovery.multicast.impl.MulticastMemberInfo;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 
@@ -47,6 +48,7 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
     private static final int SOCKET_TIME_TO_LIVE = 255;
     private static final int SOCKET_TIMEOUT = 3000;
     private static final String DEFAULT_MULTICAST_GROUP = "224.2.2.3";
+    private static final Boolean DEFAULT_SAFE_SERIALIZATION = Boolean.FALSE;
 
     private DiscoveryNode discoveryNode;
     private MulticastSocket multicastSocket;
@@ -68,6 +70,16 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             PortValueValidator validator = new PortValueValidator();
             validator.validate(port);
             String group = getOrDefault(MulticastProperties.GROUP, DEFAULT_MULTICAST_GROUP);
+            boolean safeSerialization = getOrDefault(MulticastProperties.SAFE_SERIALIZATION, DEFAULT_SAFE_SERIALIZATION);
+            if (!safeSerialization) {
+                String prop = MulticastProperties.SAFE_SERIALIZATION.key();
+                logger.warning("The " + getClass().getSimpleName()
+                        + " Hazelcast member discovery strategy is configured without the " + prop + " parameter enabled."
+                        + " Set the " + prop + " property to 'true' in the strategy configuration to protect the cluster"
+                        + " against untrusted deserialization attacks.");
+            }
+            MulticastDiscoverySerializationHelper serializationHelper = new MulticastDiscoverySerializationHelper(
+                    safeSerialization);
             multicastSocket = new MulticastSocket(null);
             multicastSocket.bind(new InetSocketAddress(port));
             if (discoveryNode != null) {
@@ -83,8 +95,9 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             multicastSocket.setSendBufferSize(DATA_OUTPUT_BUFFER_SIZE);
             multicastSocket.setSoTimeout(SOCKET_TIMEOUT);
             multicastSocket.joinGroup(InetAddress.getByName(group));
-            multicastDiscoverySender = new MulticastDiscoverySender(discoveryNode, multicastSocket, logger, group, port);
-            multicastDiscoveryReceiver = new MulticastDiscoveryReceiver(multicastSocket, logger);
+            multicastDiscoverySender = new MulticastDiscoverySender(discoveryNode, multicastSocket, logger, group, port,
+                    serializationHelper);
+            multicastDiscoveryReceiver = new MulticastDiscoveryReceiver(multicastSocket, logger, serializationHelper);
             if (discoveryNode == null) {
                 isClient = true;
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyFactory.java
@@ -39,6 +39,7 @@ public class MulticastDiscoveryStrategyFactory implements DiscoveryStrategyFacto
         List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
         propertyDefinitions.add(MulticastProperties.GROUP);
         propertyDefinitions.add(MulticastProperties.PORT);
+        propertyDefinitions.add(MulticastProperties.SAFE_SERIALIZATION);
         PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(propertyDefinitions);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 import com.hazelcast.config.properties.ValueValidator;
 
+import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
@@ -38,6 +39,22 @@ public final class MulticastProperties {
      * Property used to define zones for node filtering.
      */
     public static final PropertyDefinition GROUP = property("group", STRING);
+
+    /**
+     * Property which determines if Java Serialization is used ({@code false}) or rather the safer and portable one
+     * ({@code true}).
+     * <p/>
+     * Safe serialization format of the MulticastMemberInfo:
+     *
+     * <pre>
+     * boolean: flag if memberInfo provided (false mean memberInfo is null)
+     * UTF-8:   host
+     * int:     port
+     * </pre>
+     *
+     * @since 5.1
+     */
+    public static final PropertyDefinition SAFE_SERIALIZATION = property("safe-serialization", BOOLEAN);
 
     private MulticastProperties() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
@@ -25,8 +25,6 @@ import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
-import java.io.DataOutputStream;
-
 /**
  * Defines the name and default value for the Multicast Discovery Strategy.
  */
@@ -56,7 +54,7 @@ public final class MulticastProperties {
      * int:    (4b):              port
      * </pre>
      *
-     * <b>UTF-8 format notes (see {@link DataOutputStream#writeUTF(String)}):<b>
+     * <b>UTF-8 format notes (see {@link java.io.DataOutputStream#writeUTF(String)}):<b>
      * <p/>
      * Two bytes (short) provides subsequent length to read. This value is the number of bytes actually, not the length of the
      * string. Modified UTF-8 is used for decoding.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
@@ -25,6 +25,8 @@ import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
+import java.io.DataOutputStream;
+
 /**
  * Defines the name and default value for the Multicast Discovery Strategy.
  */
@@ -42,15 +44,22 @@ public final class MulticastProperties {
 
     /**
      * Property which determines if Java Serialization is used ({@code false}) or rather the safer and portable one
-     * ({@code true}).
+     * ({@code true}). The Java native serialization format which is used by default is sensitive to
+     * <a href="https://owasp.org/www-project-top-ten/2017/A8_2017-Insecure_Deserialization">insecure deserialization
+     * attacks</a>.
      * <p/>
      * Safe serialization format of the MulticastMemberInfo:
      *
      * <pre>
-     * boolean: flag if memberInfo provided (false mean memberInfo is null)
-     * UTF-8:   host
-     * int:     port
+     * boolean (1b):              flag if memberInfo provided (false mean memberInfo is null)
+     * UTF-8   (variable length): host
+     * int:    (4b):              port
      * </pre>
+     *
+     * <b>UTF-8 format notes (see {@link DataOutputStream#writeUTF(String)}):<b>
+     * <p/>
+     * Two bytes (short) provides subsequent length to read. This value is the number of bytes actually, not the length of the
+     * string. Modified UTF-8 is used for decoding.
      *
      * @since 5.1
      */

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
@@ -20,10 +20,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.MulticastSocket;
@@ -36,18 +33,19 @@ public class MulticastDiscoverySender implements Runnable {
     private MulticastSocket multicastSocket;
     private MulticastMemberInfo multicastMemberInfo;
     private DatagramPacket datagramPacket;
-    private ILogger logger;
-    private String group;
-    private int port;
+    private final ILogger logger;
+    private final String group;
+    private final int port;
+    private final MulticastDiscoverySerializationHelper serializationHelper;
     private volatile boolean stop;
 
-    public MulticastDiscoverySender(DiscoveryNode discoveryNode, MulticastSocket multicastSocket,
-                                    ILogger logger, String group, int port)
-            throws IOException {
+    public MulticastDiscoverySender(DiscoveryNode discoveryNode, MulticastSocket multicastSocket, ILogger logger, String group,
+            int port, MulticastDiscoverySerializationHelper serializationHelper) throws IOException {
         this.multicastSocket = multicastSocket;
         this.logger = logger;
         this.group = group;
         this.port = port;
+        this.serializationHelper = serializationHelper;
         if (discoveryNode != null) {
             Address address = discoveryNode.getPublicAddress();
             multicastMemberInfo = new MulticastMemberInfo(address.getHost(), address.getPort());
@@ -56,11 +54,7 @@ public class MulticastDiscoverySender implements Runnable {
     }
 
     private void initDatagramPacket() throws IOException {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        ObjectOutput out;
-        out = new ObjectOutputStream(bos);
-        out.writeObject(multicastMemberInfo);
-        byte[] yourBytes = bos.toByteArray();
+        byte[] yourBytes = serializationHelper.serialize(multicastMemberInfo);
         datagramPacket = new DatagramPacket(yourBytes, yourBytes.length,
                 InetAddress.getByName(group), port);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySerializationHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySerializationHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.multicast.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+
+/**
+ * Helps to serialize and deserialize the {@link MulticastMemberInfo}.
+ *
+ * @see com.hazelcast.spi.discovery.multicast.MulticastProperties#SAFE_SERIALIZATION
+ */
+public class MulticastDiscoverySerializationHelper {
+
+    private final boolean safeSerialization;
+
+    public MulticastDiscoverySerializationHelper(boolean safeSerialization) {
+        this.safeSerialization = safeSerialization;
+    }
+
+    public byte[] serialize(MulticastMemberInfo memberInfo) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        if (safeSerialization) {
+            try (DataOutputStream dos = new DataOutputStream(bos)) {
+                dos.writeBoolean(memberInfo != null);
+                if (memberInfo != null) {
+                    dos.writeUTF(memberInfo.getHost());
+                    dos.writeInt(memberInfo.getPort());
+                }
+            }
+        } else {
+            try (ObjectOutput oo = new ObjectOutputStream(bos)) {
+                oo.writeObject(memberInfo);
+            }
+        }
+        return bos.toByteArray();
+    }
+
+    public MulticastMemberInfo deserialize(byte[] data) throws IOException, ClassNotFoundException {
+        if (data == null) {
+            return null;
+        }
+        MulticastMemberInfo memberInfo = null;
+        ByteArrayInputStream bis = new ByteArrayInputStream(data);
+        if (safeSerialization) {
+            try (DataInputStream dis = new DataInputStream(bis)) {
+                boolean memberInfoIncluded = dis.readBoolean();
+                if (memberInfoIncluded) {
+                    String tmpHost = dis.readUTF();
+                    int tmpPort = dis.readInt();
+                    memberInfo = new MulticastMemberInfo(tmpHost, tmpPort);
+                }
+            }
+        } else {
+            try (ObjectInputStream in = new ObjectInputStream(bis)) {
+                memberInfo = (MulticastMemberInfo) in.readObject();
+            }
+        }
+        return memberInfo;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.multicast;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.internal.util.OsHelper;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import example.serialization.TestDeserialized;
+
+/**
+ * Tests if safe-serialization property works in {@link MulticastDiscoveryStrategy}.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MulticastDiscoveryStrategyDeserializationTest {
+
+    private static final String GROUP = "224.0.0.219";
+    private static final int PORT = 54328;
+
+    private volatile boolean stop;
+    private volatile Thread datadgramsThread;
+    private volatile Exception datagramsThreadException;
+
+    @Before
+    public void before() {
+        HazelcastInstanceFactory.terminateAll();
+        TestDeserialized.isDeserialized = false;
+        stop = false;
+        datagramsThreadException = null;
+        datadgramsThread = new Thread(() -> sendDatagrams());
+        datadgramsThread.start();
+    }
+
+    @After
+    public void after() {
+        if (datadgramsThread != null) {
+            stop = true;
+            try {
+                datadgramsThread.join();
+            } catch (InterruptedException e) {
+            }
+            datadgramsThread = null;
+        }
+        assertNull(datagramsThreadException);
+        HazelcastInstanceFactory.terminateAll();
+        TestDeserialized.isDeserialized = false;
+
+    }
+
+    @Test
+    public void testSafeSerialization() throws Exception {
+        Config config = createConfig(true);
+        Hazelcast.newHazelcastInstance(config);
+
+        TimeUnit.SECONDS.sleep(3);
+        assertFalse("Untrusted deserialization is possible", TestDeserialized.isDeserialized);
+    }
+
+    @Test
+    public void testDefaultPacketFormat() throws Exception {
+        Config config = createConfig(null);
+        Hazelcast.newHazelcastInstance(config);
+        assertTrueEventually(() -> assertTrue("Object was not deserialized", TestDeserialized.isDeserialized), 15);
+    }
+
+    private Config createConfig(Boolean safeSerialization) {
+        Config config = smallInstanceConfig().setProperty("hazelcast.discovery.enabled", "true");
+        DiscoveryStrategyConfig dsc = new DiscoveryStrategyConfig(MulticastDiscoveryStrategy.class.getName())
+                .addProperty("group", GROUP).addProperty("port", String.valueOf(PORT));
+        if (safeSerialization != null) {
+            dsc.addProperty("safe-serialization", safeSerialization.toString());
+        }
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(dsc);
+        // joinConfig.getAutoDetectionConfig().setEnabled(false);
+        return config;
+    }
+
+    private void sendDatagrams() {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        MulticastSocket multicastSocket = null;
+        try {
+            try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+                oos.writeObject(new TestDeserialized());
+            }
+            byte[] data = bos.toByteArray();
+            multicastSocket = new MulticastSocket(PORT);
+            multicastSocket.setTimeToLive(0);
+            if (OsHelper.isMac()) {
+                multicastSocket.setInterface(InetAddress.getByName("127.0.0.1"));
+            }
+            InetAddress group = InetAddress.getByName(GROUP);
+            multicastSocket.joinGroup(group);
+            DatagramPacket packet = new DatagramPacket(data, data.length, group, PORT);
+            while (!stop) {
+                try {
+                    multicastSocket.send(packet);
+                    TimeUnit.SECONDS.sleep(1);
+                } catch (Exception e) {
+                }
+            }
+            multicastSocket.leaveGroup(group);
+        } catch (Exception e) {
+            datagramsThreadException = e;
+            e.printStackTrace();
+        } finally {
+            if (multicastSocket != null) {
+                multicastSocket.close();
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
@@ -111,7 +111,6 @@ public class MulticastDiscoveryStrategyDeserializationTest {
         }
         JoinConfig joinConfig = config.getNetworkConfig().getJoin();
         joinConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(dsc);
-        // joinConfig.getAutoDetectionConfig().setEnabled(false);
         return config;
     }
 


### PR DESCRIPTION
This PR adds an alternative and safer serialization format for `MulticastDiscoveryStrategy` datagrams.

By using the property configuration `safe-serialization=true`, users might protect themselves against Java deserialization-based attacks.