### PR TITLE
Use google-http-client-bom [5.1.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1516,6 +1516,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client-bom</artifactId>
+                <version>1.41.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -1680,11 +1687,6 @@
                 <version>1.7.4</version>
             </dependency>
             <dependency>
-                <groupId>com.google.http-client</groupId>
-                <artifactId>google-http-client</artifactId>
-                <version>1.36.0</version>
-            </dependency>
-            <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>7.9</version>
@@ -1778,11 +1780,6 @@
               <groupId>io.netty</groupId>
               <artifactId>netty-tcnative-classes</artifactId>
               <version>2.0.48.Final</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.http-client</groupId>
-              <artifactId>google-http-client-jackson2</artifactId>
-              <version>1.40.1</version>
             </dependency>
             <dependency>
               <groupId>com.google.api-client</groupId>


### PR DESCRIPTION
Fixes a dependency conflict in hazelcast-jet-files-gcs.

Backport of #21131

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
