### PR TITLE
bumping json schema validator to 1.14.1

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -486,7 +486,7 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.14.0</version>
+            <version>1.14.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.re2j</groupId>


### PR DESCRIPTION
Requested by @kwart on [slack](https://hazelcast.slack.com/archives/G01LH0K3VK8/p1648714310472949?thread_ts=1648714007.131469&cid=G01LH0K3VK8).

Bumps `com.github.erosb:everit-json-schema` to [`1.14.1`](https://github.com/everit-org/json-schema/releases/tag/1.14.1) which depends on `org.json:json:20220320`.
