### PR TITLE
Improve PhoneHomeCPSubsystemTest [5.1.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
@@ -63,10 +63,12 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
     public void testGroupsCount_defaultGroups() {
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast");
 
-        Map<String, String> parameters = phoneHome.phoneHome(true);
+        assertTrueEventually(() -> {
+            Map<String, String> parameters = phoneHome.phoneHome(true);
 
-        // two default groups METADATA and DEFAULT
-        assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("2");
+            // two default groups METADATA and DEFAULT
+            assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("2");
+        });
     }
 
     @Test
@@ -77,10 +79,12 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast");
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@thirdGroup");
 
-        Map<String, String> parameters = phoneHome.phoneHome(true);
+        assertTrueEventually(() -> {
+            Map<String, String> parameters = phoneHome.phoneHome(true);
 
-        // two default groups METADATA and DEFAULT + 3 created
-        assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("5");
+            // two default groups METADATA and DEFAULT + 3 created
+            assertThat(parameters.get(PhoneHomeMetrics.CP_GROUPS_COUNT.getRequestParameterName())).isEqualTo("5");
+        });
     }
 
     @Test
@@ -93,8 +97,10 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
         node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@secondGroup").init(1);
         node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast2@firstGroup").init(1);
 
-        parameters = phoneHome.phoneHome(true);
-        assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertTrueEventually(() -> {
+            Map<String, String> params = phoneHome.phoneHome(true);
+            assertThat(params.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("3");
+        });
     }
 
     @Test
@@ -107,36 +113,43 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
         node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@secondGroup").lock();
         node.hazelcastInstance.getCPSubsystem().getLock("hazelcast2@firstGroup").lock();
 
-        parameters = phoneHome.phoneHome(true);
-        assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertTrueEventually(() -> {
+            Map<String, String> params = phoneHome.phoneHome(true);
+            assertThat(params.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("3");
+        });
     }
 
     @Test
     public void testCountdownLatchesCount() {
         Map<String, String> parameters;
         parameters = phoneHome.phoneHome(true);
-        assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("0");
+        assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName()))
+                .isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@firstGroup").trySetCount(1);
         node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast@secondGroup").trySetCount(1);
         node.hazelcastInstance.getCPSubsystem().getCountDownLatch("hazelcast2@firstGroup").trySetCount(1);
 
-        parameters = phoneHome.phoneHome(true);
-        assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertTrueEventually(() -> {
+            Map<String, String> params = phoneHome.phoneHome(true);
+            assertThat(params.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName()))
+                    .isEqualTo("3");
+        });
     }
 
     @Test
     public void testAtomicLongsCount() {
-        Map<String, String> parameters;
-        parameters = phoneHome.phoneHome(true);
+        Map<String, String> parameters = phoneHome.phoneHome(true);
         assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast@firstGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast@secondGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicLong("hazelcast2@firstGroup").set(42L);
 
-        parameters = phoneHome.phoneHome(true);
-        assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertTrueEventually(() -> {
+            Map<String, String> params = phoneHome.phoneHome(true);
+            assertThat(params.get(PhoneHomeMetrics.CP_ATOMIC_LONGS_COUNT.getRequestParameterName())).isEqualTo("3");
+        });
     }
 
     @Test
@@ -149,8 +162,10 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@secondGroup").set(42L);
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast2@firstGroup").set(42L);
 
-        parameters = phoneHome.phoneHome(true);
-        assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("3");
+        assertTrueEventually(() -> {
+            Map<String, String> params = phoneHome.phoneHome(true);
+            assertThat(params.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("3");
+        });
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeCPSubsystemTest.java
@@ -89,8 +89,7 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
 
     @Test
     public void testSemaphoresCount() {
-        Map<String, String> parameters;
-        parameters = phoneHome.phoneHome(true);
+        Map<String, String> parameters = phoneHome.phoneHome(true);
         assertThat(parameters.get(PhoneHomeMetrics.CP_SEMAPHORES_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getSemaphore("hazelcast@firstGroup").init(1);
@@ -105,8 +104,7 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
 
     @Test
     public void testFencedLocksCount() {
-        Map<String, String> parameters;
-        parameters = phoneHome.phoneHome(true);
+        Map<String, String> parameters = phoneHome.phoneHome(true);
         assertThat(parameters.get(PhoneHomeMetrics.CP_FENCED_LOCKS_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getLock("hazelcast@firstGroup").lock();
@@ -121,8 +119,7 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
 
     @Test
     public void testCountdownLatchesCount() {
-        Map<String, String> parameters;
-        parameters = phoneHome.phoneHome(true);
+        Map<String, String> parameters = phoneHome.phoneHome(true);
         assertThat(parameters.get(PhoneHomeMetrics.CP_COUNTDOWN_LATCHES_COUNT.getRequestParameterName()))
                 .isEqualTo("0");
 
@@ -154,8 +151,7 @@ public class PhoneHomeCPSubsystemTest extends HazelcastTestSupport {
 
     @Test
     public void testAtomicRefsCount() {
-        Map<String, String> parameters;
-        parameters = phoneHome.phoneHome(true);
+        Map<String, String> parameters = phoneHome.phoneHome(true);
         assertThat(parameters.get(PhoneHomeMetrics.CP_ATOMIC_REFS_COUNT.getRequestParameterName())).isEqualTo("0");
 
         node.hazelcastInstance.getCPSubsystem().getAtomicReference("hazelcast@firstGroup").set(42L);


### PR DESCRIPTION
A CP subsystem operation returns when it is committed on the majority of the
nodes, 2 out of 3 in this test. It can happen that an operation is not
finished on the first member (127.0.0.0:5701) and the phoneHome
collection don't see the atomic value, semaphore, .. yet.

It can be reproduced by slowing down the operation on the first member
e.g. in `com.hazelcast.cp.internal.NodeEngineRaftIntegration#runOperation`

```
if (operation instanceof GetAndSetOp
                && nodeEngine.getLocalMember().getAddress().toString().equals("[127.0.0.1]:5701")) {
            try {
                Thread.sleep(1000);
            } catch (InterruptedException e) {
                e.printStackTrace();
            }
        }
```

The test is fixed by moving the phoneHome collection and the assert to
`assertTrueEventually` block.

Fixes #21014
Fixes #20903
HZ-1038, HZ-1039

Backport of #21084

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
