### PR TITLE
Warn about config overrides in javadoc [5.1.z]

### DIFF
--- a/distribution/src/bin-filemode-755/hz-cluster-admin
+++ b/distribution/src/bin-filemode-755/hz-cluster-admin
@@ -3,7 +3,7 @@
 if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "Utility to query and change the state of a Hazelcast cluster."
     echo "It uses the Hazelcast REST API, which must be enabled in the cluster's"
-    echo "configuration.  To enable REST API, please do one of the following:"
+    echo "configuration.  To enable REST API, do one of the following:"
     echo "- Change member config using JAVA API: config.getNetworkConfig().getRestApiConfig().setEnabled(true);"
     echo "- Change XML/YAML configuration property: hazelcast.network.rest-api.enabled to true"
     echo "- Add system property: -Dhz.network.rest-api.enabled=true"
@@ -12,7 +12,7 @@ if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
     echo "'REST endpoint group is not enabled - CP'."
     echo "In that case you must change the cluster's configuration to enable"
     echo "the CP endpoint group. "
-    echo "To enable CP endpoint group, please do one of the following:"
+    echo "To enable CP endpoint group, do one of the following:"
     echo "- Change member config using JAVA API: config.getNetworkConfig().getRestApiConfig().enableGroups(RestEndpointGroup.CP);"
     echo "- Change XML/YAML configuration property: hazelcast.network.rest-api.endpoint-group CP with `enabled` set to true"
     echo "- Add system property: -Dhz.network.rest-api.endpoint-groups.cp.enabled=true"

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
@@ -26,6 +26,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
 /**
  * A {@link Config} which is initialized by loading an XML configuration file from the classpath.
+ * <p>
+ * Unlike {@link Config#loadFromClasspath(ClassLoader, String)} and its variants, a configuration constructed via
+ * {@code ClasspathXmlConfig} does not apply overrides found in environment variables/system properties.
  *
  * @see FileSystemXmlConfig
  */

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
@@ -26,6 +26,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
 /**
  * A {@link Config} which is initialized by loading a YAML configuration file from the classpath.
+ * <p>
+ * Unlike {@link Config#loadFromClasspath(ClassLoader, String)} and its variants, a configuration constructed via
+ * {@code ClasspathYamlConfig} does not apply overrides found in environment variables/system properties.
  *
  * @see FileSystemYamlConfig
  */

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -97,6 +97,9 @@ import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBas
  * <p>
  * Config instances can be shared between threads, but should not be
  * modified after they are used to create HazelcastInstances.
+ * <p>
+ * Unlike {@code Config} instances obtained via {@link Config#load()} and its variants,
+ * a {@code Config} does not apply overrides found in environment variables/system properties.
  */
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity", "checkstyle:classdataabstractioncoupling"})
 public class Config {

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
@@ -30,6 +30,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 /**
  * A {@link Config} which includes functionality for loading itself from a
  * XML configuration file.
+ * <p>
+ * Unlike {@link Config#loadFromFile(File)} and its variants, a configuration constructed via
+ * {@code FileSystemXmlConfig} does not apply overrides found in environment variables/system properties.
  */
 public class FileSystemXmlConfig extends Config {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
@@ -30,6 +30,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 /**
  * A {@link Config} which includes functionality for loading itself from a
  * YAML configuration file.
+ * <p>
+ * Unlike {@link Config#loadFromFile(File)} and its variants, a configuration constructed via
+ * {@code FileSystemYamlConfig} does not apply overrides found in environment variables/system properties.
  */
 public class FileSystemYamlConfig extends Config {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
@@ -29,6 +29,10 @@ import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 /**
  * Creates a {@link Config} loaded from an in-memory Hazelcast XML String.
+ *
+ * <p>
+ * Unlike {@link Config#loadFromString(String)} and its variants, a configuration constructed via
+ * {@code InMemoryXmlConfig} does not apply overrides found in environment variables/system properties.
  */
 public class InMemoryXmlConfig extends Config {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
@@ -29,6 +29,9 @@ import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 /**
  * Creates a {@link Config} loaded from an in-memory Hazelcast YAML String.
+ * <p>
+ * Unlike {@link Config#loadFromString(String)} and its variants, a configuration constructed via
+ * {@code InMemoryYamlConfig} does not apply overrides found in environment variables/system properties.
  */
 public class InMemoryYamlConfig extends Config {
     private static final ILogger LOGGER = Logger.getLogger(InMemoryYamlConfig.class);

--- a/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
@@ -29,6 +29,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
 /**
  * A {@link Config} which is loaded using some url pointing to a Hazelcast XML file.
+ * <p>
+ * Unlike {@link Config#load()} and its variants, a configuration constructed via
+ * {@code UrlXmlConfig} does not apply overrides found in environment variables/system properties.
  */
 public class UrlXmlConfig extends Config {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/UrlYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UrlYamlConfig.java
@@ -29,6 +29,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
 
 /**
  * A {@link Config} which is loaded using some url pointing to a Hazelcast YAML file.
+ * <p>
+ * Unlike {@link Config#load()} and its variants, a configuration constructed via
+ * {@code UrlYamlConfig} does not apply overrides found in environment variables/system properties.
  */
 public class UrlYamlConfig extends Config {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -43,6 +43,9 @@ import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFacto
 
 /**
  * A XML {@link ConfigBuilder} implementation.
+ * <p>
+ * Unlike {@link Config#load()} and its variants, a configuration constructed via
+ * {@code XmlConfigBuilder} does not apply overrides found in environment variables/system properties.
  */
 public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements ConfigBuilder {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -46,6 +46,9 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
  * <p>
  * This config builder is compatible with the YAML 1.2 specification and
  * supports the JSON Schema.
+ * <p>
+ * Unlike {@link Config#load()} and its variants, a configuration constructed via
+ * {@code YamlConfigBuilder} does not apply overrides found in environment variables/system properties.
  */
 public class YamlConfigBuilder extends AbstractYamlConfigBuilder implements ConfigBuilder {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/RestApiFilter.java
@@ -25,6 +25,9 @@ import com.hazelcast.logging.LoggingService;
 
 import java.util.StringTokenizer;
 
+import static com.hazelcast.jet.impl.util.Util.CONFIG_CHANGE_TEMPLATE;
+import static java.lang.String.format;
+
 /**
  * This class is a policy enforcement point for HTTP REST API. It checks incoming command lines and validates if the command can
  * be processed. If the command is unknown or not allowed the connection is closed.
@@ -48,15 +51,12 @@ public class RestApiFilter implements TextProtocolFilter {
             if (!restApiConfig.isGroupEnabled(restEndpointGroup)) {
                 String name = restEndpointGroup.name();
                 connection.close("REST endpoint group is not enabled - " + restEndpointGroup
-                        + ". To enable it, please do one of the following:\n"
-                        + "  - Change member config using JAVA API: "
-                        + " config.getNetworkConfig().getRestApiConfig().enableGroups(RestEndpointGroup." + name + ");\n"
-                        + "  - Change XML/YAML configuration property: "
-                        + "hazelcast.network.rest-api.endpoint-group " + name + " with `enabled` set to true\n"
-                        + "  - Add system property: "
-                        + "  -Dhz.network.rest-api.endpoint-groups." + name.toLowerCase() + ".enabled=true\n"
-                        + "  - Add environment variable property: HZ_NETWORK_RESTAPI_ENDPOINTGROUPS." + name + ".ENABLED=true"
-                        + " (recommended when running container/docker image)",
+                        + ". To enable it, do one of the following:\n"
+                        + format(CONFIG_CHANGE_TEMPLATE,
+                        "config.getNetworkConfig().getRestApiConfig().enableGroups(RestEndpointGroup." + name + ");",
+                        "hazelcast.network.rest-api.endpoint-group " + name + " with `enabled` set to true",
+                        "-Dhz.network.rest-api.endpoint-groups." + name.toLowerCase() + ".enabled=true",
+                        "HZ_NETWORK_RESTAPI_ENDPOINTGROUPS." + name + ".ENABLED=true"),
                         null);
             }
         } else if (!commandLine.isEmpty()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
@@ -50,8 +50,10 @@ import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.bytesToString;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
+import static com.hazelcast.jet.impl.util.Util.CONFIG_CHANGE_TEMPLATE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_RECEIVE_BUFFER_SIZE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_RECEIVE_BUFFER_SIZE;
+import static java.lang.String.format;
 
 /**
  * A {@link InboundHandler} that reads the protocol bytes
@@ -105,27 +107,24 @@ public class UnifiedProtocolDecoder
                 RestApiConfig restApiConfig = serverContext.getRestApiConfig();
                 if (!restApiConfig.isEnabledAndNotEmpty()) {
                     throw new IllegalStateException("REST API is not enabled. "
-                            + "To enable REST API, please do one of the following:\n"
-                            + "- Change member config using JAVA API: "
-                            + "config.getNetworkConfig().getRestApiConfig().setEnabled(true);\n"
-                            + "- Change XML/YAML configuration property: hazelcast.network.rest-api.enabled to true\n"
-                            + "- Add system property: -Dhz.network.rest-api.enabled=true\n"
-                            + "- Add environment variable property: HZ_NETWORK_RESTAPI_ENABLED=true"
-                            + " (recommended when running container/docker image)");
+                            + "To enable REST API, do one of the following:\n"
+                            + format(CONFIG_CHANGE_TEMPLATE,
+                            "config.getNetworkConfig().getRestApiConfig().setEnabled(true);",
+                            "hazelcast.network.rest-api.enabled to true",
+                            "-Dhz.network.rest-api.enabled=true",
+                            "HZ_NETWORK_RESTAPI_ENABLED=true"));
                 }
                 initChannelForText(protocol, true);
             } else if (MemcacheTextDecoder.TEXT_PARSERS.isCommandPrefix(protocol)) {
                 MemcacheProtocolConfig memcacheProtocolConfig = serverContext.getMemcacheProtocolConfig();
                 if (!memcacheProtocolConfig.isEnabled()) {
                     throw new IllegalStateException("Memcache text protocol is not enabled. "
-                            + "To enable Memcache, please do one of the following:\n"
-                            + "- Change member config using JAVA API: "
-                            + "config.getNetworkConfig().getMemcacheProtocolConfig().setEnabled(true);\n"
-                            + "- Change XML/YAML configuration property: "
-                            + "hazelcast.network.memcache-protocol.enabled to true\n"
-                            + "- Add system property: -Dhz.network.memcache-protocol.enabled=true\n"
-                            + "- Add environment variable property: HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED=true"
-                            + " (recommended when running container/docker image)");
+                            + "To enable Memcache, do one of the following:\n"
+                            + format(CONFIG_CHANGE_TEMPLATE,
+                                "config.getNetworkConfig().getMemcacheProtocolConfig().setEnabled(true);",
+                                "hazelcast.network.memcache-protocol.enabled to true",
+                                "-Dhz.network.memcache-protocol.enabled=true",
+                                "HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED=true"));
                 }
                 // text doesn't have a protocol; anything that isn't cluster/client protocol will be interpreted as txt.
                 initChannelForText(protocol, false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentService.java
@@ -35,6 +35,8 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.internal.usercodedeployment.impl.filter.ClassNameFilterParser.parseClassNameFilters;
 import static com.hazelcast.internal.usercodedeployment.impl.filter.MemberProviderFilterParser.parseMemberFilter;
+import static com.hazelcast.jet.impl.util.Util.CONFIG_CHANGE_TEMPLATE;
+import static java.lang.String.format;
 
 public final class UserCodeDeploymentService implements ManagedService {
 
@@ -70,13 +72,12 @@ public final class UserCodeDeploymentService implements ManagedService {
     public void defineClasses(List<Map.Entry<String, byte[]>> classDefinitions) {
         if (!enabled) {
             throw new IllegalStateException("User Code Deployment is not enabled. "
-                    + "To enable User Code Deployment, please do one of the following:\n"
-                    + "- Change member config using JAVA API: "
-                    + "config.getUserCodeDeploymentConfig().setEnabled(true);\n"
-                    + "- Change XML/YAML configuration property: Set hazelcast.user-code-deployment.enabled to true\n"
-                    + "- Add system property: -Dhz.user-code-deployment.enabled=true\n"
-                    + "- Add environment variable: HZ_USERCODEDEPLOYMENT_ENABLED=true"
-                    + " (recommended when running container/docker image)");
+                    + "To enable User Code Deployment, do one of the following:\n"
+                    + format(CONFIG_CHANGE_TEMPLATE,
+                        "config.getUserCodeDeploymentConfig().setEnabled(true);",
+                        "hazelcast.user-code-deployment.enabled to true",
+                        "-Dhz.user-code-deployment.enabled=true",
+                        "HZ_USERCODEDEPLOYMENT_ENABLED=true"));
         }
         locator.defineClassesFromClient(classDefinitions);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -104,18 +104,22 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.IntStream.range;
 
 public final class Util {
+    public static final String CONFIG_OVERRIDE_WARNING = "(for Hazelcast embedded, works only when " +
+            "loading config via Config.load)";
+    public static final String CONFIG_OVERRIDE_WARNING_ENV = "(recommended when running container image. " +
+            "For Hazelcast embedded, works only when loading config via Config.load)";
+
     public static final String CONFIG_CHANGE_TEMPLATE =
-            "  - Change member config using Java API: %s;\n" +
+            "  - Change member config using Java API: %s\n" +
                     "  - Change XML/YAML configuration property: Set %s\n" +
-                    "  - Add system property: %s\n" +
-                    "  - Add environment variable: %s" +
-                    " (recommended when running container/docker image)";
+                    "  - Add system property: %s " + CONFIG_OVERRIDE_WARNING + "\n" +
+                    "  - Add environment variable: %s " + CONFIG_OVERRIDE_WARNING_ENV;
 
     public static final String JET_IS_DISABLED_MESSAGE = "The Jet engine is disabled.\n" +
-            "To enable the Jet engine on the members, please do one of the following:\n" +
+            "To enable the Jet engine on the members, do one of the following:\n" +
             format(CONFIG_CHANGE_TEMPLATE,
-                    "config.getJetConfig().setEnabled(true);",
-                    "Set hazelcast.jet.enabled to true",
+                    "config.getJetConfig().setEnabled(true)",
+                    "hazelcast.jet.enabled to true",
                     "-Dhz.jet.enabled=true",
                     "HZ_JET_ENABLED=true"
             );
@@ -125,7 +129,7 @@ public final class Util {
             "resource upload on the members, using one of the following:\n" +
             format(CONFIG_CHANGE_TEMPLATE,
                     "config.getJetConfig().setResourceUploadEnabled(true);",
-                    "Set hazelcast.jet.resource-upload-enabled to true",
+                    "hazelcast.jet.resource-upload-enabled to true",
                     "-Dhz.jet.resource-upload-enabled=true",
                     "HZ_JET_RESOURCEUPLOADENABLED=true"
             );


### PR DESCRIPTION
Config overrides via env vars/system properties are only available
when using Config#load* API. Other ways to construct a Config object
do not apply those overrides.

Enhance logging / exception messages with information that config
overrides via env vars/system properties are only available
when using Config objects constructed from Config#load* API.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
