### PR TITLE
Fix for inefficient usage of replaceAll.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -531,4 +531,21 @@ public final class StringUtil {
         }
         return s.substring(maxLength - 1) + '…';
     }
+
+    /**
+     * Removes all occurrence of characters from the string.
+     */
+    public static String removeCharacter(String str, char charToRemove) {
+        if (str == null || str.indexOf(charToRemove) == -1) {
+            return str;
+        }
+        char[] chars = str.toCharArray();
+        int pos = 0;
+        for (int i = 0; i < chars.length; i++) {
+            if (chars[i] != charToRemove) {
+                chars[pos++] = chars[i];
+            }
+        }
+        return new String(chars, 0, pos);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -533,7 +533,8 @@ public final class StringUtil {
     }
 
     /**
-     * Removes all occurrence of {@code charToRemove} from {@code str}.
+     * Removes all occurrence of {@code charToRemove} from {@code str}. This method is more efficient than
+     * {@link String#replaceAll(String, String)} which compiles a regex from the first parameter every invocation.
      */
     public static String removeCharacter(String str, char charToRemove) {
         if (str == null || str.indexOf(charToRemove) == -1) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -533,7 +533,7 @@ public final class StringUtil {
     }
 
     /**
-     * Removes all occurrence of characters from the string.
+     * Removes all occurrence of {@code charToRemove} from {@code str}.
      */
     public static String removeCharacter(String str, char charToRemove) {
         if (str == null || str.indexOf(charToRemove) == -1) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/Util.java
@@ -22,6 +22,7 @@ import com.hazelcast.cache.impl.journal.CacheEventJournalFunctions;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.map.impl.journal.MapEventJournalFunctions;
@@ -155,7 +156,7 @@ public final class Util {
         if (str == null || !ID_PATTERN.matcher(str).matches()) {
             return -1;
         }
-        str = str.replaceAll("-", "");
+        str = StringUtil.removeCharacter(str, '-');
         return Long.parseUnsignedLong(str, 16);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -234,6 +234,19 @@ public class StringUtilTest extends HazelcastTestSupport {
         assertFalse(isAnyNullOrEmptyAfterTrim("", "", null));
     }
 
+    @Test
+    public void when_removingCharactersFromString_then_properValue() {
+        assertEquals("", StringUtil.removeCharacter("-------", '-'));
+        assertEquals("-------", StringUtil.removeCharacter("-------", '0'));
+        assertEquals("-------", StringUtil.removeCharacter("-0-0-0-0-0-0-", '0'));
+        assertEquals("-------", StringUtil.removeCharacter("-00000-0-0000-0000-0-0-", '0'));
+    }
+
+    @Test
+    public void when_removingNotExistingCharactersFromString_then_sameInstanceIsReturned() {
+        assertTrue("-------" == StringUtil.removeCharacter("-------", '0'));
+    }
+
     private void assertResolvePlaceholder(String expected,
                                           String pattern,
                                           String placeholderNamespace,

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -244,7 +245,7 @@ public class StringUtilTest extends HazelcastTestSupport {
 
     @Test
     public void when_removingNotExistingCharactersFromString_then_sameInstanceIsReturned() {
-        assertTrue("-------" == StringUtil.removeCharacter("-------", '0'));
+        assertSame("-------", StringUtil.removeCharacter("-------", '0'));
     }
 
     private void assertResolvePlaceholder(String expected,


### PR DESCRIPTION
A small improvement in ```Util``` class that will cause lower heap consumption in metrics components. Found during 1 billion benchmark

![image](https://user-images.githubusercontent.com/57556371/162185506-caeb48f6-0a78-4f02-b609-34afa6ab1b4c.png)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
