### PR TITLE
Prevent infinite loop when local partition missing

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -29,7 +29,6 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.connector.AbstractIndexReader;
 import com.hazelcast.jet.sql.impl.ExpressionUtil;
-import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.map.impl.operation.MapFetchIndexOperation;
 import com.hazelcast.map.impl.operation.MapFetchIndexOperation.MapFetchIndexOperationResult;
 import com.hazelcast.map.impl.operation.MapFetchIndexOperation.MissingPartitionException;
@@ -50,6 +49,7 @@ import com.hazelcast.sql.impl.exec.scan.MapIndexScanMetadata;
 import com.hazelcast.sql.impl.exec.scan.MapScanRow;
 import com.hazelcast.sql.impl.exec.scan.index.IndexFilter;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.row.JetSqlRow;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -68,6 +68,7 @@ import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -90,6 +91,8 @@ import static java.util.stream.Collectors.toList;
  * `split` is removed from execution.
  */
 final class MapIndexScanP extends AbstractProcessor {
+
+    private static final long DELAY_AFTER_MISSING_PARTITION = MILLISECONDS.toNanos(100);
 
     private final MapIndexScanMetadata metadata;
 
@@ -257,7 +260,15 @@ final class MapIndexScanP extends AbstractProcessor {
             ).partitions.add(partitionId);
         }
 
-        return new ArrayList<>(newSplits.values());
+        ArrayList<Split> res = new ArrayList<>(newSplits.values());
+        // if the resulting split is the same as the input split, postpone retrying it
+        if (res.size() == 1) {
+            Split newSplit = res.get(0);
+            if (newSplit.owner.equals(split.owner) && newSplit.partitions.equals(split.partitions)) {
+                newSplit.postponeUntil(System.nanoTime() + DELAY_AFTER_MISSING_PARTITION);
+            }
+        }
+        return res;
     }
 
     /**
@@ -272,6 +283,7 @@ final class MapIndexScanP extends AbstractProcessor {
         private JetSqlRow currentRow;
         private int currentBatchPosition;
         private CompletableFuture<MapFetchIndexOperationResult> future;
+        private long postponeUntil = Long.MIN_VALUE;
 
         private Split(PartitionIdSet partitions, Address owner, IndexIterationPointer[] pointers) {
             this.partitions = partitions;
@@ -281,12 +293,24 @@ final class MapIndexScanP extends AbstractProcessor {
             this.future = null;
         }
 
+        private void postponeUntil(long postponeUntil) {
+            this.postponeUntil = postponeUntil;
+        }
+
         /**
          * After this call, {@link #currentRow} will return the next entry to emit.
          * They are set to null, if there's no row available
          * because we're either done or waiting for more data.
          */
         private void peek() {
+            if (postponeUntil > Long.MIN_VALUE) {
+                if (System.nanoTime() < postponeUntil) {
+                    return;
+                } else {
+                    postponeUntil = Long.MIN_VALUE;
+                }
+            }
+
             // start a new async call, if we're not done and one isn't in flight
             if (future == null && pointers.length > 0) {
                 future = reader.readBatch(owner, partitions, pointers);
@@ -361,6 +385,15 @@ final class MapIndexScanP extends AbstractProcessor {
 
         private boolean done() {
             return currentBatchPosition == currentBatch.size() && pointers.length == 0;
+        }
+
+        @Override
+        public String toString() {
+            return "Split{" +
+                    "partitions=" + partitions +
+                    ", owner=" + owner +
+                    ", hash=" + System.identityHashCode(this) +
+                    '}';
         }
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_nightly/SqlSplitBrainTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_nightly/SqlSplitBrainTest.java
@@ -49,7 +49,7 @@ public class SqlSplitBrainTest extends JetSplitBrainTestSupport {
     @Test
     // test for https://github.com/hazelcast/hazelcast/issues/19472
     public void test_indexScan() throws InterruptedException {
-        Thread[] threads = new Thread[2];
+        Thread[] threads = new Thread[16];
         AtomicBoolean done = new AtomicBoolean();
         AtomicInteger numQueries = new AtomicInteger();
 
@@ -89,7 +89,7 @@ public class SqlSplitBrainTest extends JetSplitBrainTestSupport {
         done.set(true);
         boolean stuck = false;
         for (Thread t : threads) {
-            t.join(5000);
+            t.join(1000);
             if (t.isAlive()) {
                 logger.info("thread " + t + " stuck");
                 stuck = true;


### PR DESCRIPTION
This could have happened:
- reading of local partition throws MissingPartitionException
- processor looks at partition table, the partition is assigned to the same owner
- the new split is immediately retried. Since it's local partition, the
operation is run in-thread.

The above loops forever because of #20876. But even if it is fixed, the new
algorithm will be more robust as it will not spin until the situation resolves,
but will rather do it after a delay. We only insert the delay if there was no
change in the splits. If there was, it makes sense to retry immediately.