### PR TITLE
Excluding sql classes from compatibility test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -69,6 +69,7 @@ public class SamplingSerializationService implements InternalSerializationServic
     private static final String TEST_PACKAGE_INFIX = ".test";
     private static final String EXAMPLE_PACKAGE_PREFIX = "example.";
     private static final String JET_PACKAGE_PREFIX = "com.hazelcast.jet";
+    private static final String SQL_PACKAGE_PREFIX = "com.hazelcast.sql";
 
     // Only a small subset of Jet classes requires backwards-compatibility. Jet doesn't provide client
     // compatibility nor does it support rolling upgrades.
@@ -286,6 +287,10 @@ public class SamplingSerializationService implements InternalSerializationServic
         }
 
         if (className.startsWith(JET_PACKAGE_PREFIX) && !JET_BACKWARD_COMPATIBLE_CLASSES.contains(className)) {
+            return false;
+        }
+
+        if (className.startsWith(SQL_PACKAGE_PREFIX)) {
             return false;
         }
 


### PR DESCRIPTION
Will fix https://github.com/hazelcast/hazelcast-enterprise/issues/4884 after regeneration.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
