### PR TITLE
Enable emojis only if UTF-8 is the JVM default charset

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -31,6 +31,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
 import com.hazelcast.internal.diagnostics.HealthMonitorLevel;
+import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.QueryResultSizeExceededException;
@@ -1758,7 +1759,7 @@ public final class ClusterProperty {
      * @since 5.0
      */
     public static final HazelcastProperty LOG_EMOJI_ENABLED = new HazelcastProperty("hazelcast.logging.emoji.enabled",
-            StandardCharsets.UTF_8.equals(Charset.defaultCharset()));
+            StandardCharsets.UTF_8.equals(Charset.defaultCharset()) && !OsHelper.isWindows());
 
     /**
      * When set to any not-{@code null} value, security recommendations are logged on INFO level during the node start. The

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -31,7 +31,6 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.fd.ClusterFailureDetectorType;
 import com.hazelcast.internal.diagnostics.HealthMonitorLevel;
-import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.QueryResultSizeExceededException;
@@ -51,6 +50,9 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Defines the name and default value for Hazelcast properties.
@@ -1756,7 +1758,7 @@ public final class ClusterProperty {
      * @since 5.0
      */
     public static final HazelcastProperty LOG_EMOJI_ENABLED = new HazelcastProperty("hazelcast.logging.emoji.enabled",
-            !OsHelper.isWindows());
+            StandardCharsets.UTF_8.equals(Charset.defaultCharset()));
 
     /**
      * When set to any not-{@code null} value, security recommendations are logged on INFO level during the node start. The

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.OverridePropertyRule;

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeSecurityBannerTest.java
@@ -78,7 +78,7 @@ public class NodeSecurityBannerTest extends HazelcastTestSupport {
         assertEquals(1, appender.events.size());
         LogEvent logEvent = appender.events.get(0);
         assertEquals(Level.DEBUG, logEvent.getLevel());
-        assertRecommendationContent(logEvent, !OsHelper.isWindows());
+        assertRecommendationContent(logEvent, Boolean.parseBoolean(LOG_EMOJI_ENABLED.getDefaultValue()));
     }
 
     @Test


### PR DESCRIPTION
This PR improves enabling emojis (Hazelcast property `hazelcast.logging.emoji.enabled`).

They are not enabled if `UTF-8` is not the JVM default charset.

Resolves hazelcast/hazelcast-enterprise#4787