### PR TITLE
Use google-http-client-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1542,6 +1542,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client-bom</artifactId>
+                <version>1.41.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -1704,11 +1711,6 @@
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value-annotations</artifactId>
                 <version>1.7.4</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.http-client</groupId>
-                <artifactId>google-http-client</artifactId>
-                <version>1.36.0</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1808,11 +1808,6 @@
               <version>2.0.48.Final</version>
             </dependency>
             <dependency>
-              <groupId>com.google.http-client</groupId>
-              <artifactId>google-http-client-jackson2</artifactId>
-              <version>1.40.1</version>
-            </dependency>
-            <dependency>
               <groupId>com.google.api-client</groupId>
               <artifactId>google-api-client</artifactId>
               <version>1.32.2</version>


### PR DESCRIPTION
Fixes a dependency conflict in hazelcast-jet-files-gcs.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
