### PR TITLE
Fix ModularJavaUtilsTest on OpenJ9 JVM 9+ #19874 HZ-668

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ModularJavaUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ModularJavaUtils.java
@@ -85,7 +85,7 @@ public final class ModularJavaUtils {
         if (JavaVm.CURRENT_VM == JavaVm.OPENJ9) {
             return packages(
                     open("com.sun.management.internal"),
-                    open("com.ibm.lang.management.internal")
+                    export("com.ibm.lang.management.internal")
             );
         }
         return packages(open("com.sun.management.internal"));


### PR DESCRIPTION
In shell script we use `--add-exports` while in the test we checked for `--add-opens`

Fixes https://github.com/hazelcast/hazelcast/issues/19874
Fixes https://hazelcast.atlassian.net/browse/HZ-668
