### PR TITLE
Fix test not waiting for partitions to be applied [HZ-962]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.test.Accessors;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -131,10 +132,13 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
         terminateInstance(hz2);
         terminateInstance(hz3);
 
-        hz3 = factory.newHazelcastInstance(hz3Address);
-        final Member newMember3 = getClusterService(hz3).getLocalMember();
+        HazelcastInstance newInstance = factory.newHazelcastInstance(hz3Address);
+        hz3 = newInstance;
+        Member newMember3 = getClusterService(hz3).getLocalMember();
 
         assertClusterSizeEventually(2, hz1, hz3);
+        // ensure partition state is applied on the new member
+        assertTrueEventually(() -> Accessors.isPartitionStateInitialized(newInstance));
 
         final List<HazelcastInstance> instanceList = asList(hz1, hz3);
         assertTrueAllTheTime(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionReplicaStateChecker;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.server.ServerConnectionManager;
@@ -85,6 +86,11 @@ public class Accessors {
 
     public static InternalPartitionService getPartitionService(HazelcastInstance hz) {
         return getNode(hz).getPartitionService();
+    }
+
+    public static boolean isPartitionStateInitialized(HazelcastInstance hz) {
+        InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(hz);
+        return partitionService.getPartitionStateManager().isInitialized();
     }
 
     public static InternalSerializationService getSerializationService(HazelcastInstance hz) {


### PR DESCRIPTION
Introduce wait for partition table to be applied on new member
joining the cluster, otherwise sometimes test fails due to all
partition assignments being null. The existing wait for desired
cluster size is not enough to guarantee partition assignments are
applied, because member list is updated before partition state
is applied.

Fixes #19858