### PR TITLE
Add missing generator parts

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigXmlGenerator.java
@@ -170,7 +170,9 @@ public final class DynamicConfigXmlGenerator {
             gen.node("split-brain-protection-ref", c.getSplitBrainProtectionName());
             cachePartitionLostListenerConfigXmlGenerator(gen, c.getPartitionLostListenerConfigs());
 
-            gen.node("merge-policy", c.getMergePolicyConfig().getPolicy());
+            gen.node("merge-policy", c.getMergePolicyConfig().getPolicy(),
+                    "batch-size", c.getMergePolicyConfig().getBatchSize());
+
             appendEventJournalConfig(gen, c.getEventJournalConfig());
             appendDataPersistenceConfig(gen, c.getDataPersistenceConfig());
             if (c.getMerkleTreeConfig().getEnabled() != null) {
@@ -708,6 +710,7 @@ public final class DynamicConfigXmlGenerator {
             gen.open("map-store", "enabled", s.isEnabled(), "initial-mode", initialMode.toString())
                     .node("class-name", clazz)
                     .node("factory-class-name", factoryClass)
+                    .node("write-coalescing", s.isWriteCoalescing())
                     .node("write-delay-seconds", s.getWriteDelaySeconds())
                     .node("write-batch-size", s.getWriteBatchSize())
                     .appendProperties(s.getProperties())

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
@@ -1283,6 +1283,7 @@ public class DynamicConfigYamlGenerator {
         );
 
         addNonNullToMap(mapStoreConfigAsMap, "initial-mode", mapStoreConfig.getInitialLoadMode().name());
+        addNonNullToMap(mapStoreConfigAsMap, "write-coalescing", mapStoreConfig.isWriteCoalescing());
         addNonNullToMap(mapStoreConfigAsMap, "write-delay-seconds", mapStoreConfig.getWriteDelaySeconds());
         addNonNullToMap(mapStoreConfigAsMap, "write-batch-size", mapStoreConfig.getWriteBatchSize());
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1016,7 +1016,11 @@ public class ConfigCompatibilityChecker {
                 && nullSafeEqual(
                     classNameOrImpl(c1.getFactoryClassName(), c1.getFactoryImplementation()),
                     classNameOrImpl(c2.getFactoryClassName(), c2.getFactoryImplementation()))
-                && nullSafeEqual(c1.getProperties(), c2.getProperties()));
+                && nullSafeEqual(c1.getProperties(), c2.getProperties()))
+                && nullSafeEqual(c1.isWriteCoalescing(), c2.isWriteCoalescing())
+                && nullSafeEqual(c1.getWriteBatchSize(), c2.getWriteBatchSize())
+                && nullSafeEqual(c1.getWriteDelaySeconds(), c2.getWriteDelaySeconds())
+                && nullSafeEqual(c1.getInitialLoadMode(), c2.getInitialLoadMode());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigGeneratorTest.java
@@ -915,15 +915,6 @@ public abstract class AbstractDynamicConfigGeneratorTest extends HazelcastTestSu
         assertEquals(attrConfig.getName(), decAttrConfig.getName());
         assertEquals(attrConfig.getExtractorClassName(), decAttrConfig.getExtractorClassName());
         ConfigCompatibilityChecker.checkMapConfig(expectedConfig, actualConfig);
-
-        assertMapStoresAreEqual(expectedConfig.getMapStoreConfig(), actualConfig.getMapStoreConfig());
-    }
-
-    public void assertMapStoresAreEqual(MapStoreConfig expected, MapStoreConfig actual) {
-        assertEquals(expected.isWriteCoalescing(), actual.isWriteCoalescing());
-        assertEquals(expected.getWriteBatchSize(), actual.getWriteBatchSize());
-        assertEquals(expected.getWriteDelaySeconds(), actual.getWriteDelaySeconds());
-        assertEquals(expected.getInitialLoadMode(), actual.getInitialLoadMode());
     }
 
     private void testQueue(QueueStoreConfig queueStoreConfig) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigGeneratorTest.java
@@ -121,7 +121,7 @@ public abstract class AbstractDynamicConfigGeneratorTest extends HazelcastTestSu
                 .setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER)
                 .setWriteDelaySeconds(10)
                 .setClassName("className")
-                .setWriteCoalescing(true)
+                .setWriteCoalescing(false)
                 .setWriteBatchSize(500)
                 .setProperty("key", "value");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigGeneratorTest.java
@@ -281,7 +281,7 @@ public abstract class AbstractDynamicConfigGeneratorTest extends HazelcastTestSu
                         new CachePartitionLostListenerConfig("partitionLostListener")))
                 .setSplitBrainProtectionName("testSplitBrainProtection");
 
-        expectedConfig.getMergePolicyConfig().setPolicy("HigherHitsMergePolicy");
+        expectedConfig.getMergePolicyConfig().setPolicy("HigherHitsMergePolicy").setBatchSize(99);
         expectedConfig.setDisablePerEntryInvalidationEvents(true);
         expectedConfig.setWanReplicationRef(wanReplicationRef());
 
@@ -915,6 +915,15 @@ public abstract class AbstractDynamicConfigGeneratorTest extends HazelcastTestSu
         assertEquals(attrConfig.getName(), decAttrConfig.getName());
         assertEquals(attrConfig.getExtractorClassName(), decAttrConfig.getExtractorClassName());
         ConfigCompatibilityChecker.checkMapConfig(expectedConfig, actualConfig);
+
+        assertMapStoresAreEqual(expectedConfig.getMapStoreConfig(), actualConfig.getMapStoreConfig());
+    }
+
+    public void assertMapStoresAreEqual(MapStoreConfig expected, MapStoreConfig actual) {
+        assertEquals(expected.isWriteCoalescing(), actual.isWriteCoalescing());
+        assertEquals(expected.getWriteBatchSize(), actual.getWriteBatchSize());
+        assertEquals(expected.getWriteDelaySeconds(), actual.getWriteDelaySeconds());
+        assertEquals(expected.getInitialLoadMode(), actual.getInitialLoadMode());
     }
 
     private void testQueue(QueueStoreConfig queueStoreConfig) {


### PR DESCRIPTION
Some files were missing from generators, I added them and extended the tests. ~`asserMapStoresAreEqual()` includes what compatibility check doesn't include.~ Also extended `MapConfigChecker.isCompatible(MapStoreConfig, MapStoreConfig)`.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4777

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
