### PR TITLE
Use URI instead of the absolute path in the *CacheConfigTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -116,7 +116,7 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
                 jcacheConfigFile.getAbsolutePath()
         );
 
-        URI uri = new URI("jar:file:" + jcacheConfigFile.getAbsolutePath() + "!/hazelcast-client-c1.xml");
+        URI uri = new URI("jar:" + jcacheConfigFile.toURI() + "!/hazelcast-client-c1.xml");
         CacheManager cacheManager = Caching.getCachingProvider().getCacheManager(uri, null, new Properties());
         assertThat(cacheManager).isNotNull();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -376,7 +376,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
                 jcacheConfigFile.getAbsolutePath()
         );
 
-        URI uri = new URI("jar:file:" + jcacheConfigFile.getAbsolutePath() + "!/test-hazelcast-jcache.xml");
+        URI uri = new URI("jar:" + jcacheConfigFile.toURI() + "!/test-hazelcast-jcache.xml");
         CacheManager cacheManager = Caching.getCachingProvider().getCacheManager(uri, null, new Properties());
         assertThat(cacheManager).isNotNull();
 


### PR DESCRIPTION
In `*CacheConfigTest#cacheCacheManagerByLocationJarFileTest`, we were
constructing the URI using the absolute path of the file, but that
causes problems in the Windows tests due to backslashes.

Using the `.toURI` on the JAR file solves that problem.

Tested on `Hazelcast-master-Windows-OracleJDK8`.

```
11:12:43 [INFO] Running com.hazelcast.client.cache.ClientCacheConfigTest
11:12:55 [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.562 s - in com.hazelcast.client.cache.ClientCacheConfigTest
```

http://jenkins.hazelcast.com/job/metin-Hazelcast-master-Windows-OracleJDK8-clone/1/console

Closes #20617 