### PR TITLE
[HZ-958] Add more logging to DefaultAddressPickerTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/ServerSocketHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/ServerSocketHelper.java
@@ -101,6 +101,9 @@ final class ServerSocketHelper {
                 return openServerSocketChannel(endpointConfig, socketBindAddress, isReuseAddress, logger);
             } catch (IOException e) {
                 error = e;
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Cannot bind socket address " + socketBindAddress, e);
+                }
             }
         }
         throw error;

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -25,11 +25,13 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -61,6 +63,9 @@ public class DefaultAddressPickerTest {
 
     private static final String PUBLIC_HOST = "www.hazelcast.org";
     private static final String HAZELCAST_LOCAL_ADDRESS_PROP = "hazelcast.local.localAddress";
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace-default-address-picker.xml");
 
     @Rule
     public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear(HAZELCAST_LOCAL_ADDRESS_PROP);

--- a/hazelcast/src/test/resources/log4j2-trace-default-address-picker.xml
+++ b/hazelcast/src/test/resources/log4j2-trace-default-address-picker.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.instance" level="trace"/>
+        <Logger name="com.hazelcast.internal" level="trace"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR sets the log level of `DefaulAddressPickerTest` logger
to `TRACE` to get more insight about the failure.
In the failing tests, the server socket could not bind to the address
in the first trial, but I did not understand why. With this 
improvement, we'll better understand the cause.
In the final version, the number of printed logs is at analyzable
granularity. See example logs of one of the tests of this class:

```
10:48:11,936 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Prefer IPv4 stack is true, prefer IPv6 addresses is false
10:48:11,938 TRACE |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - inet reuseAddress:true
10:48:11,938 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Trying to bind inet socket address: 0.0.0.0/0.0.0.0:6789
10:48:11,938 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Bind successful to inet socket address: /0:0:0:0:0:0:0:0:6789
10:48:11,938 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Picked [10.212.134.155]:6789, using socket ServerSocket[addr=/0:0:0:0:0:0:0:0,localport=6789], bind any local is true
10:48:11,938 TRACE |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Using public address the same as the bind address: [10.212.134.155]:6789
10:48:11,938 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Prefer IPv4 stack is true, prefer IPv6 addresses is false
10:48:11,939 TRACE |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - inet reuseAddress:true
10:48:11,940 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Trying to bind inet socket address: 0.0.0.0/0.0.0.0:6789
10:48:11,940 TRACE |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Cannot bind socket address 0.0.0.0/0.0.0.0:6789
java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method) ~[?:1.8.0_312]
	at sun.nio.ch.Net.bind(Net.java:461) ~[?:1.8.0_312]
	at sun.nio.ch.Net.bind(Net.java:453) ~[?:1.8.0_312]
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:222) ~[?:1.8.0_312]
	at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:85) ~[?:1.8.0_312]
	at com.hazelcast.instance.impl.ServerSocketHelper.openServerSocketChannel(ServerSocketHelper.java:136) ~[classes/:?]
	at com.hazelcast.instance.impl.ServerSocketHelper.tryOpenServerSocketChannel(ServerSocketHelper.java:101) [classes/:?]
	at com.hazelcast.instance.impl.ServerSocketHelper.createServerSocketChannel(ServerSocketHelper.java:76) [classes/:?]
	at com.hazelcast.instance.impl.DefaultAddressPicker.getPublicAddressByPortSearch(DefaultAddressPicker.java:147) [classes/:?]
	at com.hazelcast.instance.impl.DefaultAddressPicker.pickAddress(DefaultAddressPicker.java:121) [classes/:?]
	at com.hazelcast.instance.impl.DefaultAddressPickerTest.testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement(DefaultAddressPickerTest.java:220) [test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_312]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_312]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_312]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_312]
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59) [junit-4.13.2.jar:4.13.2]
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.13.2.jar:4.13.2]
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56) [junit-4.13.2.jar:4.13.2]
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.13.2.jar:4.13.2]
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:115) [test-classes/:?]
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:107) [test-classes/:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_312]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_312]
10:48:11,940 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Trying to bind inet socket address: 0.0.0.0/0.0.0.0:6790
10:48:11,941 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Bind successful to inet socket address: /0:0:0:0:0:0:0:0:6790
10:48:11,941 DEBUG |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Picked [10.212.134.155]:6790, using socket ServerSocket[addr=/0:0:0:0:0:0:0:0,localport=6790], bind any local is true
10:48:11,941 TRACE |testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement| - [AddressPicker] testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement - Using public address the same as the bind address: [10.212.134.155]:6790
```

Closes https://github.com/hazelcast/hazelcast/issues/19856
Closes https://github.com/hazelcast/hazelcast/issues/20470 (Should I backport this logger changes to 5.0.z branch?)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
