### PR TITLE
Fix hanging cluster safe query from common pool

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
@@ -23,12 +23,16 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.partition.AntiEntropyCorrectnessTest.setBackupPacketDropFilter;
@@ -153,6 +157,52 @@ public class PartitionServiceSafetyCheckTest extends PartitionCorrectnessTestSup
                 }
             }
         });
+    }
+
+    @Category(SlowTest.class)
+    @Test(timeout = 60000)
+    public void clusterSafe_completes_whenInvokedFromCommonPool() throws InterruptedException {
+        Config config = getConfig(true, true);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        startNodes(config, nodeCount);
+
+        final Collection<HazelcastInstance> instances = factory.getAllHazelcastInstances();
+
+        // ensure we start enough threads to block all threads of FJP#commonPool
+        int threadCount = ForkJoinPool.commonPool().getParallelism() + 2;
+        spawn(() -> {
+            // trigger partition assignment while many threads are querying cluster safety
+            sleepSeconds(5);
+            warmUpPartitions(instances);
+            fillData(hz);
+        });
+        ExecutorService executorService = ForkJoinPool.commonPool();
+        // no assertions are actually executed. We only care that isClusterSafe
+        // does not hang indefinitely
+        assertTrueAllTheTime(() -> {
+            CountDownLatch startQueryClusterSafe = new CountDownLatch(1);
+            CountDownLatch completed = new CountDownLatch(threadCount);
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                            try {
+                                startQueryClusterSafe.await();
+                                for (HazelcastInstance instance : instances) {
+                                    PartitionService ps = instance.getPartitionService();
+                                    // just invoke isClusterSafe, no need to assert result
+                                    // we only care about the call eventually completing
+                                    ps.isClusterSafe();
+                                }
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            } finally {
+                                completed.countDown();
+                            }
+                        });
+            }
+            startQueryClusterSafe.countDown();
+            completed.await();
+        }, 30);
     }
 
     @Test


### PR DESCRIPTION
When all FJP#commonPool threads are busy querying isClusterSafe
and partition assignments are not in sync (eg during initial
partition arrangement), then there is no chance for an important
callback to be executed after PartitionBackupReplicaAntiEntropyOperation
is done, resulting in neither partition replica sync nor cluster-safe
query being able to make any progress.
The fix is to use the Hazelcast internal async executor (instead of
the common pool) for the callback that processes replica antientropy
operation result.

(cherry picked from commit 434d731a4bd6aa2349160b2ab40e7d1a09808fec)

Backport of #21145 to 4.1.z branch