### PR TITLE
Restore shutdown sequence & offload replica sync

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -511,9 +511,6 @@ public class Node {
             waitIfAlreadyShuttingDown();
             return;
         }
-        if (nodeExtension != null) {
-            nodeExtension.shutdown();
-        }
 
         if (!terminate) {
             int maxWaitSeconds = properties.getSeconds(GRACEFUL_SHUTDOWN_MAX_WAIT);
@@ -588,6 +585,9 @@ public class Node {
 
     @SuppressWarnings("checkstyle:npathcomplexity")
     private void shutdownServices(boolean terminate) {
+        if (nodeExtension != null) {
+            nodeExtension.shutdown();
+        }
         if (textCommandService != null) {
             textCommandService.stop();
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.internal.util.BiTuple;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.CallStatus;
 import com.hazelcast.spi.impl.operationservice.Offload;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -41,6 +42,7 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.RejectedExecutionException;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
@@ -209,27 +211,33 @@ public final class PartitionReplicaSyncRequestOffloadable
 
         @Override
         public void start() throws Exception {
-            // set partition as migrating to disable mutating
-            // operations while preparing replication operations
-            if (!trySetMigratingFlag()) {
-                sendRetryResponse();
-            }
-
             try {
-                // executed on generic operation thread
-                Integer permits = getPermits();
-                if (permits == null) {
-                    return;
-                }
+                nodeEngine.getExecutionService().execute(ExecutionService.ASYNC_EXECUTOR,
+                        () -> {
+                            // set partition as migrating to disable mutating
+                            // operations while preparing replication operations
+                            if (!trySetMigratingFlag()) {
+                                sendRetryResponse();
+                            }
 
-                sendOperationsForNamespaces(permits);
-                // send retry response for remaining namespaces
-                if (!namespaces.isEmpty()) {
-                    logNotEnoughPermits();
-                    sendRetryResponse();
-                }
-            } finally {
-                clearMigratingFlag();
+                            try {
+                                Integer permits = getPermits();
+                                if (permits == null) {
+                                    return;
+                                }
+                                sendOperationsForNamespaces(permits);
+                                // send retry response for remaining namespaces
+                                if (!namespaces.isEmpty()) {
+                                    logNotEnoughPermits();
+                                    sendRetryResponse();
+                                }
+                            } finally {
+                                clearMigratingFlag();
+                            }
+                        });
+            } catch (RejectedExecutionException e) {
+                // if execution on async executor was rejected, then send retry response
+                sendRetryResponse();
             }
         }
     }


### PR DESCRIPTION
Restore shutdown sequence & offload replica sync

PartitionReplicaSyncRequestOffloadable would block the priority
generic op thread while waiting for merkle tree comparison to occur,
leading to deadlocks.

NodeExtension#shutdown should be called after graceful-shutdown-aware
services are already shutdown. Otherwise persistence is shut down
before data services, resulting in exceptions during migrations

Foward-port of #20813 to main branch