### PR TITLE
Unify creation of JetException when job fails HZ-1041

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -55,6 +55,7 @@ import com.hazelcast.jet.impl.operation.GetJobIdsOperation.GetJobIdsResult;
 import com.hazelcast.jet.impl.operation.NotifyMemberShutdownOperation;
 import com.hazelcast.jet.impl.pipeline.PipelineImpl;
 import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.impl.util.LoggingUtil;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
@@ -445,7 +446,7 @@ public class JobCoordinationService {
                             if (t instanceof CancellationException || t instanceof JetException) {
                                 throw sneakyThrow(t);
                             }
-                            throw new JetException(t.toString());
+                            throw new JetException(ExceptionUtil.stackTraceToString(t));
                         }),
                 JobResult::asCompletableFuture,
                 jobRecord -> {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -445,7 +445,7 @@ public class JobCoordinationService {
                             if (t instanceof CancellationException || t instanceof JetException) {
                                 throw sneakyThrow(t);
                             }
-                            throw new JetException(t.toString(), t);
+                            throw new JetException(t.toString());
                         }),
                 JobResult::asCompletableFuture,
                 jobRecord -> {


### PR DESCRIPTION
Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/4418

Depending on which member hits the exception first:
- if it's the master member it will send the correct exception to the client waiting for the job completion future
- but if it's the other member it will store the exception text into the job result - master later picks it up and sends to the client

This PR unify creation of JetException for failing jobs by removing the cause from the exception and leaving only the message

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/4926