### PR TITLE
Re-add accidentally removed return statement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -1131,7 +1131,7 @@ public class JobCoordinationService {
         assert jobRepository.getJobResult(jobId) == null : "jobResult should not exist at this point";
 
         if (finalizeJobIfAutoScalingOff(masterContext)) {
-            masterContext.jobContext().jobCompletionFuture();
+            return masterContext.jobContext().jobCompletionFuture();
         }
 
         if (jobExecutionRecord.isSuspended()) {


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast/pull/21048, this return statement accidentally
removed. This PR adds this return statement back.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Added backport PR for the 5.1.z
