### PR TITLE
Upgrade Kafka client to 2.8.1 HZ-952

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/ResumeTransactionUtil.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/ResumeTransactionUtil.java
@@ -18,7 +18,9 @@ package com.hazelcast.jet.kafka.impl;
 
 import com.hazelcast.internal.util.Preconditions;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.internals.TransactionManager;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,38 +32,45 @@ import java.lang.reflect.Method;
  */
 final class ResumeTransactionUtil {
 
+    private static final String TRANSACTION_MANAGER_FIELD_NAME = "transactionManager";
+    private static final String TRANSACTION_MANAGER_STATE_ENUM =
+            "org.apache.kafka.clients.producer.internals.TransactionManager$State";
+    private static final String PRODUCER_ID_AND_EPOCH_FIELD_NAME = "producerIdAndEpoch";
+
     private ResumeTransactionUtil() {
     }
 
     /**
-     * Instead of obtaining producerId and epoch from the transaction coordinator, re-use previously obtained ones,
-     * so that we can resume transaction after a restart. Implementation of this method is based on
-     * {@link KafkaProducer#initTransactions}.
+     * Instead of obtaining producerId and epoch from the transaction coordinator, re-use previously
+     * obtained ones, so that we can resume transaction after a restart. Implementation of this
+     * method is based on {@link KafkaProducer#initTransactions}.
      * https://github.com/apache/kafka/commit/5d2422258cb975a137a42a4e08f03573c49a387e
      * #diff-f4ef1afd8792cd2a2e9069cd7ddea630
      */
-    static void resumeTransaction(KafkaProducer producer, long producerId, short epoch, String txnId) {
+    static void resumeTransaction(KafkaProducer producer, long producerId, short epoch) {
         Preconditions.checkState(producerId >= 0 && epoch >= 0,
                 "Incorrect values for producerId " + producerId + " and epoch " + epoch);
 
-        Object transactionManager = getValue(producer, "transactionManager");
-        Object nextSequence = getValue(transactionManager, "nextSequence");
+        Object transactionManager = getTransactionManager(producer);
+        synchronized (transactionManager) {
+            Object topicPartitionBookkeeper =
+                    getField(transactionManager, "topicPartitionBookkeeper");
 
-        invoke(transactionManager, "transitionTo",
-                getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.INITIALIZING"));
-        invoke(nextSequence, "clear");
+            transitionTransactionManagerStateTo(transactionManager, "INITIALIZING");
+            invoke(topicPartitionBookkeeper, "reset");
 
-        Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
-        setValue(producerIdAndEpoch, "producerId", producerId);
-        setValue(producerIdAndEpoch, "epoch", epoch);
+            setField(
+                    transactionManager,
+                    PRODUCER_ID_AND_EPOCH_FIELD_NAME,
+                    createProducerIdAndEpoch(producerId, epoch));
 
-        invoke(transactionManager, "transitionTo",
-                getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.READY"));
+            transitionTransactionManagerStateTo(transactionManager, "READY");
 
-        invoke(transactionManager, "transitionTo",
-                getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.IN_TRANSACTION"));
-        setValue(transactionManager, "transactionStarted", true);
+            transitionTransactionManagerStateTo(transactionManager, "IN_TRANSACTION");
+            setField(transactionManager, "transactionStarted", true);
+        }
     }
+
 
     static long getProducerId(KafkaProducer kafkaProducer) {
         Object transactionManager = getValue(kafkaProducer, "transactionManager");
@@ -73,22 +82,6 @@ final class ResumeTransactionUtil {
         Object transactionManager = getValue(kafkaProducer, "transactionManager");
         Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
         return (short) getValue(producerIdAndEpoch, "epoch");
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Enum<?> getEnum(String enumFullName) {
-        String[] x = enumFullName.split("\\.(?=[^\\.]+$)");
-        if (x.length == 2) {
-            String enumClassName = x[0];
-            String enumName = x[1];
-            try {
-                Class<Enum> cl = (Class<Enum>) Class.forName(enumClassName);
-                return Enum.valueOf(cl, enumName);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException("Incompatible KafkaProducer version", e);
-            }
-        }
-        return null;
     }
 
     private static Object invoke(Object object, String methodName, Object... args) {
@@ -123,9 +116,75 @@ final class ResumeTransactionUtil {
         }
     }
 
-    private static void setValue(Object object, String fieldName, Object value) {
+    private static Object createProducerIdAndEpoch(long producerId, short epoch) {
         try {
-            Field field = object.getClass().getDeclaredField(fieldName);
+            Field field =
+                    TransactionManager.class.getDeclaredField(PRODUCER_ID_AND_EPOCH_FIELD_NAME);
+            Class<?> clazz = field.getType();
+            Constructor<?> constructor = clazz.getDeclaredConstructor(Long.TYPE, Short.TYPE);
+            constructor.setAccessible(true);
+            return constructor.newInstance(producerId, epoch);
+        } catch (InvocationTargetException
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchFieldException
+                | NoSuchMethodException e) {
+            throw new RuntimeException("Incompatible KafkaProducer version", e);
+        }
+    }
+
+    private static Object getTransactionManager(KafkaProducer kafkaProducer) {
+        return getField(kafkaProducer, TRANSACTION_MANAGER_FIELD_NAME);
+    }
+
+    /**
+     * Gets and returns the field {@code fieldName} from the given Object {@code object} using
+     * reflection.
+     */
+    private static Object getField(Object object, String fieldName) {
+        return getField(object, object.getClass(), fieldName);
+    }
+
+    /**
+     * Gets and returns the field {@code fieldName} from the given Object {@code object} using
+     * reflection.
+     */
+    private static Object getField(Object object, Class<?> clazz, String fieldName) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(object);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Incompatible KafkaProducer version", e);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Enum<?> getTransactionManagerState(String enumName) {
+        try {
+            Class<Enum> cl = (Class<Enum>) Class.forName(TRANSACTION_MANAGER_STATE_ENUM);
+            return Enum.valueOf(cl, enumName);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Incompatible KafkaProducer version", e);
+        }
+    }
+
+    private static void transitionTransactionManagerStateTo(
+            Object transactionManager, String state) {
+        invoke(transactionManager, "transitionTo", getTransactionManagerState(state));
+    }
+
+    /**
+     * Sets the field {@code fieldName} on the given Object {@code object} to {@code value} using
+     * reflection.
+     */
+    private static void setField(Object object, String fieldName, Object value) {
+        setField(object, object.getClass(), fieldName, value);
+    }
+
+    private static void setField(Object object, Class<?> clazz, String fieldName, Object value) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
             field.setAccessible(true);
             field.set(object, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/ResumeTransactionUtil.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/ResumeTransactionUtil.java
@@ -43,9 +43,8 @@ final class ResumeTransactionUtil {
     /**
      * Instead of obtaining producerId and epoch from the transaction coordinator, re-use previously
      * obtained ones, so that we can resume transaction after a restart. Implementation of this
-     * method is based on {@link KafkaProducer#initTransactions}.
-     * https://github.com/apache/kafka/commit/5d2422258cb975a137a42a4e08f03573c49a387e
-     * #diff-f4ef1afd8792cd2a2e9069cd7ddea630
+     * method is based on https://github.com/apache/flink/blob/577648379c2abb429259ac1a46ca6a04550f3dbd/flink-connectors
+     * /flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java#L276-L308
      */
     static void resumeTransaction(KafkaProducer producer, long producerId, short epoch) {
         Preconditions.checkState(producerId >= 0 && epoch >= 0,

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -281,7 +282,7 @@ public final class WriteKafkaP<T, K, V> implements Processor {
 
         @Override
         public void release() {
-            producer.close();
+            producer.close(Duration.ZERO);
         }
     }
 

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java
@@ -181,8 +181,7 @@ public final class WriteKafkaP<T, K, V> implements Processor {
         properties2.put("transactional.id", txnId.getKafkaId());
         try (KafkaProducer<?, ?> p  = new KafkaProducer<>(properties2)) {
             if (commit) {
-                ResumeTransactionUtil.resumeTransaction(p, txnId.producerId(), txnId.epoch(),
-                        txnId.getKafkaId());
+                ResumeTransactionUtil.resumeTransaction(p, txnId.producerId(), txnId.epoch());
                 try {
                     p.commitTransaction();
                 } catch (InvalidTxnStateException e) {

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
@@ -249,8 +249,8 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
         long producerId = ResumeTransactionUtil.getProducerId(producer);
         short epoch = ResumeTransactionUtil.getEpoch(producer);
 
-        // close the producer
-        producer.close();
+        // close the producer immediately to avoid aborting transaction
+        producer.close(Duration.ZERO);
 
         // verify items are not visible
         KafkaConsumer<Integer, String> consumer = kafkaTestSupport.createConsumer(topic);

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
@@ -259,8 +259,7 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
 
         // recover and commit
         producer = new KafkaProducer<>(properties);
-        ResumeTransactionUtil.resumeTransaction(producer, producerId, epoch,
-                properties.getProperty("transactional.id"));
+        ResumeTransactionUtil.resumeTransaction(producer, producerId, epoch);
         producer.commitTransaction();
 
         // verify items are visible

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <json-surfer.version>0.10</json-surfer.version>
         <jsr107.api.version>1.1.1</jsr107.api.version> <!-- JCache -->
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
-        <kafka.version>2.2.2</kafka.version>
+        <kafka.version>2.8.1</kafka.version>
         <kotlin.version>1.5.32</kotlin.version>
         <log4j.version>1.2.17.redhat-00008</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>
@@ -141,7 +141,7 @@
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <zookeeper.version>3.5.8</zookeeper.version>
+        <zookeeper.version>3.5.9</zookeeper.version>
         <archunit.version>0.22.0</archunit.version>
         <errorprone.version>2.11.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>


### PR DESCRIPTION
This PR upgrades Kafka client library to the version 2.8.1. 

I had to fix a test with transaction resumption because the calling `close()` on the producer from the newer version aborts ongoing transactions. To avoid that we need to call `close(Duration.ZERO)` see https://github.com/apache/kafka/blob/242253a51008946e66d80202dc08bba5bbae5827/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L1216-L1218

More information about the same problem:
- https://github.com/apache/flink/commit/889705c7ab580737f0650f39dcd3712ec19c99e9
- https://github.com/apache/flink/pull/12589/commits/893e45b76371081b2702c30d6bedb13b043cf417

### Question
The tests are green now but I'm wondering if we should change our connector to use `close(Duration.ZERO)/close(Duration.ofSeconds(XX))` instead of `close()` here:
- https://github.com/hazelcast/hazelcast/blob/23711e40a30935bc330d199a4ef5c906a4c8bcfc/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java#L285
- https://github.com/hazelcast/hazelcast/blob/23711e40a30935bc330d199a4ef5c906a4c8bcfc/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/WriteKafkaP.java#L182

Feedback from more experienced Kafka integrators would be appreciated.

Related to https://hazelcast.atlassian.net/browse/HZ-952

After the merge we can close https://github.com/hazelcast/hazelcast/issues/20024 