### PR TITLE
Return mutable namespace collection

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NameSpaceUtil.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static java.util.Collections.singleton;
-
 /**
  * Helper class for retrieving ServiceNamespace objects.
  */
@@ -42,7 +40,8 @@ public final class NameSpaceUtil {
      * @param containerFilter allows only matching containers
      * @param toNamespace     returns {@link ObjectNamespace} for a container
      *
-     * @return all service namespaces after functions are applied
+     * @return  a mutable collection of all service namespaces after functions are applied
+     *          or an immutable empty collection, when no containers match the given predicate
      */
     public static <T> Collection<ServiceNamespace> getAllNamespaces(Map<?, T> containers,
                                                                     Predicate<T> containerFilter,
@@ -60,15 +59,7 @@ public final class NameSpaceUtil {
             ObjectNamespace namespace = toNamespace.apply(container);
 
             if (collection.isEmpty()) {
-                collection = singleton(namespace);
-                continue;
-            }
-
-            if (collection.size() == 1) {
-                // previous is an immutable singleton set
                 collection = new HashSet<>(collection);
-                collection.add(namespace);
-                continue;
             }
 
             collection.add(namespace);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/NameSpaceUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/NameSpaceUtilTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.impl;
+
+import com.hazelcast.internal.services.DistributedObjectNamespace;
+import com.hazelcast.internal.services.ObjectNamespace;
+import com.hazelcast.internal.services.ServiceNamespace;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class NameSpaceUtilTest {
+
+    private static final String SERVICE_NAME = "service";
+    private Map<Integer, Integer> containers;
+
+    @Before
+    public void setup() {
+        containers = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            containers.put(i, i);
+        }
+    }
+
+    @Test
+    public void testGetAllNamespaces_whenAllMatch() {
+        Collection<ServiceNamespace> namespaces = NameSpaceUtil.getAllNamespaces(containers, container -> true,
+                container -> new DistributedObjectNamespace(SERVICE_NAME, Integer.toString(container)));
+        assertEquals(containers.size(), namespaces.size());
+    }
+
+    @Test
+    public void testGetAllNamespaces_whenOneMatches() {
+        Collection<ServiceNamespace> namespaces =
+                NameSpaceUtil.getAllNamespaces(containers,
+                container -> container == 5,
+                container -> new DistributedObjectNamespace(SERVICE_NAME, Integer.toString(container)));
+        assertEquals(1, namespaces.size());
+    }
+
+    @Test
+    public void testGetAllNamespaces_namespacesMutable() {
+        Collection<ServiceNamespace> namespaces =
+                NameSpaceUtil.getAllNamespaces(containers,
+                container -> container == 5,
+                container -> new DistributedObjectNamespace(SERVICE_NAME, Integer.toString(container)));
+        ObjectNamespace namespaceToRetain = new DistributedObjectNamespace(SERVICE_NAME, Integer.toString(6));
+        namespaces.retainAll(Collections.singleton(namespaceToRetain));
+        assertEquals(0, namespaces.size());
+    }
+}


### PR DESCRIPTION
The namespace collection returned by NameSpaceUtil#getAllNamespaces
is mutated by some services while preparing replication operations,
so singleton immutable collection shouldn't be returned.

(cherry picked from commit 03a4cf814896d9e288134a2dc18355ddf6cede44)

Fixes #20929 on `5.1.z` (backport of #20930 )