### PR TITLE
Call lifecycleListener method in finally block for MockServerConnection#close

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -179,16 +179,18 @@ public class MockServerConnection implements ServerConnection {
     }
 
     public void close(String msg, Throwable cause) {
-        if (!alive.compareAndSet(true, false)) {
-            return;
-        }
+        try {
+            if (!alive.compareAndSet(true, false)) {
+                return;
+            }
 
-        if (otherConnection != null) {
-            otherConnection.close(msg, cause);
-        }
-
-        if (lifecycleListener != null) {
-            lifecycleListener.onConnectionClose(this, cause, false);
+            if (otherConnection != null) {
+                otherConnection.close(msg, cause);
+            }
+        } finally {
+            if (lifecycleListener != null) {
+                lifecycleListener.onConnectionClose(this, cause, false);
+            }
         }
     }
 


### PR DESCRIPTION
came across during investigations of https://github.com/hazelcast/hazelcast/issues/17460

**Issue:**
`MockServerConnection#close` is not calling `lifecycleListener.onConnectionClose`.
 Due to the mutual refs between `MockServerConnection` and its `otherConnection` field.
 Closing one of them triggers close of another recursively. And this call chain finishes without calling lifecycleListener method. This problem makes itself visible as a `MockServerConnection` leak in `server.connectionMap`.
 
**Fix:**
Put lifecycleListener call in finally block.