### PR TITLE
Disable hadoop test on IBM JDK17 #20754 HZ-980

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlHadoopTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlHadoopTest.java
@@ -57,6 +57,11 @@ public class SqlHadoopTest extends SqlTestSupport {
     public static void setUpClass() throws Exception {
         assumeThatNoWindowsOS();
 
+        // Tests will fail on IBM JDK17 with error:
+        // No LoginModule found for com.ibm.security.auth.module.JAASLoginModule
+        // see https://github.com/hazelcast/hazelcast/issues/20754
+        assumeThatNotIBMJDK17();
+
         initialize(1, null);
         sqlService = instance().getSql();
 


### PR DESCRIPTION
Ignoring one more Hadoop test on OpenJ9 17.

Read more: https://github.com/hazelcast/hazelcast/pull/21068