### PR TITLE
[HZ-960] Add logging to DynamicMapConfigTest

### DIFF
--- a/hazelcast/src/test/resources/log4j2-trace-dynamic-map-config-update.xml
+++ b/hazelcast/src/test/resources/log4j2-trace-dynamic-map-config-update.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.map.impl" level="trace"/>
+        <Logger name="com.hazelcast.spi.impl.operationservice" level="trace"/>
+        <Logger name="com.hazelcast.map.impl.recordstore.expiry" level="trace"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Sets the log level of `DynamicMapConfigTest` to `TRACE` for
understanding it better in next occurrence. I checked the map put
operation flow to see if there was any possible race while initializing
`Evictor` and `ExpirySystem` in the`RecordStore`, but I couldn't find any
race there. My biggest guess was that we ran into this failure because
of an early eviction. But, I couldn't come with an exact conclusion, since
I could not reproduce this failure and there are not enough logs on this
failure occurrence.

Closes https://github.com/hazelcast/hazelcast/issues/20589

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
