### PR TITLE
Stop thread gracefully to avoid leak

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -133,7 +133,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         Terminal terminal = createTerminal();
 
         lineReader = LineReaderBuilder.builder()
-                // Check whether a real or dump terminal. Dump terminal enters an endless loop.
+                // Check whether a real or dumb terminal. Dumb terminal enters an endless loop.
                 // see issue: https://github.com/jline/jline3/issues/751
                 .variable(LineReader.SECONDARY_PROMPT_PATTERN, isRealTerminal(terminal)
                         ? new AttributedStringBuilder().style(AttributedStyle.BOLD.foreground(COLOR))
@@ -215,7 +215,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
                 writer.flush();
                 break;
             } catch (UserInterruptException e) {
-                // Handle thread interruption for dump terminal
+                // Handle thread interruption for dumb terminal
                 if (!isRealTerminal(lineReader.getTerminal())) {
                     writer.flush();
                     break;

--- a/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/console/ClientConsoleTest.java
@@ -16,15 +16,19 @@
 
 package com.hazelcast.client.console;
 
-import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
-import static com.hazelcast.internal.util.StringUtil.stringToBytes;
-import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
-import static com.hazelcast.test.Accessors.getAddress;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.TestAwareInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -35,20 +39,16 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.OverridePropertyRule;
-import com.hazelcast.test.TestAwareInstanceFactory;
-import com.hazelcast.test.annotation.QuickTest;
+import static com.hazelcast.internal.util.StringUtil.LINE_SEPARATOR;
+import static com.hazelcast.internal.util.StringUtil.stringToBytes;
+import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
+import static com.hazelcast.test.Accessors.getAddress;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * End-to-end test(s) for {@link ClientConsoleApp}. The tests use real network.
@@ -96,6 +96,11 @@ public class ClientConsoleTest {
             LineEndingsInputStream bqIn = new LineEndingsInputStream();
             System.setIn(bqIn);
             tp.execute(() -> ClientConsoleApp.run(HazelcastClient.newHazelcastClient()));
+
+            // Give some time to executor work otherwise,
+            // HazelcastClient.shutdownAll() can be quicker
+            sleepSeconds(5);
+
             assertTrueEventually(() -> assertFalse(hz.getClientService().getConnectedClients().isEmpty()));
             HazelcastInstance client = HazelcastClient.getHazelcastClientByName("clientConsoleApp");
             assertNotNull(client);
@@ -104,7 +109,7 @@ public class ClientConsoleTest {
         } finally {
             System.setIn(origIn);
             HazelcastClient.shutdownAll();
-            tp.shutdown();
+            tp.shutdownNow();
         }
     }
 


### PR DESCRIPTION
Came across during investigations of https://github.com/hazelcast/hazelcast/issues/17460

**Issue:**
See thread dump here: https://jenkins.hazelcast.com/view/Official%20Builds/job/Hazelcast-5.maintenance-OracleJDK8/25/testReport/com.hazelcast.map/IndexStatsChangingNumberOfMembersTest/testIndexStatsOperationChangingNumberOfMembers_format_OBJECT_/

```
"consoleAppTestThread" 
	java.lang.Thread.State: RUNNABLE, cpu=3493507720681 nsecs, usr=3485590000000 nsecs, blocked=0 msecs, waited=3 msecs
		at org.jline.reader.impl.LineReaderImpl$TerminalLine.<init>(LineReaderImpl.java:5139)
		at org.jline.reader.impl.LineReaderImpl.insertSecondaryPrompts(LineReaderImpl.java:4170)
		at org.jline.reader.impl.LineReaderImpl.insertSecondaryPrompts(LineReaderImpl.java:4154)
		at org.jline.reader.impl.LineReaderImpl.getDisplayedBufferWithPrompts(LineReaderImpl.java:3982)
		at org.jline.reader.impl.LineReaderImpl.redisplay(LineReaderImpl.java:3848)
		at org.jline.reader.impl.LineReaderImpl.redisplay(LineReaderImpl.java:3784)
		at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:640)
		at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:468)
		at com.hazelcast.client.console.ClientConsoleApp.start(ClientConsoleApp.java:183)
		at com.hazelcast.client.console.ClientConsoleApp.run(ClientConsoleApp.java:1592)
		at com.hazelcast.client.console.ClientConsoleTest.lambda$connectsToHazelcastCluster$1(ClientConsoleTest.java:98)
		at com.hazelcast.client.console.ClientConsoleTest$$Lambda$5294/314985531.run(Unknown Source)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at java.lang.Thread.run(Thread.java:748)
```

And see the issue:  https://github.com/jline/jline3/issues/751

**Modification:**
- There shouldn't be any behavioral change in end user console app, changes are test related
- Executor is closed with shutDownNow to interrupt running task
- When terminal is dump and UserInterruptException is raised, exit from the app
