### PR TITLE
Add Transactional IMap operation stats [HZ-1001]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxySupport.java
@@ -22,7 +22,7 @@ import com.hazelcast.cache.impl.CacheSyncListenerCompleter;
 import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.cache.impl.ClientCacheProxySupportUtil.EmptyCompletionListener;
-import com.hazelcast.internal.nearcache.impl.NearCachingHook;
+import com.hazelcast.internal.nearcache.impl.RemoteCallHook;
 import com.hazelcast.client.impl.ClientDelegatingFuture;
 import com.hazelcast.client.impl.clientside.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
@@ -891,7 +891,7 @@ abstract class ClientCacheProxySupport<K, V> extends ClientProxy implements ICac
                                   List<Map.Entry<Data, Data>>[] entriesPerPartition,
                                   long startNanos) {
         try {
-            NearCachingHook<K, V> nearCachingHook = createPutAllNearCachingHook(userInputMap.size());
+            RemoteCallHook<K, V> nearCachingHook = createPutAllNearCachingHook(userInputMap.size());
             // first we fill entry set per partition
             groupDataToPartitions(userInputMap, entriesPerPartition, nearCachingHook);
             // then we invoke the operations and sync on completion of these operations
@@ -903,13 +903,13 @@ abstract class ClientCacheProxySupport<K, V> extends ClientProxy implements ICac
     }
 
     // Overridden to inject hook for near cache population.
-    protected NearCachingHook<K, V> createPutAllNearCachingHook(int keySetSize) {
-        return NearCachingHook.EMPTY_HOOK;
+    protected RemoteCallHook<K, V> createPutAllNearCachingHook(int keySetSize) {
+        return RemoteCallHook.EMPTY_HOOK;
     }
 
     private void groupDataToPartitions(Map<? extends K, ? extends V> userInputMap,
                                        List<Map.Entry<Data, Data>>[] entriesPerPartition,
-                                       NearCachingHook nearCachingHook) {
+                                       RemoteCallHook nearCachingHook) {
         ClientPartitionService partitionService = getContext().getPartitionService();
 
         for (Map.Entry<? extends K, ? extends V> entry : userInputMap.entrySet()) {
@@ -935,7 +935,7 @@ abstract class ClientCacheProxySupport<K, V> extends ClientProxy implements ICac
 
     protected void callPutAllSync(List<Map.Entry<Data, Data>>[] entriesPerPartition,
                                   Data expiryPolicyData,
-                                  NearCachingHook<K, V> nearCachingHook, long startNanos) {
+                                  RemoteCallHook<K, V> nearCachingHook, long startNanos) {
 
         List<ClientCacheProxySupportUtil.FutureEntriesTuple> futureEntriesTuples
                 = new ArrayList<>(entriesPerPartition.length);

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/nearcache/NearCachedClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/nearcache/NearCachedClientCacheProxy.java
@@ -34,13 +34,15 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
-import com.hazelcast.internal.nearcache.impl.NearCachingHook;
+import com.hazelcast.internal.nearcache.impl.RemoteCallHook;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.integration.CompletionListener;
 import java.util.ArrayList;
@@ -467,10 +469,10 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
 
     @Override
     protected void callPutAllSync(List<Map.Entry<Data, Data>>[] entriesPerPartition, Data expiryPolicyData,
-                                  NearCachingHook<K, V> nearCachingHook, long startNanos) {
+                                  RemoteCallHook<K, V> nearCachingHook, long startNanos) {
         try {
             super.callPutAllSync(entriesPerPartition, expiryPolicyData, nearCachingHook, startNanos);
-            nearCachingHook.onRemoteCallSuccess();
+            nearCachingHook.onRemoteCallSuccess(null);
         } catch (Throwable t) {
             nearCachingHook.onRemoteCallFailure();
             throw rethrow(t);
@@ -478,7 +480,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     }
 
     @Override
-    protected NearCachingHook<K, V> createPutAllNearCachingHook(int keySetSize) {
+    protected RemoteCallHook<K, V> createPutAllNearCachingHook(int keySetSize) {
         return cacheOnUpdate
                 ? new PutAllCacheOnUpdateHook(keySetSize)
                 : new PutAllInvalidateHook(keySetSize);
@@ -491,7 +493,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
      *  
      * Only used with putAll calls.
      */
-    private class PutAllCacheOnUpdateHook implements NearCachingHook<K, V> {
+    private class PutAllCacheOnUpdateHook implements RemoteCallHook<K, V> {
         // Holds near-cache-key, near-cache-value and reservation-id
         private final List<Object> keyValueId;
 
@@ -507,7 +509,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         }
 
         @Override
-        public void onRemoteCallSuccess() {
+        public void onRemoteCallSuccess(Operation remoteCall) {
             for (int i = 0; i < keyValueId.size(); i += 3) {
                 Object nearCacheKey = keyValueId.get(i);
                 Object nearCacheValue = keyValueId.get(i + 1);
@@ -542,7 +544,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
      *  
      * Only used with putAll calls.
      */
-    private class PutAllInvalidateHook implements NearCachingHook<K, V> {
+    private class PutAllInvalidateHook implements RemoteCallHook<K, V> {
 
         private final List<Object> nearCacheKeys;
 
@@ -556,7 +558,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         }
 
         @Override
-        public void onRemoteCallSuccess() {
+        public void onRemoteCallSuccess(@Nullable Operation remoteCall) {
             for (Object nearCacheKey : nearCacheKeys) {
                 invalidateNearCache(nearCacheKey);
             }
@@ -564,7 +566,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
 
         @Override
         public void onRemoteCallFailure() {
-            onRemoteCallSuccess();
+            onRemoteCallSuccess(null);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/CompositeRemoteCallHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/CompositeRemoteCallHook.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nearcache.impl;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompositeRemoteCallHook<K, V> implements RemoteCallHook<K, V> {
+
+    private final List<RemoteCallHook> hooks = new ArrayList<>();
+
+    public void add(RemoteCallHook newHook) {
+        hooks.add(newHook);
+    }
+
+    @Override
+    public void beforeRemoteCall(K key, Data keyData,
+                                 @Nullable V value, @Nullable Data valueData) {
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).beforeRemoteCall(key, keyData, value, valueData);
+        }
+    }
+
+    @Override
+    public void onRemoteCallSuccess(@Nullable Operation remoteCall) {
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).onRemoteCallSuccess(remoteCall);
+        }
+    }
+
+    @Override
+    public void onRemoteCallFailure() {
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).onRemoteCallFailure();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/RemoteCallHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/RemoteCallHook.java
@@ -18,18 +18,19 @@ package com.hazelcast.internal.nearcache.impl;
 
 
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import javax.annotation.Nullable;
 
 /**
- * Hook to be used by near cache enabled proxy objects.
- *
- * With this hook, you can implement needed logic
- * for truly invalidate/populate local near cache.
+ * Hook to be used by near cache invalidations or by statistics updates.
+ * <p>
+ * For instance, with this hook, you can implement needed
+ * logic for truly invalidate/populate local near cache.
  */
-public interface NearCachingHook<K, V> {
+public interface RemoteCallHook<K, V> {
 
-    NearCachingHook EMPTY_HOOK = new NearCachingHook() {
+    RemoteCallHook EMPTY_HOOK = new RemoteCallHook() {
 
         @Override
         public void beforeRemoteCall(Object key, Data keyData,
@@ -37,7 +38,7 @@ public interface NearCachingHook<K, V> {
         }
 
         @Override
-        public void onRemoteCallSuccess() {
+        public void onRemoteCallSuccess(Operation remoteCall) {
         }
 
         @Override
@@ -46,9 +47,10 @@ public interface NearCachingHook<K, V> {
         }
     };
 
-    void beforeRemoteCall(K key, Data keyData, @Nullable V value, @Nullable Data valueData);
+    void beforeRemoteCall(K key, Data keyData,
+                          @Nullable V value, @Nullable Data valueData);
 
-    void onRemoteCallSuccess();
+    void onRemoteCallSuccess(@Nullable Operation remoteCall);
 
     void onRemoteCallFailure();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapOperationStatsUpdater.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapOperationStatsUpdater.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.internal.util.Timer;
+import com.hazelcast.map.impl.operation.BasePutOperation;
+import com.hazelcast.map.impl.operation.BaseRemoveOperation;
+import com.hazelcast.map.impl.operation.GetOperation;
+import com.hazelcast.map.impl.operation.SetOperation;
+import com.hazelcast.map.impl.tx.TxnDeleteOperation;
+import com.hazelcast.map.impl.tx.TxnSetOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+/**
+ * Helper to update map operation stats on caller side.
+ */
+public final class MapOperationStatsUpdater {
+
+    private MapOperationStatsUpdater() {
+    }
+
+    /**
+     * Updates stats upon operation-call
+     * on {@link com.hazelcast.map.IMap}
+     */
+    public static void incrementOperationStats(Operation operation,
+                                               LocalMapStatsImpl localMapStats,
+                                               long startTimeNanos) {
+
+        long durationNanos = Timer.nanosElapsed(startTimeNanos);
+
+        if (operation instanceof SetOperation) {
+            localMapStats.incrementSetLatencyNanos(durationNanos);
+            return;
+        }
+
+        if (operation instanceof BasePutOperation) {
+            localMapStats.incrementPutLatencyNanos(durationNanos);
+            return;
+        }
+
+        if (operation instanceof BaseRemoveOperation) {
+            localMapStats.incrementRemoveLatencyNanos(durationNanos);
+            return;
+        }
+
+        if (operation instanceof GetOperation) {
+            localMapStats.incrementGetLatencyNanos(durationNanos);
+            return;
+        }
+    }
+
+    /**
+     * Updates stats upon operation-call on {@link
+     * com.hazelcast.transaction.TransactionalMap}
+     */
+    public static void incrementTxnOperationStats(Operation operation,
+                                               LocalMapStatsImpl localMapStats,
+                                               long startTimeNanos) {
+
+        long durationNanos = Timer.nanosElapsed(startTimeNanos);
+
+        if (operation instanceof TxnSetOperation) {
+            localMapStats.incrementSetLatencyNanos(durationNanos);
+            return;
+        }
+
+        if (operation instanceof TxnDeleteOperation) {
+            localMapStats.incrementRemoveLatencyNanos(durationNanos);
+            return;
+        }
+
+        if (operation instanceof GetOperation) {
+            localMapStats.incrementGetLatencyNanos(durationNanos);
+            return;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.internal.eviction.ExpirationManager;
-import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.internal.util.comparators.ValueComparator;
@@ -43,7 +42,6 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
-import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.Map;
 import java.util.UUID;
@@ -172,8 +170,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
     IndexProvider getIndexProvider(MapConfig mapConfig);
 
     Extractors getExtractors(String mapName);
-
-    void incrementOperationStats(long startTime, LocalMapStatsImpl localMapStats, String mapName, Operation operation);
 
     boolean removeMapContainer(MapContainer mapContainer);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.internal.eviction.ExpirationManager;
-import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.DataType;
@@ -32,7 +31,6 @@ import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.internal.util.ContextMutexFactory;
 import com.hazelcast.internal.util.InvocationUtil;
 import com.hazelcast.internal.util.LocalRetryableExecution;
-import com.hazelcast.internal.util.Timer;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.internal.util.comparators.ValueComparator;
 import com.hazelcast.internal.util.comparators.ValueComparatorUtil;
@@ -47,13 +45,9 @@ import com.hazelcast.map.impl.journal.RingbufferMapEventJournalImpl;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.writebehind.NodeWideUsedCapacityCounter;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
-import com.hazelcast.map.impl.operation.BasePutOperation;
-import com.hazelcast.map.impl.operation.BaseRemoveOperation;
-import com.hazelcast.map.impl.operation.GetOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.operation.MapOperationProviders;
 import com.hazelcast.map.impl.operation.MapPartitionDestroyOperation;
-import com.hazelcast.map.impl.operation.SetOperation;
 import com.hazelcast.map.impl.query.AccumulationExecutor;
 import com.hazelcast.map.impl.query.AggregationResult;
 import com.hazelcast.map.impl.query.AggregationResultProcessor;
@@ -84,7 +78,6 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
-import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -796,21 +789,6 @@ class MapServiceContextImpl implements MapServiceContext {
     public Extractors getExtractors(String mapName) {
         MapContainer mapContainer = getMapContainer(mapName);
         return mapContainer.getExtractors();
-    }
-
-    @Override
-    public void incrementOperationStats(long startTimeNanos, LocalMapStatsImpl localMapStats, String mapName,
-                                        Operation operation) {
-        final long durationNanos = Timer.nanosElapsed(startTimeNanos);
-        if (operation instanceof SetOperation) {
-            localMapStats.incrementSetLatencyNanos(durationNanos);
-        } else if (operation instanceof BasePutOperation) {
-            localMapStats.incrementPutLatencyNanos(durationNanos);
-        } else if (operation instanceof BaseRemoveOperation) {
-            localMapStats.incrementRemoveLatencyNanos(durationNanos);
-        } else if (operation instanceof GetOperation) {
-            localMapStats.incrementGetLatencyNanos(durationNanos);
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -129,6 +129,7 @@ import static com.hazelcast.internal.util.SetUtil.createHashSet;
 import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
 import static com.hazelcast.internal.util.TimeUtil.timeInMsOrOneIfResultIsZero;
 import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
+import static com.hazelcast.map.impl.MapOperationStatsUpdater.incrementOperationStats;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.query.Target.createPartitionTarget;
 import static com.hazelcast.query.Predicates.alwaysFalse;
@@ -477,7 +478,7 @@ abstract class MapProxySupport<K, V>
                         .setResultDeserialized(false)
                         .invoke();
                 result = future.get();
-                mapServiceContext.incrementOperationStats(startTimeNanos, localMapStats, name, operation);
+                incrementOperationStats(operation, localMapStats, startTimeNanos);
             } else {
                 Future future = operationService
                         .createInvocationBuilder(SERVICE_NAME, operation, partitionId)
@@ -1436,7 +1437,7 @@ abstract class MapProxySupport<K, V>
         @Override
         public void accept(T t, Throwable throwable) {
             if (throwable == null) {
-                mapServiceContext.incrementOperationStats(startTime, localMapStats, name, operation);
+                incrementOperationStats(operation, localMapStats, startTime);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
@@ -45,14 +45,14 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
     private UUID ownerUuid;
     private Operation op;
 
-    private transient RemoteCallHook nearCachingHook = RemoteCallHook.EMPTY_HOOK;
+    private transient RemoteCallHook remoteCallHook = RemoteCallHook.EMPTY_HOOK;
 
     public MapTransactionLogRecord() {
     }
 
     public MapTransactionLogRecord(String name, Data key, int partitionId,
                                    Operation op, UUID ownerUuid, UUID transactionId,
-                                   @Nonnull RemoteCallHook nearCachingHook) {
+                                   @Nonnull RemoteCallHook remoteCallHook) {
         this.name = name;
         this.key = key;
         if (!(op instanceof MapTxnOperation)) {
@@ -62,7 +62,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
         this.ownerUuid = ownerUuid;
         this.partitionId = partitionId;
         this.transactionId = transactionId;
-        this.nearCachingHook = nearCachingHook;
+        this.remoteCallHook = remoteCallHook;
     }
 
     @Override
@@ -85,12 +85,12 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
 
     @Override
     public void onCommitSuccess() {
-        nearCachingHook.onRemoteCallSuccess(op);
+        remoteCallHook.onRemoteCallSuccess(op);
     }
 
     @Override
     public void onCommitFailure() {
-        nearCachingHook.onRemoteCallFailure();
+        remoteCallHook.onRemoteCallFailure();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.map.impl.tx;
 
-import com.hazelcast.internal.nearcache.impl.NearCachingHook;
+import com.hazelcast.internal.nearcache.impl.RemoteCallHook;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.IterationType;
+import com.hazelcast.internal.util.Timer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryEngine;
@@ -52,11 +53,13 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * Proxy implementation of {@link TransactionalMap} interface.
  */
-public class TransactionalMapProxy extends TransactionalMapProxySupport implements TransactionalMap {
+public class TransactionalMapProxy
+        extends TransactionalMapProxySupport implements TransactionalMap {
 
     private final Map<Data, TxnValueWrapper> txMap = new HashMap<>();
 
-    public TransactionalMapProxy(String name, MapService mapService, NodeEngine nodeEngine, Transaction transaction) {
+    public TransactionalMapProxy(String name, MapService mapService,
+                                 NodeEngine nodeEngine, Transaction transaction) {
         super(name, mapService, nodeEngine, transaction);
     }
 
@@ -110,13 +113,15 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
+        long startNanos = statisticsEnabled ? Timer.nanos() : -1;
         Object nearCacheKey = toNearCacheKeyWithStrategy(key);
         Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
         TxnValueWrapper currentValue = txMap.get(keyData);
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
-        return toObjectIfNeeded(getInternal(nearCacheKey, keyData, skipNearCacheLookup));
+        return toObjectIfNeeded(getInternal(nearCacheKey, keyData,
+                skipNearCacheLookup, startNanos));
     }
 
     @Override
@@ -148,10 +153,11 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data valueData = mapServiceContext.toData(value);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, value, valueData);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, value, valueData);
 
-        Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, valueData, ttl, timeUnit, invalidationHook));
+        Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, valueData,
+                ttl, timeUnit, remoteCallHook));
         TxnValueWrapper currentValue = txMap.get(keyData);
         Type type = valueBeforeTxn == null ? Type.NEW : Type.UPDATED;
         TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
@@ -168,10 +174,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data valueData = mapServiceContext.toData(value);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, value, valueData);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, value, valueData);
 
-        Data dataBeforeTxn = putInternal(keyData, valueData, UNSET, MILLISECONDS, invalidationHook);
+        Data dataBeforeTxn = putInternal(keyData, valueData, UNSET, MILLISECONDS, remoteCallHook);
         Type type = dataBeforeTxn == null ? Type.NEW : Type.UPDATED;
         TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
         txMap.put(keyData, wrapper);
@@ -186,8 +192,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data valueData = mapServiceContext.toData(value);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, value, valueData);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, value, valueData);
 
         TxnValueWrapper wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
@@ -195,11 +201,11 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             if (wrapper.type != Type.REMOVED) {
                 return wrapper.value;
             }
-            putInternal(keyData, valueData, UNSET, MILLISECONDS, invalidationHook);
+            putInternal(keyData, valueData, UNSET, MILLISECONDS, remoteCallHook);
             txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
             return null;
         } else {
-            Data oldValue = putIfAbsentInternal(keyData, valueData, invalidationHook);
+            Data oldValue = putIfAbsentInternal(keyData, valueData, remoteCallHook);
             if (oldValue == null) {
                 txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
             }
@@ -216,8 +222,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data valueData = mapServiceContext.toData(value);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, value, valueData);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, value, valueData);
 
         TxnValueWrapper wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
@@ -225,11 +231,11 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             if (wrapper.type == Type.REMOVED) {
                 return null;
             }
-            putInternal(keyData, valueData, UNSET, MILLISECONDS, invalidationHook);
+            putInternal(keyData, valueData, UNSET, MILLISECONDS, remoteCallHook);
             txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
             return wrapper.value;
         } else {
-            Data oldValue = replaceInternal(keyData, valueData, invalidationHook);
+            Data oldValue = replaceInternal(keyData, valueData, remoteCallHook);
             if (oldValue != null) {
                 txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
             }
@@ -247,8 +253,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data newValueData = mapServiceContext.toData(newValue);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, newValue, newValueData);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, newValue, newValueData);
 
         TxnValueWrapper wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
@@ -256,12 +262,12 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             if (!wrapper.value.equals(oldValue)) {
                 return false;
             }
-            putInternal(keyData, newValueData, UNSET, MILLISECONDS, invalidationHook);
+            putInternal(keyData, newValueData, UNSET, MILLISECONDS, remoteCallHook);
             txMap.put(keyData, new TxnValueWrapper(wrapper.value, Type.UPDATED));
             return true;
         } else {
             boolean success = replaceIfSameInternal(keyData, mapServiceContext.toData(oldValue),
-                    newValueData, invalidationHook);
+                    newValueData, remoteCallHook);
             if (success) {
                 txMap.put(keyData, new TxnValueWrapper(newValue, Type.UPDATED));
             }
@@ -280,10 +286,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         TxnValueWrapper wrapper = txMap.get(keyData);
         // wrapper is null which means this entry is not touched by transaction
         if (wrapper == null) {
-            NearCachingHook invalidationHook = newNearCachingHook();
-            invalidationHook.beforeRemoteCall(key, keyData, null, null);
+            RemoteCallHook remoteCallHook = newRemoteCallHook();
+            remoteCallHook.beforeRemoteCall(key, keyData, null, null);
 
-            boolean removed = removeIfSameInternal(keyData, value, invalidationHook);
+            boolean removed = removeIfSameInternal(keyData, value, remoteCallHook);
             if (removed) {
                 txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
             }
@@ -298,10 +304,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             return false;
         }
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, null, null);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, null, null);
         // wrapper value is equal to passed value, we call removeInternal just to add delete log
-        removeInternal(keyData, invalidationHook);
+        removeInternal(keyData, remoteCallHook);
         txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
 
         return true;
@@ -314,10 +320,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, null, null);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, null, null);
 
-        Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData, invalidationHook));
+        Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData, remoteCallHook));
 
         TxnValueWrapper wrapper = null;
         if (valueBeforeTxn != null || txMap.containsKey(keyData)) {
@@ -333,10 +339,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        NearCachingHook invalidationHook = newNearCachingHook();
-        invalidationHook.beforeRemoteCall(key, keyData, null, null);
+        RemoteCallHook remoteCallHook = newRemoteCallHook();
+        remoteCallHook.beforeRemoteCall(key, keyData, null, null);
 
-        Data data = removeInternal(keyData, invalidationHook);
+        Data data = removeInternal(keyData, remoteCallHook);
         if (data != null || txMap.containsKey(keyData)) {
             txMap.put(keyData, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
         }
@@ -353,7 +359,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     public Set keySet(Predicate predicate) {
         checkTransactionState();
         checkNotNull(predicate, "Predicate should not be null!");
-        checkNotInstanceOf(PagingPredicate.class, predicate, "Paging is not supported for Transactional queries!");
+        checkNotInstanceOf(PagingPredicate.class, predicate,
+                "Paging is not supported for Transactional queries!");
 
         QueryEngine queryEngine = mapServiceContext.getQueryEngine(name);
 
@@ -383,6 +390,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                 }
             }
         }
+
+        incrementOtherOperationsStat();
         return returningKeySet;
     }
 
@@ -397,7 +406,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     public Collection values(Predicate predicate) {
         checkTransactionState();
         checkNotNull(predicate, "Predicate can not be null!");
-        checkNotInstanceOf(PagingPredicate.class, predicate, "Paging is not supported for Transactional queries");
+        checkNotInstanceOf(PagingPredicate.class, predicate,
+                "Paging is not supported for Transactional queries");
 
         QueryEngine queryEngine = mapServiceContext.getQueryEngine(name);
 
@@ -431,6 +441,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             }
         }
         removeFromResultSet(result, valueSet, keyWontBeIncluded);
+        incrementOtherOperationsStat();
         return valueSet;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -17,12 +17,15 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.nearcache.NearCache;
-import com.hazelcast.internal.nearcache.impl.NearCachingHook;
+import com.hazelcast.internal.nearcache.impl.CompositeRemoteCallHook;
+import com.hazelcast.internal.nearcache.impl.RemoteCallHook;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.ThreadUtil;
+import com.hazelcast.internal.util.Timer;
 import com.hazelcast.internal.util.comparators.ValueComparator;
 import com.hazelcast.map.impl.InterceptorRegistry;
 import com.hazelcast.map.impl.MapService;
@@ -33,6 +36,7 @@ import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.TransactionalDistributedObject;
+import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationFactory;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.transaction.TransactionNotActiveException;
@@ -48,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
 import static com.hazelcast.internal.nearcache.NearCache.NOT_CACHED;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.map.impl.MapOperationStatsUpdater.incrementTxnOperationStats;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.record.Record.UNSET;
 
@@ -59,6 +64,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     protected final Map<Data, VersionedValue> valueMap = new HashMap<>();
 
     protected final String name;
+    protected final boolean statisticsEnabled;
     protected final MapServiceContext mapServiceContext;
     protected final MapNearCacheManager mapNearCacheManager;
     protected final MapOperationProvider operationProvider;
@@ -70,6 +76,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     private final boolean serializeKeys;
     private final boolean nearCacheEnabled;
     private final ValueComparator valueComparator;
+    private final LocalMapStatsImpl localMapStats;
 
     TransactionalMapProxySupport(String name, MapService mapService,
                                  NodeEngine nodeEngine, Transaction transaction) {
@@ -88,6 +95,8 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         this.nearCacheEnabled = mapConfig.isNearCacheEnabled();
         this.serializeKeys = nearCacheEnabled && mapConfig.getNearCacheConfig().isSerializeKeys();
         this.valueComparator = mapServiceContext.getValueComparatorOf(mapConfig.getInMemoryFormat());
+        this.statisticsEnabled = mapConfig.isStatisticsEnabled();
+        this.localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
     }
 
     @Override
@@ -124,13 +133,15 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         int partitionId = partitionService.getPartitionId(dataKey);
         try {
             Future future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
-            return (Boolean) future.get();
+            Object result = future.get();
+            incrementOtherOperationsStat();
+            return (Boolean) result;
         } catch (Throwable t) {
             throw rethrow(t);
         }
     }
 
-    Object getInternal(Object nearCacheKey, Data keyData, boolean skipNearCacheLookup) {
+    Object getInternal(Object nearCacheKey, Data keyData, boolean skipNearCacheLookup, long startNanos) {
         if (!skipNearCacheLookup && nearCacheEnabled) {
             Object value = getCachedValue(nearCacheKey, true);
             if (value != NOT_CACHED) {
@@ -145,7 +156,13 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
             Future future = operationService.createInvocationBuilder(SERVICE_NAME, operation, partitionId)
                     .setResultDeserialized(false)
                     .invoke();
-            return future.get();
+            Object result = future.get();
+
+            if (statisticsEnabled) {
+                updateOpStats(operation, startNanos);
+            }
+
+            return result;
         } catch (Throwable t) {
             throw rethrow(t);
         }
@@ -208,13 +225,14 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
                 Integer size = getNodeEngine().toObject(result);
                 total += size;
             }
+            incrementOtherOperationsStat();
             return total;
         } catch (Throwable t) {
             throw rethrow(t);
         }
     }
 
-    Data putInternal(Data key, Data value, long ttl, TimeUnit timeUnit, NearCachingHook hook) {
+    Data putInternal(Data key, Data value, long ttl, TimeUnit timeUnit, RemoteCallHook hook) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         long timeInMillis = getTimeInMillis(ttl, timeUnit);
         MapOperation op = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, timeInMillis);
@@ -222,7 +240,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         return versionedValue.value;
     }
 
-    Data putIfAbsentInternal(Data key, Data value, NearCachingHook hook) {
+    Data putIfAbsentInternal(Data key, Data value, RemoteCallHook hook) {
         boolean unlockImmediately = !valueMap.containsKey(key);
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         if (versionedValue.value != null) {
@@ -241,7 +259,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         return versionedValue.value;
     }
 
-    Data replaceInternal(Data key, Data value, NearCachingHook hook) {
+    Data replaceInternal(Data key, Data value, RemoteCallHook hook) {
         boolean unlockImmediately = !valueMap.containsKey(key);
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         if (versionedValue.value == null) {
@@ -260,7 +278,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     }
 
     boolean replaceIfSameInternal(Data key, Object oldValue,
-                                  Data newValue, NearCachingHook hook) {
+                                  Data newValue, RemoteCallHook hook) {
         boolean unlockImmediately = !valueMap.containsKey(key);
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         if (!isEquals(oldValue, versionedValue.value)) {
@@ -279,7 +297,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         return true;
     }
 
-    Data removeInternal(Data key, NearCachingHook hook) {
+    Data removeInternal(Data key, RemoteCallHook hook) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key),
                 operationProvider.createTxnDeleteOperation(name, key, versionedValue.version),
@@ -287,7 +305,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         return versionedValue.value;
     }
 
-    boolean removeIfSameInternal(Data key, Object value, NearCachingHook hook) {
+    boolean removeIfSameInternal(Data key, Object value, RemoteCallHook hook) {
         boolean unlockImmediately = !valueMap.containsKey(key);
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         if (!isEquals(versionedValue.value, value)) {
@@ -323,12 +341,13 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     private void addUnlockTransactionRecord(Data key, long version) {
         TxnUnlockOperation operation = new TxnUnlockOperation(name, key, version);
         tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key),
-                operation, tx.getOwnerUuid(), tx.getTxnId(), NearCachingHook.EMPTY_HOOK));
+                operation, tx.getOwnerUuid(), tx.getTxnId(), RemoteCallHook.EMPTY_HOOK));
     }
 
     /**
-     * Locks the key on the partition owner and returns the value with the version. Does not invokes maploader if
-     * the key is missing in memory
+     * Locks the key on the partition owner and returns
+     * the value with the version. Does not invokes
+     * maploader if the key is missing in memory.
      *
      * @param key     serialized key
      * @param timeout timeout in millis
@@ -365,11 +384,65 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         return timeunit != null ? timeunit.toMillis(time) : time;
     }
 
-    protected NearCachingHook newNearCachingHook() {
-        return nearCacheEnabled ? new InvalidationHook() : NearCachingHook.EMPTY_HOOK;
+    protected RemoteCallHook newRemoteCallHook() {
+        CompositeRemoteCallHook hook = null;
+
+        if (nearCacheEnabled) {
+            hook = new CompositeRemoteCallHook();
+            hook.add(new InvalidationHook());
+        }
+
+        if (statisticsEnabled) {
+            hook = hook != null ? hook : new CompositeRemoteCallHook();
+            hook.add(new StatsUpdaterHook());
+        }
+
+        return hook != null ? hook : RemoteCallHook.EMPTY_HOOK;
     }
 
-    private class InvalidationHook implements NearCachingHook {
+    /**
+     * Hook to be used by local map stats updates.
+     */
+    private class StatsUpdaterHook implements RemoteCallHook {
+
+        private long startNanos;
+
+        @Override
+        public void beforeRemoteCall(Object key, Data keyData,
+                                     Object value, Data valueData) {
+            startNanos = Timer.nanos();
+        }
+
+        @Override
+        public void onRemoteCallSuccess(Operation remoteCall) {
+            updateOpStats(remoteCall, startNanos);
+        }
+
+        @Override
+        public void onRemoteCallFailure() {
+        }
+    }
+
+    protected void updateOpStats(Operation op, long startNanos) {
+        if (!statisticsEnabled) {
+            return;
+        }
+
+        incrementTxnOperationStats(op, localMapStats, startNanos);
+    }
+
+    protected void incrementOtherOperationsStat() {
+        if (!statisticsEnabled) {
+            return;
+        }
+
+        localMapStats.incrementOtherOperations();
+    }
+
+    /**
+     * Hook for near cahe invalidations.
+     */
+    private class InvalidationHook implements RemoteCallHook {
 
         private Object nearCacheKey;
 
@@ -379,7 +452,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         }
 
         @Override
-        public void onRemoteCallSuccess() {
+        public void onRemoteCallSuccess(Operation remoteCall) {
             invalidateNearCache(nearCacheKey);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -424,9 +424,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     }
 
     protected void updateOpStats(Operation op, long startNanos) {
-        if (!statisticsEnabled) {
-            return;
-        }
+        assert statisticsEnabled;
 
         incrementTxnOperationStats(op, localMapStats, startNanos);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/LocalTxnMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/LocalTxnMapStatsTest.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.tx;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.Clock;
+import com.hazelcast.map.LocalMapStats;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionalMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Tests whether {@link LocalMapStats} is updated after remote calls.
+ * <p>
+ * These updates generally will be visible after txn commit step.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class LocalTxnMapStatsTest extends HazelcastTestSupport {
+
+    static final int OPERATION_COUNT = 10;
+
+    private String mapName = "mapName";
+    private String mapWithObjectFormat = "mapWithObjectFormat";
+    private HazelcastInstance instance;
+    private TransactionContext context;
+
+    @Before
+    public void setUp() {
+        instance = createHazelcastInstance(createMemberConfig());
+    }
+
+    protected final LocalMapStats getMapStats() {
+        return getMapStats(mapName);
+    }
+
+    protected LocalMapStats getMapStats(String mapName) {
+        return instance.getMap(mapName).getLocalMapStats();
+    }
+
+    protected final <K, V> TransactionalMap<K, V> getMap() {
+        return getMap(mapName);
+    }
+
+    protected <K, V> TransactionalMap<K, V> getMap(String mapName) {
+        warmUpPartitions(instance);
+        context = instance.newTransactionContext();
+        context.beginTransaction();
+        return context.getMap(mapName);
+    }
+
+    protected Config createMemberConfig() {
+        return getConfig().addMapConfig(new MapConfig()
+                .setName(mapWithObjectFormat)
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+        );
+    }
+
+    @Test
+    public void memoryCostIsMinusOne_ifInMemoryFormat_is_OBJECT() {
+        TransactionalMap<Object, Object> map = getMap(mapWithObjectFormat);
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats(mapWithObjectFormat);
+        assertEquals(-1, localMapStats.getOwnedEntryMemoryCost());
+        assertEquals(-1, localMapStats.getBackupEntryMemoryCost());
+    }
+
+    @Test
+    public void testHitsGenerated() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+        context.commitTransaction();
+
+        map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.get(i);
+        }
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(100, localMapStats.getHits());
+    }
+
+    @Test
+    public void testPutAndHitsGenerated() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(100, localMapStats.getSetOperationCount());
+    }
+
+    @Test
+    public void testPutIfAbsentAndHitsGenerated() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.putIfAbsent(i, i);
+            map.get(i);
+        }
+        context.commitTransaction();
+
+        map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.get(i);
+        }
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(100, localMapStats.getSetOperationCount());
+        assertEquals(100, localMapStats.getHits());
+    }
+
+
+    @Test
+    public void testGetAndHitsGenerated() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+        context.commitTransaction();
+
+        map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.get(i);
+        }
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(100, localMapStats.getGetOperationCount());
+    }
+
+    @Test
+    public void testDelete() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.delete(i);
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(100, localMapStats.getRemoveOperationCount());
+    }
+
+    @Test
+    public void testSet() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.set(i, i);
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(0, localMapStats.getPutOperationCount());
+        assertEquals(100, localMapStats.getSetOperationCount());
+        assertEquals(0, localMapStats.getHits());
+        assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+        assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
+    }
+
+    @Test
+    public void testSetAndHitsGenerated() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 1; i++) {
+            map.set(i, i);
+            map.set(i, i);
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(0, localMapStats.getPutOperationCount());
+        assertEquals(1, localMapStats.getSetOperationCount());
+        assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+        assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
+    }
+
+
+    @Test
+    public void testRemove() {
+        TransactionalMap<Integer, Integer> map = getMap();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.remove(i);
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats localMapStats = getMapStats();
+        assertEquals(100, localMapStats.getRemoveOperationCount());
+    }
+
+    @Test
+    public void testLastAccessTime() throws InterruptedException {
+        final long startTime = Clock.currentTimeMillis();
+
+        TransactionalMap<String, String> map = getMap();
+
+        String key = "key";
+        map.put(key, "value");
+        map.get(key);
+
+        context.commitTransaction();
+
+        map = getMap();
+        map.get(key);
+        context.commitTransaction();
+
+        long lastAccessTime = getMapStats().getLastAccessTime();
+        assertTrue("lastAccessTime=" + lastAccessTime + ", startTime=" + startTime,
+                lastAccessTime >= startTime);
+
+        Thread.sleep(5);
+        map = getMap();
+        map.put(key, "value2");
+        context.commitTransaction();
+
+        long lastAccessTime2 = getMapStats().getLastAccessTime();
+        assertTrue(lastAccessTime2 > lastAccessTime);
+    }
+
+    @Test
+    public void testOtherOperationCount_containsKey() {
+        TransactionalMap map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsKey(i);
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_keySet() {
+        TransactionalMap map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.keySet();
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_values() {
+        TransactionalMap map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.values();
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_valuesWithPredicate() {
+        TransactionalMap map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+
+            map.values(Predicates.lessThan("this", 0));
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_isEmpty() {
+        TransactionalMap map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.isEmpty();
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_size() {
+        TransactionalMap map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.size();
+        }
+
+        context.commitTransaction();
+
+        LocalMapStats stats = getMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+}


### PR DESCRIPTION
**Issue:**
Statistics like Puts, Removals don't increase when the operations are executed through Transactional interface. 

The expectation is that when an entry is added and committed via Tx API, the statistics shown on Management Center should change in a correct way. 
see: https://hazelcast.atlassian.net/browse/HZ-1001

**Modifications:**
- Collected operation stats updater code under `MapOperationStatsUpdater`
- Renamed `NearCachingHook` as `RemoteCallHook`
- Introduced `StatsUpdaterHook` to update txn map stats
- Added test