### PR TITLE
Update vulnerable dependencies and extend OWASP suppressions (5.0.z)

### DIFF
--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/hadoop-dist/files-s3/pom.xml
+++ b/extensions/hadoop-dist/files-s3/pom.xml
@@ -47,6 +47,23 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk-bundle</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <!-- hadoop-aws also depends on dynamodb module-->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>${aws.sdk.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -127,33 +127,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>${hadoop.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-servlet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-webapp</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.servlet.jsp</groupId>
-                    <artifactId>jsp-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-servlet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jline</groupId>
-                    <artifactId>jline</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
@@ -170,5 +143,12 @@
             <artifactId>parquet-avro</artifactId>
             <version>${parquet.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -71,12 +71,6 @@
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
@@ -96,7 +90,6 @@
             <version>${parquet.version}</version>
             <scope>provided</scope>
         </dependency>
-
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.slf4j.binding.version}</version>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/owasp-check-suppressions.xml
+++ b/owasp-check-suppressions.xml
@@ -35,4 +35,260 @@
        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\.avatica/avatica\-core@.*$</packageUrl>
        <cpe>cpe:/a:apache:calcite</cpe>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The Hazelcast fork of JsonSurfer is based on top of original JsonSurfer version v1.6.3.
+       See https://github.com/hazelcast/JsonSurfer/
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.hazelcast\.jsurfer/.*$</packageUrl>
+       <cve>CVE-2016-10750</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the jackson-databind version and not the jackson-mapper-asl.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@.*$</packageUrl>
+       <vulnerabilityName>CVE-2017-15095</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-17485</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-100873</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-14718</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-14540</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-14893</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-16335</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-17267</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-7525</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the FasterXML jackson version (2+) and not the codehaus one.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@.*$</packageUrl>
+       <vulnerabilityName>CVE-2018-1000873</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the postgres version and not the debezium-connector-postgres.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/io\.debezium/debezium\-connector\-postgres@.*$</packageUrl>
+       <vulnerabilityName>CVE-2007-2138</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-0733</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0060</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0061</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0062</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0063</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0064</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0065</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0066</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0067</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-8161</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-0241</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-0242</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-0243</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-0244</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-3165</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-3166</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-3167</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-5288</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-5289</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-0766</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-0768</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-0773</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-5423</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-5424</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-7048</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-14798</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-7484</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-1115</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-10127</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-10128</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-10210</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-10211</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-25694</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-25695</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-3393</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-23214</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the Hadoop version and not the shaded guava.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop\-shaded\-guava@.*$</packageUrl>
+       <vulnerabilityName>CVE-2013-2192</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-7430</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-5001</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-3161</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-3162</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the Hadoop version and not the shaded protobuf.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop\-shaded\-protobuf_3_7@.*$</packageUrl>
+       <vulnerabilityName>CVE-2013-2192</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-7430</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-5001</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-3161</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-3162</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the Elasticsearch version and not the JNA.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.elasticsearch/jna@.*$</packageUrl>
+       <vulnerabilityName>CVE-2019-7611</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-7614</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-7019</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-7020</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-7021</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-22135</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-22137</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-22144</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the MySQL version and not the MySQL Binary Log connector.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.github\.shyiko/mysql\-binlog\-connector\-java@.*$</packageUrl>
+       <vulnerabilityName>CVE-2007-1420</vulnerabilityName>
+       <vulnerabilityName>CVE-2007-2691</vulnerabilityName>
+       <vulnerabilityName>CVE-2007-5925</vulnerabilityName>
+       <vulnerabilityName>CVE-2009-0819</vulnerabilityName>
+       <vulnerabilityName>CVE-2009-4028</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-1621</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-1626</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-3677</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-3682</vulnerabilityName>
+       <vulnerabilityName>CVE-2012-5627</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-2575</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-15945</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the MySQL version and not the MySQL Debezium connector.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/io\.debezium/debezium\-connector\-mysql@.*$</packageUrl>
+       <vulnerabilityName>CVE-2007-1420</vulnerabilityName>
+       <vulnerabilityName>CVE-2007-2691</vulnerabilityName>
+       <vulnerabilityName>CVE-2007-5925</vulnerabilityName>
+       <vulnerabilityName>CVE-2009-0819</vulnerabilityName>
+       <vulnerabilityName>CVE-2009-4028</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-1621</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-1626</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-3677</vulnerabilityName>
+       <vulnerabilityName>CVE-2010-3682</vulnerabilityName>
+       <vulnerabilityName>CVE-2012-5627</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-2575</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-15945</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive. The flaws are relatated to the WildFly and OpenSSL version and not the wildfly-openssl library.
+       The OpenSSL is linked dynamically in the wildly-openssl.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.wildfly\.openssl/wildfly\-openssl.*@.*$</packageUrl>
+       <vulnerabilityName>CVE-2010-5298</vulnerabilityName>
+       <vulnerabilityName>CVE-2013-0169</vulnerabilityName>
+       <vulnerabilityName>CVE-2013-6449</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0160</vulnerabilityName>
+       <vulnerabilityName>CVE-2014-0224</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-3195</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-4000</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-2106</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-2107</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-2108</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-2109</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-2176</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-7055</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-7056</vulnerabilityName>
+       <vulnerabilityName>CVE-2016-8610</vulnerabilityName>
+       <vulnerabilityName>CVE-2017-3736</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-0732</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-0734</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-14627</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-5407</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-1547</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-1551</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-1552</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-1559</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-1563</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-3805</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-10718</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-10740</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-1719</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-1968</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-1971</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-25640</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-25689</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-23840</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-23841</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-3536</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-3712</vulnerabilityName>
+       <vulnerabilityName>CVE-2022-0778</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       The memory leak was fixed already in the wildfly-openssl-1.0.11.Final.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.wildfly\.openssl/wildfly\-openssl.*@1\.0\.12.*$</packageUrl>
+       <cve>CVE-2020-25644</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive - these log4j CVEs have the fixes present in the version 1.2.17.redhat-00008.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/log4j/log4j@.*$</packageUrl>
+       <cve>CVE-2020-9488</cve>
+       <cve>CVE-2022-23307</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive - these CVEs are related to Grafana version and not the AWS SDK APIs for communicating with Amazon Managed Grafana Service
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-managedgrafana@.*$</packageUrl>
+       <vulnerabilityName>CVE-2018-12099</vulnerabilityName>
+       <vulnerabilityName>CVE-2018-19039</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-13068</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-19499</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-11110</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-12052</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-12245</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-12458</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-13430</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-24303</vulnerabilityName>
+       <vulnerabilityName>CVE-2020-27846</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-27358</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-39226</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-43815</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive - these CVEs are related to Chef version and not the AWS Java SDK for AWS OpsWorks for Chef Automate module.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-opsworkscm@.*$</packageUrl>
+       <vulnerabilityName>CVE-2015-8559</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive - these CVEs are related to Kubernetes Java client version and not the AWS Java SDK for Amazon Elastic Container Service for Kubernetes module.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-eks@.*$</packageUrl>
+       <cve>CVE-2020-8570</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       False positive - these CVEs are related to netty version and not the netty-tcnative.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
+       <vulnerabilityName>CVE-2014-3488</vulnerabilityName>
+       <vulnerabilityName>CVE-2015-2156</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-16869</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-20444</vulnerabilityName>
+       <vulnerabilityName>CVE-2019-20445</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-21290</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-21295</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-21409</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-37136</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-37137</vulnerabilityName>
+       <vulnerabilityName>CVE-2021-43797</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1456,6 +1456,88 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client</artifactId>
+                <version>${hadoop.version}</version>
+                <exclusions>
+                    <!-- The following dependencies are not needed for our use of Hadoop -->
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-servlet</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-webapp</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.servlet.jsp</groupId>
+                        <artifactId>jsp-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.jersey</groupId>
+                        <artifactId>jersey-servlet</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jline</groupId>
+                        <artifactId>jline</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-yarn-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-yarn-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-yarn-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.kerby</groupId>
+                        <artifactId>kerb-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.kerby</groupId>
+                        <artifactId>kerb-simplekdc</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-recipes</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-framework</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-mapred</artifactId>
+                <version>${avro.version}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <!-- The following dependencies are not needed for our use of Avro -->
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro-ipc</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro-ipc-jetty</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1631,6 +1631,11 @@
               <artifactId>wildfly-openssl</artifactId>
               <version>1.0.12.Final</version>
             </dependency>
+            <dependency>
+              <groupId>org.codehaus.woodstox</groupId>
+              <artifactId>stax2-api</artifactId>
+              <version>4.2.1</version>
+            </dependency>
             <!--
             The following are test dependencies, they are not in the final distribution.
             We put them there for the dependency convergence task to succeed.

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
                 <plugin>
                     <groupId>com.hazelcast.maven</groupId>
                     <artifactId>attribution-maven-plugin</artifactId>
-                    <version>1.0.1</version>
+                    <version>1.0.2</version>
                     <configuration>
                         <exclusionPatterns>
                         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -93,31 +93,32 @@
 
         <!-- Third-party dependencies (sorted alphabetically) -->
         <!--<affinity.version>3.2.3</affinity.version>-->
+        <antlr4.version>4.9.3</antlr4.version>
         <avro.version>1.11.0</avro.version>
-        <aws.sdk.version>1.12.120</aws.sdk.version>
-        <classgraph.version>4.8.66</classgraph.version>
-        <grpc.version>1.34.0</grpc.version>
+        <aws.sdk.version>1.12.183</aws.sdk.version>
+        <classgraph.version>4.8.139</classgraph.version>
+        <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
-        <hadoop.version>3.3.0</hadoop.version>
-        <jackson.version>2.12.1</jackson.version>
-        <jline.version>3.19.0</jline.version>
+        <hadoop.version>3.3.1</hadoop.version>
+        <jackson.version>2.12.6</jackson.version>
+        <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
+        <jline.version>3.21.0</jline.version>
         <jms.api.version>2.0.1</jms.api.version>
         <jsr107.api.version>1.1.1</jsr107.api.version> <!-- JCache -->
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
         <kafka.version>2.2.2</kafka.version>
         <kotlin.version>1.5.32</kotlin.version>
-        <log4j.version>1.2.17</log4j.version>
-        <log4j2.slf4j.binding.version>2.13.2</log4j2.slf4j.binding.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j.version>1.2.17.redhat-00008</log4j.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <mysql.connector.version>8.0.20</mysql.connector.version>
-        <netty.version>4.1.63.Final</netty.version>
+        <netty.version>4.1.75.Final</netty.version>
         <osgi.version>4.2.0</osgi.version>
         <parquet.version>1.12.0</parquet.version>
         <picocli.version>4.4.0</picocli.version>
         <prometheus.version>0.14.0</prometheus.version>
         <protobuf.version>3.13.0</protobuf.version>
         <scala.version>2.12</scala.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <spring.version>4.3.0.RELEASE</spring.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <snakeyaml.engine.version>2.1</snakeyaml.engine.version>
@@ -1341,6 +1342,25 @@
 
     <repositories>
         <repository>
+            <!--
+            This is the same as central in the super pom.
+            Putting it here changes the order in which the repositories are queried.
+            Most artefacts are stored in central so this provides best build times when a mirror is not used.
+            Repository order reference:
+            https://maven.apache.org/guides/mini/guide-multiple-repositories.html#repository-order
+            -->
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
@@ -1349,6 +1369,30 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>hazelcast-security</id>
+            <name>Thirdparty security fixes</name>
+            <url>https://repository.hazelcast.com/security-maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- Red Hat Maven repository provides patches for several vulnerable libraries (dependencies) which are not patched in the Maven Central repository. -->
+        <repository>
+            <id>redhat-ga</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>
@@ -1476,11 +1520,16 @@
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.connector.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.htrace</groupId>
+                <artifactId>htrace-core4</artifactId>
+                <version>4.2.0-incubating.hazelcast-2</version>
+            </dependency>
             <!-- NOTE: httpcore and httpclient versions are not in sync -->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.13</version>
+                <version>4.4.15</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -1505,7 +1554,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.6</version>
+                <version>2.8.9</version>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -1542,6 +1591,46 @@
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.21.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>${jackson.mapper.asl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+                <version>${jackson.mapper.asl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.4.7</version>
+            </dependency>
+            <dependency>
+              <groupId>org.wildfly.openssl</groupId>
+              <artifactId>wildfly-openssl</artifactId>
+              <version>1.0.12.Final</version>
+            </dependency>
             <!--
             The following are test dependencies, they are not in the final distribution.
             We put them there for the dependency convergence task to succeed.
@@ -1559,7 +1648,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.26.0-GA</version>
+                <version>3.28.0-GA</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
This PR resolves **some** of the currently vulnerable dependencies found by the OWASP checker.

There still remain 2 `jackson-databind` related findings.

Once the PR is reviewed, I'll prepare a backport to 5.0.3 and forward ports where needed.