### PR TITLE
Revert "Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.10"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1077,7 +1077,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.10</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>release-repository</serverId>


### PR DESCRIPTION
Reverts hazelcast/hazelcast#20701

We could have problems during the release with the new version.

I've hit the issue with one of my personal projects. The 1.6.8 plugin version works fine.

The 1.6.10 fails with:
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.10:deploy (injected-nexus-deploy) on project jsign-pkcs11: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.10:deploy failed: Nexus connection problem to URL [https://s01.oss.sonatype.org/ ]: XPP3 pull parser library not present. Specify another driver. For example: new XStream(new DomDriver()): org.xmlpull.mxp1.MXParser -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
Error: Process completed with exit code 1.
```

The 1.6.11 fails with:
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy (injected-nexus-deploy) on project jsign-pkcs11: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11:deploy: java.lang.IllegalAccessError: tried to access method com.google.common.base.Stopwatch.<init>()V from class com.sonatype.nexus.staging.client.internal.StagingWorkflowV3ServiceImpl
Error:  -----------------------------------------------------
Error:  realm =    extension>org.sonatype.plugins:nexus-staging-maven-plugin:1.6.11
Error:  strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
Error:  urls[0] = file:/home/runner/.m2/repository/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.11/nexus-staging-maven-plugin-1.6.11.jar
...
```