### PR TITLE
Add helper method to XmlUtil to enable XXE protection in the SAXParserFactory and XMLInputFactory (4.0)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.ConfigRecognizer;
 import com.hazelcast.config.ConfigStream;
+import com.hazelcast.internal.util.XmlUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.xml.sax.Attributes;
@@ -53,7 +54,7 @@ public class AbstractXmlConfigRootTagRecognizer implements ConfigRecognizer {
 
     public AbstractXmlConfigRootTagRecognizer(String expectedRootNode) throws Exception {
         this.expectedRootNode = expectedRootNode;
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParserFactory factory = XmlUtil.getSAXParserFactory();
         saxParser = factory.newSAXParser();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/XmlUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/XmlUtilTest.java
@@ -18,17 +18,39 @@ package com.hazelcast.internal.util;
 
 import static com.hazelcast.internal.util.XmlUtil.SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES;
 import static com.hazelcast.internal.util.XmlUtil.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.validation.SchemaFactory;
 
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.xml.sax.HandlerBase;
 import org.xml.sax.SAXException;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -43,6 +65,30 @@ public class XmlUtilTest {
     public OverridePropertyRule ignoreXxeFailureProp = OverridePropertyRule
             .clear(SYSTEM_PROPERTY_IGNORE_XXE_PROTECTION_FAILURES);
 
+    private DummyServer server;
+
+    @Before
+    public void before() throws IOException {
+        server = new DummyServer();
+        server.start();
+    }
+
+    @After
+    public void after() {
+        server.stop();
+    }
+
+    @Test
+    public void testUnprotectedXxe() throws Exception {
+        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        try {
+            db.parse(new ByteArrayInputStream(server.getTestXml().getBytes(UTF_8)));
+        } catch (Exception e) {
+            // not important if it fails
+        }
+        assertThat(server.getHits(), Matchers.greaterThan(0));
+    }
+
     @Test
     public void testFormat() throws Exception {
         assertEquals("<a> <b>c</b></a>", format("<a><b>c</b></a>", 1).replaceAll("[\r\n]", ""));
@@ -52,9 +98,9 @@ public class XmlUtilTest {
         assertThrows(IllegalArgumentException.class, () -> format("<a><b>c</b></a>", 0));
 
         // check if the XXE protection is enabled
-        String xxeAttack = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + "  <!DOCTYPE test [\n"
-                + "    <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n" + "  ]>" + "<a><b>&xxe;</b></a>";
-        assertEquals(xxeAttack, format(xxeAttack, 1));
+        String xml = server.getTestXml();
+        assertEquals(xml, format(xml, 1));
+        assertEquals(0, server.getHits());
 
         // wrongly formatted XML
         assertEquals("<a><b>c</b><a>", format("<a><b>c</b><a>", 1));
@@ -80,5 +126,111 @@ public class XmlUtilTest {
         assertThrows(IllegalArgumentException.class, () -> XmlUtil.setAttribute(transformerFactory, "test://no-such-property"));
         ignoreXxeFailureProp.setOrClearProperty("true");
         XmlUtil.setAttribute(transformerFactory, "test://no-such-property");
+    }
+
+    @Test
+    public void testGetDocumentBuilderFactory() throws Exception {
+        DocumentBuilderFactory dbf = XmlUtil.getNsAwareDocumentBuilderFactory();
+        assertNotNull(dbf);
+        assertThrows(ParserConfigurationException.class, () -> XmlUtil.setFeature(dbf, "test://no-such-feature"));
+        ignoreXxeFailureProp.setOrClearProperty("false");
+        assertThrows(ParserConfigurationException.class, () -> XmlUtil.setFeature(dbf, "test://no-such-feature"));
+        ignoreXxeFailureProp.setOrClearProperty("true");
+        XmlUtil.setFeature(dbf, "test://no-such-feature");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testGetSAXParserFactory() throws Exception {
+        SAXParserFactory saxParserFactory = XmlUtil.getSAXParserFactory();
+        assertNotNull(saxParserFactory);
+        // check if the XXE protection is enabled
+        SAXParser saxParser = saxParserFactory.newSAXParser();
+        assertThrows(SAXException.class,
+                () -> saxParser.parse(new ByteArrayInputStream(server.getTestXml().getBytes(UTF_8)), new HandlerBase()));
+        assertEquals(0, server.getHits());
+
+        assertThrows(SAXException.class, () -> XmlUtil.setFeature(saxParserFactory, "test://no-such-feature"));
+        ignoreXxeFailureProp.setOrClearProperty("false");
+        assertThrows(SAXException.class, () -> XmlUtil.setFeature(saxParserFactory, "test://no-such-feature"));
+        ignoreXxeFailureProp.setOrClearProperty("true");
+        XmlUtil.setFeature(saxParserFactory, "test://no-such-feature");
+    }
+
+    @Test
+    public void testGetXmlInputFactory() throws Exception {
+        XMLInputFactory xmlInputFactory = XmlUtil.getXMLInputFactory();
+        assertNotNull(xmlInputFactory);
+        // check if the XXE protection is enabled
+        assertThrows(XMLStreamException.class,
+                () -> staxReadEvents(xmlInputFactory.createXMLEventReader(new StringReader(server.getTestXml()))));
+        assertEquals(0, server.getHits());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> XmlUtil.setProperty(xmlInputFactory, "test://no-such-property", false));
+        ignoreXxeFailureProp.setOrClearProperty("false");
+        assertThrows(IllegalArgumentException.class,
+                () -> XmlUtil.setProperty(xmlInputFactory, "test://no-such-property", false));
+        ignoreXxeFailureProp.setOrClearProperty("true");
+        XmlUtil.setProperty(xmlInputFactory, "test://no-such-feature", false);
+    }
+
+    private void staxReadEvents(XMLEventReader reader) throws XMLStreamException {
+        try {
+            while (reader.hasNext()) {
+                reader.nextEvent();
+            }
+        } finally {
+            reader.close();
+        }
+    }
+
+    static class DummyServer implements Runnable {
+        private static final String XXE_TEST_STR_TEMPLATE = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                + "  <!DOCTYPE test [\n" + "    <!ENTITY xxe SYSTEM \"%s\">\n" + "  ]>" + "<a><b>&xxe;</b></a>";
+
+        private final ServerSocket serverSocket;
+        private final AtomicInteger counter = new AtomicInteger();
+
+        DummyServer() throws IOException {
+            serverSocket = new ServerSocket(0, 5, InetAddress.getLoopbackAddress());
+        }
+
+        public void start() {
+            new Thread(this, "DummyServer-acceptor").start();
+        }
+
+        public String getUrlString() {
+            return "http://127.0.0.1:" + serverSocket.getLocalPort();
+        }
+
+        public String getTestXml() {
+            return String.format(XXE_TEST_STR_TEMPLATE, getUrlString());
+        }
+
+        public int getHits() {
+            return counter.get();
+        }
+
+        public void stop() {
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        @Override
+        public void run() {
+            while (true) {
+                try (Socket socket = serverSocket.accept()) {
+                    System.out.println(">> connection accepted: " + socket);
+                    counter.incrementAndGet();
+                } catch (Exception e) {
+                    System.out.println(">> stopping the server. Cause: " + e.getClass().getName());
+                    return;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Backport (`git cherry-pick [...]`) of the changes in #20407 into the Hazelcast 4.0.z version branch.

Fixes #20928 (for 4.0.z branch)

Backport of: #20407

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc