### PR TITLE
Update postgresql driver to 42.2.25 [HZ-1050]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -724,7 +724,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1684,6 +1684,11 @@
                 <version>${mysql.connector.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.2.25</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.htrace</groupId>
                 <artifactId>htrace-core4</artifactId>
                 <version>4.2.0-incubating.hazelcast-2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <osgi.version>4.2.0</osgi.version>
         <parquet.version>1.12.2</parquet.version>
         <picocli.version>4.4.0</picocli.version>
+        <postgresql.version>42.2.25</postgresql.version>
         <prometheus.version>0.14.0</prometheus.version>
         <protobuf.version>3.19.4</protobuf.version>
         <scala.version>2.13</scala.version>
@@ -1686,7 +1687,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.25</version>
+                <version>${postgresql.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.htrace</groupId>


### PR DESCRIPTION
Fixes #21124

Backports will be sent for 5.1.z and 5.0.z.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
