### PR TITLE
Update maven-compiler-plugin to 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <hazelcast.serialization.version>1</hazelcast.serialization.version>
         <hazelcast.serverMainClass>com.hazelcast.core.server.HazelcastMemberStarter</hazelcast.serverMainClass>
 
-        <maven.compiler.plugin.version>3.9.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.10.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.3.2</maven.javadoc.plugin.version>
@@ -306,11 +306,6 @@
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <!-- Exclude package-info.java from compiler's scope to avoid recompiling all classes every time. -->
-                    <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
-                    <excludes>
-                        <exclude>**/package-info.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This version fixes the issue
https://issues.apache.org/jira/browse/MCOMPILER-205

Also, our workaround was not working for test classes, they were
recompiled every build. Now no workaround is needed.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
