### PR TITLE
[5.1.z] Fix wrong assertTrueEventually usages

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
@@ -63,6 +63,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -138,7 +139,7 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(2, hz1, hz3);
         // ensure partition state is applied on the new member
-        assertTrueEventually(() -> Accessors.isPartitionStateInitialized(newInstance));
+        assertTrueEventually(() -> assertTrue(Accessors.isPartitionStateInitialized(newInstance)));
 
         final List<HazelcastInstance> instanceList = asList(hz1, hz3);
         assertTrueAllTheTime(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_ConnectionListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager_ConnectionListenerTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -48,7 +49,7 @@ public class TcpServerConnectionManager_ConnectionListenerTest
 
         Connection c = connect(tcpServerA, addressB);
 
-        assertTrueEventually(() -> listener.connectionAdded(c));
+        assertTrueEventually(() -> verify(listener).connectionAdded(c));
     }
 
     @Test
@@ -61,7 +62,7 @@ public class TcpServerConnectionManager_ConnectionListenerTest
         Connection c = connect(tcpServerA, addressB);
         c.close(null, null);
 
-        assertTrueEventually(() -> listener.connectionRemoved(c));
+        assertTrueEventually(() -> verify(listener).connectionRemoved(c));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -269,6 +270,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     }
 
     @Test
+    @Ignore("Execution tracker future doesn't complete in this test")
     public void when_blockingSleepingTaskletIsCancelled_then_completeEarly() throws Exception {
         // Given
         final List<MockTasklet> tasklets =
@@ -281,7 +283,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
 
         // Then
         tasklets.forEach(MockTasklet::assertNotDone);
-        assertTrueEventually(f::isDone);
+        assertTrueEventually(() -> assertTrue(f.isDone()), 10);
 
         exceptionRule.expect(CancellationException.class);
         cancellationFuture.get();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -720,13 +720,11 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void waitInstanceForSafeState(final HazelcastInstance instance) {
-        assertTrueEventually(() -> {
-            isInstanceInSafeState(instance);
-        });
+        assertTrueEventually(() -> assertTrue(isInstanceInSafeState(instance)));
     }
 
     public static void waitClusterForSafeState(final HazelcastInstance instance) {
-        assertTrueEventually((() -> assertTrue(isClusterInSafeState(instance))));
+        assertTrueEventually(() -> assertTrue(isClusterInSafeState(instance)));
     }
 
     public static void waitUntilClusterState(HazelcastInstance hz, ClusterState state, int timeoutSeconds) {


### PR DESCRIPTION
`assertTrueEventually` expects an assert task, but in these
usages, simple boolean returning tasks are used, even
if this task returns false, this assertTrueEventually passes
since the task completes without a failure. In this PR, we
fixed this kind of usages.

(cherry picked from commit 0419fe49e93cda319e77aaee3116c7f1a6eb6b5b)

Clean backport of #21037

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
