### PR TITLE
Rename sync-backup to plain backup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
@@ -93,7 +93,7 @@ public class CacheClearOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return cache != null ? cache.getConfig().getBackupCount() : 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
@@ -141,7 +141,7 @@ public class CacheLoadAllOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return cache.getConfig().getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -59,7 +59,7 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
 
     @Override
     protected void beforeRunInternal() {
-        hasBackups = getSyncBackupCount() + getAsyncBackupCount() > 0;
+        hasBackups = getBackupCount() + getAsyncBackupCount() > 0;
         if (hasBackups) {
             backupRecords = createHashMap(mergingEntries.size());
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheOperation.java
@@ -171,7 +171,7 @@ public abstract class CacheOperation extends AbstractNamedOperation
     }
 
     // region BackupAwareOperation will use these
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return recordStore != null ? recordStore.getConfig().getBackupCount() : 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
@@ -110,7 +110,7 @@ public class CacheRemoveAllOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return cache != null ? cache.getConfig().getBackupCount() : 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
@@ -37,7 +37,7 @@ public abstract class CardinalityEstimatorBackupAwareOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return getCardinalityEstimatorContainer().getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionBackupAwareOperation.java
@@ -28,7 +28,7 @@ public abstract class CollectionBackupAwareOperation extends CollectionOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return getOrCreateContainer().getConfig().getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueBackupAwareOperation.java
@@ -36,7 +36,7 @@ public abstract class QueueBackupAwareOperation extends QueueOperation implement
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return getContainer().getConfig().getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/unsafe/UnsafeRaftReplicateOp.java
@@ -55,7 +55,7 @@ public class UnsafeRaftReplicateOp extends AbstractUnsafeRaftOp implements Backu
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 1;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/AbstractDurableExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/AbstractDurableExecutorOperation.java
@@ -47,7 +47,7 @@ abstract class AbstractDurableExecutorOperation extends AbstractNamedOperation i
         return executorContainer;
     }
 
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return executorContainer.getDurability();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/operations/AbstractLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/operations/AbstractLockOperation.java
@@ -87,7 +87,7 @@ public abstract class AbstractLockOperation extends Operation
         return service.getLockStore(getPartitionId(), namespace);
     }
 
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         if (asyncBackup) {
             return 0;
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/longregister/operations/LongRegisterBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/longregister/operations/LongRegisterBackupAwareOperation.java
@@ -36,7 +36,7 @@ public abstract class LongRegisterBackupAwareOperation extends AbstractLongRegis
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 1;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -62,7 +62,7 @@ public class AddIndexOperation extends MapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getTotalBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -81,7 +81,7 @@ public abstract class BasePutOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -61,7 +61,7 @@ public abstract class BaseRemoveOperation extends LockAwareOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -68,7 +68,7 @@ public class ClearOperation extends MapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapServiceContext.getMapContainer(name).getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -139,7 +139,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -292,7 +292,7 @@ EntryOperation extends LockAwareOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -77,7 +77,7 @@ public class EvictAllOperation extends MapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapServiceContext.getMapContainer(name).getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
@@ -83,7 +83,7 @@ public class EvictOperation extends LockAwareOperation implements MutatingOperat
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         if (asyncBackup) {
             return 0;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
@@ -61,7 +61,7 @@ public class MapFlushOperation extends MapOperation implements BackupAwareOperat
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -186,7 +186,7 @@ public class MergeOperation extends MapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -95,7 +95,7 @@ public class MultipleEntryOperation extends MapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -200,7 +200,7 @@ public class PartitionWideEntryOperation extends MapOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -179,7 +179,7 @@ public class PutAllOperation extends MapOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -147,7 +147,7 @@ public class PutFromLoadAllOperation extends MapOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlOperation.java
@@ -78,7 +78,7 @@ public class SetTtlOperation extends LockAwareOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -107,7 +107,7 @@ public class TxnPrepareOperation extends KeyBasedMapOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -96,7 +96,7 @@ public class TxnRollbackOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -104,7 +104,7 @@ public class TxnUnlockOperation extends LockAwareOperation
     }
 
     @Override
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return mapContainer.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractMultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractMultiMapOperation.java
@@ -106,7 +106,7 @@ public abstract class AbstractMultiMapOperation extends Operation
         return getOrCreateContainer().getConfig().isBinary();
     }
 
-    public final int getSyncBackupCount() {
+    public final int getBackupCount() {
         return getOrCreateContainer().getConfig().getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -96,7 +96,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         RingbufferContainer ringbuffer = getRingBufferContainer();
         return ringbuffer.getConfig().getBackupCount();
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -89,7 +89,7 @@ public class AddOperation extends AbstractRingBufferOperation implements Notifie
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         RingbufferContainer ringbuffer = getRingBufferContainer();
         return ringbuffer.getConfig().getBackupCount();
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
@@ -166,7 +166,7 @@ public class MergeOperation extends Operation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return config.getBackupCount();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractBackupAwareSchedulerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractBackupAwareSchedulerOperation.java
@@ -36,7 +36,7 @@ public abstract class AbstractBackupAwareSchedulerOperation
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return getContainer().getDurability();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/BackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/BackupAwareOperation.java
@@ -34,11 +34,14 @@ public interface BackupAwareOperation extends PartitionAwareOperation {
     boolean shouldBackup();
 
     /**
-     * The synchronous backup count. If no backups need to be made, 0 is returned.
+     * The backup count. If no backups need to be made, 0 is returned.
+     * Waiting for completion of backup operation
+     * is not a concern of operation execution. It is
+     * handled by {@link com.hazelcast.spi.impl.operationservice.impl.Invocation}.
      *
-     * @return the synchronous backup count.
+     * @return the backup count.
      */
-    int getSyncBackupCount();
+    int getBackupCount();
 
     /**
      * The asynchronous backup count. If no asynchronous backups need to be made, 0 is returned.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -136,7 +136,7 @@ final class OperationBackupHandler {
     }
 
     private int requestedSyncBackups(BackupAwareOperation op) {
-        int backups = op.getSyncBackupCount();
+        int backups = op.getBackupCount();
 
         if (backups < 0) {
             throw new IllegalArgumentException("Can't create backup for " + op
@@ -169,12 +169,12 @@ final class OperationBackupHandler {
     }
 
     private int requestedTotalBackups(BackupAwareOperation op) {
-        int backups = op.getSyncBackupCount() + op.getAsyncBackupCount();
+        int backups = op.getBackupCount() + op.getAsyncBackupCount();
 
         if (backups > MAX_BACKUP_COUNT) {
             throw new IllegalArgumentException("Can't create backup for " + op
                     + ", the sum of async and sync backups is larger than " + MAX_BACKUP_COUNT
-                    + ", sync backup count is " + op.getSyncBackupCount()
+                    + ", sync backup count is " + op.getBackupCount()
                     + ", async backup count is " + op.getAsyncBackupCount());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
@@ -58,7 +58,7 @@ public class ClearRemoteTransactionOperation extends AbstractXAOperation impleme
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
@@ -90,7 +90,7 @@ public class FinalizeRemoteTransactionOperation extends AbstractXAOperation impl
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
@@ -72,7 +72,7 @@ public class PutRemoteTransactionOperation extends AbstractXAOperation implement
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return 0;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -473,7 +473,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 1;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateCheckerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateCheckerTest.java
@@ -253,13 +253,13 @@ public class PartitionReplicaStateCheckerTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 0;
         }
 
         @Override
         public int getAsyncBackupCount() {
-            return super.getSyncBackupCount();
+            return super.getBackupCount();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestIncrementOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestIncrementOperation.java
@@ -38,7 +38,7 @@ public class TestIncrementOperation extends Operation implements BackupAwareOper
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         TestMigrationAwareService service = getService();
         return service.backupCount;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestPutOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestPutOperation.java
@@ -46,7 +46,7 @@ public class TestPutOperation extends Operation implements BackupAwareOperation 
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         TestMigrationAwareService service = getService();
         return service.backupCount;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentIncrementOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentIncrementOperation.java
@@ -43,7 +43,7 @@ public class TestFragmentIncrementOperation extends TestAbstractFragmentOperatio
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         TestFragmentedMigrationAwareService service = getService();
         return service.backupCount;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentPutOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentPutOperation.java
@@ -48,7 +48,7 @@ public class TestFragmentPutOperation extends TestAbstractFragmentOperation impl
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         TestFragmentedMigrationAwareService service = getService();
         return service.backupCount;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionTxnUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionTxnUtilTest.java
@@ -175,7 +175,7 @@ public class CollectionTxnUtilTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 0;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
@@ -86,7 +86,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
     public InMemoryFormat inMemoryFormat;
 
     @Parameter(1)
-    public int syncBackupCount;
+    public int backupCount;
 
     @Parameter(2)
     public int asyncBackupCount;
@@ -104,7 +104,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
     }
 
     private boolean isBackup() {
-        return syncBackupCount + asyncBackupCount > 0;
+        return backupCount + asyncBackupCount > 0;
     }
 
     @Override
@@ -113,7 +113,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(inMemoryFormat);
         mapConfig.setAsyncBackupCount(asyncBackupCount);
-        mapConfig.setBackupCount(syncBackupCount);
+        mapConfig.setBackupCount(backupCount);
         config.addMapConfig(mapConfig);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
@@ -241,7 +241,7 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 1;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
@@ -322,7 +322,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return syncBackups;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
@@ -96,7 +96,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             stressThread.runDelayMs = 1;
             stressThread.shouldBackup = false;
             stressThread.asyncBackups = 0;
-            stressThread.syncBackups = 0;
+            stressThread.backups = 0;
             stressThread.backupRunDelayMs = 0;
             stressThread.partitionId = getPartitionId(remote);
             return stressThread;
@@ -112,7 +112,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             stressThread.runDelayMs = 0;
             stressThread.shouldBackup = false;
             stressThread.asyncBackups = 0;
-            stressThread.syncBackups = 1;
+            stressThread.backups = 1;
             stressThread.backupRunDelayMs = 1;
             stressThread.partitionId = getPartitionId(remote);
             return stressThread;
@@ -128,7 +128,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             stressThread.runDelayMs = 0;
             stressThread.shouldBackup = true;
             stressThread.asyncBackups = 1;
-            stressThread.syncBackups = 0;
+            stressThread.backups = 0;
             stressThread.backupRunDelayMs = 1;
             stressThread.partitionId = getPartitionId(remote);
             return stressThread;
@@ -144,7 +144,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             stressThread.runDelayMs = 0;
             stressThread.shouldBackup = true;
             stressThread.asyncBackups = 1;
-            stressThread.syncBackups = 0;
+            stressThread.backups = 0;
             stressThread.backupRunDelayMs = 1;
             stressThread.partitionId = getPartitionId(remote);
             return stressThread;
@@ -160,7 +160,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             stressThread.runDelayMs = 0;
             stressThread.shouldBackup = true;
             stressThread.asyncBackups = 1;
-            stressThread.syncBackups = 1;
+            stressThread.backups = 1;
             stressThread.backupRunDelayMs = 1;
             stressThread.partitionId = getPartitionId(remote);
             return stressThread;
@@ -199,7 +199,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
         public int partitionId;
         public boolean syncInvocation;
         public int asyncBackups;
-        public int syncBackups;
+        public int backups;
         public boolean shouldBackup;
         public boolean returnsResponse;
         public int runDelayMs = 1;
@@ -231,7 +231,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
                 DummyOperation operation = new DummyOperation(expectedResult);
 
                 operation.returnsResponse = returnsResponse;
-                operation.syncBackups = syncBackups;
+                operation.backups = backups;
                 operation.asyncBackups = asyncBackups;
                 operation.runDelayMs = runDelayMs;
                 operation.backupRunDelayMs = backupRunDelayMs;
@@ -293,7 +293,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
     static class DummyOperation extends Operation implements BackupAwareOperation {
         long result;
         int asyncBackups;
-        int syncBackups;
+        int backups;
         boolean shouldBackup = false;
         boolean returnsResponse = true;
         int runDelayMs = 1;
@@ -323,7 +323,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
 
         @Override
         public int getBackupCount() {
-            return syncBackups;
+            return backups;
         }
 
         @Override
@@ -351,7 +351,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             out.writeInt(runDelayMs);
 
             out.writeBoolean(shouldBackup);
-            out.writeInt(syncBackups);
+            out.writeInt(backups);
             out.writeInt(asyncBackups);
             out.writeInt(backupRunDelayMs);
             byte[] bytes = new byte[MEMORY_STRESS_PAYLOAD_SIZE];
@@ -366,7 +366,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             runDelayMs = in.readInt();
 
             shouldBackup = in.readBoolean();
-            syncBackups = in.readInt();
+            backups = in.readInt();
             asyncBackups = in.readInt();
             backupRunDelayMs = in.readInt();
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -209,7 +209,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 0;
         }
 
@@ -240,7 +240,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 0;
         }
 
@@ -271,7 +271,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 0;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
@@ -72,7 +72,7 @@ public class Backup_CallerUuidTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 1;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
@@ -29,7 +29,7 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
 
     public static final ConcurrentMap<String, Integer> backupCompletedMap = new ConcurrentHashMap<String, Integer>();
 
-    public int syncBackupCount;
+    public int backupCount;
     public int asyncBackupCount;
     public boolean returnsResponse = true;
     public String backupKey;
@@ -53,7 +53,7 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
 
     @Override
     public int getBackupCount() {
-        return syncBackupCount;
+        return backupCount;
     }
 
     @Override
@@ -78,7 +78,7 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeInt(syncBackupCount);
+        out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
         out.writeBoolean(returnsResponse);
         out.writeString(backupKey);
@@ -87,7 +87,7 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        syncBackupCount = in.readInt();
+        backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         returnsResponse = in.readBoolean();
         backupKey = in.readString();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
@@ -52,7 +52,7 @@ public class DummyBackupAwareOperation extends Operation implements BackupAwareO
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return syncBackupCount;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
@@ -146,7 +146,7 @@ public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 1;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -74,10 +74,10 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         backupHandler = operationService.backupHandler;
     }
 
-    // ============================ syncBackups =================================
+    // ============================ backups =================================
 
     @Test
-    public void syncBackups_whenForceSyncEnabled() {
+    public void backups_whenForceSyncEnabled() {
         setup(BACKPRESSURE_ENABLED);
 
         // when force sync enabled, we sum tot sync and asyncs
@@ -93,7 +93,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void syncBackups_whenForceSyncDisabled() {
+    public void backups_whenForceSyncDisabled() {
         setup(BACKPRESSURE_ENABLED);
 
         // when force-sync disabled, we only look at the sync backups
@@ -207,8 +207,8 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         assertBackup(0, BACKUPS + 1, BACKUPS);
     }
 
-    private void assertBackup(final int syncBackups, final int asyncBackups, int expectedResult) throws Exception {
-        final DummyBackupAwareOperation backupAwareOp = makeOperation(syncBackups, asyncBackups);
+    private void assertBackup(final int backups, final int asyncBackups, int expectedResult) throws Exception {
+        final DummyBackupAwareOperation backupAwareOp = makeOperation(backups, asyncBackups);
 
         int result = backupHandler.sendBackups0(backupAwareOp);
 
@@ -220,15 +220,15 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
                 if (completed == null) {
                     completed = 0;
                 }
-                int totalBackups = min(BACKUPS, syncBackups + asyncBackups);
+                int totalBackups = min(BACKUPS, backups + asyncBackups);
                 assertEquals(new Integer(totalBackups), completed);
             }
         });
     }
 
-    private DummyBackupAwareOperation makeOperation(int syncBackupCount, int asyncBackupCount) {
+    private DummyBackupAwareOperation makeOperation(int backupCount, int asyncBackupCount) {
         DummyBackupAwareOperation operation = new DummyBackupAwareOperation();
-        operation.syncBackupCount = syncBackupCount;
+        operation.backupCount = backupCount;
         operation.asyncBackupCount = asyncBackupCount;
         operation.backupKey = randomUUID().toString();
         setCallerAddress(operation, getAddress(local));

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -81,15 +81,15 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         // when force sync enabled, we sum tot sync and asyncs
-        assertEquals(0, backupHandler.syncBackups(0, 0, FORCE_SYNC_ENABLED));
-        assertEquals(1, backupHandler.syncBackups(1, 0, FORCE_SYNC_ENABLED));
-        assertEquals(0, backupHandler.syncBackups(0, 0, FORCE_SYNC_ENABLED));
-        assertEquals(3, backupHandler.syncBackups(1, 2, FORCE_SYNC_ENABLED));
+        assertEquals(0, backupHandler.backups(0, 0, FORCE_SYNC_ENABLED));
+        assertEquals(1, backupHandler.backups(1, 0, FORCE_SYNC_ENABLED));
+        assertEquals(0, backupHandler.backups(0, 0, FORCE_SYNC_ENABLED));
+        assertEquals(3, backupHandler.backups(1, 2, FORCE_SYNC_ENABLED));
 
         // checking to see what happens when we are at or above the maximum number of backups
-        assertEquals(BACKUPS, backupHandler.syncBackups(BACKUPS, 0, FORCE_SYNC_ENABLED));
-        assertEquals(BACKUPS, backupHandler.syncBackups(BACKUPS + 1, 0, FORCE_SYNC_ENABLED));
-        assertEquals(BACKUPS, backupHandler.syncBackups(BACKUPS, 1, FORCE_SYNC_ENABLED));
+        assertEquals(BACKUPS, backupHandler.backups(BACKUPS, 0, FORCE_SYNC_ENABLED));
+        assertEquals(BACKUPS, backupHandler.backups(BACKUPS + 1, 0, FORCE_SYNC_ENABLED));
+        assertEquals(BACKUPS, backupHandler.backups(BACKUPS, 1, FORCE_SYNC_ENABLED));
     }
 
     @Test
@@ -97,14 +97,14 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         // when force-sync disabled, we only look at the sync backups
-        assertEquals(0, backupHandler.syncBackups(0, 0, FORCE_SYNC_DISABLED));
-        assertEquals(1, backupHandler.syncBackups(1, 0, FORCE_SYNC_DISABLED));
-        assertEquals(0, backupHandler.syncBackups(0, 0, FORCE_SYNC_DISABLED));
-        assertEquals(1, backupHandler.syncBackups(1, 1, FORCE_SYNC_DISABLED));
+        assertEquals(0, backupHandler.backups(0, 0, FORCE_SYNC_DISABLED));
+        assertEquals(1, backupHandler.backups(1, 0, FORCE_SYNC_DISABLED));
+        assertEquals(0, backupHandler.backups(0, 0, FORCE_SYNC_DISABLED));
+        assertEquals(1, backupHandler.backups(1, 1, FORCE_SYNC_DISABLED));
 
         // checking to see what happens when we are at or above the maximum number of backups
-        assertEquals(BACKUPS, backupHandler.syncBackups(BACKUPS, 0, FORCE_SYNC_DISABLED));
-        assertEquals(BACKUPS, backupHandler.syncBackups(BACKUPS + 1, 0, FORCE_SYNC_DISABLED));
+        assertEquals(BACKUPS, backupHandler.backups(BACKUPS, 0, FORCE_SYNC_DISABLED));
+        assertEquals(BACKUPS, backupHandler.backups(BACKUPS + 1, 0, FORCE_SYNC_DISABLED));
     }
 
     // ============================ asyncBackups =================================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationFailureTest.java
@@ -127,7 +127,7 @@ public class OperationFailureTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 1;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationOutOfOrderBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationOutOfOrderBackupTest.java
@@ -167,7 +167,7 @@ public class OperationOutOfOrderBackupTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 1;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -164,7 +164,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
         }
 
         @Override
-        public int getSyncBackupCount() {
+        public int getBackupCount() {
             return 0;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/TargetAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/TargetAwareOperation.java
@@ -85,7 +85,7 @@ public class TargetAwareOperation extends Operation implements TargetAware, Back
     }
 
     @Override
-    public int getSyncBackupCount() {
+    public int getBackupCount() {
         return syncBackupCount;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/TargetAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/TargetAwareOperation.java
@@ -32,7 +32,7 @@ public class TargetAwareOperation extends Operation implements TargetAware, Back
 
     public static final List<Address> TARGETS = new CopyOnWriteArrayList<Address>();
 
-    private int syncBackupCount;
+    private int backupCount;
     private int asyncBackupCount;
     private TargetAwareOperation backupOp;
     private Address targetAddress;
@@ -41,8 +41,8 @@ public class TargetAwareOperation extends Operation implements TargetAware, Back
         this(0, 0, -1);
     }
 
-    TargetAwareOperation(int syncBackupCount, int asyncBackupCount, int partitionId) {
-        this.syncBackupCount = syncBackupCount;
+    TargetAwareOperation(int backupCount, int asyncBackupCount, int partitionId) {
+        this.backupCount = backupCount;
         this.asyncBackupCount = asyncBackupCount;
         this.setPartitionId(partitionId);
     }
@@ -61,7 +61,7 @@ public class TargetAwareOperation extends Operation implements TargetAware, Back
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(targetAddress);
-        out.writeInt(syncBackupCount);
+        out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
     }
 
@@ -69,7 +69,7 @@ public class TargetAwareOperation extends Operation implements TargetAware, Back
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         targetAddress = in.readObject();
-        syncBackupCount = in.readInt();
+        backupCount = in.readInt();
         asyncBackupCount = in.readInt();
     }
 
@@ -81,12 +81,12 @@ public class TargetAwareOperation extends Operation implements TargetAware, Back
 
     @Override
     public boolean shouldBackup() {
-        return (syncBackupCount + asyncBackupCount) > 0;
+        return (backupCount + asyncBackupCount) > 0;
     }
 
     @Override
     public int getBackupCount() {
-        return syncBackupCount;
+        return backupCount;
     }
 
     @Override


### PR DESCRIPTION
Rename sync backup to plain "backup", replication is always asynchronous.

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
