### PR TITLE
Revert "Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.10 (#20701)" (5.1.z)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1077,7 +1077,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.10</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>release-repository</serverId>


### PR DESCRIPTION
This reverts commit bea5d4570dec6540f49abfae256a9c34d87272ef.

Backports #20797 to `5.1.z`
