### PR TITLE
Do not try to serialize unsupported field types in the reflective compact serializer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -213,6 +213,8 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                     }
                 };
                 writers[index] = (w, o) -> w.writeInt8(name, field.getByte(o));
+            } else if (Character.TYPE.equals(type)) {
+                throwUnsupportedFieldTypeException("char");
             } else if (Short.TYPE.equals(type)) {
                 readers[index] = (reader, schema, o) -> {
                     if (fieldExists(schema, name, INT16, NULLABLE_INT16)) {
@@ -304,6 +306,8 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                     }
                 };
                 writers[index] = (w, o) -> w.writeNullableInt8(name, (Byte) field.get(o));
+            } else if (Character.class.equals(type)) {
+                throwUnsupportedFieldTypeException("Character");
             } else if (Boolean.class.equals(type)) {
                 readers[index] = (reader, schema, o) -> {
                     if (fieldExists(schema, name, BOOLEAN, NULLABLE_BOOLEAN)) {
@@ -374,6 +378,8 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfInt8(name, (byte[]) field.get(o));
+                } else if (Character.TYPE.equals(componentType)) {
+                    throwUnsupportedFieldTypeException("char[]");
                 } else if (Short.TYPE.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
@@ -423,6 +429,8 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
                         }
                     };
                     writers[index] = (w, o) -> w.writeArrayOfNullableInt8(name, (Byte[]) field.get(o));
+                } else if (Character.class.equals(componentType)) {
+                    throwUnsupportedFieldTypeException("Character[]");
                 } else if (Short.class.equals(componentType)) {
                     readers[index] = (reader, schema, o) -> {
                         if (fieldExists(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
@@ -558,6 +566,12 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
             }
         }
         return enumArray;
+    }
+
+    private void throwUnsupportedFieldTypeException(String typeName) {
+        throw new HazelcastSerializationException("Compact serialization format does not support "
+                + "fields of type '" + typeName + "'. If you want to use such fields with the compact"
+                + " serialization format, consider adding an explicit serializer for it.");
     }
 
     interface Reader {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactReflectiveSerializerUnsupportedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactReflectiveSerializerUnsupportedFieldsTest.java
@@ -83,7 +83,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     class CharClass {
         private final char c;
 
-        public CharClass(char c) {
+        CharClass(char c) {
             this.c = c;
         }
     }
@@ -91,7 +91,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     class CharacterClass {
         private final Character c;
 
-        public CharacterClass(Character c) {
+        CharacterClass(Character c) {
             this.c = c;
         }
     }
@@ -99,7 +99,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     class CharArrayClass {
         private final char[] ca;
 
-        public CharArrayClass(char[] ca) {
+        CharArrayClass(char[] ca) {
             this.ca = ca;
         }
     }
@@ -107,7 +107,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     class CharacterArrayClass {
         private final Character[] ca;
 
-        public CharacterArrayClass(Character[] ca) {
+        CharacterArrayClass(Character[] ca) {
             this.ca = ca;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactReflectiveSerializerUnsupportedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactReflectiveSerializerUnsupportedFieldsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl.compact;
+
+import com.hazelcast.config.CompactSerializationConfig;
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CompactReflectiveSerializerUnsupportedFieldsTest {
+
+    private final SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
+    private InternalSerializationService service;
+
+    @Before
+    public void createSerializationService() {
+        CompactSerializationConfig compactSerializationConfig = new CompactSerializationConfig();
+        compactSerializationConfig.setEnabled(true);
+        service = new DefaultSerializationServiceBuilder()
+                .setSchemaService(schemaService)
+                .setConfig(new SerializationConfig().setCompactSerializationConfig(compactSerializationConfig))
+                .build();
+    }
+
+    @Test
+    public void shouldThrowWhileSerializingRecordWithCharField() {
+        CharClass charClass = new CharClass('x');
+        assertThatThrownBy(() -> service.toData(charClass))
+                .hasRootCauseInstanceOf(HazelcastSerializationException.class)
+                .hasStackTraceContaining("does not support fields of type 'char'");
+    }
+
+    @Test
+    public void shouldThrowWhileSerializingRecordWithCharacterField() {
+        CharacterClass characterClass = new CharacterClass('x');
+        assertThatThrownBy(() -> service.toData(characterClass))
+                .hasRootCauseInstanceOf(HazelcastSerializationException.class)
+                .hasStackTraceContaining("does not support fields of type 'Character'");
+    }
+
+    @Test
+    public void shouldThrowWhileSerializingRecordWithCharArrayField() {
+        CharArrayClass charArrayClass = new CharArrayClass(new char[]{'x'});
+        assertThatThrownBy(() -> service.toData(charArrayClass))
+                .hasRootCauseInstanceOf(HazelcastSerializationException.class)
+                .hasStackTraceContaining("does not support fields of type 'char[]'");
+    }
+
+    @Test
+    public void shouldThrowWhileSerializingRecordWithCharacterArrayField() {
+        CharacterArrayClass characterArrayClass = new CharacterArrayClass(new Character[]{'x'});
+        assertThatThrownBy(() -> service.toData(characterArrayClass))
+                .hasRootCauseInstanceOf(HazelcastSerializationException.class)
+                .hasStackTraceContaining("does not support fields of type 'Character[]'");
+    }
+
+    class CharClass {
+        private final char c;
+
+        public CharClass(char c) {
+            this.c = c;
+        }
+    }
+
+    class CharacterClass {
+        private final Character c;
+
+        public CharacterClass(Character c) {
+            this.c = c;
+        }
+    }
+
+    class CharArrayClass {
+        private final char[] ca;
+
+        public CharArrayClass(char[] ca) {
+            this.ca = ca;
+        }
+    }
+
+    class CharacterArrayClass {
+        private final Character[] ca;
+
+        public CharacterArrayClass(Character[] ca) {
+            this.ca = ca;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactReflectiveSerializerUnsupportedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactReflectiveSerializerUnsupportedFieldsTest.java
@@ -49,7 +49,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     }
 
     @Test
-    public void shouldThrowWhileSerializingRecordWithCharField() {
+    public void shouldThrowWhileSerializingClassWithCharField() {
         CharClass charClass = new CharClass('x');
         assertThatThrownBy(() -> service.toData(charClass))
                 .hasRootCauseInstanceOf(HazelcastSerializationException.class)
@@ -57,7 +57,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     }
 
     @Test
-    public void shouldThrowWhileSerializingRecordWithCharacterField() {
+    public void shouldThrowWhileSerializingClassWithCharacterField() {
         CharacterClass characterClass = new CharacterClass('x');
         assertThatThrownBy(() -> service.toData(characterClass))
                 .hasRootCauseInstanceOf(HazelcastSerializationException.class)
@@ -65,7 +65,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     }
 
     @Test
-    public void shouldThrowWhileSerializingRecordWithCharArrayField() {
+    public void shouldThrowWhileSerializingClassWithCharArrayField() {
         CharArrayClass charArrayClass = new CharArrayClass(new char[]{'x'});
         assertThatThrownBy(() -> service.toData(charArrayClass))
                 .hasRootCauseInstanceOf(HazelcastSerializationException.class)
@@ -73,7 +73,7 @@ public class CompactReflectiveSerializerUnsupportedFieldsTest {
     }
 
     @Test
-    public void shouldThrowWhileSerializingRecordWithCharacterArrayField() {
+    public void shouldThrowWhileSerializingClassWithCharacterArrayField() {
         CharacterArrayClass characterArrayClass = new CharacterArrayClass(new Character[]{'x'});
         assertThatThrownBy(() -> service.toData(characterArrayClass))
                 .hasRootCauseInstanceOf(HazelcastSerializationException.class)


### PR DESCRIPTION
We have decided to remove `char`, `Character`, `char[]`, and
`Character[]` type support from the `CompactReader/Writer` APIs,
as we thought this types are not a good fit for some non-Java clients
and most of other serialization libraries do not support it.

The users still can serialize these types as they wish (possibly as
int), but that responsibility is left to the user.

We could make an exception for the zero-config use case, as it
will be primarily used by the Java-only users, but we decided
to postpone this decision to 5.2.

Therefore, to not fail with counterintuitive errors when confronted
with these types, we decided to fail fast and throw an error which
describes what to do, in case the user wants to use these types
in their classes.