### PR TITLE
Thread-safe Map/Cache replication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
@@ -43,8 +43,8 @@ import static java.util.Collections.emptyList;
  */
 public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
 
-    private UUID partitionUuid;
-    private List<Object> cacheNameSequencePairs = emptyList();
+    private volatile UUID partitionUuid;
+    private volatile List<Object> cacheNameSequencePairs = emptyList();
     private Operation cacheReplicationOperation;
 
     public CacheNearCacheStateHolder() {
@@ -61,14 +61,15 @@ public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
         int partitionId = segment.getPartitionId();
         partitionUuid = metaData.getOrCreateUuid(partitionId);
 
-        cacheNameSequencePairs = new ArrayList(namespaces.size());
+        List<Object> nameSeqPairs = new ArrayList<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
             ObjectNamespace ns = (ObjectNamespace) namespace;
             String cacheName = ns.getObjectName();
 
-            cacheNameSequencePairs.add(cacheName);
-            cacheNameSequencePairs.add(metaData.currentSequence(cacheName, partitionId));
+            nameSeqPairs.add(cacheName);
+            nameSeqPairs.add(metaData.currentSequence(cacheName, partitionId));
         }
+        cacheNameSequencePairs = nameSeqPairs;
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator(ICacheService cacheService) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -505,8 +505,8 @@ public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K,
     public int hashCode() {
         int result = cacheLoaderFactory != null ? cacheLoaderFactory.hashCode() : 0;
         result = 31 * result + listenerConfigurations.hashCode();
-        result = 31 * result + keyType.hashCode();
-        result = 31 * result + valueType.hashCode();
+        result = keyType == null ? result : 31 * result + keyType.hashCode();
+        result = valueType == null ? result : 31 * result + valueType.hashCode();
         result = 31 * result + (cacheWriterFactory != null ? cacheWriterFactory.hashCode() : 0);
         result = 31 * result + (expiryPolicyFactory != null ? expiryPolicyFactory.hashCode() : 0);
         result = 31 * result + (isReadThrough ? 1 : 0);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
@@ -18,6 +18,8 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidator;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -26,8 +28,6 @@ import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.internal.services.ObjectNamespace;
-import com.hazelcast.internal.services.ServiceNamespace;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.hazelcast.map.impl.MapDataSerializerHook.MAP_NEAR_CACHE_STATE_HOLDER;
-import static java.util.Collections.emptyList;
+import static java.util.Collections.EMPTY_LIST;
 
 /**
  * Holder for Near Cache metadata.
@@ -44,8 +44,8 @@ import static java.util.Collections.emptyList;
 public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
 
     // keep this `protected`, extended in another context
-    protected UUID partitionUuid;
-    protected List<Object> mapNameSequencePairs = emptyList();
+    protected volatile UUID partitionUuid;
+    protected volatile List<Object> mapNameSequencePairs = EMPTY_LIST;
 
     private MapReplicationOperation mapReplicationOperation;
 
@@ -68,17 +68,15 @@ public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
         int partitionId = container.getPartitionId();
         partitionUuid = metaData.getOrCreateUuid(partitionId);
 
+        List<Object> nameSeqPairs = new ArrayList<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
-            if (mapNameSequencePairs == emptyList()) {
-                mapNameSequencePairs = new ArrayList(namespaces.size());
-            }
-
             ObjectNamespace mapNamespace = (ObjectNamespace) namespace;
             String mapName = mapNamespace.getObjectName();
 
-            mapNameSequencePairs.add(mapName);
-            mapNameSequencePairs.add(metaData.currentSequence(mapName, partitionId));
+            nameSeqPairs.add(mapName);
+            nameSeqPairs.add(metaData.currentSequence(mapName, partitionId));
         }
+        mapNameSequencePairs = nameSeqPairs;
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator(MapService mapService) {

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -91,6 +91,12 @@ public class CacheConfigTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testHashCode() {
+        CacheConfig cacheConfig = new CacheConfig();
+        assertTrue(cacheConfig.hashCode() != 0);
+    }
+
+    @Test
     public void testCacheConfigLoaderWriterXml() throws Exception {
         Config config = new XmlConfigBuilder(configUrl2).build();
 


### PR DESCRIPTION
Map/CacheNearCacheStateHolder fields may be populated from one thread,
then serialized from another thread. This is the case with differential
sync, where prepare is invoked from generic thread, then data are
serialized from partition thread.

Also includes a fix for AbstractCacheConfig#hashCode that should
take into account keyType and valueType are nullable.

(cherry picked from commit 94063c91bc7f29e3964b32fdd2cfb454e63e65f8)

Backport of #20726 to `5.0.z`