### PR TITLE
Fast class cache return

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -239,7 +239,6 @@ public final class ClassLoaderUtil {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         ClassLoader theClassLoader = belongsToHazelcastPackage(className) ? ClassLoaderUtil.class.getClassLoader() : null;
 
-        // The order of class loaders is:
         // - first we try to load a class with classLoaderHint if provided
         // - if that doesn't give us a result and the class is a hazelcast class then we try our class loader
         // - if that doesn't give us a result then we try context class loader if it exists

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -251,7 +251,7 @@ public final class ClassLoaderUtil {
             return cachedClass;
         }
 
-        Class<?> loadedClass = tryLoadClass(className, classLoadersInOrder);
+        Class<?> loadedClass = loadClass(className, classLoadersInOrder);
         assert loadedClass != null;
 
         return loadedClass;
@@ -298,7 +298,7 @@ public final class ClassLoaderUtil {
         return null;
     }
 
-    private static Class<?> tryLoadClass(String className, ClassLoader... classLoaders) {
+    private static Class<?> loadClass(String className, ClassLoader... classLoaders) {
         for (ClassLoader classLoader : classLoaders) {
             if (classLoader == null) {
                 continue;


### PR DESCRIPTION
Fixes few performance degradation issues:
- user-provided classes in ```org.hazelcast``` package.
- class cached with ```NULL_FALLBACK_CLASSLOADER``` will not be tried to be loaded by other classloaders

It changes the behavior of that method, if new behavior is not acceptable then this PR should be dismissed. For a situation like that:
- we load a class class with ```NULL_FALLBACK_CLASSLOADER```
- after then we execute ```loadClass``` with ```classLoaderHint``` set that could load the class (same for the context one), then before that PR the class would be loaded again, after this PR the class will be fetched from ```NULL_FALLBACK_CLASSLOADER``` cache.

Flame graph from first issue:
![image](https://user-images.githubusercontent.com/57556371/160368250-3a89370a-6fdf-4999-b708-d9ecdf89d187.png)


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
