### PR TITLE
Don't use Versioned in Data going out from the client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.config.MetricsConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.jet.JetException;
@@ -35,7 +34,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.StreamSerializer;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.annotation.PrivateApi;
 
@@ -66,7 +64,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *
  * @since Jet 3.0
  */
-public class JobConfig implements IdentifiedDataSerializable, Versioned {
+public class JobConfig implements IdentifiedDataSerializable {
 
     private static final long SNAPSHOT_INTERVAL_MILLIS_DEFAULT = SECONDS.toMillis(10);
 
@@ -1379,11 +1377,7 @@ public class JobConfig implements IdentifiedDataSerializable, Versioned {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeString(name);
-        if (out.getVersion().isGreaterOrEqual(Versions.V5_1)) {
-            out.writeString(processingGuarantee == null ? null : processingGuarantee.name());
-        }  else {
-            out.writeObject(processingGuarantee);
-        }
+        out.writeObject(processingGuarantee);
         out.writeLong(snapshotIntervalMillis);
         out.writeBoolean(autoScaling);
         out.writeBoolean(suspendOnFailure);
@@ -1403,12 +1397,7 @@ public class JobConfig implements IdentifiedDataSerializable, Versioned {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readString();
-        if (in.getVersion().isGreaterOrEqual(Versions.V5_1)) {
-            String processingGuarantee = in.readString();
-            this.processingGuarantee = processingGuarantee == null ? null : ProcessingGuarantee.valueOf(processingGuarantee);
-        } else {
-            this.processingGuarantee = in.readObject();
-        }
+        processingGuarantee = in.readObject();
         snapshotIntervalMillis = in.readLong();
         autoScaling = in.readBoolean();
         suspendOnFailure = in.readBoolean();


### PR DESCRIPTION
Reverts an improvement done in the following pr
https://github.com/hazelcast/hazelcast/pull/20578

The EE client does not use the versioned serialization whereas the EE server does
Therefore Identified/DataSerializable that can potentially go
out from the client can not use Versioned.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4783
