### PR TITLE
The `binarySearch` method is used on unsorted arrays

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
@@ -491,6 +491,7 @@ public class LocalRaftTest extends HazelcastTestSupport {
         RaftEndpoint leaderEndpoint = group.waitUntilLeaderElected().getLocalMember();
 
         int[] split = group.createMajoritySplitIndexes(false);
+        Arrays.sort(split);
         group.split(split);
 
         assertTrueEventually(() -> {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftGroup.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftGroup.java
@@ -500,6 +500,7 @@ public class LocalRaftGroup {
     public void split(int... indexes) {
         assertThat(indexes.length, greaterThan(0));
         assertThat(indexes.length, lessThan(size()));
+        Arrays.sort(indexes);
 
         int runningMemberCount = 0;
         for (int i = 0; i < size(); i++) {


### PR DESCRIPTION
Added array sorting before `binarySearch` usage.
