### PR TITLE
Fix failure in TestCacheManager test [HZ-996]

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
@@ -124,6 +124,8 @@ public class TestCacheManager extends HazelcastTestSupport {
         Collection<String> test = cacheManager.getCacheNames();
         assertContains(test, testMap);
         testInstance.shutdown();
+        // Wait for the cluster to scale down, so it doesn't affect other tests
+        assertClusterSizeEventually(1, instance);
     }
 
     public static class DummyBean implements IDummyBean {

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
@@ -44,7 +44,7 @@
                               class-name="com.hazelcast.spring.cache.CacheMapLoader"/>
             </hz:map>
             <hz:map name="null-map"/>
-            <hz:map name="map-with-ttl" time-to-live-seconds="1">
+            <hz:map name="map-with-ttl" time-to-live-seconds="2">
             </hz:map>
         </hz:config>
     </hz:hazelcast>


### PR DESCRIPTION
The TTL was set to 1, ttl has resolution in seconds.
When the entry is stored at e.g. 5.99 seconds and fetched at 6.01
seconds it is already expired. Increase ttl to 2 s ensures at least 1
second needs to pass between the 2 calls for the entry to expire.

Also improve test isolation of test in the same class, which made this
test failure more likely to occur.

Fixes #19527
