### PR TITLE
[HZ-940] Improve IO pipelines

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/InboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/InboundPipeline.java
@@ -43,7 +43,7 @@ public interface InboundPipeline {
      * No verification is done if the handler is already added and a handler
      * should only be added once.
      *
-     * This method should only be made on the thread 'owning' the handler.
+     * This method should only be made on the thread 'owning' the pipeline.
      *
      * @param handlers the handlers to add
      * @return this
@@ -58,7 +58,7 @@ public interface InboundPipeline {
      * No verification is done if any of the handlers is already added and a
      * handler should only be added once.
      *
-     * This method should only be made on the thread 'owning' the handler.
+     * This method should only be made on the thread 'owning' the pipeline.
      *
      * @param oldHandler  the handler to replace
      * @param newHandlers the new handlers to insert
@@ -71,7 +71,7 @@ public interface InboundPipeline {
     /**
      * Removes the given handler from the pipeline.
      *
-     * This method should only be made on the thread 'owning' the handler.
+     * This method should only be made on the thread 'owning' the pipeline.
      *
      * @param handler the handler to remove
      * @return this

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundPipeline.java
@@ -28,7 +28,7 @@ public interface OutboundPipeline {
      * No verification is done if the handler is already added and a handler
      * should only be added once.
      *
-     * This method should only be made on the thread 'owning' the handler.
+     * This method should only be made on the thread 'owning' the pipeline.
      *
      * @param handlers the handlers to add.
      * @return this
@@ -43,7 +43,7 @@ public interface OutboundPipeline {
      * No verification is done if any of the handlers is already added and a
      * handler should only be added once.
      *
-     * This method should only be made on the thread 'owning' the handler.
+     * This method should only be made on the thread 'owning' the pipeline.
      *
      * @param oldHandler  the handlers to replace
      * @param newHandlers the new handlers to insert.
@@ -56,7 +56,7 @@ public interface OutboundPipeline {
     /**
      * Removes the given handler from the pipeline.
      *
-     * This method should only be made on the thread 'owning' the handler.
+     * This method should only be made on the thread 'owning' the pipeline.
      *
      * @param handler the handler to remove.
      * @return this

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberChannelInitializer.java
@@ -40,7 +40,7 @@ public class MemberChannelInitializer
 
         SingleProtocolEncoder protocolEncoder = new SingleProtocolEncoder(new MemberProtocolEncoder(outboundHandlers));
         SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(ProtocolType.MEMBER,
-                inboundHandlers, protocolEncoder, true);
+                inboundHandlers, protocolEncoder);
 
         channel.outboundPipeline().addLast(protocolEncoder);
         channel.inboundPipeline().addLast(protocolDecoder);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -88,9 +88,8 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
         }
     }
 
-    public void signalEncoderCanReplace() {
+    public void setEncoderCanReplace() {
         encoderCanReplace = true;
-        channel.outboundPipeline().wakeup();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -20,13 +20,12 @@ import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.nio.ConnectionType;
 import com.hazelcast.internal.server.ServerConnection;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.internal.networking.HandlerStatus.BLOCKED;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
-import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
@@ -36,9 +35,6 @@ import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
 
     private final OutboundHandler[] outboundHandlers;
-    private volatile boolean encoderCanReplace;
-
-    private boolean clusterProtocolBuffered;
 
     /**
      * Decodes first 3 incoming bytes, validates against {@code supportedProtocol} and, when
@@ -54,7 +50,7 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
 
     @Override
     public void handlerAdded() {
-        initDstBuffer(PROTOCOL_LENGTH);
+        initDstBuffer(PROTOCOL_LENGTH, stringToBytes(CLUSTER));
     }
 
     @Override
@@ -62,34 +58,18 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
         compactOrClear(dst);
 
         try {
-            if (!clusterProtocolBuffered) {
-                clusterProtocolBuffered = true;
-                dst.put(stringToBytes(CLUSTER));
-                return CLEAN;
-            }
-
-            if (!isProtocolBufferDrained()) {
-                // Return DIRTY because ProtocolEncoder is not ready yet; but first we need to flush protocol
-                return DIRTY;
-            }
-
-            if (encoderCanReplace) {
+            if (isProtocolBufferDrained()) {
                 // replace!
                 ServerConnection connection = (TcpServerConnection) channel.attributeMap().get(ServerConnection.class);
                 connection.setConnectionType(ConnectionType.MEMBER);
                 channel.outboundPipeline().replace(this, outboundHandlers);
-            } else {
-                return BLOCKED;
             }
 
+            // Return CLEAN as we already have all the necessary data in the destination buffer.
             return CLEAN;
         } finally {
             upcast(dst).flip();
         }
-    }
-
-    public void setEncoderCanReplace() {
-        encoderCanReplace = true;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -38,7 +38,7 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
     private final OutboundHandler[] outboundHandlers;
     private volatile boolean encoderCanReplace;
 
-    private volatile boolean clusterProtocolBuffered;
+    private boolean clusterProtocolBuffered;
 
     /**
      * Decodes first 3 incoming bytes, validates against {@code supportedProtocol} and, when

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -24,6 +24,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
 
+import static com.hazelcast.internal.networking.HandlerStatus.BLOCKED;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
@@ -77,6 +78,8 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
                 ServerConnection connection = (TcpServerConnection) channel.attributeMap().get(ServerConnection.class);
                 connection.setConnectionType(ConnectionType.MEMBER);
                 channel.outboundPipeline().replace(this, outboundHandlers);
+            } else {
+                return BLOCKED;
             }
 
             return CLEAN;

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -37,7 +37,7 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
     private final OutboundHandler[] outboundHandlers;
     private volatile boolean encoderCanReplace;
 
-    private boolean clusterProtocolBuffered;
+    private volatile boolean clusterProtocolBuffered;
 
     /**
      * Decodes first 3 incoming bytes, validates against {@code supportedProtocol} and, when
@@ -64,12 +64,11 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
             if (!clusterProtocolBuffered) {
                 clusterProtocolBuffered = true;
                 dst.put(stringToBytes(CLUSTER));
-                // Return false because ProtocolEncoder is not ready yet; but first we need to flush protocol
-                return DIRTY;
+                return CLEAN;
             }
 
             if (!isProtocolBufferDrained()) {
-                // Return false because ProtocolEncoder is not ready yet; but first we need to flush protocol
+                // Return DIRTY because ProtocolEncoder is not ready yet; but first we need to flush protocol
                 return DIRTY;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
@@ -51,10 +51,9 @@ public class SingleProtocolDecoder
      */
     protected volatile boolean verifyProtocolCalled;
     final SingleProtocolEncoder encoder;
-    private final boolean shouldSignalMemberProtocolEncoder;
 
     public SingleProtocolDecoder(ProtocolType supportedProtocol, InboundHandler next, SingleProtocolEncoder encoder) {
-        this(supportedProtocol, new InboundHandler[]{next}, encoder, false);
+        this(supportedProtocol, new InboundHandler[]{next}, encoder);
     }
 
     /**
@@ -73,19 +72,13 @@ public class SingleProtocolDecoder
      *                                          that will be notified when
      *                                          non-matching protocol bytes have
      *                                          been received
-     * @param shouldSignalMemberProtocolEncoder a boolean used to notify the
-     *                                          next encoder in the pipeline
-     *                                          after the {@link SingleProtocolEncoder}
-     *                                          when matching protocol bytes
-     *                                          have been received
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public SingleProtocolDecoder(ProtocolType supportedProtocol, InboundHandler[] next,
-                                 SingleProtocolEncoder encoder, boolean shouldSignalMemberProtocolEncoder) {
+                                 SingleProtocolEncoder encoder) {
         this.supportedProtocol = supportedProtocol;
         this.inboundHandlers = next;
         this.encoder = encoder;
-        this.shouldSignalMemberProtocolEncoder = shouldSignalMemberProtocolEncoder;
         this.verifyProtocolCalled = false;
     }
 
@@ -123,16 +116,6 @@ public class SingleProtocolDecoder
             // Initialize the connection
             initConnection();
             setupNextDecoder();
-            if (!channel.isClientMode()) {
-                // Set up the next encoder in the pipeline if in server mode
-                // This replaces SignalProtocolEncoder with next one in the pipeline
-                encoder.setupNextEncoder();
-            }
-
-            // Signal the member protocol encoder only if it's needed
-            if (shouldSignalMemberProtocolEncoder) {
-                ((MemberProtocolEncoder) encoder.getFirstOutboundHandler()).signalEncoderCanReplace();
-            }
 
             return CLEAN;
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -105,10 +105,6 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
 
     // Swap this encoder with the next one
     private void setupNextEncoder() {
-        OutboundHandler next = outboundHandlers[0];
-        if (next instanceof MemberProtocolEncoder) {
-            ((MemberProtocolEncoder) next).setEncoderCanReplace();
-        }
         channel.outboundPipeline().replace(this, outboundHandlers);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -81,7 +81,7 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
                 throw new ProtocolException(exceptionMessage);
             }
 
-            if (channel.isClientMode()) {
+            if (isDecoderVerifiedProtocol || channel.isClientMode()) {
                 // Set up the next encoder in the pipeline if in client mode
                 setupNextEncoder();
             }
@@ -104,7 +104,11 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
     }
 
     // Swap this encoder with the next one
-    protected void setupNextEncoder() {
+    private void setupNextEncoder() {
+        OutboundHandler next = outboundHandlers[0];
+        if (next instanceof MemberProtocolEncoder) {
+            ((MemberProtocolEncoder) next).setEncoderCanReplace();
+        }
         channel.outboundPipeline().replace(this, outboundHandlers);
     }
 


### PR DESCRIPTION
This is the OS side of the fix for hazelcast/hazelcast-enterprise#4531

It improves protocol handshake processiong on IO pipelines. It mainly:
* prevents busy waiting on `MemberProtocolEncoder`;
* prevents changing outbound pipeline from the inbound one (`SingleProtocolDecoder` calling `SingleProtocolEncoder.setupNextEncoder()`) as it was causing troubles. The handler chain changes can only be made by the owning thread. See `OutboundPipeline.replace()` javadoc for instance.