### PR TITLE
Fix MigrationInterceptorTest [HZ-1004]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationInterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationInterceptorTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.impl.MigrationCommitTest.DelayMigrationStart;
 import com.hazelcast.internal.partition.impl.MigrationInterceptor.MigrationParticipant;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -64,6 +65,11 @@ public class MigrationInterceptorTest extends HazelcastTestSupport {
         config2.setProperty(ClusterProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT));
         config2.addListenerConfig(new ListenerConfig(listener));
         final HazelcastInstance hz2 = factory.newHazelcastInstance(config2);
+
+        // Wait for the partition state is initialized on the second member.
+        // Otherwise, some migrations can fail with a PartitionStateVersionMismatchException
+        // with message "Local partition stamp is not equal to master's stamp! Local: 0, Master: 1"
+        assertTrueEventually(() -> Accessors.isPartitionStateInitialized(hz2));
 
         migrationStartLatch.countDown();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationInterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationInterceptorTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import static com.hazelcast.test.Accessors.getAddress;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -69,7 +70,7 @@ public class MigrationInterceptorTest extends HazelcastTestSupport {
         // Wait for the partition state is initialized on the second member.
         // Otherwise, some migrations can fail with a PartitionStateVersionMismatchException
         // with message "Local partition stamp is not equal to master's stamp! Local: 0, Master: 1"
-        assertTrueEventually(() -> Accessors.isPartitionStateInitialized(hz2));
+        assertTrueEventually(() -> assertTrue(Accessors.isPartitionStateInitialized(hz2)));
 
         migrationStartLatch.countDown();
 


### PR DESCRIPTION
In this test, a migration request was received before initializing the
partition state in the newly joining member then this request was
retried. This results in the number of migration events more than the
expected number of migration events in the test.
Resolved this problem by waiting for that partitions to be initialized 
before starting the migrations.

The issue can be reproduced by adding this conditional sleep:
```
  if (node.getLocalMember().getAddress().getPort() == 5702) {
            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(500));
            logger.info("Stall on process partition runtime state state");
        }
```

before applying partition state here: https://github.com/hazelcast/hazelcast/blob/d2f0c631913de4507ecfed7422fbb268287e073f/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java#L621-L622
 

See the related error and related exceptions:
```
MigrationProgressNotification{event=START, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=37327e9d-b980-4094-894d-917b3790110c, partitionId=1, source=null, sourceCurrentReplicaIndex=-1, sourceNewReplicaIndex=-1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=1, master=[127.0.0.1]:5701, initialPartitionVersion=1, partitionVersionIncrement=1, status=ACTIVE}, success=true}, 
MigrationProgressNotification{event=START, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=ce915dc4-6baa-4deb-a14e-a8402aa88763, partitionId=0, source=[127.0.0.1]:5701 - 72c30aca-3155-44f1-9d6d-cc4cef1e95f2, sourceCurrentReplicaIndex=0, sourceNewReplicaIndex=1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=0, master=[127.0.0.1]:5701, initialPartitionVersion=1, partitionVersionIncrement=2, status=ACTIVE}, success=true}, 
MigrationProgressNotification{event=START, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=00b37590-624a-4605-ae61-24a9d5b8c5c1, partitionId=1, source=null, sourceCurrentReplicaIndex=-1, sourceNewReplicaIndex=-1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=1, master=[127.0.0.1]:5701, initialPartitionVersion=3, partitionVersionIncrement=1, status=SUCCESS}, success=true}, 
MigrationProgressNotification{event=START, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=ef138bb2-e6df-434e-820f-0ca5b6e90d9a, partitionId=0, source=[127.0.0.1]:5701 - 72c30aca-3155-44f1-9d6d-cc4cef1e95f2, sourceCurrentReplicaIndex=0, sourceNewReplicaIndex=1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=0, master=[127.0.0.1]:5701, initialPartitionVersion=4, partitionVersionIncrement=2, status=SUCCESS}, success=true}, 
MigrationProgressNotification{event=COMPLETE, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=ef138bb2-e6df-434e-820f-0ca5b6e90d9a, partitionId=0, source=[127.0.0.1]:5701 - 72c30aca-3155-44f1-9d6d-cc4cef1e95f2, sourceCurrentReplicaIndex=0, sourceNewReplicaIndex=1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=0, master=[127.0.0.1]:5701, initialPartitionVersion=4, partitionVersionIncrement=2, status=ACTIVE}, success=true}, 
MigrationProgressNotification{event=COMPLETE, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=00b37590-624a-4605-ae61-24a9d5b8c5c1, partitionId=1, source=null, sourceCurrentReplicaIndex=-1, sourceNewReplicaIndex=-1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=1, master=[127.0.0.1]:5701, initialPartitionVersion=3, partitionVersionIncrement=1, status=ACTIVE}, success=true}, 
MigrationProgressNotification{event=COMMIT, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=ef138bb2-e6df-434e-820f-0ca5b6e90d9a, partitionId=0, source=[127.0.0.1]:5701 - 72c30aca-3155-44f1-9d6d-cc4cef1e95f2, sourceCurrentReplicaIndex=0, sourceNewReplicaIndex=1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=0, master=[127.0.0.1]:5701, initialPartitionVersion=4, partitionVersionIncrement=2, status=SUCCESS}, success=true}, 
MigrationProgressNotification{event=COMMIT, participant=DESTINATION, migrationInfo=MigrationInfo{uuid=00b37590-624a-4605-ae61-24a9d5b8c5c1, partitionId=1, source=null, sourceCurrentReplicaIndex=-1, sourceNewReplicaIndex=-1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=1, master=[127.0.0.1]:5701, initialPartitionVersion=3, partitionVersionIncrement=1, status=SUCCESS}, success=true}]
 expected:<6> but was:<8>

10:46:57,437  WARN |shouldInvokeInternalMigrationListenerOnSuccessfulMigration| - [MigrationRequestOperation] hz.unruffled_goldwasser.async.thread-1 - [127.0.0.1]:5701 [dev] [5.1.1-SNAPSHOT] Failure while executing MigrationInfo{uuid=ce915dc4-6baa-4deb-a14e-a8402aa88763, partitionId=0, source=[127.0.0.1]:5701 - 72c30aca-3155-44f1-9d6d-cc4cef1e95f2, sourceCurrentReplicaIndex=0, sourceNewReplicaIndex=1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=0, master=[127.0.0.1]:5701, initialPartitionVersion=1, partitionVersionIncrement=2, status=ACTIVE}
com.hazelcast.internal.partition.PartitionStateVersionMismatchException: Local partition stamp is not equal to master's stamp! Local: 0, Master: 1
	at com.hazelcast.internal.partition.operation.BaseMigrationOperation.verifyPartitionVersion(BaseMigrationOperation.java:143) ~[classes/:?]
	at com.hazelcast.internal.partition.operation.BaseMigrationOperation.beforeRun(BaseMigrationOperation.java:96) ~[classes/:?]
	at com.hazelcast.internal.partition.operation.MigrationOperation.beforeRun(MigrationOperation.java:57) ~[classes/:?]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:247) ~[classes/:?]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:471) ~[classes/:?]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:197) ~[classes/:?]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:137) ~[classes/:?]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123) ~[classes/:?]
	at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102) [classes/:?]

10:46:57,438  WARN |shouldInvokeInternalMigrationListenerOnSuccessfulMigration| - [MigrationRequestOperation] hz.unruffled_goldwasser.async.thread-2 - [127.0.0.1]:5701 [dev] [5.1.1-SNAPSHOT] Failure while executing MigrationInfo{uuid=37327e9d-b980-4094-894d-917b3790110c, partitionId=1, source=null, sourceCurrentReplicaIndex=-1, sourceNewReplicaIndex=-1, destination=[127.0.0.1]:5702 - 14ffeea2-dbfd-4df9-831a-9b840857722d, destinationCurrentReplicaIndex=-1, destinationNewReplicaIndex=1, master=[127.0.0.1]:5701, initialPartitionVersion=1, partitionVersionIncrement=1, status=ACTIVE}
com.hazelcast.internal.partition.PartitionStateVersionMismatchException: Local partition stamp is not equal to master's stamp! Local: 0, Master: 1
	at com.hazelcast.internal.partition.operation.BaseMigrationOperation.verifyPartitionVersion(BaseMigrationOperation.java:143) ~[classes/:?]
	at com.hazelcast.internal.partition.operation.BaseMigrationOperation.beforeRun(BaseMigrationOperation.java:96) ~[classes/:?]
	at com.hazelcast.internal.partition.operation.MigrationOperation.beforeRun(MigrationOperation.java:57) ~[classes/:?]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:247) ~[classes/:?]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:471) ~[classes/:?]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:197) ~[classes/:?]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:137) ~[classes/:?]
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123) ~[classes/:?]
	at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102) [classes/:?]
```

Fixes https://github.com/hazelcast/hazelcast/issues/20050

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

