### PR TITLE
Add compact to generic record apidoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -63,7 +63,7 @@ import java.util.Set;
  * the objects will be returned as {@link GenericRecord}. This way, the clients can read and write objects back to
  * the cluster without the need to have the domain classes on the classpath.
  * <p>
- * Currently this is valid for {@link Portable} objects.
+ * Currently, this is valid for {@link Portable} and compact serializable objects.
  *
  * @since 4.1
  */


### PR DESCRIPTION
Change sentence to indicate generic records is supported for compact

Breaking changes (list specific methods/types/messages):

none

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
