### PR TITLE
MC-1344 - phone home for new/missing features

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/atomic/RaftAtomicValueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/atomic/RaftAtomicValueService.java
@@ -150,6 +150,10 @@ public abstract class RaftAtomicValueService<T, V extends RaftAtomicValue<T>, S 
         return atomicValues.remove(key) != null;
     }
 
+    public int getAtomicValuesCount() {
+        return atomicValues.size();
+    }
+
     public final V getAtomicValue(CPGroupId groupId, String name) {
         checkNotNull(groupId);
         checkNotNull(name);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
@@ -272,6 +272,12 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
         return Collections.unmodifiableCollection(registry.getLiveOperations());
     }
 
+    public int getTotalResourcesCount() {
+        return registries.values().stream()
+                .map(collection -> collection.resources.size())
+                .reduce(0, Integer::sum);
+    }
+
     protected final RR getOrInitRegistry(CPGroupId groupId) {
         checkNotNull(groupId);
         RR registry = registries.get(groupId);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/AbstractBlockingService.java
@@ -274,8 +274,8 @@ public abstract class AbstractBlockingService<W extends WaitKey, R extends Block
 
     public int getTotalResourcesCount() {
         return registries.values().stream()
-                .map(collection -> collection.resources.size())
-                .reduce(0, Integer::sum);
+                .mapToInt(collection -> collection.resources.size())
+                .sum();
     }
 
     protected final RR getOrInitRegistry(CPGroupId groupId) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -630,6 +630,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
 
     protected void handleConfigReload(HttpPostCommand command) throws UnsupportedEncodingException {
         prepareResponse(
+                SC_500,
                 command,
                 response(FAIL, "message", "Configuration Reload requires Hazelcast Enterprise Edition")
         );
@@ -637,6 +638,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
 
     protected void handleConfigUpdate(HttpPostCommand command) throws UnsupportedEncodingException {
         prepareResponse(
+                SC_500,
                 command,
                 response(FAIL, "message", "Configuration Update requires Hazelcast Enterprise Edition")
         );

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestCallCollector.java
@@ -22,6 +22,9 @@ import com.hazelcast.internal.util.counters.MwCounter;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.internal.ascii.rest.HttpCommandProcessor.URI_CONFIG_RELOAD;
+import static com.hazelcast.internal.ascii.rest.HttpCommandProcessor.URI_CONFIG_UPDATE;
+
 public class RestCallCollector {
 
     public static final int SET_SIZE_LIMIT = 1000;
@@ -72,6 +75,11 @@ public class RestCallCollector {
     private final MwCounter queueDeleteSuccCount = MwCounter.newMwCounter();
     private final MwCounter queueDeleteFailCount = MwCounter.newMwCounter();
     private final MwCounter queueTotalRequestCount = MwCounter.newMwCounter();
+
+    private final MwCounter configUpdateSuccCount = MwCounter.newMwCounter();
+    private final MwCounter configUpdateFailCount = MwCounter.newMwCounter();;
+    private final MwCounter configReloadSuccCount = MwCounter.newMwCounter();
+    private final MwCounter configReloadFailCount = MwCounter.newMwCounter();
 
     private final MwCounter requestCount = MwCounter.newMwCounter();
     private final ConcurrentHashMap.KeySetView<RequestIdentifier, Boolean> uniqueRequests = ConcurrentHashMap.newKeySet();
@@ -136,6 +144,11 @@ public class RestCallCollector {
     private void handlePost(RestCallExecution execution) {
         RestCallExecution.ObjectType objectType = execution.getObjectType();
         if (objectType == null) {
+            if (execution.getRequestPath().endsWith(URI_CONFIG_UPDATE)) {
+                (execution.isSuccess() ? configUpdateSuccCount : configUpdateFailCount).inc();
+            }  else if (execution.getRequestPath().endsWith(URI_CONFIG_RELOAD)) {
+                (execution.isSuccess() ? configReloadSuccCount : configReloadFailCount).inc();
+            }
             return;
         }
         switch (objectType) {
@@ -257,6 +270,22 @@ public class RestCallCollector {
 
     public String getTotalMapRequestCount() {
         return String.valueOf(mapTotalRequestCount.get());
+    }
+
+    public String getConfigUpdateSuccessCount() {
+        return String.valueOf(configUpdateSuccCount.get());
+    }
+
+    public String getConfigUpdateFailureCount() {
+        return String.valueOf(configUpdateFailCount.get());
+    }
+
+    public String getConfigReloadSuccessCount() {
+        return String.valueOf(configReloadSuccCount.get());
+    }
+
+    public String getConfigReloadFailureCount() {
+        return String.valueOf(configReloadFailCount.get());
     }
 
     public String getTotalQueueRequestCount() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/CPSubsystemInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/CPSubsystemInfoCollector.java
@@ -16,6 +16,12 @@
 
 package com.hazelcast.internal.util.phonehome;
 
+import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.datastructures.atomiclong.AtomicLongService;
+import com.hazelcast.cp.internal.datastructures.atomicref.AtomicRefService;
+import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchService;
+import com.hazelcast.cp.internal.datastructures.lock.LockService;
+import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.instance.impl.Node;
 
 import java.util.function.BiConsumer;
@@ -25,6 +31,32 @@ public class CPSubsystemInfoCollector implements MetricsCollector {
     @Override
     public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
         int cpMemberCount = node.getNodeEngine().getConfig().getCPSubsystemConfig().getCPMemberCount();
-        metricsConsumer.accept(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED, String.valueOf(cpMemberCount != 0));
+        boolean cpSubsystemEnabled = cpMemberCount != 0;
+        metricsConsumer.accept(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED, String.valueOf(cpSubsystemEnabled));
+        if (cpSubsystemEnabled) {
+            RaftService raftService = node.getNodeEngine().getService(RaftService.SERVICE_NAME);
+            int groupsCount = raftService.getMetadataGroupManager().getGroupIds().size();
+            metricsConsumer.accept(PhoneHomeMetrics.CP_GROUPS_COUNT, String.valueOf(groupsCount));
+
+            SemaphoreService semaphoreService = node.getNodeEngine().getService(SemaphoreService.SERVICE_NAME);
+            int semaphoresCount = semaphoreService.getTotalResourcesCount();
+            metricsConsumer.accept(PhoneHomeMetrics.CP_SEMAPHORES_COUNT, String.valueOf(semaphoresCount));
+
+            CountDownLatchService clService = node.getNodeEngine().getService(CountDownLatchService.SERVICE_NAME);
+            int clCount = clService.getTotalResourcesCount();
+            metricsConsumer.accept(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT, String.valueOf(clCount));
+
+            LockService lockService = node.getNodeEngine().getService(LockService.SERVICE_NAME);
+            int locksCount = lockService.getTotalResourcesCount();
+            metricsConsumer.accept(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT, String.valueOf(locksCount));
+
+            AtomicLongService atomicLongService = node.getNodeEngine().getService(AtomicLongService.SERVICE_NAME);
+            int atomicLongsCount = atomicLongService.getAtomicValuesCount();
+            metricsConsumer.accept(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT, String.valueOf(atomicLongsCount));
+
+            AtomicRefService atomicRefService = node.getNodeEngine().getService(AtomicRefService.SERVICE_NAME);
+            int atomicRefsCount = atomicRefService.getAtomicValuesCount();
+            metricsConsumer.accept(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT, String.valueOf(atomicRefsCount));
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/CPSubsystemInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/CPSubsystemInfoCollector.java
@@ -34,6 +34,8 @@ public class CPSubsystemInfoCollector implements MetricsCollector {
         boolean cpSubsystemEnabled = cpMemberCount != 0;
         metricsConsumer.accept(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED, String.valueOf(cpSubsystemEnabled));
         if (cpSubsystemEnabled) {
+            metricsConsumer.accept(PhoneHomeMetrics.CP_MEMBERS_COUNT, String.valueOf(cpMemberCount));
+
             RaftService raftService = node.getNodeEngine().getService(RaftService.SERVICE_NAME);
             int groupsCount = raftService.getMetadataGroupManager().getGroupIds().size();
             metricsConsumer.accept(PhoneHomeMetrics.CP_GROUPS_COUNT, String.valueOf(groupsCount));

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/ClusterInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/ClusterInfoCollector.java
@@ -33,6 +33,7 @@ class ClusterInfoCollector implements MetricsCollector {
         ClusterServiceImpl clusterService = node.getClusterService();
         int clusterSize = clusterService.getMembers().size();
         long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
+        int partitionCount = node.getPartitionService().getPartitionCount();
         RuntimeMXBean rt = ManagementFactory.getRuntimeMXBean();
 
         metricsConsumer.accept(PhoneHomeMetrics.UUID_OF_CLUSTER, node.getThisUuid().toString());
@@ -42,5 +43,6 @@ class ClusterInfoCollector implements MetricsCollector {
         metricsConsumer.accept(PhoneHomeMetrics.TIME_TAKEN_TO_CLUSTER_UP, Long.toString(clusterUpTime));
         metricsConsumer.accept(PhoneHomeMetrics.UPTIME_OF_RUNTIME_MXBEAN, Long.toString(rt.getUptime()));
         metricsConsumer.accept(PhoneHomeMetrics.RUNTIME_MXBEAN_VM_NAME, rt.getVmName());
+        metricsConsumer.accept(PhoneHomeMetrics.PARTITION_COUNT, String.valueOf(partitionCount));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/DynamicConfigInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/DynamicConfigInfoCollector.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.phonehome;
+
+import com.hazelcast.instance.impl.Node;
+
+import java.util.function.BiConsumer;
+
+public class DynamicConfigInfoCollector implements MetricsCollector {
+
+    @Override
+    public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
+        boolean isEnabled = node.getNodeEngine().getConfig().getDynamicConfigurationConfig().isPersistenceEnabled();
+        metricsConsumer.accept(PhoneHomeMetrics.DYNAMIC_CONFIG_PERSISTENCE_ENABLED, String.valueOf(isEnabled));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -82,7 +82,7 @@ public class PhoneHome {
                 new BuildInfoCollector(new HashMap<>(envVars)), new ClusterInfoCollector(), new ClientInfoCollector(),
                 new MapInfoCollector(), new OSInfoCollector(), new DistributedObjectCounterCollector(),
                 new CacheInfoCollector(), new JetInfoCollector(), new CPSubsystemInfoCollector(),
-                new SqlInfoCollector());
+                new SqlInfoCollector(), new StorageInfoCollector());
         Collections.addAll(metricsCollectorList, additionalCollectors);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -82,7 +82,7 @@ public class PhoneHome {
                 new BuildInfoCollector(new HashMap<>(envVars)), new ClusterInfoCollector(), new ClientInfoCollector(),
                 new MapInfoCollector(), new OSInfoCollector(), new DistributedObjectCounterCollector(),
                 new CacheInfoCollector(), new JetInfoCollector(), new CPSubsystemInfoCollector(),
-                new SqlInfoCollector(), new StorageInfoCollector());
+                new SqlInfoCollector(), new StorageInfoCollector(), new DynamicConfigInfoCollector());
         Collections.addAll(metricsCollectorList, additionalCollectors);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -41,6 +41,7 @@ import static java.lang.System.getenv;
 /**
  * Pings phone home server with cluster info daily.
  */
+@SuppressWarnings("checkstyle:classdataabstractioncoupling")
 public class PhoneHome {
 
     private static final String FALSE = "false";

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -143,6 +143,9 @@ public enum PhoneHomeMetrics {
     // SQL METRICS
     SQL_QUERIES_SUBMITTED("sqlqs"),
 
+    // DYNAMIC CONFIG PERSISTENCE
+    DYNAMIC_CONFIG_PERSISTENCE_ENABLED("dcpe"),
+
     // STORAGE METRICS
     HD_MEMORY_ENABLED("hdme"),
     MEMORY_USED_HEAP_SIZE("mhs"),
@@ -177,6 +180,11 @@ public enum PhoneHomeMetrics {
     REST_QUEUE_DELETE_FAILURE("restqueuedeletefail"),
     REST_QUEUE_TOTAL_REQUEST_COUNT("restqueuerequestct"),
     REST_ACCESSED_QUEUE_COUNT("restqueuect"),
+
+    REST_CONFIG_UPDATE_SUCCESS("restconfigupdatesucc"),
+    REST_CONFIG_UPDATE_FAILURE("restconfigupdatefail"),
+    REST_CONFIG_RELOAD_SUCCESS("restconfigreloadsucc"),
+    REST_CONFIG_RELOAD_FAILURE("restconfigreloadfail"),
 
     REST_REQUEST_COUNT("restrequestct"),
     REST_UNIQUE_REQUEST_COUNT("restuniqrequestct");

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -145,6 +145,12 @@ public enum PhoneHomeMetrics {
 
     //CP SUBSYSTEM METRICS
     CP_SUBSYSTEM_ENABLED("cp"),
+    CP_GROUPS_COUNT("cpgct"),
+    CP_SEMAPHORES_COUNT("cpsect"),
+    CP_COUNTDOWN_LATCHES_COUNT("cpclct"),
+    CP_FENCED_LOCKS_COUNT("cpflct"),
+    CP_ATOMIC_LONGS_COUNT("cpalct"),
+    CP_ATOMIC_REFS_COUNT("cparct"),
 
     // REST API metrics
     REST_ENABLED("restenabled"),

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -72,6 +72,7 @@ public enum PhoneHomeMetrics {
     TIME_TAKEN_TO_CLUSTER_UP("cuptm"),
     UPTIME_OF_RUNTIME_MXBEAN("nuptm"),
     RUNTIME_MXBEAN_VM_NAME("jvmn"),
+    PARTITION_COUNT("parct"),
 
     //OS INFO METRICS
     OPERATING_SYSTEM_NAME("osn"),

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -154,6 +154,7 @@ public enum PhoneHomeMetrics {
 
     //CP SUBSYSTEM METRICS
     CP_SUBSYSTEM_ENABLED("cp"),
+    CP_MEMBERS_COUNT("cpmc"),
     CP_GROUPS_COUNT("cpgct"),
     CP_SEMAPHORES_COUNT("cpsect"),
     CP_COUNTDOWN_LATCHES_COUNT("cpclct"),

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -143,6 +143,12 @@ public enum PhoneHomeMetrics {
     // SQL METRICS
     SQL_QUERIES_SUBMITTED("sqlqs"),
 
+    // STORAGE METRICS
+    HD_MEMORY_ENABLED("hdme"),
+    MEMORY_USED_HEAP_SIZE("mhs"),
+    MEMORY_USED_NATIVE_SIZE("muns"),
+    TIERED_STORAGE_ENABLED("tse"),
+
     //CP SUBSYSTEM METRICS
     CP_SUBSYSTEM_ENABLED("cp"),
     CP_GROUPS_COUNT("cpgct"),

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -151,6 +151,7 @@ public enum PhoneHomeMetrics {
     MEMORY_USED_HEAP_SIZE("muhs"),
     MEMORY_USED_NATIVE_SIZE("muns"),
     TIERED_STORAGE_ENABLED("tse"),
+    DATA_MEMORY_COST("dmc"),
 
     //CP SUBSYSTEM METRICS
     CP_SUBSYSTEM_ENABLED("cp"),

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -148,7 +148,7 @@ public enum PhoneHomeMetrics {
 
     // STORAGE METRICS
     HD_MEMORY_ENABLED("hdme"),
-    MEMORY_USED_HEAP_SIZE("mhs"),
+    MEMORY_USED_HEAP_SIZE("muhs"),
     MEMORY_USED_NATIVE_SIZE("muns"),
     TIERED_STORAGE_ENABLED("tse"),
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/RestApiMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/RestApiMetricsCollector.java
@@ -44,6 +44,10 @@ public class RestApiMetricsCollector implements MetricsCollector {
         metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_DELETE_FAILURE, collector.getQueueDeleteFailureCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_ACCESSED_QUEUE_COUNT, collector.getAccessedQueueCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_QUEUE_TOTAL_REQUEST_COUNT, collector.getTotalQueueRequestCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_CONFIG_UPDATE_SUCCESS, collector.getConfigUpdateSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_CONFIG_UPDATE_FAILURE, collector.getConfigUpdateFailureCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_CONFIG_RELOAD_SUCCESS, collector.getConfigReloadSuccessCount());
+        metricsConsumer.accept(PhoneHomeMetrics.REST_CONFIG_RELOAD_FAILURE, collector.getConfigReloadFailureCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_REQUEST_COUNT, collector.getRequestCount());
         metricsConsumer.accept(PhoneHomeMetrics.REST_UNIQUE_REQUEST_COUNT, collector.getUniqueRequestCount());
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/StorageInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/StorageInfoCollector.java
@@ -49,8 +49,8 @@ public class StorageInfoCollector implements MetricsCollector {
         long totalEntryMemoryCost = Stream.concat(
                         mapService.getStats().values().stream(),
                         replicatedMapService.getStats().values().stream()
-                ).map(LocalMapStats::getOwnedEntryMemoryCost)
-                .reduce(0L, Long::sum);
+                ).mapToLong(LocalMapStats::getOwnedEntryMemoryCost)
+                .sum();
         metricsConsumer.accept(PhoneHomeMetrics.DATA_MEMORY_COST, String.valueOf(totalEntryMemoryCost));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/StorageInfoCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/StorageInfoCollector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.phonehome;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NativeMemoryConfig;
+import com.hazelcast.instance.impl.Node;
+
+import java.util.function.BiConsumer;
+
+public class StorageInfoCollector implements MetricsCollector {
+
+    @Override
+    public void forEachMetric(Node node, BiConsumer<PhoneHomeMetrics, String> metricsConsumer) {
+        Config config = node.getNodeEngine().getConfig();
+        NativeMemoryConfig nativeMemoryConfig = config.getNativeMemoryConfig();
+        boolean isHdEnabled = nativeMemoryConfig.isEnabled();
+        metricsConsumer.accept(PhoneHomeMetrics.HD_MEMORY_ENABLED, String.valueOf(isHdEnabled));
+        if (isHdEnabled) {
+            long offHeapMemorySize = node.getNodeExtension().getMemoryStats().getUsedNative();
+            metricsConsumer.accept(PhoneHomeMetrics.MEMORY_USED_NATIVE_SIZE, String.valueOf(offHeapMemorySize));
+        }
+        long usedHeap = node.getNodeExtension().getMemoryStats().getUsedHeap();
+        metricsConsumer.accept(PhoneHomeMetrics.MEMORY_USED_HEAP_SIZE, String.valueOf(usedHeap));
+        boolean tieredStorageEnabled = config.getMapConfigs().values().stream()
+                .anyMatch(mapConfig -> mapConfig.getTieredStoreConfig().isEnabled());
+        metricsConsumer.accept(PhoneHomeMetrics.TIERED_STORAGE_ENABLED, String.valueOf(tieredStorageEnabled));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.internal.util.phonehome;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.cp.CPSubsystemConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static com.hazelcast.test.Accessors.getNode;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
+
+    private Node node;
+    private PhoneHome phoneHome;
+
+    @Before
+    public void initialise() {
+        Config config = getConfig();
+        CPSubsystemConfig cpSubsystemConfig = new CPSubsystemConfig().setCPMemberCount(3);
+        config.setCPSubsystemConfig(cpSubsystemConfig);
+        HazelcastInstance hz = createHazelcastInstances(config, 3)[0];
+        node = getNode(hz);
+        phoneHome = new PhoneHome(node);
+    }
+
+    @Test
+    public void testGroupsCount_noGroups() {
+        Map<String, String> parameters = phoneHome.phoneHome(true);
+
+        // no groups are created w/o CP data structures
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("0");
+    }
+
+    @Test
+    public void testGroupsCount_defaultGroups() {
+        node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast");
+
+        Map<String, String> parameters = phoneHome.phoneHome(true);
+
+        // two default groups METADATA and DEFAULT
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("2");
+    }
+
+    @Test
+    public void testGroupsCount_createdGroups() {
+        node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@firstGroup");
+        node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@secondGroup");
+        node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@firstGroup");
+        node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast");
+        node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@thirdGroup");
+
+        Map<String, String> parameters = phoneHome.phoneHome(true);
+
+        // two default groups METADATA and DEFAULT + 3 created
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("5");
+    }
+
+    @Test
+    public void testSemaphoresCount() {
+        Map<String, String> parameters;
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("0");
+
+        node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@firstGroup").init(1);
+        node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@secondGroup").init(1);
+        node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast2@firstGroup").init(1);
+
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("3");
+    }
+
+    @Test
+    public void testFencedLocksCount() {
+        Map<String, String> parameters;
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("0");
+
+        node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@firstGroup").lock();
+        node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@secondGroup").lock();
+        node.hazelcastInstance.getCPSubsystem().getLock("hazelcast2@firstGroup").lock();
+
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("3");
+    }
+
+    @Test
+    public void testCountdownLatchesCount() {
+        Map<String, String> parameters;
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("0");
+
+        node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@firstGroup").trySetCount(1);
+        node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@secondGroup").trySetCount(1);
+        node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast2@firstGroup").trySetCount(1);
+
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("3");
+    }
+
+    @Test
+    public void testAtomicLongsCount() {
+        Map<String, String> parameters;
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("0");
+
+        node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast@firstGroup").set(42L);
+        node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast@secondGroup").set(42L);
+        node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast2@firstGroup").set(42L);
+
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("3");
+    }
+
+    @Test
+    public void testAtomicRefsCount() {
+        Map<String, String> parameters;
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("0");
+
+        node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@firstGroup").set(42L);
+        node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@secondGroup").set(42L);
+        node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast2@firstGroup").set(42L);
+
+        parameters = phoneHome.phoneHome(true);
+        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("3");
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
@@ -32,6 +32,8 @@ import org.junit.runner.RunWith;
 import java.util.Map;
 
 import static com.hazelcast.test.Accessors.getNode;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -51,11 +53,11 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testGroupsCount_noGroups() {
+    public void testCPSubsystemEnabled() {
         Map<String, String> parameters = phoneHome.phoneHome(true);
-
+        assertEquals("true", parameters.get(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED.getRequestParameterName()));
         // no groups are created w/o CP data structures
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("0");
     }
 
     @Test
@@ -65,7 +67,7 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
         Map<String, String> parameters = phoneHome.phoneHome(true);
 
         // two default groups METADATA and DEFAULT
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("2");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("2");
     }
 
     @Test
@@ -79,77 +81,77 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
         Map<String, String> parameters = phoneHome.phoneHome(true);
 
         // two default groups METADATA and DEFAULT + 3 created
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("5");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("5");
     }
 
     @Test
     public void testSemaphoresCount() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@firstGroup").init(1);
         node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@secondGroup").init(1);
         node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast2@firstGroup").init(1);
 
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("3");
     }
 
     @Test
     public void testFencedLocksCount() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@firstGroup").lock();
         node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@secondGroup").lock();
         node.hazelcastInstance.getCPSubsystem().getLock("hazelcast2@firstGroup").lock();
 
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("3");
     }
 
     @Test
     public void testCountdownLatchesCount() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@firstGroup").trySetCount(1);
         node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@secondGroup").trySetCount(1);
         node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast2@firstGroup").trySetCount(1);
 
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("3");
     }
 
     @Test
     public void testAtomicLongsCount() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast@firstGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast@secondGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast2@firstGroup").set(42L);
 
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("3");
     }
 
     @Test
     public void testAtomicRefsCount() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@firstGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@secondGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast2@firstGroup").set(42L);
 
         parameters = phoneHome.phoneHome(true);
-        Assertions.assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("3");
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import static com.hazelcast.test.Accessors.getNode;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -54,7 +53,8 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
     @Test
     public void testCPSubsystemEnabled() {
         Map<String, String> parameters = phoneHome.phoneHome(true);
-        assertEquals("true", parameters.get(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED.getRequestParameterName()));
+        assertThat(parameters.get(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED.getRequestParameterName())).isEqualTo("true");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_MEMBERS_COUNT.getRequestParameterName())).isEqualTo("3");
         // no groups are created w/o CP data structures
         assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("0");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,7 +31,7 @@ import org.junit.runner.RunWith;
 import java.util.Map;
 
 import static com.hazelcast.test.Accessors.getNode;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
@@ -101,7 +101,7 @@ public class PhoneHomeDifferentConfigTest extends HazelcastTestSupport {
     public void testHdStorage() {
         NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig()
                 .setEnabled(true)
-                .setSize(new MemorySize(256L, MEGABYTES));
+                .setSize(new MemorySize(64L, MEGABYTES));
         Config config = new Config()
                 .setNativeMemoryConfig(nativeMemoryConfig);
         HazelcastInstance hazelcastInstance = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
@@ -16,10 +16,13 @@
 package com.hazelcast.internal.util.phonehome;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.cp.CPSubsystemConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.NativeMemoryConfig;
+import com.hazelcast.config.TieredStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.memory.MemorySize;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -31,8 +34,10 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
+import static com.hazelcast.memory.MemoryUnit.MEGABYTES;
 import static com.hazelcast.test.Accessors.getNode;
 import static java.lang.System.getenv;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -79,31 +84,52 @@ public class PhoneHomeDifferentConfigTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testCPSubsystemEnabled() {
-        Config config = new Config()
-                .setCPSubsystemConfig(new CPSubsystemConfig()
-                        .setCPMemberCount(3));
-
-        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(config, 3);
-        Node node = getNode(hazelcastInstances[0]);
-
-        PhoneHome phoneHome = new PhoneHome(node);
-
-        Map<String, String> parameters = phoneHome.phoneHome(true);
-        assertEquals("true", parameters.get(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED.getRequestParameterName()));
-    }
-
-    @Test
     public void testJetDisabled() {
         Config config = new Config()
                 .setJetConfig(new JetConfig().setEnabled(false));
-        HazelcastInstance hazelcastInstances = createHazelcastInstance(config);
-        Node node = getNode(hazelcastInstances);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+        Node node = getNode(hazelcastInstance);
 
         PhoneHome phoneHome = new PhoneHome(node);
 
         Map<String, String> parameters = phoneHome.phoneHome(true);
         assertEquals("false", parameters.get(PhoneHomeMetrics.JET_ENABLED.getRequestParameterName()));
         assertEquals("false", parameters.get(PhoneHomeMetrics.JET_RESOURCE_UPLOAD_ENABLED.getRequestParameterName()));
+    }
+
+    @Test
+    public void testHdStorage() {
+        NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig()
+                .setEnabled(true)
+                .setSize(new MemorySize(256L, MEGABYTES));
+        Config config = new Config()
+                .setNativeMemoryConfig(nativeMemoryConfig);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+        Node node = getNode(hazelcastInstance);
+
+        PhoneHome phoneHome = new PhoneHome(node);
+
+        Map<String, String> parameters = phoneHome.phoneHome(true);
+        assertThat(parameters.get(PhoneHomeMetrics.HD_MEMORY_ENABLED.getRequestParameterName())).isEqualTo("true");
+        assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_HEAP_SIZE.getRequestParameterName())).isNotNull();
+        assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_NATIVE_SIZE.getRequestParameterName())).isNotNull();
+        assertThat(parameters.get(PhoneHomeMetrics.TIERED_STORAGE_ENABLED.getRequestParameterName())).isEqualTo("false");
+    }
+
+    @Test
+    public void testTieredStorage() {
+        MapConfig mapConfig = new MapConfig()
+                .setName("ts-map")
+                .setTieredStoreConfig(new TieredStoreConfig().setEnabled(true));
+        Config config = new Config()
+                .addMapConfig(mapConfig);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+        Node node = getNode(hazelcastInstance);
+
+        PhoneHome phoneHome = new PhoneHome(node);
+
+        Map<String, String> parameters = phoneHome.phoneHome(true);
+        assertThat(parameters.get(PhoneHomeMetrics.TIERED_STORAGE_ENABLED.getRequestParameterName())).isEqualTo("true");
+        assertThat(parameters.get(PhoneHomeMetrics.HD_MEMORY_ENABLED.getRequestParameterName())).isEqualTo("false");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
@@ -114,6 +114,7 @@ public class PhoneHomeDifferentConfigTest extends HazelcastTestSupport {
         assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_HEAP_SIZE.getRequestParameterName())).isGreaterThan("0");
         assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_NATIVE_SIZE.getRequestParameterName())).isEqualTo("0");
         assertThat(parameters.get(PhoneHomeMetrics.TIERED_STORAGE_ENABLED.getRequestParameterName())).isEqualTo("false");
+        assertThat(parameters.get(PhoneHomeMetrics.DATA_MEMORY_COST.getRequestParameterName())).isEqualTo("0");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeDifferentConfigTest.java
@@ -111,8 +111,8 @@ public class PhoneHomeDifferentConfigTest extends HazelcastTestSupport {
 
         Map<String, String> parameters = phoneHome.phoneHome(true);
         assertThat(parameters.get(PhoneHomeMetrics.HD_MEMORY_ENABLED.getRequestParameterName())).isEqualTo("true");
-        assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_HEAP_SIZE.getRequestParameterName())).isNotNull();
-        assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_NATIVE_SIZE.getRequestParameterName())).isNotNull();
+        assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_HEAP_SIZE.getRequestParameterName())).isGreaterThan("0");
+        assertThat(parameters.get(PhoneHomeMetrics.MEMORY_USED_NATIVE_SIZE.getRequestParameterName())).isEqualTo("0");
         assertThat(parameters.get(PhoneHomeMetrics.TIERED_STORAGE_ENABLED.getRequestParameterName())).isEqualTo("false");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -97,6 +97,7 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         assertEquals(parameters.get(PhoneHomeMetrics.HAZELCAST_DOWNLOAD_ID.getRequestParameterName()), "source");
         assertEquals(parameters.get(PhoneHomeMetrics.CLUSTER_SIZE.getRequestParameterName()), "A");
         assertEquals(parameters.get(PhoneHomeMetrics.EXACT_CLUSTER_SIZE.getRequestParameterName()), "1");
+        assertEquals(parameters.get(PhoneHomeMetrics.PARTITION_COUNT.getRequestParameterName()), "271");
         assertEquals(parameters.get(PhoneHomeMetrics.CLIENT_ENDPOINT_COUNT.getRequestParameterName()), "A");
 
         assertEquals(parameters.get(PhoneHomeMetrics.ACTIVE_CPP_CLIENTS_COUNT.getRequestParameterName()), "0");

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -481,6 +481,23 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), String.valueOf(2000));
     }
 
+    @Test
+    public void testStoa() {
+        Map<String, String> parameters;
+        parameters = phoneHome.phoneHome(true);
+        assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), "-1");
+
+        IMap<Object, Object> iMap = node.hazelcastInstance.getMap("hazelcast");
+        LocalMapStatsImpl localMapStats = (LocalMapStatsImpl) iMap.getLocalMapStats();
+        localMapStats.incrementGetLatencyNanos(2000000000L);
+        parameters = phoneHome.phoneHome(true);
+        assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), String.valueOf(2000));
+
+        localMapStats.incrementGetLatencyNanos(2000000000L);
+        parameters = phoneHome.phoneHome(true);
+        assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), String.valueOf(2000));
+    }
+
     private IMap<Object, Object> initialiseForMapStore(String mapName) {
         IMap<Object, Object> iMap = node.hazelcastInstance.getMap(mapName);
         MapStoreConfig mapStoreConfig = new MapStoreConfig();

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeTest.java
@@ -143,6 +143,7 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         assertEquals(parameters.get(PhoneHomeMetrics.JET_ENABLED.getRequestParameterName()), "true");
         assertEquals(parameters.get(PhoneHomeMetrics.JET_RESOURCE_UPLOAD_ENABLED.getRequestParameterName()), "false");
         assertEquals(parameters.get(PhoneHomeMetrics.CP_SUBSYSTEM_ENABLED.getRequestParameterName()), "false");
+        assertEquals(parameters.get(PhoneHomeMetrics.DYNAMIC_CONFIG_PERSISTENCE_ENABLED.getRequestParameterName()), "false");
     }
 
     @Test
@@ -466,23 +467,6 @@ public class PhoneHomeTest extends HazelcastTestSupport {
 
     @Test
     public void testMapGetLatencyWithoutMapStore() {
-        Map<String, String> parameters;
-        parameters = phoneHome.phoneHome(true);
-        assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), "-1");
-
-        IMap<Object, Object> iMap = node.hazelcastInstance.getMap("hazelcast");
-        LocalMapStatsImpl localMapStats = (LocalMapStatsImpl) iMap.getLocalMapStats();
-        localMapStats.incrementGetLatencyNanos(2000000000L);
-        parameters = phoneHome.phoneHome(true);
-        assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), String.valueOf(2000));
-
-        localMapStats.incrementGetLatencyNanos(2000000000L);
-        parameters = phoneHome.phoneHome(true);
-        assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), String.valueOf(2000));
-    }
-
-    @Test
-    public void testStoa() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
         assertEquals(parameters.get(PhoneHomeMetrics.AVERAGE_GET_LATENCY_OF_MAPS_WITHOUT_MAPSTORE.getRequestParameterName()), "-1");

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
@@ -66,9 +66,12 @@ public class RESTClientPhoneHomeTest {
 
     private HTTPCommunicator http;
 
+    private Config config;
+
     @Before
     public void setUp() {
-        instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
+        config = createConfigWithRestEnabled();
+        instance = factory.newHazelcastInstance(config);
         http = new HTTPCommunicator(instance);
         stubFor(post(urlPathEqualTo("/ping")).willReturn(aResponse().withStatus(200)));
     }
@@ -146,6 +149,22 @@ public class RESTClientPhoneHomeTest {
                 .withRequestBody(containingParam("restqueuedeletefail", "1"))
                 .withRequestBody(containingParam("restqueuegetsucc", "2"))
                 .withRequestBody(containingParam("restqueuect", "1"))
+        );
+    }
+
+    @Test
+    public void configUpdateOperations() throws IOException {
+        http.configReload(config.getClusterName(), "");
+        http.configUpdate(config.getClusterName(), "", "hazelcast:\n");
+
+        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
+        phoneHome.phoneHome(false);
+
+        verify(1, postRequestedFor(urlPathEqualTo("/ping"))
+                .withRequestBody(containingParam("restconfigreloadsucc", "0"))
+                .withRequestBody(containingParam("restconfigreloadfail", "1"))
+                .withRequestBody(containingParam("restconfigupdatesucc", "0"))
+                .withRequestBody(containingParam("restconfigupdatefail", "1"))
         );
     }
 


### PR DESCRIPTION
New PhoneHome metrics for:
**Storage**
- A boolean variable for HD memory (nice to have) - **added**
- Used Heap & Off-Heap Memory - **added**
- Boolean if Tiered Storage is on or off - **added**
- Amount of data stored in the cluster - publish what’s available in MC (IMap at least) - **added** - works for `IMap` and `ReplicatedMap` with non-OBJECT In memoryFormat
- How much data is stored within in-memory and on-disk regions of Tiered Storage - **not available in TS code yet**
- Partition count - **added**

**CP Subsystem**
- Total number of CP members (across all groups) - **added**
- Number of CP Groups - **added**
- What CP data structures are being used - **added**

**Dynamic Configuration**
- Boolean if the feature is on or off - **added**
- count calls of “configuration reload” operation - **added**

Fixes [1344](https://hazelcast.atlassian.net/browse/MC-1344)

EE PR: [4773](https://github.com/hazelcast/hazelcast-enterprise/pull/4773)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
