### PR TITLE
Better message when compact serialization disabled

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -38,7 +38,6 @@ import com.hazelcast.jet.sql.impl.connector.keyvalue.KvProcessors;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvProjector;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvRowProjector;
 import com.hazelcast.jet.sql.impl.inject.UpsertTargetDescriptor;
-import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -49,6 +48,7 @@ import com.hazelcast.sql.impl.exec.scan.index.IndexFilter;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.extract.QueryPath;
+import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.ConstantTableStatistics;
 import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
@@ -83,10 +83,17 @@ public class IMapSqlConnector implements SqlConnector {
     public static final String TYPE_NAME = "IMap";
     public static final List<String> PRIMARY_KEY_LIST = singletonList(QueryPath.KEY);
 
-    private static final KvMetadataResolvers METADATA_RESOLVERS = new KvMetadataResolvers(
+    private static final KvMetadataResolvers METADATA_RESOLVERS_WITH_COMPACT = new KvMetadataResolvers(
             KvMetadataJavaResolver.INSTANCE,
             MetadataPortableResolver.INSTANCE,
             MetadataCompactResolver.INSTANCE,
+            MetadataJsonResolver.INSTANCE
+    );
+
+    private static final KvMetadataResolvers METADATA_RESOLVERS_WITHOUT_COMPACT = new KvMetadataResolvers(
+            KvMetadataJavaResolver.INSTANCE,
+            MetadataPortableResolver.INSTANCE,
+            MetadataCompactDisabledResolver.INSTANCE,
             MetadataJsonResolver.INSTANCE
     );
 
@@ -107,7 +114,11 @@ public class IMapSqlConnector implements SqlConnector {
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields
     ) {
-        return METADATA_RESOLVERS.resolveAndValidateFields(userFields, options, nodeEngine);
+        if (nodeEngine.getConfig().getSerializationConfig().getCompactSerializationConfig().isEnabled()) {
+            return METADATA_RESOLVERS_WITH_COMPACT.resolveAndValidateFields(userFields, options, nodeEngine);
+        } else {
+            return METADATA_RESOLVERS_WITHOUT_COMPACT.resolveAndValidateFields(userFields, options, nodeEngine);
+        }
     }
 
     @Nonnull
@@ -122,8 +133,8 @@ public class IMapSqlConnector implements SqlConnector {
     ) {
         InternalSerializationService ss = (InternalSerializationService) nodeEngine.getSerializationService();
 
-        KvMetadata keyMetadata = METADATA_RESOLVERS.resolveMetadata(true, resolvedFields, options, ss);
-        KvMetadata valueMetadata = METADATA_RESOLVERS.resolveMetadata(false, resolvedFields, options, ss);
+        KvMetadata keyMetadata = METADATA_RESOLVERS_WITH_COMPACT.resolveMetadata(true, resolvedFields, options, ss);
+        KvMetadata valueMetadata = METADATA_RESOLVERS_WITH_COMPACT.resolveMetadata(false, resolvedFields, options, ss);
         List<TableField> fields = concat(keyMetadata.getFields().stream(), valueMetadata.getFields().stream())
                 .collect(toList());
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataCompactDisabledResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataCompactDisabledResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.map;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadata;
+import com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolver;
+import com.hazelcast.sql.impl.QueryException;
+import com.hazelcast.sql.impl.schema.MappingField;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.COMPACT_FORMAT;
+
+final class MetadataCompactDisabledResolver implements KvMetadataResolver {
+
+    static final MetadataCompactDisabledResolver INSTANCE = new MetadataCompactDisabledResolver();
+
+    private MetadataCompactDisabledResolver() {
+    }
+
+    @Override
+    public Stream<String> supportedFormats() {
+        return Stream.of(COMPACT_FORMAT);
+    }
+
+    @Override
+    public Stream<MappingField> resolveAndValidateFields(
+            boolean isKey,
+            List<MappingField> userFields,
+            Map<String, String> options,
+            InternalSerializationService serializationService
+    ) {
+        throw QueryException.error("Compact serialization is disabled in the config");
+    }
+
+    @Override
+    public KvMetadata resolveMetadata(
+            boolean isKey,
+            List<MappingField> resolvedFields,
+            Map<String, String> options,
+            InternalSerializationService serializationService
+    ) {
+        throw QueryException.error("Compact serialization is disabled in the config");
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataCompactResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataCompactResolver.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.connector.map;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
 import com.hazelcast.internal.serialization.impl.compact.FieldDescriptor;
 import com.hazelcast.internal.serialization.impl.compact.Schema;
 import com.hazelcast.internal.serialization.impl.compact.SchemaWriter;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataCompactResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataCompactResolver.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.sql.impl.connector.map;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
 import com.hazelcast.internal.serialization.impl.compact.FieldDescriptor;
 import com.hazelcast.internal.serialization.impl.compact.Schema;
 import com.hazelcast.internal.serialization.impl.compact.SchemaWriter;

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlCompactTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlCompactTest.java
@@ -144,7 +144,7 @@ public class SqlCompactTest extends SqlTestSupport {
         float f;
         double d;
 
-        public Primitives() {}
+        public Primitives() { }
 
         public Primitives(boolean b, byte bt, short s, int i, long l, float f, double d) {
             this.b = b;

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlCompactTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlCompactTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.map;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.CompactSerializationConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
@@ -134,7 +135,6 @@ public class SqlCompactTest extends SqlTestSupport {
         ).updateCount()).hasMessageContaining("Cannot derive Compact type for 'OBJECT'");
     }
 
-
     public static class Primitives {
         boolean b;
         byte bt;
@@ -144,9 +144,7 @@ public class SqlCompactTest extends SqlTestSupport {
         float f;
         double d;
 
-        public Primitives() {
-
-        }
+        public Primitives() {}
 
         public Primitives(boolean b, byte bt, short s, int i, long l, float f, double d) {
             this.b = b;
@@ -157,8 +155,6 @@ public class SqlCompactTest extends SqlTestSupport {
             this.f = f;
             this.d = d;
         }
-
-
     }
 
     @Test
@@ -611,6 +607,18 @@ public class SqlCompactTest extends SqlTestSupport {
                         + ")").iterator().next())
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessage("Cannot use the '" + field + "' field with Compact serialization");
+    }
+
+    @Test
+    public void when_compactDisabled_then_compactFormatNotAllowed() {
+        HazelcastInstance inst = createHazelcastInstance(smallInstanceConfig());
+        assertFalse(inst.getConfig().getSerializationConfig().getCompactSerializationConfig().isEnabled());
+        assertThatThrownBy(() -> inst.getSql().execute("create mapping m " +
+                "type imap " +
+                "options (" +
+                "'keyFormat'='int', 'valueFormat'='compact', " +
+                "'valueCompactTypeName'='foo')"))
+                .hasMessage("Compact serialization is disabled in the config");
     }
 
     @SuppressWarnings({"OptionalGetWithoutIsPresent", "unchecked", "rawtypes"})


### PR DESCRIPTION
Before:
- mapping was created
- when used for writing, we threw `Failed to serialize 'com.hazelcast.internal.serialization.impl.compact.DeserializedGenericRecord'`

After:
- we throw `Compact serialization is disabled in the config` and don't create the mapping.

Fixes #20995
