### PR TITLE
Reduce allocations from InvocationMonitor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -320,9 +320,8 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
             int normalTimeouts = 0;
             int invocationCount = 0;
 
-            for (Entry<Long, Invocation> e : invocationRegistry.entrySet()) {
+            for (Invocation inv : invocationRegistry) {
                 invocationCount++;
-                Invocation inv = e.getValue();
                 try {
                     if (inv.detectAndHandleTimeout(invocationTimeoutMillis)) {
                         normalTimeouts++;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -38,7 +38,6 @@ import com.hazelcast.spi.impl.operationservice.OperationControl;
 import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;


### PR DESCRIPTION
Hi,

this PR reduces `ConcurrentHashMap$MapEntry` allocations from `InvocationMonitor` - specifically from its `MonitorInvocationsTask`. 

As shown in the screenshots below this makes up for ~8-15% of all allocation samples in async-profiler profilings for us. I should note that this is related to #20055 and thus is mainly driven by a huge `InvocationRegistry`. 

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/6304496/154895232-7c275d48-677b-4ca3-8812-c894bf81084a.png">
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/6304496/154895594-8990b7ec-616a-4ccd-8095-9ee71f14c1bf.png">

As a side benefit this is (subjectively) cleaner.

Because this is related to #20055 I would highly appreciate backports to 4.2.x.

Cheers,
Christoph

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
