### PR TITLE
Fix cleanup in SimpleTestInClusterSupport [HZ-947]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -115,19 +115,19 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
 
     @AfterClass
     public static void supportAfterClass() throws Exception {
-        if (factory != null) {
-            SUPPORT_LOGGER.info("Terminating instance factory in SimpleTestInClusterSupport.@AfterClass");
-            try {
+        try {
+            if (factory != null) {
+                SUPPORT_LOGGER.info("Terminating instance factory in SimpleTestInClusterSupport.@AfterClass");
                 spawn(() -> factory.terminateAll())
                         .get(5, TimeUnit.SECONDS);
-            } catch (TimeoutException e) {
-                SUPPORT_LOGGER.warning("Terminating instance factory timed out", e);
             }
+        } catch (TimeoutException e) {
+            SUPPORT_LOGGER.warning("Terminating instance factory timed out", e);
+        } finally {
+            factory = null;
+            instances = null;
+            client = null;
         }
-
-        factory = null;
-        instances = null;
-        client = null;
     }
 
     @Nonnull

--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.Util.idToString;
@@ -116,8 +117,12 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     public static void supportAfterClass() throws Exception {
         if (factory != null) {
             SUPPORT_LOGGER.info("Terminating instance factory in SimpleTestInClusterSupport.@AfterClass");
-            spawn(() -> factory.terminateAll())
-                    .get(1, TimeUnit.MINUTES);
+            try {
+                spawn(() -> factory.terminateAll())
+                        .get(5, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                SUPPORT_LOGGER.warning("Terminating instance factory timed out", e);
+            }
         }
 
         factory = null;


### PR DESCRIPTION
When `factory.terminateAll()` in supportAfterClass() times out the
factory is not set to null, causing next class using
SimpleTestInClusterSupport to fail with
`java.lang.AssertionError: already initialized`

Fixes #19737

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
