### PR TITLE
Removed leaking clients from OutOfMemoryErrorDispatcher in test code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -487,4 +487,8 @@ public final class HazelcastClient {
         }
         return instanceName;
     }
+
+    static ConcurrentMap<String, InstanceFuture<HazelcastClientProxy>> getClients() {
+        return CLIENTS;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/OutOfMemoryErrorDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/OutOfMemoryErrorDispatcher.java
@@ -219,4 +219,8 @@ public final class OutOfMemoryErrorDispatcher {
         }
     }
 
+    // Only used for testing purposes
+    public static AtomicReference<HazelcastInstance[]> getClientInstancesRef() {
+        return CLIENT_INSTANCES_REF;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 
 public class HazelcastClientUtil {
 
@@ -29,6 +30,15 @@ public class HazelcastClientUtil {
 
     public static String getInstanceName(ClientConfig config) {
         return HazelcastClient.getInstanceName(config, null);
+    }
+
+    public static void registerProxyFuture(String instanceName,
+                                           HazelcastInstanceFactory.InstanceFuture future) {
+        HazelcastClient.getClients().put(instanceName, future);
+    }
+
+    public static boolean hasRegisteredClientWithName(String instanceName) {
+        return HazelcastClient.getClients().containsKey(instanceName);
     }
 
     public static ClientMessage.Frame fastForwardToEndFrame(ClientMessage.ForwardFrameIterator iterator) {

--- a/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class TestHazelcastFactoryTest extends HazelcastTestSupport {
+
+    private HazelcastInstance server;
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Before
+    public void setUp() throws Exception {
+        server = factory.newHazelcastInstance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void no_leaking_client_after_shutdown() {
+        HazelcastInstance client = factory.newHazelcastClient();
+        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).client;
+
+        client.getLifecycleService().shutdown();
+
+        assertNoLeakingClient(clientInstanceImpl);
+    }
+
+    @Test
+    public void no_leaking_client_after_terminate() {
+        HazelcastInstance client = factory.newHazelcastClient();
+        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).client;
+
+        client.getLifecycleService().terminate();
+
+        assertNoLeakingClient(clientInstanceImpl);
+    }
+
+    @Test
+    public void no_leaking_client_after_shutdownAll() {
+        HazelcastInstance client1 = factory.newHazelcastClient();
+        HazelcastInstance client2 = factory.newHazelcastClient();
+        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).client;
+        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).client;
+
+        factory.shutdownAll();
+
+        assertNoLeakingClient(clientInstanceImpl1);
+        assertNoLeakingClient(clientInstanceImpl2);
+    }
+
+    @Test
+    public void no_leaking_client_after_terminateAll() {
+        HazelcastInstance client1 = factory.newHazelcastClient();
+        HazelcastInstance client2 = factory.newHazelcastClient();
+        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).client;
+        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).client;
+
+        factory.terminateAll();
+
+        assertNoLeakingClient(clientInstanceImpl1);
+        assertNoLeakingClient(clientInstanceImpl2);
+    }
+
+    /**
+     * Check if we removed all client object related
+     * references from {@link OutOfMemoryErrorDispatcher}
+     * and {@link HazelcastClient} internal client registry.
+     */
+    private static void assertNoLeakingClient(HazelcastClientInstanceImpl clientInstanceImpl) {
+        String instanceName = clientInstanceImpl.getName();
+        HazelcastInstance[] registeredClients = OutOfMemoryErrorDispatcher.getClientInstancesRef().get();
+        for (HazelcastInstance registeredClient : registeredClients) {
+            assertTrue("We expect no registered ref for the clientInstanceImpl",
+                    clientInstanceImpl != registeredClient);
+        }
+
+        assertFalse(HazelcastClientUtil.hasRegisteredClientWithName(instanceName));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheClearTest;
 import com.hazelcast.cache.ICache;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
@@ -184,11 +183,11 @@ public class ClientCacheClearTest extends CacheClearTest {
 
     @Override
     protected void onTearDown() {
-        super.onTearDown();
+        clientFactory.shutdownAll();
         // Client factory is already shutdown at this test's super class (`CachePutAllTest`)
         // because it is returned instance factory from overridden `getInstanceFactory` method.
         client = null;
-        HazelcastClient.shutdownAll();
+        super.onTearDown();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheContextTest;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -48,7 +47,7 @@ public class ClientCacheContextTest extends CacheContextTest {
 
     @After
     public void tearDown() {
-        HazelcastClient.shutdownAll();
+        factory.shutdownAll();
         driverInstance.shutdown();
         hazelcastInstance1.shutdown();
         hazelcastInstance2.shutdown();

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheEventJournalBasicTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.impl.journal.CacheEventJournalBasicTest;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
@@ -63,6 +62,5 @@ public class ClientCacheEventJournalBasicTest extends CacheEventJournalBasicTest
         if (factory != null) {
             factory.terminateAll();
         }
-        HazelcastClient.shutdownAll();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheIteratorAbstractTest;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
@@ -50,7 +49,5 @@ public class ClientCacheIteratorTest extends CacheIteratorAbstractTest {
     @After
     public void tear() {
         factory.shutdownAll();
-        HazelcastClient.shutdownAll();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.cache;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
@@ -42,11 +41,5 @@ public class ClientCachePartitionIteratorTest extends AbstractClientCachePartiti
 
         HazelcastInstance client = factory.newHazelcastClient();
         cachingProvider = createClientCachingProvider(client);
-    }
-
-    @Override
-    public void teardown() {
-        super.teardown();
-        HazelcastClient.shutdownAll();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCachePutAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCachePutAllTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CachePutAllTest;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
@@ -57,10 +56,10 @@ public class ClientCachePutAllTest extends CachePutAllTest {
     @Override
     protected void onTearDown() {
         super.onTearDown();
+        clientFactory.shutdownAll();
         // Client factory is already shutdown at this test's super class (`CachePutAllTest`)
         // because it is returned instance factory from overridden `getInstanceFactory` method.
         client = null;
-        HazelcastClient.shutdownAll();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheReadWriteThroughTest;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -86,7 +85,6 @@ public class ClientCacheReadWriteThroughTest extends CacheReadWriteThroughTest {
     @Override
     protected void onTearDown() {
         serverCachingProvider.close();
-        HazelcastClient.shutdownAll();
     }
 
     // https://github.com/hazelcast/hazelcast/issues/6676

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.test;
 
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils;
@@ -30,6 +31,7 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -88,7 +90,8 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
             if (tccl == ClassLoader.getSystemClassLoader()) {
                 currentThread.setContextClassLoader(HazelcastClient.class.getClassLoader());
             }
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(getInstanceName(config), config,
+            String instanceName = getInstanceName(config);
+            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(instanceName, config,
                     null, clientRegistry.createClientServiceFactory(sourceIp), createAddressProvider(config));
             registerJvmNameAndPidMetric(client);
             client.start();
@@ -97,8 +100,13 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
                         + "' already exists!");
             }
 
+            HazelcastInstanceFactory.InstanceFuture future = new HazelcastInstanceFactory.InstanceFuture<>();
+            HazelcastClientUtil.registerProxyFuture(instanceName, future);
+
             OutOfMemoryErrorDispatcher.registerClient(client);
-            return new HazelcastClientProxy(client);
+            HazelcastClientProxy proxy = new HazelcastClientProxy(client);
+            future.set(proxy);
+            return proxy;
         } finally {
             currentThread.setContextClassLoader(tccl);
         }

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -920,14 +920,14 @@ public class SinksTest extends PipelineTestSupport {
     @Test
     public void remoteReliableTopicSinkClosesClient() {
         // Check we are in a clean state
-        assertThat(HazelcastClient.getAllHazelcastClients()).hasSize(0);
+        assertThat(HazelcastClient.getAllHazelcastClients()).hasSize(1);
 
         // When
         Sink<Object> sink = Sinks.remoteReliableTopic(sinkName, clientConfig);
         p.readFrom(Sources.list(srcName)).writeTo(sink);
         execute();
 
-        assertThat(HazelcastClient.getAllHazelcastClients()).hasSize(0);
+        assertThat(HazelcastClient.getAllHazelcastClients()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
came across during investigations of https://github.com/hazelcast/hazelcast/issues/17460

**Issue:**
Client instances were leaking. After shutdown they were still in OutOfMemoryErrorDispatcher.

**Modifications:**
- Registered test-client-instance to global `HazelcastClient.CLIENT` registry, before this was not inline with production code. This results removal of leaking clients from `OutOfMemoryErrorDispatcher` on TestHazelcastFactory shutdown/terminate calls.
- Fixed tests accordingly