### PR TITLE
Use sleep seconds

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
@@ -166,7 +166,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
         public Boolean call() throws InterruptedException {
             hz.getCPSubsystem().getCountDownLatch(taskStartedLatchName).countDown();
 
-            sleepAtLeastSeconds((int) sleepSeconds);
+            sleepSeconds((int) sleepSeconds);
             return true;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -209,7 +209,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
         @Override
         public Boolean call() throws InterruptedException {
-            sleepAtLeastSeconds((int) sleepSeconds);
+            sleepSeconds((int) sleepSeconds);
             return true;
         }
 


### PR DESCRIPTION
Came across during investigations of https://github.com/hazelcast/hazelcast/issues/17460

Some tests are sleeping `Integer.MAX_VALUE` seconds to mimic a long running task. But sleeping with method `sleepAtLeastSeconds` makes thread uninterruptible even you close hazelcast instance, since `sleepAtLeastSeconds` swallow interrupt-exception till timeout. For example in this case timeout is 68 years.