### PR TITLE
Fix detection of automatic module name in gradle HZ-994 [5.1.z]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -364,11 +364,13 @@
                         <configuration>
                             <target>
                                 <unzip src="${project.build.directory}/${project.build.finalName}.jar"
-                                    dest="${project.build.directory}/tmp-repack" />
+                                       dest="${project.build.directory}/tmp-repack"/>
                                 <copy file="${project.build.directory}/classes/META-INF/MANIFEST.MF"
                                       tofile="${project.build.directory}/tmp-repack/META-INF/MANIFEST.MF"/>
-                                <zip basedir="${project.build.directory}/tmp-repack"
-                                    destfile="${project.build.directory}/${project.build.finalName}.jar" />
+                                <jar basedir="${project.build.directory}/tmp-repack"
+                                     destfile="${project.build.directory}/${project.build.finalName}.jar"
+                                     manifest="${project.build.directory}/tmp-repack/META-INF/MANIFEST.MF"
+                                />
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/20969
