### PR TITLE
Restore shutdown sequence & offload replica sync

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -497,9 +497,6 @@ public class Node {
             waitIfAlreadyShuttingDown();
             return;
         }
-        if (nodeExtension != null) {
-            nodeExtension.shutdown();
-        }
 
         if (!terminate) {
             int maxWaitSeconds = properties.getSeconds(GRACEFUL_SHUTDOWN_MAX_WAIT);
@@ -574,6 +571,9 @@ public class Node {
 
     @SuppressWarnings("checkstyle:npathcomplexity")
     private void shutdownServices(boolean terminate) {
+        if (nodeExtension != null) {
+            nodeExtension.shutdown();
+        }
         if (textCommandService != null) {
             textCommandService.stop();
         }


### PR DESCRIPTION
PartitionReplicaSyncRequestOffloadable would block the priority
generic op thread while waiting for merkle tree comparison to occur,
leading to deadlocks.

NodeExtension#shutdown should be called after graceful-shutdown-aware
services are already shutdown. Otherwise persistence is shut down
before data services, resulting in exceptions during migrations

Backport of #20813 to `5.0.z` branch