### PR TITLE
Fix double lag when dropping late events

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DropLateItemsLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DropLateItemsLogicalRel.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.sql.impl.opt.logical;
 
-import com.hazelcast.function.ToLongFunctionEx;
-import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -38,26 +36,19 @@ import java.util.List;
  */
 public class DropLateItemsLogicalRel extends SingleRel implements LogicalRel {
     private final RexNode wmField;
-    private final ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider;
 
     protected DropLateItemsLogicalRel(
             RelOptCluster cluster,
             RelTraitSet traitSet,
             RelNode input,
-            RexNode wmField,
-            ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider
+            RexNode wmField
     ) {
         super(cluster, traitSet, input);
         this.wmField = wmField;
-        this.allowedLagProvider = allowedLagProvider;
     }
 
     public RexNode wmField() {
         return wmField;
-    }
-
-    public ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider() {
-        return allowedLagProvider;
     }
 
     @Override
@@ -67,7 +58,7 @@ public class DropLateItemsLogicalRel extends SingleRel implements LogicalRel {
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new DropLateItemsLogicalRel(getCluster(), traitSet, sole(inputs), wmField, allowedLagProvider);
+        return new DropLateItemsLogicalRel(getCluster(), traitSet, sole(inputs), wmField);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/WatermarkLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/WatermarkLogicalRel.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
@@ -36,7 +35,6 @@ import java.util.List;
 public class WatermarkLogicalRel extends SingleRel implements LogicalRel {
 
     private final FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider;
-    private final ToLongFunctionEx<ExpressionEvalContext> lagTimeProvider;
     private final int watermarkedColumnIndex;
 
     WatermarkLogicalRel(
@@ -44,22 +42,16 @@ public class WatermarkLogicalRel extends SingleRel implements LogicalRel {
             RelTraitSet traits,
             RelNode input,
             FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider,
-            ToLongFunctionEx<ExpressionEvalContext> lagTimeProvider,
             int watermarkedColumnIndex
     ) {
         super(cluster, traits, input);
 
         this.eventTimePolicyProvider = eventTimePolicyProvider;
-        this.lagTimeProvider = lagTimeProvider;
         this.watermarkedColumnIndex = watermarkedColumnIndex;
     }
 
     public FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider() {
         return eventTimePolicyProvider;
-    }
-
-    public ToLongFunctionEx<ExpressionEvalContext> lagTimeProvider() {
-        return lagTimeProvider;
     }
 
     public int watermarkedColumnIndex() {
@@ -70,7 +62,6 @@ public class WatermarkLogicalRel extends SingleRel implements LogicalRel {
     public RelWriter explainTerms(RelWriter pw) {
         return super.explainTerms(pw)
                 .item("eventTimePolicyProvider", eventTimePolicyProvider)
-                .item("lagTimeProvider", lagTimeProvider)
                 .item("watermarkedColumnIndex", watermarkedColumnIndex);
     }
 
@@ -87,7 +78,6 @@ public class WatermarkLogicalRel extends SingleRel implements LogicalRel {
                 traitSet,
                 sole(inputs),
                 eventTimePolicyProvider,
-                lagTimeProvider,
                 watermarkedColumnIndex
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/WatermarkRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/WatermarkRules.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.google.common.collect.Iterables;
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.WatermarkPolicy;
 import com.hazelcast.jet.impl.util.Util;
@@ -75,7 +74,6 @@ final class WatermarkRules {
                     OptUtils.toLogicalConvention(scan.getTraitSet()),
                     Iterables.getOnlyElement(Util.toList(scan.getInputs(), OptUtils::toLogicalInput)),
                     toEventTimePolicyProvider(scan),
-                    lagTimeProvider(scan),
                     wmIndex);
 
             if (wmIndex < 0) {
@@ -98,8 +96,7 @@ final class WatermarkRules {
                     scan.getCluster(),
                     OptUtils.toLogicalConvention(scan.getTraitSet()),
                     wmRel,
-                    watermarkedField.getValue(),
-                    wmRel.lagTimeProvider()
+                    watermarkedField.getValue()
             );
             call.transformTo(dropLateItemsRel);
         }
@@ -120,11 +117,6 @@ final class WatermarkRules {
                         0,
                         EventTimePolicy.DEFAULT_IDLE_TIMEOUT);
             };
-        }
-
-        private ToLongFunctionEx<ExpressionEvalContext> lagTimeProvider(LogicalTableFunctionScan function) {
-            Expression<?> lagExpression = lagExpression(function);
-            return context -> WindowUtils.extractMillis(lagExpression, context);
         }
 
         private int orderingColumnFieldIndex(LogicalTableFunctionScan function) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateDagVisitor.java
@@ -381,9 +381,8 @@ public class CreateDagVisitor {
 
     public Vertex onDropLateItems(DropLateItemsPhysicalRel rel) {
         Expression<?> timestampExpression = rel.timestampExpression();
-        ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider = rel.allowedLagProvider();
 
-        SupplierEx<Processor> lateItemsDropPSupplier = () -> new LateItemsDropP(timestampExpression, allowedLagProvider);
+        SupplierEx<Processor> lateItemsDropPSupplier = () -> new LateItemsDropP(timestampExpression);
         Vertex vertex = dag.newUniqueVertex("Drop-Late-Items", lateItemsDropPSupplier);
 
         connectInput(rel.getInput(), vertex, null);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DropLateItemsPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DropLateItemsPhysicalRel.java
@@ -16,12 +16,10 @@
 
 package com.hazelcast.jet.sql.impl.opt.physical;
 
-import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.expression.Expression;
-import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
 import org.apache.calcite.plan.HazelcastRelOptCluster;
 import org.apache.calcite.plan.RelOptCluster;
@@ -42,28 +40,21 @@ import static com.hazelcast.jet.sql.impl.opt.OptUtils.createRexToExpressionVisit
 
 public class DropLateItemsPhysicalRel extends SingleRel implements PhysicalRel {
     private final RexNode wmField;
-    private final ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider;
 
     protected DropLateItemsPhysicalRel(
             RelOptCluster cluster,
             RelTraitSet traitSet,
             RelNode input,
-            RexNode wmField,
-            ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider
+            RexNode wmField
     ) {
         super(cluster, traitSet, input);
         this.wmField = wmField;
-        this.allowedLagProvider = allowedLagProvider;
     }
 
     public Expression<?> timestampExpression() {
         QueryParameterMetadata parameterMetadata = ((HazelcastRelOptCluster) getCluster()).getParameterMetadata();
         RexVisitor<Expression<?>> visitor = createRexToExpressionVisitor(schema(parameterMetadata), parameterMetadata);
         return wmField.accept(visitor);
-    }
-
-    public ToLongFunctionEx<ExpressionEvalContext> allowedLagProvider() {
-        return allowedLagProvider;
     }
 
     @Override
@@ -78,7 +69,7 @@ public class DropLateItemsPhysicalRel extends SingleRel implements PhysicalRel {
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new DropLateItemsPhysicalRel(getCluster(), traitSet, sole(inputs), wmField, allowedLagProvider);
+        return new DropLateItemsPhysicalRel(getCluster(), traitSet, sole(inputs), wmField);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DropLateItemsPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DropLateItemsPhysicalRule.java
@@ -46,8 +46,7 @@ public final class DropLateItemsPhysicalRule extends ConverterRule {
                 rel.getCluster(),
                 OptUtils.toPhysicalConvention(logicalRel.getTraitSet()),
                 OptUtils.toPhysicalInput(logicalRel.getInput()),
-                logicalRel.wmField(),
-                logicalRel.allowedLagProvider()
+                logicalRel.wmField()
         );
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlImposeOrderFunctionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlImposeOrderFunctionTest.java
@@ -268,18 +268,18 @@ public class SqlImposeOrderFunctionTest extends SqlTestSupport {
     public void test_lateItemsDropping() {
         String name = createTable(
                 row(timestampTz(28), "Alice"),
-                row(timestampTz(29), "Bob"),
+                row(timestampTz(27), "Bob"),
                 row(timestampTz(30), "Caitlyn"),
                 row(timestampTz(30), "Dorian"),
                 row(timestampTz(31), "Elijah"),
-                row(timestampTz(5), "Zedd")
+                row(timestampTz(29), "Zedd")
         );
 
         assertRowsEventuallyInAnyOrder(
                 "SELECT * FROM TABLE(IMPOSE_ORDER(TABLE " + name + ", DESCRIPTOR(ts), INTERVAL '0.001' SECONDS))",
                 asList(
                         new Row(timestampTz(28), "Alice"),
-                        new Row(timestampTz(29), "Bob"),
+                        new Row(timestampTz(27), "Bob"),
                         new Row(timestampTz(30), "Caitlyn"),
                         new Row(timestampTz(30), "Dorian"),
                         new Row(timestampTz(31), "Elijah")

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/LateItemsDropPTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/LateItemsDropPTest.java
@@ -50,7 +50,7 @@ public class LateItemsDropPTest extends SqlTestSupport {
 
     @Test
     public void when_noEventIsLate_then_successful() {
-        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx, c -> 0L);
+        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx);
 
         TestSupport.verifyProcessor(adaptSupplier(ProcessorSupplier.of(supplier)))
                 .hazelcastInstance(instance())
@@ -75,7 +75,7 @@ public class LateItemsDropPTest extends SqlTestSupport {
 
     @Test
     public void when_oneEventIsLate_then_dropEvent() {
-        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx, c -> 0L);
+        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx);
 
         TestSupport.verifyProcessor(adaptSupplier(ProcessorSupplier.of(supplier)))
                 .hazelcastInstance(instance())
@@ -99,7 +99,7 @@ public class LateItemsDropPTest extends SqlTestSupport {
 
     @Test
     public void when_fewEventsAreLate_then_dropEvents() {
-        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx, c -> 0L);
+        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx);
 
         TestSupport.verifyProcessor(adaptSupplier(ProcessorSupplier.of(supplier)))
                 .hazelcastInstance(instance())
@@ -121,31 +121,6 @@ public class LateItemsDropPTest extends SqlTestSupport {
                         jetRow(1L, 2L),
                         wm(3L),
                         wm(5L)
-                ));
-    }
-
-    @Test
-    public void when_oneEventIsLateWithAllowedLag_then_doNotDropEvent() {
-        SupplierEx<Processor> supplier = () -> new LateItemsDropP(timestampEx, c -> 2L);
-
-        TestSupport.verifyProcessor(adaptSupplier(ProcessorSupplier.of(supplier)))
-                .hazelcastInstance(instance())
-                .jobConfig(new JobConfig().setArgument(SQL_ARGUMENTS_KEY_NAME, emptyList()))
-                .outputChecker(SqlTestSupport::compareRowLists)
-                .disableSnapshots()
-                .input(asList(
-                        wm(0L),
-                        jetRow(0L, 1L),
-                        jetRow(1L, 2L),
-                        wm(3L),
-                        jetRow(2L, 3L)
-                ))
-                .expectOutput(asList(
-                        wm(0L),
-                        jetRow(0L, 1L),
-                        jetRow(1L, 2L),
-                        wm(3L),
-                        jetRow(2L, 3L)
                 ));
     }
 }


### PR DESCRIPTION
The watermark is already lagged, we don't need to add the lag again.