### PR TITLE
Initialize list structures in config objects

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -83,7 +83,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
     private String cacheWriter;
 
     private ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig;
-    private List<CacheSimpleEntryListenerConfig> cacheEntryListeners;
+    private List<CacheSimpleEntryListenerConfig> cacheEntryListeners = new ArrayList<>();
 
     private int asyncBackupCount = MIN_BACKUP_COUNT;
     private int backupCount = DEFAULT_BACKUP_COUNT;
@@ -96,7 +96,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
 
     private String splitBrainProtectionName;
 
-    private List<CachePartitionLostListenerConfig> partitionLostListenerConfigs;
+    private List<CachePartitionLostListenerConfig> partitionLostListenerConfigs = new ArrayList<>();
 
     private HotRestartConfig hotRestartConfig = new HotRestartConfig();
 
@@ -449,7 +449,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
      */
     public List<CacheSimpleEntryListenerConfig> getCacheEntryListeners() {
         if (cacheEntryListeners == null) {
-            cacheEntryListeners = new ArrayList<CacheSimpleEntryListenerConfig>();
+            cacheEntryListeners = new ArrayList<>();
         }
         return cacheEntryListeners;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -50,7 +50,7 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, NamedCon
     private boolean asyncFillup = DEFAULT_ASNYC_FILLUP;
     private String name;
     private String splitBrainProtectionName;
-    private List<ListenerConfig> listenerConfigs;
+    private List<ListenerConfig> listenerConfigs = new ArrayList<>();
     private InMemoryFormat inMemoryFormat = DEFAULT_IN_MEMORY_FORMAT;
     private MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
 


### PR DESCRIPTION
This PR aims to initialize list objects in `CacheSimpleConfig` and `ReplicatedMapConfig`. These fields create issues for `equals()` method due to get or create nature of their getters. Normally these are fixed in 

https://github.com/hazelcast/hazelcast/pull/12591 - replicated (listenerConfigs)
https://github.com/hazelcast/hazelcast/pull/16170 - cache (partitionLostListenerConfigs and cacheEntryListeners)

however hazelcast cloud encounter this problem again for a reason we couldn't identify. https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1644259459743089.

At this point initializing these lists would be a better choice.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
