### PR TITLE
Introduce on record create&update hooks [HZ-1007]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -666,4 +666,16 @@ public interface RecordStore<R extends Record> {
     default void afterOperation() {
         // no-op
     }
+
+    default void onRecordCreate(R record) {
+        // no-op
+    }
+
+    default void onRecordUpdate(R record) {
+        // no-op
+    }
+
+    default void onRecordStore(R record) {
+        // no-op
+    }
 }


### PR DESCRIPTION
ee: https://github.com/hazelcast/hazelcast-enterprise/pull/4934

Goal is to unify recordStore methods to easily refactor them. 
This PR adds hooks for tiered storage methods.

