### PR TITLE
[5.1.z] Add warning log to address set override in LocalAddressRegistry (#21165)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
@@ -119,11 +119,18 @@ public class LocalAddressRegistry {
                     linkedAddressesRegistrationCountPair = new Pair(linkedAddresses, new AtomicInteger(1));
                     // remove previous addresses from the addressToUuid map
                     previousAddresses.getAllAddresses().forEach(address -> addressToUuid.remove(address, uuid));
+                    logger.warning(previousAddresses + " previously registered for the instance uuid=" + instanceUuid
+                            + " are overridden by a new distinct set of addresses: " + linkedAddresses
+                            + ". We expect to see this log only when persistence is enabled"
+                            + " where a new member restarts with the same member uuid by picking up"
+                            + " different addresses for itself AND where some stale connections to the"
+                            + " old shutdown member having the same uuid, is not closed yet on this"
+                            + " member.");
                 }
             }
             linkedAddresses.getAllAddresses().forEach(address -> addressToUuid.put(address, instanceUuid));
-            if (logger.isFinestEnabled()) {
-                logger.finest(linkedAddresses + " registered for the instance uuid=" + instanceUuid
+            if (logger.isFineEnabled()) {
+                logger.fine(linkedAddresses + " registered for the instance uuid=" + instanceUuid
                         + " currently all registered addresses for this instance uuid: "
                         + linkedAddressesRegistrationCountPair.getAddresses());
             }


### PR DESCRIPTION
Also, changed the level of registration logs from TRACE to DEBUG.

Co-authored-by: Vassilis Bekiaris <vbekiaris@gmail.com>
(cherry picked from commit 0d1ebb28cf1e8f4ca4733bee71983538228f588d)

Backport of: #21165

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

