### PR TITLE
Fix ignored test in TaskletExecutionServiceTest [HZ-1029]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -270,7 +270,6 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     }
 
     @Test
-    @Ignore("Execution tracker future doesn't complete in this test")
     public void when_blockingSleepingTaskletIsCancelled_then_completeEarly() throws Exception {
         // Given
         final List<MockTasklet> tasklets =
@@ -413,9 +412,11 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
             }
             if (isSleeping) {
                 try {
-                    Thread.currentThread().join();
+                    Thread.sleep(500);
+                    return NO_PROGRESS;
                 } catch (InterruptedException e) {
-                    return DONE;
+                    throw new RuntimeException("Sleeping interrupted, this should not happen because " +
+                            "we don't interrupt blocking workers", e);
                 }
             }
             if (latch != null) {


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-jet/pull/1971 we stopped to
interrupt the blocking threads.

The test has been broken due to incorrect use of assertTrueEventually
and didn't report failure.

After this change, the MockTasklet sleeps for a short period of time and
never makes progress.

Fixes #21046

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
