### PR TITLE
Enable the animal-snifer maven plugin for the tests too

### DIFF
--- a/hazelcast-it/jdk17-tests/pom.xml
+++ b/hazelcast-it/jdk17-tests/pom.xml
@@ -15,6 +15,21 @@
         <jdk.version>17</jdk.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>source-java8-check</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoderAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoderAbstractTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -83,7 +84,7 @@ public abstract class HyperLogLogEncoderAbstractTest {
             int toCount = random.nextInt();
             actualCount.add(toCount);
 
-            bb.clear();
+            upcast(bb).clear();
             bb.putInt(toCount);
             encoder.add(HashUtil.MurmurHash3_x64_64(bb.array(), 0, bb.array().length));
 

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
@@ -35,6 +35,7 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Random;
 
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -111,7 +112,7 @@ public class HyperLogLogImplTest {
             int toCount = random.nextInt();
             actualCount.add(toCount);
 
-            bb.clear();
+            upcast(bb).clear();
             bb.putInt(toCount);
             hyperLogLog.add(HashUtil.MurmurHash3_x64_64(bb.array(), 0, bb.array().length));
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
@@ -52,6 +52,7 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
 import static com.hazelcast.client.impl.protocol.util.ClientMessageSplitter.getFragments;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -71,7 +72,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -82,7 +83,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -104,7 +105,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -115,7 +116,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -146,7 +147,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -157,7 +158,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -199,7 +200,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -210,7 +211,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -264,7 +265,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -275,7 +276,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -314,7 +315,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         });
 
         ByteBuffer buffer = ByteBuffer.allocate(200);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -325,7 +326,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessageRef::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitAndBuildTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.client.impl.protocol.util.ClientMessageSplitter.getFragments;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
 import static groovy.util.GroovyTestCase.assertEquals;
 
@@ -87,7 +88,7 @@ public class ClientMessageSplitAndBuildTest {
         encoder.src(outputQueue::poll);
 
         ByteBuffer buffer = ByteBuffer.allocate(100000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -98,7 +99,7 @@ public class ClientMessageSplitAndBuildTest {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -136,7 +137,7 @@ public class ClientMessageSplitAndBuildTest {
         encoder.src(outputQueue::poll);
 
         ByteBuffer buffer = ByteBuffer.allocate(100000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -147,7 +148,7 @@ public class ClientMessageSplitAndBuildTest {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, inputQueue::offer, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -172,7 +173,7 @@ public class ClientMessageSplitAndBuildTest {
         encoder.src(outputQueue::poll);
 
         ByteBuffer buffer = ByteBuffer.allocate(100000);
-        buffer.flip();
+        upcast(buffer).flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -183,7 +184,7 @@ public class ClientMessageSplitAndBuildTest {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        buffer.position(buffer.limit());
+        upcast(buffer).position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
@@ -53,6 +53,7 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
 import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.Collections.emptyList;
@@ -262,7 +263,7 @@ public class ClientMessageProtectionTest {
     }
 
     private static byte[] byteBufferToBytes(ByteBuffer buffer) {
-        buffer.flip();
+        upcast(buffer).flip();
         byte[] requestBytes = new byte[buffer.limit()];
         buffer.get(requestBytes);
         return requestBytes;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder.DEFAULT_BYTE_ORDER;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -174,8 +175,8 @@ public class DataInputNavigableJsonAdapterTest {
             buffer.append((char) next);
             next = reader.read();
         }
-        buffer.limit(buffer.position());
-        buffer.rewind();
+        upcast(buffer).limit(buffer.position());
+        upcast(buffer).rewind();
         String actual = buffer.toString();
         assertEquals(expected, actual);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/PacketEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/PacketEncoderTest.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -56,7 +57,7 @@ public class PacketEncoderTest extends HazelcastTestSupport {
     public void whenPacketFullyWritten() {
         final Packet packet = new Packet(serializationService.toBytes("foobar"));
         ByteBuffer dst = ByteBuffer.allocate(1000);
-        dst.flip();
+        upcast(dst).flip();
 
         PacketSupplier src = new PacketSupplier();
         src.queue.add(packet);
@@ -77,7 +78,7 @@ public class PacketEncoderTest extends HazelcastTestSupport {
     public void whenNotEnoughSpace() {
         final Packet packet = new Packet(serializationService.toBytes(new byte[2000]));
         ByteBuffer dst = ByteBuffer.allocate(1000);
-        dst.flip();
+        upcast(dst).flip();
 
         PacketSupplier src = new PacketSupplier();
         src.queue.add(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/TestUtil.java
@@ -44,6 +44,7 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
 import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class TestUtil {
 
@@ -166,7 +167,7 @@ public class TestUtil {
         }
 
         private byte[] byteBufferToBytes(ByteBuffer buffer) {
-            buffer.flip();
+            upcast(buffer).flip();
             byte[] requestBytes = new byte[buffer.limit()];
             buffer.get(requestBytes);
             return requestBytes;

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -78,6 +78,7 @@ import static com.hazelcast.internal.nio.IOUtil.writeObject;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createObjectDataInputStream;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createObjectDataOutputStream;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.Integer.min;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -687,8 +688,8 @@ public class IOUtilTest extends HazelcastTestSupport {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
         buffer.put((byte) 0xFF);
         buffer.put((byte) 0xFF);
-        buffer.flip();
-        buffer.position(1);
+        upcast(buffer).flip();
+        upcast(buffer).position(1);
         compactOrClear(buffer);
         assertEquals("Buffer position invalid", 1, buffer.position());
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/PacketIOHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/PacketIOHelperTest.java
@@ -43,6 +43,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationConcurrency
 import static com.hazelcast.internal.serialization.impl.SerializationConcurrencyTest.Person;
 import static com.hazelcast.internal.serialization.impl.SerializationConcurrencyTest.PortableAddress;
 import static com.hazelcast.internal.serialization.impl.SerializationConcurrencyTest.PortablePerson;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -105,7 +106,7 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
         ByteBuffer buffer = ByteBuffer.allocate(originalPayload.length * 2);
         Packet originalPacket = new Packet(originalPayload);
         assertTrue(packetWriter.writeTo(originalPacket, buffer));
-        buffer.flip();
+        upcast(buffer).flip();
 
         SerializationService ss2 = createSerializationServiceBuilder().build();
         Packet clonedPacket = packetReader.readFrom(buffer);
@@ -132,9 +133,9 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
         boolean writeCompleted;
         do {
             writeCompleted = packetWriter.writeTo(originalPacket, bb);
-            bb.flip();
+            upcast(bb).flip();
             clonedPacket = packetReader.readFrom(bb);
-            bb.clear();
+            upcast(bb).clear();
         } while (!writeCompleted);
 
         assertNotNull(clonedPacket);
@@ -159,9 +160,9 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
             boolean writeCompleted;
             do {
                 writeCompleted = packetWriter.writeTo(originalPacket, bb);
-                bb.flip();
+                upcast(bb).flip();
                 clonedPacket = packetReader.readFrom(bb);
-                bb.clear();
+                upcast(bb).clear();
             } while (!writeCompleted);
 
             assertNotNull(clonedPacket);
@@ -180,7 +181,7 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
         boolean written = packetWriter.writeTo(originalPacket, bb);
         assertTrue(written);
 
-        bb.flip();
+        upcast(bb).flip();
 
         Packet clonedPacket = packetReader.readFrom(bb);
         assertNotNull(clonedPacket);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.mocknetwork.MockServer.isTargetLeft;
 import static org.junit.Assert.assertNotNull;
 
@@ -156,12 +157,12 @@ public class MockServerConnection implements ServerConnection {
         boolean writeDone;
         do {
             writeDone = packetWriter.writeTo(packet, buffer);
-            buffer.flip();
+            upcast(buffer).flip();
             newPacket = packetReader.readFrom(buffer);
             if (buffer.hasRemaining()) {
                 throw new IllegalStateException("Buffer should be empty! " + buffer);
             }
-            buffer.clear();
+            upcast(buffer).clear();
         } while (!writeDone);
 
         assertNotNull(newPacket);

--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -51,6 +51,16 @@
                     <release>9</release>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>source-java8-check</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -562,8 +562,8 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
+                    <checkTestClasses>true</checkTestClasses>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
                         <artifactId>java18</artifactId>
@@ -666,6 +666,11 @@
                             <exclusionPattern>inside edge crossings that are between</exclusionPattern>
                         </exclusionPatterns>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>${maven.animal.sniffer.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Follow-up for #20661

This PR enables animal-sniffer Java 8 compatibility checks for test classes too.
Again the method `JVMUtil.upcast()` is used to fix issues with covariant return types (in `Buffer` types). It's for cases when code is compiled with a newer Java version and run on Java 8.