### PR TITLE
Fix validation of unsupported features

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/QueryParser.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/QueryParser.java
@@ -29,7 +29,6 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.impl.ParseException;
-import org.apache.calcite.sql.util.SqlVisitor;
 
 /**
  * Performs syntactic and semantic validation of the query.
@@ -75,12 +74,11 @@ public class QueryParser {
         if (statements.size() != 1) {
             throw QueryException.error(SqlErrorCode.PARSING, "The command must contain a single statement");
         }
+
         SqlNode topNode = statements.get(0);
-
+        topNode.accept(new UnsupportedOperationVisitor(false));
         SqlNode node = validator.validate(topNode);
-
-        SqlVisitor<Void> visitor = new UnsupportedOperationVisitor();
-        node.accept(visitor);
+        node.accept(new UnsupportedOperationVisitor(true));
 
         return new QueryParseResult(
                 node,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
@@ -282,8 +282,14 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
         SUPPORTED_SYMBOLS.add(SqlJsonConstructorNullClause.ABSENT_ON_NULL);
     }
 
+    private final boolean isValidated;
+
     // The top level select is used to filter out nested selects with FETCH/OFFSET
     private SqlSelect topLevelSelect;
+
+    public UnsupportedOperationVisitor(boolean isValidated) {
+        this.isValidated = isValidated;
+    }
 
     @Override
     public Void visit(SqlCall call) {
@@ -418,6 +424,15 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
                 processOtherDdl(call);
                 break;
 
+            case ORDER_BY:
+            case EXPLICIT_TABLE:
+            case MAP_VALUE_CONSTRUCTOR:
+                // these kinds do not occur after validation
+                if (isValidated) {
+                    throw unsupported(call, kind);
+                }
+                break;
+
             default:
                 throw unsupported(call, kind);
         }
@@ -448,6 +463,13 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
     }
 
     private void processOther(SqlCall call) {
+        // Before the validation, som function calls are SqlUnresolvedFunction, some have the calcite
+        // representation, such as SqlJsonValueFunction instead of HazelcastJsonValueFunction etc.
+        // They will be validated after validation, ignore it in the pre-validation check.
+        if (!isValidated) {
+            return;
+        }
+
         SqlOperator operator = call.getOperator();
 
         if (SUPPORTED_OPERATORS.contains(operator)) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/UnsupportedOperationVisitor.java
@@ -463,7 +463,7 @@ public final class UnsupportedOperationVisitor extends SqlBasicVisitor<Void> {
     }
 
     private void processOther(SqlCall call) {
-        // Before the validation, som function calls are SqlUnresolvedFunction, some have the calcite
+        // Before the validation, some function calls are SqlUnresolvedFunction, some have the calcite
         // representation, such as SqlJsonValueFunction instead of HazelcastJsonValueFunction etc.
         // They will be validated after validation, ignore it in the pre-validation check.
         if (!isValidated) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSortTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlSortTest.java
@@ -130,7 +130,7 @@ public class SqlSortTest extends SqlTestSupport {
 
         assertThatThrownBy(() -> sqlService.execute(
                 String.format("SELECT name, distance FROM %s ORDER BY distance ASC NULLS FIRST, name ASC", tableName)
-        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS FIRST' does not exist");
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("NULLS FIRST not supported");
     }
 
     @Test
@@ -145,7 +145,7 @@ public class SqlSortTest extends SqlTestSupport {
 
         assertThatThrownBy(() -> sqlService.execute(
                 String.format("SELECT name, distance FROM %s ORDER BY distance ASC NULLS LAST, name ASC", tableName)
-        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS LAST' does not exist");
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("NULLS LAST not supported");
     }
 
     @Test
@@ -160,8 +160,7 @@ public class SqlSortTest extends SqlTestSupport {
 
         assertThatThrownBy(() -> sqlService.execute(
                 String.format("SELECT name, distance FROM %s ORDER BY distance DESC NULLS FIRST, name DESC", tableName)
-        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS FIRST' does not exist");
-
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("NULLS FIRST not supported");
     }
 
     @Test
@@ -176,7 +175,7 @@ public class SqlSortTest extends SqlTestSupport {
 
         assertThatThrownBy(() -> sqlService.execute(
                 String.format("SELECT name, distance FROM %s ORDER BY distance DESC NULLS LAST, name DESC", tableName)
-        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("Function 'NULLS LAST' does not exist");
+        )).isInstanceOf(HazelcastSqlException.class).hasMessageContaining("NULLS LAST not supported");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnsupportedFeaturesTest.java
@@ -113,4 +113,10 @@ public class SqlUnsupportedFeaturesTest extends SqlTestSupport {
         assertThatThrownBy(() -> sqlService.execute("DELETE FROM b WHERE v=1"))
                 .hasMessageContaining("PRIMARY KEY not supported by connector: TestBatch");
     }
+
+    @Test
+    public void test_upsert() {
+        assertThatThrownBy(() -> sqlService.execute("UPSERT INTO foo VALUES(1, 2, 3)"))
+                .hasMessageEndingWith("UPSERT is not supported");
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/SqlAggregateTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/SqlAggregateTest.java
@@ -1045,7 +1045,7 @@ public class SqlAggregateTest extends SqlTestSupport {
         assertThatThrownBy(
                 () -> sqlService.execute("SELECT COUNT(*) FROM " + name + " GROUP BY ROLLUP(name, distance)"))
                 .isInstanceOf(HazelcastSqlException.class)
-                .hasMessageContaining("Function 'ROLLUP' does not exist");
+                .hasMessageContaining("ROLLUP not supported");
     }
 
     @Test
@@ -1054,7 +1054,7 @@ public class SqlAggregateTest extends SqlTestSupport {
         assertThatThrownBy(
                 () -> sqlService.execute("SELECT COUNT(*) FROM " + name + " GROUP BY CUBE(name, distance)"))
                 .isInstanceOf(HazelcastSqlException.class)
-                .hasMessageContaining("Function 'CUBE' does not exist");
+                .hasMessageContaining("CUBE not supported");
     }
 
     @Test
@@ -1063,7 +1063,7 @@ public class SqlAggregateTest extends SqlTestSupport {
         assertThatThrownBy(
                 () -> sqlService.execute("SELECT COUNT(*) FROM " + name + " GROUP BY GROUPING SETS ((name), (distance))"))
                 .isInstanceOf(HazelcastSqlException.class)
-                .hasMessageContaining("Function 'GROUPING SETS' does not exist");
+                .hasMessageContaining("GROUPING SETS not supported");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/ParserOperationsTest.java
@@ -134,8 +134,8 @@ public class ParserOperationsTest extends SqlTestSupport {
 
     @Test
     public void testNullsFirstLast() {
-        checkFailure("SELECT a, b FROM t ORDER BY a DESC NULLS FIRST", "Function 'NULLS FIRST' does not exist");
-        checkFailure("SELECT a, b FROM t ORDER BY a DESC NULLS LAST", "Function 'NULLS LAST' does not exist");
+        checkFailure("SELECT a, b FROM t ORDER BY a DESC NULLS FIRST", "NULLS FIRST not supported");
+        checkFailure("SELECT a, b FROM t ORDER BY a DESC NULLS LAST", "NULLS LAST not supported");
     }
 
     @Test


### PR DESCRIPTION
We used to run UnsupportedOperationVisitor after the validation. But it could
have happened that an unsupported feature was used (e.g. UPSERT) and the error
thrown was misleading because it was thrown during the validation, such as
"Number of INSERT target columns (6) does not equal number of source items (4)",
which was confusing to the user, because the UPSERT isn't supported in the first
place. In this specific case, the target indeed had 4 columns, but UPSERT also
includes the hidden columns `__key` and `this`.
