### PR TITLE
Fix maven-gpg-plugin configuration after the version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1072,6 +1072,12 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <gpgArgument>--pinentry-mode</gpgArgument>
+                                <gpgArgument>loopback</gpgArgument>
+                            </gpgArguments>
+                        </configuration>
                     </plugin>
 
                     <plugin>


### PR DESCRIPTION
Follow up to #20069 which fixes the configuration to resolve the following release issue:

```
08:32:02  [INFO] --- maven-gpg-plugin:3.0.1:sign (sign-artifacts) @ hazelcast-root ---
08:32:02  gpg: cannot open tty `/dev/tty': No such device or address
```