### PR TITLE
Do not use dockerized kafka on Arm Mac

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.kafka.impl;
 
+import com.hazelcast.internal.util.OsHelper;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
@@ -60,11 +61,11 @@ public abstract class KafkaTestSupport {
     private KafkaProducer<String, String> stringStringProducer;
 
     public static KafkaTestSupport create() {
-        if (DockerClientFactory.instance().isDockerAvailable()) {
+        if (DockerClientFactory.instance().isDockerAvailable() && !OsHelper.isArmMac()) {
             return new DockerizedKafkaTestSupport();
         } else {
             if (System.getProperties().containsKey("test.kafka.version")) {
-                throw new IllegalArgumentException("'test.kafka.version' system property requires docker ");
+                throw new IllegalArgumentException("'test.kafka.version' system property requires docker and x86_64 CPU");
             }
             return new EmbeddedKafkaTestSupport();
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.internal.util;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
 /**
  * Helper methods related to operating system on which the code is actually running.
  */
@@ -54,6 +59,31 @@ public final class OsHelper {
      */
     public static boolean isMac() {
         return (OS.contains("mac") || OS.contains("darwin"));
+    }
+
+    /**
+     * Returns {@code true} if the system is a Mac OS with Arm CPU, e.g. M1.
+     *
+     * @return {@code true} if the system is a Mac OS with Arm CPU, e.g. M1.
+     */
+    public static boolean isArmMac() {
+        if (!isMac()) {
+            return false;
+        }
+        try {
+            Process process = new ProcessBuilder("sysctl", "-n", "hw.optional.arm64")
+                    .redirectErrorStream(true)
+                    .start();
+            process.waitFor();
+            try (InputStream is = process.getInputStream()) {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                String line = reader.readLine();
+                return line.equals("1");
+            }
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, Kafka doesn't support docker images for ARM64 architecture. This PR forces use of the embedded Kafka on Apple M1 Macs