### PR TITLE
Use testcontainers for kafka tests HZ-951

### DIFF
--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -115,6 +115,12 @@
             <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -65,56 +65,6 @@
             <version>${kafka.version}</version>
         </dependency>
 
-        <!-- TEST -->
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${scala.version}</artifactId>
-            <version>${kafka.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- override zookeeper version to remedy https://issues.apache.org/jira/browse/ZOOKEEPER-3779 -->
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${scala.version}</artifactId>
-            <version>${kafka.version}</version>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -65,6 +65,33 @@
             <version>${kafka.version}</version>
         </dependency>
 
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.impl;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.Properties;
+
+class DockerizedKafkaTestSupport extends KafkaTestSupport {
+
+    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.0.1");
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerizedKafkaTestSupport.class);
+
+    private KafkaContainer kafkaContainer;
+
+    public void createKafkaCluster() throws IOException {
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:" + TEST_KAFKA_VERSION))
+                .withEmbeddedZookeeper()
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+        kafkaContainer.start();
+
+        brokerConnectionString = kafkaContainer.getBootstrapServers();
+        Properties props = new Properties();
+        props.setProperty("bootstrap.servers", brokerConnectionString);
+        admin = Admin.create(props);
+    }
+
+    public void shutdownKafkaCluster() {
+        if (kafkaContainer != null) {
+            kafkaContainer.stop();
+            if (admin != null) {
+                admin.close();
+            }
+            if (producer != null) {
+                producer.close();
+            }
+            producer = null;
+            admin = null;
+            kafkaContainer = null;
+            brokerConnectionString = null;
+        }
+    }
+
+}

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/EmbeddedKafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/EmbeddedKafkaTestSupport.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.impl;
+
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.TestUtils;
+import kafka.zk.EmbeddedZookeeper;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.SystemTime;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import static com.hazelcast.internal.util.OsHelper.isWindows;
+
+class EmbeddedKafkaTestSupport extends KafkaTestSupport {
+    private static final String ZK_HOST = "127.0.0.1";
+    private static final String BROKER_HOST = "127.0.0.1";
+    private EmbeddedZookeeper zkServer;
+    private String zkConnect;
+    private KafkaServer kafkaServer;
+    private int brokerPort = -1;
+
+    @Override
+    public void createKafkaCluster() throws IOException {
+        System.setProperty("zookeeper.preAllocSize", Integer.toString(128));
+        zkServer = new EmbeddedZookeeper();
+        zkConnect = ZK_HOST + ':' + zkServer.port();
+
+        Properties brokerProps = new Properties();
+        brokerProps.setProperty("zookeeper.connect", zkConnect);
+        brokerProps.setProperty("broker.id", "0");
+        brokerProps.setProperty("log.dirs", Files.createTempDirectory("kafka-").toAbsolutePath().toString());
+        brokerProps.setProperty("listeners", "PLAINTEXT://" + BROKER_HOST + ":0");
+        brokerProps.setProperty("offsets.topic.replication.factor", "1");
+        brokerProps.setProperty("offsets.topic.num.partitions", "1");
+        // we need this due to avoid OOME while running tests, see https://issues.apache.org/jira/browse/KAFKA-3872
+        brokerProps.setProperty("log.cleaner.dedupe.buffer.size", Long.toString(2 * 1024 * 1024L));
+        brokerProps.setProperty("transaction.state.log.replication.factor", "1");
+        brokerProps.setProperty("transaction.state.log.num.partitions", "1");
+        brokerProps.setProperty("transaction.state.log.min.isr", "1");
+        brokerProps.setProperty("transaction.abort.timed.out.transaction.cleanup.interval.ms", "200");
+        brokerProps.setProperty("group.initial.rebalance.delay.ms", "0");
+        KafkaConfig config = new KafkaConfig(brokerProps);
+        kafkaServer = TestUtils.createServer(config, new SystemTime());
+        brokerPort = TestUtils.boundPort(kafkaServer, SecurityProtocol.PLAINTEXT);
+
+        brokerConnectionString = BROKER_HOST + ':' + brokerPort;
+        Properties props = new Properties();
+        props.setProperty("bootstrap.servers", brokerConnectionString);
+        admin = Admin.create(props);
+    }
+
+    @Override
+    public void shutdownKafkaCluster() {
+        if (kafkaServer != null) {
+            kafkaServer.shutdown();
+            if (admin != null) {
+                admin.close();
+            }
+            if (producer != null) {
+                producer.close();
+            }
+            try {
+                zkServer.shutdown();
+            } catch (Exception e) {
+                // ignore error on Windows, it fails there, see https://issues.apache.org/jira/browse/KAFKA-6291
+                if (!isWindows()) {
+                    throw e;
+                }
+            }
+            producer = null;
+            kafkaServer = null;
+            admin = null;
+            zkServer = null;
+        }
+    }
+}

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -83,7 +83,9 @@ public class KafkaTestSupport {
     public void shutdownKafkaCluster() {
         if (kafkaContainer != null) {
             kafkaContainer.stop();
-            admin.close();
+            if (admin != null) {
+                admin.close();
+            }
             if (producer != null) {
                 producer.close();
             }

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -16,12 +16,6 @@
 
 package com.hazelcast.jet.kafka.impl;
 
-import com.hazelcast.internal.util.StringUtil;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaServer;
-import kafka.utils.MockTime;
-import kafka.utils.TestUtils;
-import kafka.zk.EmbeddedZookeeper;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
@@ -32,16 +26,18 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,82 +59,43 @@ import static org.junit.Assert.assertTrue;
 
 public class KafkaTestSupport {
 
-    private static final String ZK_HOST = "127.0.0.1";
-    private static final String BROKER_HOST = "127.0.0.1";
-
-    private EmbeddedZookeeper zkServer;
-    private String zkConnect;
+    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.0.1");
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaTestSupport.class);
     private Admin admin;
 
-    private KafkaServer kafkaServer;
     private KafkaProducer<Integer, String> producer;
     private KafkaProducer<String, String> stringStringProducer;
-    private int brokerPort = -1;
     private String brokerConnectionString;
+    private KafkaContainer kafkaContainer;
 
     public void createKafkaCluster() throws IOException {
-        System.setProperty("zookeeper.preAllocSize", Integer.toString(128));
-        zkServer = new EmbeddedZookeeper();
-        zkConnect = ZK_HOST + ':' + zkServer.port();
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:" + TEST_KAFKA_VERSION))
+                .withEmbeddedZookeeper()
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+        kafkaContainer.start();
 
-        Properties brokerProps = new Properties();
-        brokerProps.setProperty("zookeeper.connect", zkConnect);
-        brokerProps.setProperty("broker.id", "0");
-        brokerProps.setProperty("log.dirs", Files.createTempDirectory("kafka-").toAbsolutePath().toString());
-        brokerProps.setProperty("listeners", "PLAINTEXT://" + BROKER_HOST + ":0");
-        brokerProps.setProperty("offsets.topic.replication.factor", "1");
-        brokerProps.setProperty("offsets.topic.num.partitions", "1");
-        // we need this due to avoid OOME while running tests, see https://issues.apache.org/jira/browse/KAFKA-3872
-        brokerProps.setProperty("log.cleaner.dedupe.buffer.size", Long.toString(2 * 1024 * 1024L));
-        brokerProps.setProperty("transaction.state.log.replication.factor", "1");
-        brokerProps.setProperty("transaction.state.log.num.partitions", "1");
-        brokerProps.setProperty("transaction.state.log.min.isr", "1");
-        brokerProps.setProperty("transaction.abort.timed.out.transaction.cleanup.interval.ms", "200");
-        brokerProps.setProperty("group.initial.rebalance.delay.ms", "0");
-        KafkaConfig config = new KafkaConfig(brokerProps);
-        Time mock = new MockTime();
-        kafkaServer = TestUtils.createServer(config, mock);
-        brokerPort = TestUtils.boundPort(kafkaServer, SecurityProtocol.PLAINTEXT);
-
-        brokerConnectionString = BROKER_HOST + ':' + brokerPort;
+        brokerConnectionString = kafkaContainer.getBootstrapServers();
         Properties props = new Properties();
         props.setProperty("bootstrap.servers", brokerConnectionString);
         admin = Admin.create(props);
     }
 
     public void shutdownKafkaCluster() {
-        if (kafkaServer != null) {
-            kafkaServer.shutdown();
+        if (kafkaContainer != null) {
+            kafkaContainer.stop();
             admin.close();
             if (producer != null) {
                 producer.close();
             }
-            try {
-                zkServer.shutdown();
-            } catch (Exception e) {
-                // ignore error on Windows, it fails there, see https://issues.apache.org/jira/browse/KAFKA-6291
-                if (!isWindows()) {
-                    throw e;
-                }
-            }
-
             producer = null;
-            kafkaServer = null;
             admin = null;
-            zkServer = null;
+            kafkaContainer = null;
+            brokerConnectionString = null;
         }
-    }
-
-    public String getZookeeperConnectionString() {
-        return zkConnect;
     }
 
     public String getBrokerConnectionString() {
         return brokerConnectionString;
-    }
-
-    private static boolean isWindows() {
-        return StringUtil.lowerCaseInternal(System.getProperty("os.name")).contains("windows");
     }
 
     public void createTopic(String topicId, int partitionCount) {
@@ -172,7 +129,7 @@ public class KafkaTestSupport {
     private KafkaProducer<Integer, String> getProducer() {
         if (producer == null) {
             Properties producerProps = new Properties();
-            producerProps.setProperty("bootstrap.servers", BROKER_HOST + ':' + brokerPort);
+            producerProps.setProperty("bootstrap.servers", brokerConnectionString);
             producerProps.setProperty("key.serializer", IntegerSerializer.class.getCanonicalName());
             producerProps.setProperty("value.serializer", StringSerializer.class.getCanonicalName());
             producer = new KafkaProducer<>(producerProps);
@@ -183,7 +140,7 @@ public class KafkaTestSupport {
     private KafkaProducer<String, String> getStringStringProducer() {
         if (stringStringProducer == null) {
             Properties producerProps = new Properties();
-            producerProps.setProperty("bootstrap.servers", BROKER_HOST + ':' + brokerPort);
+            producerProps.setProperty("bootstrap.servers", brokerConnectionString);
             producerProps.setProperty("key.serializer", StringSerializer.class.getCanonicalName());
             producerProps.setProperty("value.serializer", StringSerializer.class.getCanonicalName());
             stringStringProducer = new KafkaProducer<>(producerProps);

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -100,7 +100,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
     @BeforeClass
     public static void beforeClass() throws IOException {
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
         initialize(2, null);
     }

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_StandaloneKafkaTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_StandaloneKafkaTest.java
@@ -45,7 +45,7 @@ public class StreamKafkaP_StandaloneKafkaTest extends JetTestSupport {
 
     @Test
     public void when_cancelledAfterBrokerDown_then_cancelsPromptly() throws IOException {
-        KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
+        KafkaTestSupport kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
         kafkaTestSupport.createTopic("topic", 1);
         DAG dag = new DAG();

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_TimestampModesTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaP_TimestampModesTest.java
@@ -41,7 +41,8 @@ import static java.util.Arrays.asList;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class StreamKafkaP_TimestampModesTest extends StreamSourceStageTestBase {
 
-    private static KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
+    private static KafkaTestSupport kafkaTestSupport = KafkaTestSupport.create();
+
     private static Properties properties;
 
     private String topicName;

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
@@ -76,7 +76,7 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
 
     @BeforeClass
     public static void beforeClass() throws IOException {
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
         initialize(2, null);
     }
@@ -99,8 +99,10 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
 
     @AfterClass
     public static void afterClass() {
-        kafkaTestSupport.shutdownKafkaCluster();
-        kafkaTestSupport = null;
+        if (kafkaTestSupport != null) {
+            kafkaTestSupport.shutdownKafkaCluster();
+            kafkaTestSupport = null;
+        }
     }
 
     @Test

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -673,7 +673,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
@@ -703,6 +702,32 @@
             <artifactId>hazelcast-jet-kafka</artifactId>
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -39,7 +39,7 @@
         <checkstyle.headerLocation>${project.parent.basedir}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
 
         <calcite.version>1.29.0</calcite.version>
-        <confluent.version>4.1.4</confluent.version>
+        <confluent.version>6.2.2</confluent.version>
         <jaxb.version>2.3.1</jaxb.version>
         <immutables.version>2.8.2</immutables.version>
     </properties>
@@ -728,6 +728,12 @@
             <artifactId>hazelcast-jet-kafka</artifactId>
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -675,31 +675,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${scala.version}</artifactId>
-            <version>${kafka.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- override zookeeper version to remedy https://issues.apache.org/jira/browse/ZOOKEEPER-3779 -->
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${confluent.version}</version>
@@ -734,20 +709,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
             <version>${testcontainers.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${scala.version}</artifactId>
-            <version>${kafka.version}</version>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
-            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -78,7 +78,7 @@ public class SqlAvroTest extends SqlTestSupport {
         initialize(1, null);
         sqlService = instance().getSql();
 
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
 
         Properties properties = new Properties();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -83,7 +83,7 @@ public class SqlAvroTest extends SqlTestSupport {
 
         Properties properties = new Properties();
         properties.put("listeners", "http://0.0.0.0:0");
-        properties.put("kafkastore.connection.url", kafkaTestSupport.getZookeeperConnectionString());
+        properties.put("kafkastore.bootstrap.servers", kafkaTestSupport.getBrokerConnectionString());
         SchemaRegistryConfig config = new SchemaRegistryConfig(properties);
         SchemaRegistryRestApplication schemaRegistryApplication = new SchemaRegistryRestApplication(config);
         schemaRegistry = schemaRegistryApplication.createServer();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -92,8 +92,12 @@ public class SqlAvroTest extends SqlTestSupport {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        schemaRegistry.stop();
-        kafkaTestSupport.shutdownKafkaCluster();
+        if (schemaRegistry != null) {
+            schemaRegistry.stop();
+        }
+        if (kafkaTestSupport != null) {
+            kafkaTestSupport.shutdownKafkaCluster();
+        }
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
@@ -61,7 +61,7 @@ public class SqlJsonTest extends SqlTestSupport {
         initialize(1, null);
         sqlService = instance().getSql();
 
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlKafkaAggregateTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlKafkaAggregateTest.java
@@ -49,7 +49,7 @@ public class SqlKafkaAggregateTest extends SqlTestSupport {
         initialize(1, null);
         sqlService = instance().getSql();
 
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPlanCacheTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPlanCacheTest.java
@@ -41,7 +41,7 @@ public class SqlPlanCacheTest extends SqlTestSupport {
         initialize(1, null);
         sqlService = instance().getSql();
 
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPojoTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPojoTest.java
@@ -67,7 +67,7 @@ public class SqlPojoTest extends SqlTestSupport {
         initialize(1, null);
         sqlService = instance().getSql();
 
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
@@ -57,7 +57,7 @@ public class SqlPrimitiveTest extends SqlTestSupport {
         initialize(1, null);
         sqlService = instance().getSql();
 
-        kafkaTestSupport = new KafkaTestSupport();
+        kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <picocli.version>4.4.0</picocli.version>
         <prometheus.version>0.14.0</prometheus.version>
         <protobuf.version>3.19.4</protobuf.version>
-        <scala.version>2.12</scala.version>
+        <scala.version>2.13</scala.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>4.3.0.RELEASE</spring.version>
         <snakeyaml.version>1.30</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
         <archunit.version>0.22.0</archunit.version>
         <errorprone.version>2.11.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>


### PR DESCRIPTION
Kafka tests were migrated to testcontainers to allow testing Kafka connector against different versions of the Kafka broker using a new system property `test.kafka.version`, e.g. `-Dtest.kafka.version=7.0.1`

On dockerless environments the tests will fallback to the embedded kafka.

Relates to: https://hazelcast.atlassian.net/browse/HZ-951

