### PR TITLE
[HZ-1013] Fix hanging cluster safe query from common pool

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
@@ -34,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 import static com.hazelcast.internal.partition.IPartitionService.SERVICE_NAME;
@@ -119,11 +121,13 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
 
         OperationService operationService = nodeEngine.getOperationService();
         if (hasCallback) {
+            ExecutorService asyncExecutor =
+                    nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
             operationService.createInvocationBuilder(SERVICE_NAME, op, target.address())
                     .setTryCount(OPERATION_TRY_COUNT)
                     .setTryPauseMillis(OPERATION_TRY_PAUSE_MILLIS)
                     .invoke()
-                    .whenCompleteAsync(callback);
+                    .whenCompleteAsync(callback, asyncExecutor);
         } else {
             operationService.send(op, target.address());
         }


### PR DESCRIPTION
When all `FJP#commonPool` threads are busy querying `isClusterSafe`
(eg seems this can be the case when querying via PartitionService MBean)
and partition assignments are not in sync (eg during initial
partition arrangement), then there is no chance for an important
callback to be executed after `PartitionBackupReplicaAntiEntropyOperation`
is done, resulting in neither partition replica sync nor cluster-safe
query being able to make any progress.
The fix is to use the Hazelcast internal async executor (instead of
the common pool) for the callback that processes replica anti-entropy
operation result.

Fixes #19672 
Fixes #18286
Fixes #19665 

Checklist:
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases


edit: see also https://github.com/hazelcast/hazelcast/issues/19672#issuecomment-1087460444 on how this issue might occur