### PR TITLE
HazelcastServerCachingProvider created with `try-with-resource`

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/SpringHazelcastCachingProvider.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/SpringHazelcastCachingProvider.java
@@ -59,7 +59,11 @@ public final class SpringHazelcastCachingProvider {
         if (instance instanceof HazelcastClientProxy) {
             return new HazelcastClientCachingProvider(instance).getCacheManager(uri, null, props);
         } else {
-            return new HazelcastServerCachingProvider(instance).getCacheManager(uri, null, props);
+            try (HazelcastServerCachingProvider serverCachingProvider =  new HazelcastServerCachingProvider(instance)) {
+                return serverCachingProvider.getCacheManager(uri, null, props);
+            } catch (Exception exception) {
+                throw rethrow(exception);
+            }
         }
     }
 


### PR DESCRIPTION
HazelcastServerCachingProvider implements `AutoCloseable` so i created it with try-with-resource as descripted in [SonarCloud](https://sonarcloud.io/project/issues?fileUuids=AW9qkIoKkrN6v4yKaPtE&resolved=false&severities=BLOCKER&types=BUG&id=hz-os-master&open=AW9qkTM5krN6v4yKaSPR) 

Issue: https://github.com/hazelcast/hazelcast/issues/19691