### PR TITLE
Fix detection of automatic module name in gradle #20968 HZ-994

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -364,11 +364,13 @@
                         <configuration>
                             <target>
                                 <unzip src="${project.build.directory}/${project.build.finalName}.jar"
-                                    dest="${project.build.directory}/tmp-repack" />
+                                       dest="${project.build.directory}/tmp-repack"/>
                                 <copy file="${project.build.directory}/classes/META-INF/MANIFEST.MF"
                                       tofile="${project.build.directory}/tmp-repack/META-INF/MANIFEST.MF"/>
-                                <zip basedir="${project.build.directory}/tmp-repack"
-                                    destfile="${project.build.directory}/${project.build.finalName}.jar" />
+                                <jar basedir="${project.build.directory}/tmp-repack"
+                                     destfile="${project.build.directory}/${project.build.finalName}.jar"
+                                     manifest="${project.build.directory}/tmp-repack/META-INF/MANIFEST.MF"
+                                />
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fixes detection of automatic module name in gradle by using `jar` command for repackaging HZ jar instead of the dumb `zip`. `jar` tasks makes sure the `META-INF/MANIFEST.FM` is the second entry in the jar file as required by JDK's JarInputStream. More context: https://github.com/gradle/gradle/issues/15270

### Testing

Tested against a sample project: https://github.com/hazelcast/hazelcast-gradle-modulepath

Before (using `zip`):
<img width="811" alt="image" src="https://user-images.githubusercontent.com/1242724/158331425-802c8fc4-1b3a-4aca-ad1b-6f7ad99d17b4.png">

After (using `jar`):
<img width="763" alt="image" src="https://user-images.githubusercontent.com/1242724/158331338-4ab22935-24a6-45d4-b759-349693f003ad.png">

Fixes https://github.com/hazelcast/hazelcast/issues/20968
