### PR TITLE
Fix ObjectDataInputStream tests on JDK>=11 HZ-946 [5.1.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -16,129 +16,124 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.nio.ByteOrder;
-import java.util.Arrays;
-import java.util.Random;
 
 import static com.hazelcast.internal.nio.IOUtil.readData;
-import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static java.nio.ByteOrder.BIG_ENDIAN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ObjectDataInputStream.class})
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ObjectDataInputStreamFinalMethodsTest {
 
-    static final byte[] INIT_DATA = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-
     private InternalSerializationService mockSerializationService;
     private ObjectDataInputStream in;
-    private ObjectDataInputStream inMockedDis;
-    private DataInputStream mockedDis;
     private InitableByteArrayInputStream inputStream;
     private ByteOrder byteOrder;
+    private final byte[] initData = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     @Before
     public void before() throws Exception {
-        assumeTrue("This test uses PowerMock Whitebox.setInternalState which fails in JDK >= 12", JavaVersion.isAtMost(JAVA_11));
         byteOrder = BIG_ENDIAN;
         mockSerializationService = mock(InternalSerializationService.class);
         when(mockSerializationService.getByteOrder()).thenReturn(byteOrder);
 
-        inputStream = new InitableByteArrayInputStream(INIT_DATA);
+        inputStream = new InitableByteArrayInputStream(initData);
         in = new ObjectDataInputStream(inputStream, mockSerializationService);
-
-        mockedDis = mock(DataInputStream.class);
-        inMockedDis = new ObjectDataInputStream(inputStream, mockSerializationService);
-        Whitebox.setInternalState(inMockedDis, DataInputStream.class, mockedDis);
     }
 
     @Test
     public void testRead() throws Exception {
-        inMockedDis.read();
-        verify(mockedDis).readByte();
+        assertThat(in.read()).isZero();
+        assertThat(in.read()).isOne();
     }
 
     @Test
     public void testReadB() throws Exception {
-        byte[] someInput = new byte[0];
-        inMockedDis.read(someInput);
-        verify(mockedDis).read(someInput);
+        byte[] someInput = new byte[3];
+        int readBytes = in.read(someInput);
+        assertThat(readBytes).isEqualTo(3);
+        assertArrayEquals(new byte[]{0, 1, 2}, someInput);
+
     }
 
     @Test
     public void testReadForBOffLen() throws Exception {
-        byte[] someInput = new byte[1];
-        inMockedDis.read(someInput, 0, 1);
-        verify(mockedDis).read(someInput, 0, 1);
+        byte[] someInput = new byte[5];
+        int readBytes = in.read(someInput, 2, 3);
+        assertThat(readBytes).isEqualTo(3);
+        assertArrayEquals(new byte[]{0, 0, 0, 1, 2}, someInput);
     }
 
     @Test
     public void testReadFullyB() throws Exception {
-        byte[] someInput = new byte[1];
-        inMockedDis.readFully(someInput);
-        verify(mockedDis).readFully(someInput);
+        byte[] someInput = new byte[5];
+        in.readFully(someInput);
+        assertArrayEquals(new byte[]{0, 1, 2, 3, 4}, someInput);
+
     }
 
     @Test
     public void testReadFullyForBOffLen() throws Exception {
-        byte[] someInput = new byte[1];
-        inMockedDis.readFully(someInput, 0, 1);
-        verify(mockedDis).readFully(someInput, 0, 1);
+        byte[] someInput = new byte[5];
+        in.readFully(someInput, 2, 2);
+        assertArrayEquals(new byte[]{0, 0, 0, 1, 0}, someInput);
     }
 
     @Test
     public void testSkipBytes() throws Exception {
-        int someInput = new Random().nextInt();
-        inMockedDis.skipBytes(someInput);
-        verify(mockedDis).skipBytes(someInput);
+        assertThat(in.read()).isZero();
+        in.skipBytes(3);
+        assertThat(in.read()).isEqualTo(4);
     }
 
     @Test
     public void testReadBoolean() throws Exception {
-        inMockedDis.readBoolean();
-        verify(mockedDis).readBoolean();
+        assertThat(in.readBoolean()).isFalse(); //0
+        assertThat(in.readBoolean()).isTrue(); //1
+        assertThat(in.readBoolean()).isTrue(); //2
     }
 
     @Test
     public void testReadByte() throws Exception {
-        inMockedDis.readByte();
-        verify(mockedDis).readByte();
+        assertThat(in.readByte()).isEqualTo((byte) 0);
+        assertThat(in.readByte()).isEqualTo((byte) 1);
+        assertThat(in.readByte()).isEqualTo((byte) 2);
     }
 
     @Test
     public void testReadUnsignedByte() throws Exception {
-        inMockedDis.readUnsignedByte();
-        verify(mockedDis).readUnsignedByte();
+        initData[1] = -56;
+        assertThat(in.readUnsignedByte()).isZero();
+        assertThat(in.readUnsignedByte()).isEqualTo(200);
+        assertThat(in.readUnsignedByte()).isEqualTo(2);
     }
 
     @Test
     public void testReadUnsignedShort() throws Exception {
-        inMockedDis.readUnsignedShort();
-        verify(mockedDis).readShort();
+        initData[0] = 0;
+        initData[1] = 1;
+        initData[2] = 1;
+        initData[3] = 2;
+        assertThat(in.readUnsignedShort()).isEqualTo(1);
+        assertThat(in.readUnsignedShort()).isEqualTo(258);
     }
 
     @Test
@@ -174,7 +169,7 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
         assertNull(theNullArray);
         assertArrayEquals(new boolean[0], theZeroLenghtArray);
-        assertTrue(Arrays.equals(new boolean[]{true}, booleanArray));
+        assertArrayEquals(new boolean[]{true}, booleanArray);
     }
 
     @Test
@@ -306,13 +301,13 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testReadLine() {
-        inMockedDis.readLine();
+        in.readLine();
     }
 
     @Test
     public void testReadObject() throws Exception {
-        inMockedDis.readObject();
-        verify(mockSerializationService).readObject(inMockedDis);
+        in.readObject();
+        verify(mockSerializationService).readObject(in);
     }
 
     @Test
@@ -335,18 +330,18 @@ public class ObjectDataInputStreamFinalMethodsTest {
     }
 
     @Test
-    public void testGetClassLoader() throws Exception {
+    public void testGetClassLoader() {
         in.getClassLoader();
         verify(mockSerializationService).getClassLoader();
     }
 
     @Test
-    public void testGetByteOrder() throws Exception {
+    public void testGetByteOrder() {
         ByteOrder byteOrderActual = in.getByteOrder();
         assertEquals(byteOrder, byteOrderActual);
     }
 
-    private class InitableByteArrayInputStream extends ByteArrayInputStream {
+    private static class InitableByteArrayInputStream extends ByteArrayInputStream {
 
         InitableByteArrayInputStream(byte[] buf) {
             super(buf);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -120,7 +120,9 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
     @Test
     public void testReadUnsignedByte() throws Exception {
-        initData[1] = -56;
+        initData[1] = (byte) Byte.toUnsignedInt((byte) 200);
+        assertThat(initData[1]).isEqualTo((byte) -56);
+
         assertThat(in.readUnsignedByte()).isZero();
         assertThat(in.readUnsignedByte()).isEqualTo(200);
         assertThat(in.readUnsignedByte()).isEqualTo(2);
@@ -132,8 +134,15 @@ public class ObjectDataInputStreamFinalMethodsTest {
         initData[1] = 1;
         initData[2] = 1;
         initData[3] = 2;
-        assertThat(in.readUnsignedShort()).isEqualTo(1);
-        assertThat(in.readUnsignedShort()).isEqualTo(258);
+        assertThat(in.readUnsignedShort()).isEqualTo(bytesToUnsignedShort(0, 1));
+        assertThat(in.readUnsignedShort()).isEqualTo((bytesToUnsignedShort(1, 2)));
+    }
+
+    /**
+     * Implementation from {@link java.io.DataInput#readUnsignedShort()}
+     */
+    private int bytesToUnsignedShort(int a, int b) {
+        return ((a & 0xff) << 8) | (b & 0xff);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamNonFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamNonFinalMethodsTest.java
@@ -26,7 +26,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.util.Random;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
@@ -50,7 +49,7 @@ public class ObjectDataInputStreamNonFinalMethodsTest {
         when(mockSerializationService.getByteOrder()).thenReturn(BIG_ENDIAN);
 
         inputStream = spy(new TestInputStream(INIT_DATA));
-        in = new ObjectDataInputStream(new DataInputStream(inputStream), mockSerializationService);
+        in = new ObjectDataInputStream(inputStream, mockSerializationService);
     }
 
     @Test


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/20824
Fixes https://hazelcast.atlassian.net/browse/HZ-946
Fixes https://github.com/hazelcast/hazelcast/issues/20875

* Fix ObjectDataInputStream tests on JDK>=11 HZ-915

* Use HazelcastParallelClassRunner for test
