### PR TITLE
Avoid recompiling pattern for quoting in ManagementService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
@@ -46,6 +46,7 @@ public class ManagementService implements DistributedObjectListener {
 
     static final String DOMAIN = "com.hazelcast";
     private static final int INITIAL_CAPACITY = 5;
+    private static final Pattern OBJECT_NAME_QUOTE_PATTERN = Pattern.compile("[:\",=*?]");
 
     final HazelcastInstanceImpl instance;
     private final boolean enabled;
@@ -198,7 +199,7 @@ public class ManagementService implements DistributedObjectListener {
     }
 
     public static String quote(String text) {
-        return Pattern.compile("[:\",=*?]").matcher(text).find() || text.indexOf('\n') >= 0
+        return OBJECT_NAME_QUOTE_PATTERN.matcher(text).find() || text.indexOf('\n') >= 0
                 ? ObjectName.quote(text) : text;
     }
 }


### PR DESCRIPTION
Hi,

this PR avoids the recompilation of the quoting pattern inside `ManagementService`.

<img width="1668" alt="image" src="https://user-images.githubusercontent.com/6304496/154673680-728e30d7-5398-46ac-b33a-6f4504f35dde.png">


Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
