### PR TITLE
[5.0.z] Fix race in SingleProtocolEncoder [HZ-1008]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -43,11 +43,11 @@ import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
     private final OutboundHandler[] outboundHandlers;
 
-    private boolean isDecoderVerifiedProtocol;
-    private boolean isDecoderReceivedProtocol;
     private boolean clusterProtocolBuffered;
 
-    private String exceptionMessage;
+    private volatile boolean isDecoderVerifiedProtocol;
+    private volatile boolean isDecoderReceivedProtocol;
+    private volatile String exceptionMessage;
 
     public SingleProtocolEncoder(OutboundHandler next) {
         this(new OutboundHandler[]{next});
@@ -116,19 +116,25 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
         return dst.position() == 0;
     }
 
+
+    // The signal methods below are called from the protocol decoder
+    // side that is run on IO input threads. We must synchronize the
+    // accesses of the variables which these methods share with
+    // SingleProtocolEncoder#onWrite that is run on IO output threads.
+
     // Used by SingleProtocolDecoder in order to swap
     // SingleProtocolEncoder with the next encoder in the pipeline
     public void signalProtocolVerified() {
-        isDecoderReceivedProtocol = true;
         isDecoderVerifiedProtocol = true;
+        isDecoderReceivedProtocol = true;
         channel.outboundPipeline().wakeup();
     }
 
     // Used by SingleProtocolDecoder in order to send HZX eventually
     public void signalWrongProtocol(String exceptionMessage) {
         this.exceptionMessage = exceptionMessage;
-        isDecoderReceivedProtocol = true;
         isDecoderVerifiedProtocol = false;
+        isDecoderReceivedProtocol = true;
         channel.outboundPipeline().wakeup();
     }
 


### PR DESCRIPTION
SingleProtocolEncoder#signalProtocolVerified was called from the
decoder side, which runs on the input IO-thread, while
SingleProtocolEncoder#onWrite is called from the output IO-thread.
Since the shared state variables that these methods access are not
volatile, there was a data race. Also, `isDecoderReceivedProtocol` is
the first checked state variable in onWrite method, so we have to
update it last on the signal methods -> changed the order of updates to
satisfy this.

(cherry picked from commit 9e1ec99aaa0f02d6da606d8940aa3dbc98e131b8)

Backport of: #20991

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

