### PR TITLE
Make docker tests enabled by default #19994 HZ-744

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ take a considerable amount of time. Hazelcast has 3 testing profiles:
 * All Tests: Type `mvn test -P all-tests` to run all tests serially using
   network.
 
-Some tests require Docker to run. Set `-Ddisable.docker.tests` system property to ignore them.
+Some tests require Docker to run. Set `-Dhazelcast.disable.docker.tests` system property to ignore them.
 
 ## Trigger Phrases in the Pull Request Conversation
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ take a considerable amount of time. Hazelcast has 3 testing profiles:
 * All Tests: Type `mvn test -P all-tests` to run all tests serially using
   network.
 
+Some tests require Docker to run. Set `-Ddisable.docker.tests` system property to ignore them.
+
 ## Trigger Phrases in the Pull Request Conversation
 
 When you create a pull request (PR), it must pass a build-and-test

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.DockerTestUtil;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
@@ -46,9 +45,9 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 @Category({IgnoreInJenkinsOnWindows.class})
 public class AbstractCdcIntegrationTest extends JetTestSupport {
@@ -58,7 +57,7 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
     }
 
     @Nonnull

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.map.IMap;
-
+import com.hazelcast.test.DockerTestUtil;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 
 @Category({IgnoreInJenkinsOnWindows.class})
 public class AbstractCdcIntegrationTest extends JetTestSupport {
@@ -58,7 +58,7 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
     }
 
     @Nonnull

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -46,7 +47,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.testcontainers.DockerClientFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,7 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.elasticsearch.client.RequestOptions.DEFAULT;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Base class for running Elasticsearch connector tests
@@ -83,7 +83,7 @@ public abstract class BaseElasticTest {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
     }
 
     @Before

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
-import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -56,12 +55,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableMap.of;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.elasticsearch.client.RequestOptions.DEFAULT;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * Base class for running Elasticsearch connector tests
@@ -83,7 +82,7 @@ public abstract class BaseElasticTest {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
     }
 
     @Before

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.jet.test.SerialTest;
+import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -46,7 +47,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.testcontainers.DockerClientFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.elasticsearch.client.RequestOptions.DEFAULT;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Base class for running Elasticsearch connector tests
@@ -84,7 +84,7 @@ public abstract class BaseElasticTest {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
     }
 
     @Before

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.jet.test.SerialTest;
-import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -56,13 +55,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableMap.of;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.elasticsearch.client.RequestOptions.DEFAULT;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * Base class for running Elasticsearch connector tests
@@ -84,7 +83,7 @@ public abstract class BaseElasticTest {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
     }
 
     @Before

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.kafka.impl;
 
 import com.hazelcast.internal.util.OsHelper;
+import com.hazelcast.test.DockerTestUtil;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
@@ -32,7 +33,6 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.testcontainers.DockerClientFactory;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -61,13 +61,13 @@ public abstract class KafkaTestSupport {
     private KafkaProducer<String, String> stringStringProducer;
 
     public static KafkaTestSupport create() {
-        if (DockerClientFactory.instance().isDockerAvailable() && !OsHelper.isArmMac()) {
-            return new DockerizedKafkaTestSupport();
-        } else {
+        if (DockerTestUtil.dockerDisabled() || OsHelper.isArmMac()) {
             if (System.getProperties().containsKey("test.kafka.version")) {
                 throw new IllegalArgumentException("'test.kafka.version' system property requires docker and x86_64 CPU");
             }
             return new EmbeddedKafkaTestSupport();
+        } else {
+            return new DockerizedKafkaTestSupport();
         }
     }
 

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -61,7 +61,7 @@ public abstract class KafkaTestSupport {
     private KafkaProducer<String, String> stringStringProducer;
 
     public static KafkaTestSupport create() {
-        if (DockerTestUtil.dockerDisabled() || OsHelper.isArmMac()) {
+        if (!DockerTestUtil.dockerEnabled() || OsHelper.isArmMac()) {
             if (System.getProperties().containsKey("test.kafka.version")) {
                 throw new IllegalArgumentException("'test.kafka.version' system property requires docker and x86_64 CPU");
             }

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -26,13 +26,13 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.DockerTestUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy;
@@ -51,7 +51,7 @@ import static com.hazelcast.jet.kinesis.KinesisSinks.MAX_RECORD_SIZE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.repeat;
 import static org.testcontainers.utility.DockerImageName.parse;
 
@@ -75,7 +75,7 @@ public class KinesisFailureTest extends AbstractKinesisTest {
 
     @BeforeClass
     public static void beforeClass() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
 
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.test.DockerTestUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -48,10 +47,10 @@ import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.kinesis.KinesisSinks.MAXIMUM_KEY_LENGTH;
 import static com.hazelcast.jet.kinesis.KinesisSinks.MAX_RECORD_SIZE;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assume.assumeFalse;
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.repeat;
 import static org.testcontainers.utility.DockerImageName.parse;
 
@@ -75,7 +74,7 @@ public class KinesisFailureTest extends AbstractKinesisTest {
 
     @BeforeClass
     public static void beforeClass() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
 
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
@@ -33,13 +33,13 @@ import com.hazelcast.jet.pipeline.WindowDefinition;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.testcontainers.utility.DockerImageName.parse;
 
 public class KinesisIntegrationTest extends AbstractKinesisTest {
@@ -81,7 +81,7 @@ public class KinesisIntegrationTest extends AbstractKinesisTest {
 
     @BeforeClass
     public static void beforeClass() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
 
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisIntegrationTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.pipeline.WindowDefinition;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -58,12 +57,12 @@ import static com.amazonaws.services.kinesis.model.ShardIteratorType.TRIM_HORIZO
 import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.pipeline.test.Assertions.assertCollectedEventually;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 import static org.testcontainers.utility.DockerImageName.parse;
 
 public class KinesisIntegrationTest extends AbstractKinesisTest {
@@ -81,7 +80,7 @@ public class KinesisIntegrationTest extends AbstractKinesisTest {
 
     @BeforeClass
     public static void beforeClass() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
 
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.jet.s3.S3Sinks.S3SinkContext;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -42,11 +41,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 import static software.amazon.awssdk.core.sync.ResponseTransformer.toInputStream;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -70,7 +69,7 @@ public class S3MockTest extends S3TestBase {
 
     @BeforeClass
     public static void setupS3() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
         s3MockContainer = new S3MockContainer();
         s3MockContainer.start();
         s3MockContainer.followOutput(outputFrame -> logger.info(outputFrame.getUtf8String().trim()));

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.s3.S3Sinks.S3SinkContext;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -33,8 +34,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.testcontainers.DockerClientFactory;
-
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -47,7 +46,7 @@ import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import static software.amazon.awssdk.core.sync.ResponseTransformer.toInputStream;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -71,7 +70,7 @@ public class S3MockTest extends S3TestBase {
 
     @BeforeClass
     public static void setupS3() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
         s3MockContainer = new S3MockContainer();
         s3MockContainer.start();
         s3MockContainer.followOutput(outputFrame -> logger.info(outputFrame.getUtf8String().trim()));

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
-import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
@@ -29,7 +28,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 
 import javax.jms.ConnectionFactory;
 
-import static org.junit.Assume.assumeFalse;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 
 @Category({NightlyTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
 public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestBase {
@@ -45,7 +44,7 @@ public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestB
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
@@ -18,19 +18,18 @@ package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.RabbitMQContainer;
 
-import static org.junit.Assume.assumeTrue;
-
 import javax.jms.ConnectionFactory;
+
+import static org.junit.Assume.assumeFalse;
 
 @Category({NightlyTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
 public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestBase {
@@ -46,7 +45,7 @@ public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestB
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
@@ -34,7 +35,6 @@ import org.junit.experimental.categories.Category;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.postgresql.ds.common.BaseDataSource;
 import org.postgresql.xa.PGXADataSource;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import javax.sql.CommonDataSource;
@@ -54,7 +54,7 @@ import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Util.entry;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -73,7 +73,7 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+        assumeFalse(DockerTestUtil.dockerDisabled());
     }
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
-import com.hazelcast.test.DockerTestUtil;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
@@ -53,8 +52,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -73,7 +72,7 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @BeforeClass
     public static void beforeClassCheckDocker() {
-        assumeFalse(DockerTestUtil.dockerDisabled());
+        assumeDockerEnabled();
     }
 
     @BeforeClass

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.test;
+
+public class DockerTestUtil {
+    public static boolean dockerDisabled() {
+        return System.getProperties().containsKey("disable.docker.tests");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -15,8 +15,14 @@
  */
 package com.hazelcast.test;
 
+import static org.junit.Assume.assumeTrue;
+
 public class DockerTestUtil {
-    public static boolean dockerDisabled() {
-        return System.getProperties().containsKey("disable.docker.tests");
+    public static boolean dockerEnabled() {
+        return !System.getProperties().containsKey("disable.docker.tests");
+    }
+
+    public static void assumeDockerEnabled() {
+        assumeTrue(DockerTestUtil.dockerEnabled());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -19,7 +19,7 @@ import static org.junit.Assume.assumeTrue;
 
 public class DockerTestUtil {
     public static boolean dockerEnabled() {
-        return !System.getProperties().containsKey("disable.docker.tests");
+        return !System.getProperties().containsKey("hazelcast.disable.docker.tests");
     }
 
     public static void assumeDockerEnabled() {


### PR DESCRIPTION
This PR enables all docker tests. In order to disable them one needs to set `-Dhazelcast.disable.docker.tests` system property

Fixes https://github.com/hazelcast/hazelcast/issues/19994
Fixes https://hazelcast.atlassian.net/browse/HZ-744

Breaking changes (list specific methods/types/messages):
* Default configuration requires Docker to pass all the tests

CI jobs on Windows need to be adjusted as there's no way to run Docker on the Windows server

I've added `-Dhazelcast.disable.docker.tests` to the `Hazelcast-pr-builder-windows` job to make it green