### PR TITLE
Lower heap memory footprint in MapIndexScanP

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -39,6 +39,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.getters.GetterCache;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -127,7 +128,9 @@ final class MapIndexScanP extends AbstractProcessor {
                 metadata.getValueDescriptor(),
                 metadata.getFieldPaths(),
                 metadata.getFieldTypes(),
-                Extractors.newBuilder(evalContext.getSerializationService()).build(),
+                Extractors.newBuilder(evalContext.getSerializationService())
+                        .setGetterCacheType(GetterCache.Type.NOT_EVICTABLE)
+                        .build(),
                 evalContext.getSerializationService()
         );
         isIndexSorted = metadata.getComparator() != null;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -39,7 +39,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.query.impl.getters.GetterCache;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -65,6 +64,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.impl.util.Util.getNodeEngine;
+import static com.hazelcast.query.impl.getters.GetterCache.NOT_EVICTABLE_GETTER_CACHE_SUPPLIER;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static java.util.Collections.emptyList;
@@ -129,7 +129,7 @@ final class MapIndexScanP extends AbstractProcessor {
                 metadata.getFieldPaths(),
                 metadata.getFieldTypes(),
                 Extractors.newBuilder(evalContext.getSerializationService())
-                        .setGetterCacheType(GetterCache.Type.NOT_EVICTABLE)
+                        .setGetterCacheSupplier(NOT_EVICTABLE_GETTER_CACHE_SUPPLIER)
                         .build(),
                 evalContext.getSerializationService()
         );

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -64,7 +64,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.impl.util.Util.getNodeEngine;
-import static com.hazelcast.query.impl.getters.GetterCache.NOT_EVICTABLE_GETTER_CACHE_SUPPLIER;
+import static com.hazelcast.query.impl.getters.GetterCache.SIMPLE_GETTER_CACHE_SUPPLIER;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static java.util.Collections.emptyList;
@@ -129,7 +129,7 @@ final class MapIndexScanP extends AbstractProcessor {
                 metadata.getFieldPaths(),
                 metadata.getFieldTypes(),
                 Extractors.newBuilder(evalContext.getSerializationService())
-                        .setGetterCacheSupplier(NOT_EVICTABLE_GETTER_CACHE_SUPPLIER)
+                        .setGetterCacheSupplier(SIMPLE_GETTER_CACHE_SUPPLIER)
                         .build(),
                 evalContext.getSerializationService()
         );

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/EvictableGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/EvictableGetterCache.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 
-class EvictableGetterCache {
+class EvictableGetterCache implements GetterCache {
 
     private final SampleableConcurrentHashMap<Class, SampleableConcurrentHashMap<String, Getter>> getterCache;
     private final ConstructorFunction<Class, SampleableConcurrentHashMap<String, Getter>> getterCacheConstructor;
@@ -53,7 +53,8 @@ class EvictableGetterCache {
     }
 
     @Nullable
-    Getter getGetter(Class clazz, String attributeName) {
+    @Override
+    public Getter getGetter(Class clazz, String attributeName) {
         ConcurrentMap<String, Getter> cache = getterCache.get(clazz);
         if (cache == null) {
             return null;
@@ -61,7 +62,8 @@ class EvictableGetterCache {
         return cache.get(attributeName);
     }
 
-    Getter putGetter(Class clazz, String attributeName, Getter getter) {
+    @Override
+    public Getter putGetter(Class clazz, String attributeName, Getter getter) {
         SampleableConcurrentHashMap<String, Getter> cache = getOrPutIfAbsent(getterCache, clazz, getterCacheConstructor);
         Getter foundGetter = cache.putIfAbsent(attributeName, getter);
         evictOnPut(cache);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -45,6 +45,8 @@ public final class Extractors {
     private static final int MAX_GETTERS_PER_CLASS_IN_CACHE = 100;
     private static final float EVICTION_PERCENTAGE = 0.2f;
 
+    final GetterCache getterCache;
+
     private volatile PortableGetter portableGetter;
     private volatile JsonDataGetter jsonDataGetter;
     private volatile CompactGetter compactGetter;
@@ -57,7 +59,6 @@ public final class Extractors {
     private final Map<String, ValueExtractor> extractors;
     private final InternalSerializationService ss;
     private final DefaultArgumentParser argumentsParser;
-    final GetterCache getterCache;
 
     private Extractors(
             List<AttributeConfig> attributeConfigs,

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -56,8 +56,8 @@ public final class Extractors {
      */
     private final Map<String, ValueExtractor> extractors;
     private final InternalSerializationService ss;
-    private final GetterCache getterCache;
     private final DefaultArgumentParser argumentsParser;
+    final GetterCache getterCache;
 
     private Extractors(
             List<AttributeConfig> attributeConfigs,

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -55,16 +55,31 @@ public final class Extractors {
      */
     private final Map<String, ValueExtractor> extractors;
     private final InternalSerializationService ss;
-    private final EvictableGetterCache getterCache;
+    private final GetterCache getterCache;
     private final DefaultArgumentParser argumentsParser;
 
-    private Extractors(List<AttributeConfig> attributeConfigs,
-                       ClassLoader classLoader, InternalSerializationService ss) {
+    private Extractors(
+            List<AttributeConfig> attributeConfigs,
+            ClassLoader classLoader,
+            InternalSerializationService ss,
+            GetterCache.Type getterCacheType
+    ) {
         this.extractors = attributeConfigs == null
                 ? Collections.<String, ValueExtractor>emptyMap()
                 : instantiateExtractors(attributeConfigs, classLoader);
-        this.getterCache = new EvictableGetterCache(MAX_CLASSES_IN_CACHE,
-                MAX_GETTERS_PER_CLASS_IN_CACHE, EVICTION_PERCENTAGE, false);
+
+        switch (getterCacheType) {
+            case EVICTABLE:
+                this.getterCache = new EvictableGetterCache(MAX_CLASSES_IN_CACHE,
+                        MAX_GETTERS_PER_CLASS_IN_CACHE, EVICTION_PERCENTAGE, false);
+                break;
+            case NOT_EVICTABLE:
+                this.getterCache = new NotEvictableGetterCache();
+                break;
+            default:
+                throw new IllegalStateException("Unsupported getter cache type");
+        }
+
         this.argumentsParser = new DefaultArgumentParser();
         this.ss = ss;
     }
@@ -194,11 +209,17 @@ public final class Extractors {
     public static final class Builder {
         private ClassLoader classLoader;
         private List<AttributeConfig> attributeConfigs;
+        private GetterCache.Type getterCacheType = GetterCache.Type.EVICTABLE;
 
         private final InternalSerializationService ss;
 
         public Builder(InternalSerializationService ss) {
             this.ss = Preconditions.checkNotNull(ss);
+        }
+
+        public Builder setGetterCacheType(GetterCache.Type getterCacheType) {
+            this.getterCacheType = getterCacheType;
+            return this;
         }
 
         public Builder setAttributeConfigs(List<AttributeConfig> attributeConfigs) {
@@ -215,7 +236,7 @@ public final class Extractors {
          * @return a new instance of Extractors
          */
         public Extractors build() {
-            return new Extractors(attributeConfigs, classLoader, ss);
+            return new Extractors(attributeConfigs, classLoader, ss, getterCacheType);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
@@ -1,15 +1,40 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl.getters;
 
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
+@SuppressWarnings("rawtypes")
 public interface GetterCache {
+    int EVICTABLE_CACHE_MAX_CLASSES_IN_CACHE = 1000;
+    int EVICTABLE_CACHE_MAX_GETTERS_PER_CLASS_IN_CACHE = 100;
+    float EVICTABLE_CACHE_EVICTION_PERCENTAGE = 0.2f;
+
+    Supplier<GetterCache> EVICTABLE_GETTER_CACHE_SUPPLIER = () -> new EvictableGetterCache(
+            EVICTABLE_CACHE_MAX_CLASSES_IN_CACHE,
+            EVICTABLE_CACHE_MAX_GETTERS_PER_CLASS_IN_CACHE,
+            EVICTABLE_CACHE_EVICTION_PERCENTAGE,
+            false
+    );
+    Supplier<GetterCache> NOT_EVICTABLE_GETTER_CACHE_SUPPLIER = NotEvictableGetterCache::new;
+
     @Nullable
     Getter getGetter(Class clazz, String attributeName);
 
     Getter putGetter(Class clazz, String attributeName, Getter getter);
-
-    enum Type {
-        EVICTABLE,
-        NOT_EVICTABLE,
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
@@ -30,7 +30,7 @@ public interface GetterCache {
             EVICTABLE_CACHE_EVICTION_PERCENTAGE,
             false
     );
-    Supplier<GetterCache> NOT_EVICTABLE_GETTER_CACHE_SUPPLIER = NotEvictableGetterCache::new;
+    Supplier<GetterCache> SIMPLE_GETTER_CACHE_SUPPLIER = SimpleGetterCache::new;
 
     @Nullable
     Getter getGetter(Class<?> clazz, String attributeName);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
@@ -19,7 +19,6 @@ package com.hazelcast.query.impl.getters;
 import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
-@SuppressWarnings("rawtypes")
 public interface GetterCache {
     int EVICTABLE_CACHE_MAX_CLASSES_IN_CACHE = 1000;
     int EVICTABLE_CACHE_MAX_GETTERS_PER_CLASS_IN_CACHE = 100;
@@ -34,7 +33,7 @@ public interface GetterCache {
     Supplier<GetterCache> NOT_EVICTABLE_GETTER_CACHE_SUPPLIER = NotEvictableGetterCache::new;
 
     @Nullable
-    Getter getGetter(Class clazz, String attributeName);
+    Getter getGetter(Class<?> clazz, String attributeName);
 
-    Getter putGetter(Class clazz, String attributeName, Getter getter);
+    Getter putGetter(Class<?> clazz, String attributeName, Getter getter);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterCache.java
@@ -1,0 +1,15 @@
+package com.hazelcast.query.impl.getters;
+
+import javax.annotation.Nullable;
+
+public interface GetterCache {
+    @Nullable
+    Getter getGetter(Class clazz, String attributeName);
+
+    Getter putGetter(Class clazz, String attributeName, Getter getter);
+
+    enum Type {
+        EVICTABLE,
+        NOT_EVICTABLE,
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NotEvictableGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NotEvictableGetterCache.java
@@ -23,13 +23,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 @NotThreadSafe
-@SuppressWarnings("rawtypes")
 class NotEvictableGetterCache implements GetterCache {
-    private final Map<Class, Map<String, Getter>> cache = new HashMap<>();
+    private final Map<Class<?>, Map<String, Getter>> cache = new HashMap<>();
 
     @Nullable
     @Override
-    public Getter getGetter(Class clazz, String attributeName) {
+    public Getter getGetter(Class<?> clazz, String attributeName) {
         Map<String, Getter> getterMapForClass = cache.get(clazz);
         if (getterMapForClass == null) {
             return null;
@@ -38,7 +37,7 @@ class NotEvictableGetterCache implements GetterCache {
     }
 
     @Override
-    public Getter putGetter(Class clazz, String attributeName, Getter getter) {
+    public Getter putGetter(Class<?> clazz, String attributeName, Getter getter) {
         return cache.computeIfAbsent(clazz, aClass -> new HashMap<>()).putIfAbsent(attributeName, getter);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NotEvictableGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NotEvictableGetterCache.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.HashMap;
+import java.util.Map;
+
+@NotThreadSafe
+@SuppressWarnings("rawtypes")
+class NotEvictableGetterCache implements GetterCache {
+    private final Map<Class, Map<String, Getter>> cache = new HashMap<>();
+
+    @Nullable
+    @Override
+    public Getter getGetter(Class clazz, String attributeName) {
+        Map<String, Getter> getterMapForClass = cache.get(clazz);
+        if (getterMapForClass == null) {
+            return null;
+        }
+        return getterMapForClass.get(attributeName);
+    }
+
+    @Override
+    public Getter putGetter(Class clazz, String attributeName, Getter getter) {
+        return cache.computeIfAbsent(clazz, aClass -> new HashMap<>()).putIfAbsent(attributeName, getter);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NotEvictableGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NotEvictableGetterCache.java
@@ -16,8 +16,7 @@
 
 package com.hazelcast.query.impl.getters;
 
-import org.jetbrains.annotations.Nullable;
-
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/SimpleGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/SimpleGetterCache.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @NotThreadSafe
-class NotEvictableGetterCache implements GetterCache {
+class SimpleGetterCache implements GetterCache {
     private final Map<Class<?>, Map<String, Getter>> cache = new HashMap<>();
 
     @Nullable

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/EvictableGetterCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/EvictableGetterCacheTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
 public class EvictableGetterCacheTest {
 
     @Test
-    public void get_put_correctResult() {
+    public void when_getAndPut_then_correctResult() {
         // GIVEN
         EvictableGetterCache cache = new EvictableGetterCache(10, 10, 0.5f, true);
         Getter x = mock(Getter.class);
@@ -51,7 +51,7 @@ public class EvictableGetterCacheTest {
     }
 
     @Test
-    public void get_put_correctSize() {
+    public void when_getAndPut_then_correctSize() {
         // GIVEN
         EvictableGetterCache cache = new EvictableGetterCache(10, 10, 0.5f, true);
         Getter x = mock(Getter.class);
@@ -68,7 +68,7 @@ public class EvictableGetterCacheTest {
     }
 
     @Test
-    public void getterCache_evictLimitNotReached_noEviction() {
+    public void when_getterCacheEvictLimitNotReached_then_noEviction() {
         // GIVEN
         int getterCacheSize = 10;
         float evictPercentage = 0.3f;
@@ -85,7 +85,7 @@ public class EvictableGetterCacheTest {
     }
 
     @Test
-    public void getterCache_evictLimitReached_evictionTriggered() {
+    public void when_getterCacheEvictLimitReached_then_evictionTriggered() {
         // GIVEN
         int getterCacheSize = 10;
         float evictPercentage = 0.3f;
@@ -103,12 +103,12 @@ public class EvictableGetterCacheTest {
     }
 
     @Test
-    public void classCache_evictLimitNotReached_noEviction() {
+    public void when_classCacheEvictLimitNotReached_then_noEviction() {
         // GIVEN
         int classCacheSize = 10;
         float evictPercentage = 0.3f;
         EvictableGetterCache cache = new EvictableGetterCache(classCacheSize, 10, evictPercentage, true);
-        Class[] classes = {
+        Class<?>[] classes = {
                 String.class, Character.class, Integer.class, Double.class, Byte.class, Long.class,
                 Number.class, Float.class, BigDecimal.class, BigInteger.class,
         };
@@ -123,12 +123,12 @@ public class EvictableGetterCacheTest {
     }
 
     @Test
-    public void classCache_evictLimitReached_evictionTriggered() {
+    public void when_classCacheEvictLimitReached_then_evictionTriggered() {
         // GIVEN
         int classCacheSize = 10;
         float evictPercentage = 0.3f;
         EvictableGetterCache cache = new EvictableGetterCache(classCacheSize, 10, evictPercentage, true);
-        Class[] classes = {
+        Class<?>[] classes = {
                 String.class, Character.class, Integer.class, Double.class, Byte.class, Long.class,
                 Number.class, Float.class, BigDecimal.class, BigInteger.class,
         };

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -34,7 +34,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
-import static com.hazelcast.query.impl.getters.GetterCache.NOT_EVICTABLE_GETTER_CACHE_SUPPLIER;
+import static com.hazelcast.query.impl.getters.GetterCache.SIMPLE_GETTER_CACHE_SUPPLIER;
 import static com.hazelcast.test.HazelcastTestSupport.assertInstanceOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -153,9 +153,9 @@ public class ExtractorsTest {
     }
 
     @Test
-    public void when_creatingWithBuilderWithNotEvictableCache_then_notEvictableCacheIsUsed() {
-        Extractors extractors = Extractors.newBuilder(ss).setGetterCacheSupplier(NOT_EVICTABLE_GETTER_CACHE_SUPPLIER).build();
-        assertInstanceOf(NotEvictableGetterCache.class, extractors.getterCache);
+    public void when_creatingWithBuilderWithSimpleGetterCache_then_simpleGetterCacheIsUsed() {
+        Extractors extractors = Extractors.newBuilder(ss).setGetterCacheSupplier(SIMPLE_GETTER_CACHE_SUPPLIER).build();
+        assertInstanceOf(SimpleGetterCache.class, extractors.getterCache);
     }
 
     private Extractors createExtractors(AttributeConfig config) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -34,6 +34,8 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
+import static com.hazelcast.query.impl.getters.GetterCache.NOT_EVICTABLE_GETTER_CACHE_SUPPLIER;
+import static com.hazelcast.test.HazelcastTestSupport.assertInstanceOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,7 +72,7 @@ public class ExtractorsTest {
     }
 
     @Test
-    public void getGetter_reflection_cachingWorks() {
+    public void when_getGetterByReflection_then_getterInCache() {
         // GIVEN
         Extractors extractors = createExtractors(null);
 
@@ -84,7 +86,7 @@ public class ExtractorsTest {
     }
 
     @Test
-    public void extract_reflection_correctValue() {
+    public void when_extractByReflection_then_correctValue() {
         // WHEN
         Object power = createExtractors(null).extract(bond, "car.power", null);
 
@@ -93,7 +95,7 @@ public class ExtractorsTest {
     }
 
     @Test
-    public void getGetter_extractor_cachingWorks() {
+    public void when_getGetterExtractor_then_getterInCacheWithProperType() {
         // GIVEN
         AttributeConfig config
                 = new AttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
@@ -108,19 +110,8 @@ public class ExtractorsTest {
         assertThat(getterFirstInvocation, instanceOf(ExtractorGetter.class));
     }
 
-    protected Extractors createExtractors(AttributeConfig config) {
-        Extractors.Builder builder = Extractors.newBuilder(ss);
-        if (config != null) {
-            builder.setAttributeConfigs(singletonList(config));
-        }
-        if (useClassloader) {
-            builder.setClassLoader(this.getClass().getClassLoader());
-        }
-        return builder.build();
-    }
-
     @Test
-    public void extract_extractor_correctValue() {
+    public void when_extractExtractor_then_correctValue() {
         // GIVEN
         AttributeConfig config
                 = new AttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
@@ -134,7 +125,7 @@ public class ExtractorsTest {
     }
 
     @Test
-    public void extract_nullTarget() {
+    public void when_extractWithNullTarget_then_nullValue() {
         // WHEN
         Object power = createExtractors(null).extract(null, "gimmePower", null);
 
@@ -143,7 +134,7 @@ public class ExtractorsTest {
     }
 
     @Test
-    public void extract_nullAll() {
+    public void when_extractWithNullParams_then_nullValue() {
         // WHEN
         Object power = createExtractors(null).extract(null, null, null);
 
@@ -152,8 +143,30 @@ public class ExtractorsTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void extract_nullAttribute() {
+    public void when_extractWithNullAttributeWithNotNullTarget_then_fail() {
         createExtractors(null).extract(bond, null, null);
+    }
+
+    @Test
+    public void when_creatingWithBuilder_then_evictableCacheIsUsed() {
+        assertInstanceOf(EvictableGetterCache.class, Extractors.newBuilder(ss).build().getterCache);
+    }
+
+    @Test
+    public void when_creatingWithBuilderWithNotEvictableCache_then_notEvictableCacheIsUsed() {
+        Extractors extractors = Extractors.newBuilder(ss).setGetterCacheSupplier(NOT_EVICTABLE_GETTER_CACHE_SUPPLIER).build();
+        assertInstanceOf(NotEvictableGetterCache.class, extractors.getterCache);
+    }
+
+    private Extractors createExtractors(AttributeConfig config) {
+        Extractors.Builder builder = Extractors.newBuilder(ss);
+        if (config != null) {
+            builder.setAttributeConfigs(singletonList(config));
+        }
+        if (useClassloader) {
+            builder.setClassLoader(this.getClass().getClassLoader());
+        }
+        return builder.build();
     }
 
     private static class Bond {


### PR DESCRIPTION
During benchmark of fetching single entry by index I've found that creating ```MapIndexScanP``` creates large objects on heap. The cache that creates those objects doesn't need to be evictable in ```MapIndexScanP```, not need to be thread-safe. 

Since that allocation occurs also outside TLAB that PR may speed up a bit that benchmark.

![image](https://user-images.githubusercontent.com/57556371/161919051-b19cc8c4-97aa-42a3-903d-1fb1c2e4b311.png)

![image](https://user-images.githubusercontent.com/57556371/161918785-6cc96466-5863-45e3-8721-5cb580217ac0.png)

![image](https://user-images.githubusercontent.com/57556371/161918831-3619cade-f89d-40f3-a68f-c0df858992b8.png)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
