### PR TITLE
[CN-346] Update Discovery Plugin Integration Tests

### DIFF
--- a/.github/terraform/aws/.gitignore
+++ b/.github/terraform/aws/.gitignore
@@ -1,0 +1,6 @@
+.terraform.lock.hcl
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+private_key.pem
+

--- a/.github/terraform/aws/cloud-init.yaml
+++ b/.github/terraform/aws/cloud-init.yaml
@@ -1,0 +1,8 @@
+#cloud-config
+# Update apt database on first boot (run 'apt-get update').
+package_update: true
+# Install additional packages on first boot
+packages:
+  - openjdk-8-jre-headless
+  - wget
+  - unzip

--- a/.github/terraform/aws/hazelcast-client.yaml
+++ b/.github/terraform/aws/hazelcast-client.yaml
@@ -2,6 +2,6 @@ hazelcast-client:
   network:
     aws:
       enabled: true
-      region: REGION
-      tag-key: TAG-KEY
-      tag-value: TAG-VALUE
+      region: ${REGION}
+      tag-key: ${TAG_KEY}
+      tag-value: ${TAG_VALUE}

--- a/.github/terraform/aws/hazelcast.yaml
+++ b/.github/terraform/aws/hazelcast.yaml
@@ -6,10 +6,10 @@ hazelcast:
       aws:
         enabled: true
         # discovery_role is created by main terraform script
-        iam-role: SET_PREFIX_discovery_role
+        iam-role: ${PREFIX}_discovery_role
         hz-port: 5701
-        region: REGION
-        tag-key: TAG_KEY
-        tag-value: TAG_VALUE
+        region: ${REGION}
+        tag-key: ${TAG_KEY}
+        tag-value: ${TAG_VALUE}
     rest-api:
       enabled: true

--- a/.github/terraform/aws/main.tf
+++ b/.github/terraform/aws/main.tf
@@ -2,7 +2,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.2"
+      version = ">= 3.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1.0"
     }
   }
   required_version = ">= 0.13"
@@ -28,9 +36,40 @@ data "aws_ami" "image" {
   owners = ["099720109477"]
 }
 
+resource "random_pet" "prefix" {
+  prefix    = "test"
+  length    = 2
+  separator = "_"
+}
+
+data "template_file" "hazelcast" {
+  template = file("${path.module}/hazelcast.yaml")
+  vars = {
+    PREFIX    = random_pet.prefix.id
+    REGION    = var.aws_region
+    TAG_KEY   = var.aws_tag_key
+    TAG_VALUE = var.aws_tag_value
+
+  }
+}
+
+data "template_file" "hazelcast_client" {
+  template = file("${path.module}/hazelcast-client.yaml")
+  vars = {
+    PREFIX    = random_pet.prefix.id
+    REGION    = var.aws_region
+    TAG_KEY   = var.aws_tag_key
+    TAG_VALUE = var.aws_tag_value
+  }
+}
+
+data "template_file" "user_data" {
+  template = file("${path.module}/cloud-init.yaml")
+}
+
 # IAM Role required for Hazelcast AWS Discovery
 resource "aws_iam_role" "discovery_role" {
-  name = "${var.prefix}_discovery_role"
+  name = "${random_pet.prefix.id}_discovery_role"
 
   assume_role_policy = <<-EOF
   {
@@ -50,7 +89,7 @@ resource "aws_iam_role" "discovery_role" {
 }
 
 resource "aws_iam_role_policy" "discovery_policy" {
-  name = "${var.prefix}_discovery_policy"
+  name = "${random_pet.prefix.id}_discovery_policy"
   role = aws_iam_role.discovery_role.id
 
   policy = <<-EOF
@@ -71,12 +110,12 @@ resource "aws_iam_role_policy" "discovery_policy" {
 
 
 resource "aws_iam_instance_profile" "discovery_instance_profile" {
-  name = "${var.prefix}_discovery_instance_profile"
+  name = "${random_pet.prefix.id}_discovery_instance_profile"
   role = aws_iam_role.discovery_role.name
 }
 
 resource "aws_security_group" "sg" {
-  name = "${var.prefix}_sg"
+  name = "${random_pet.prefix.id}_sg"
 
   ingress {
     from_port   = 22
@@ -109,11 +148,21 @@ resource "aws_security_group" "sg" {
   }
 }
 
-resource "aws_key_pair" "keypair" {
-  key_name   = "${var.prefix}_${var.aws_key_name}"
-  public_key = file("${var.local_key_path}/${var.aws_key_name}.pub")
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = "4096"
 }
-###########################################################################
+
+resource "local_file" "private_key" {
+  content         = tls_private_key.ssh.private_key_pem
+  filename        = "private_key.pem"
+  file_permission = "0600"
+}
+
+resource "aws_key_pair" "keypair" {
+  key_name   = "${random_pet.prefix.id}_aws_key"
+  public_key = tls_private_key.ssh.public_key_openssh
+}
 
 resource "aws_instance" "hazelcast_member" {
   count                = var.member_count
@@ -122,8 +171,9 @@ resource "aws_instance" "hazelcast_member" {
   iam_instance_profile = aws_iam_instance_profile.discovery_instance_profile.name
   security_groups      = [aws_security_group.sg.name]
   key_name             = aws_key_pair.keypair.key_name
+  user_data            = data.template_file.user_data.rendered
   tags = {
-    Name                 = "${var.prefix}-AWS-Member-${count.index}"
+    Name                 = "${random_pet.prefix.id}-AWS-Member-${count.index}"
     "${var.aws_tag_key}" = var.aws_tag_value
   }
   connection {
@@ -132,7 +182,7 @@ resource "aws_instance" "hazelcast_member" {
     host        = self.public_ip
     timeout     = "180s"
     agent       = false
-    private_key = file("${var.local_key_path}/${var.aws_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
   }
 
   provisioner "remote-exec" {
@@ -140,8 +190,6 @@ resource "aws_instance" "hazelcast_member" {
       "mkdir -p /home/${var.username}/jars",
       "mkdir -p /home/${var.username}/logs",
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "sudo apt-get update",
-      "sudo apt-get -y install openjdk-8-jdk wget",
     ]
   }
 
@@ -156,12 +204,12 @@ resource "aws_instance" "hazelcast_member" {
   }
 
   provisioner "file" {
-    source      = "~/lib/hazelcast.jar"
+    source      = var.hazelcast_path
     destination = "/home/${var.username}/jars/hazelcast.jar"
   }
 
   provisioner "file" {
-    source      = "hazelcast.yaml"
+    content     = data.template_file.hazelcast.rendered
     destination = "/home/${var.username}/hazelcast.yaml"
   }
 
@@ -169,8 +217,7 @@ resource "aws_instance" "hazelcast_member" {
     inline = [
       "cd /home/${var.username}",
       "chmod 0755 start_aws_hazelcast_member.sh",
-      "./start_aws_hazelcast_member.sh  ${var.aws_region} ${var.aws_tag_key} ${var.aws_tag_value} ",
-      "sleep 5",
+      "./start_aws_hazelcast_member.sh",
     ]
   }
 }
@@ -184,7 +231,7 @@ resource "null_resource" "verify_members" {
     host        = aws_instance.hazelcast_member[count.index].public_ip
     timeout     = "180s"
     agent       = false
-    private_key = file("${var.local_key_path}/${var.aws_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
   }
 
 
@@ -205,8 +252,9 @@ resource "aws_instance" "hazelcast_mancenter" {
   iam_instance_profile = aws_iam_instance_profile.discovery_instance_profile.name
   security_groups      = [aws_security_group.sg.name]
   key_name             = aws_key_pair.keypair.key_name
+  user_data            = data.template_file.user_data.rendered
   tags = {
-    Name                 = "${var.prefix}-AWS-Management-Center"
+    Name                 = "${random_pet.prefix.id}-AWS-Management-Center"
     "${var.aws_tag_key}" = var.aws_tag_value
   }
 
@@ -216,7 +264,7 @@ resource "aws_instance" "hazelcast_mancenter" {
     host        = self.public_ip
     timeout     = "180s"
     agent       = false
-    private_key = file("${var.local_key_path}/${var.aws_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
   }
 
   provisioner "file" {
@@ -230,15 +278,13 @@ resource "aws_instance" "hazelcast_mancenter" {
   }
 
   provisioner "file" {
-    source      = "hazelcast-client.yaml"
+    content     = data.template_file.hazelcast_client.rendered
     destination = "/home/${var.username}/hazelcast-client.yaml"
   }
 
   provisioner "remote-exec" {
     inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "sudo apt-get update",
-      "sudo apt-get -y install openjdk-8-jdk wget unzip",
     ]
   }
 
@@ -246,8 +292,7 @@ resource "aws_instance" "hazelcast_mancenter" {
     inline = [
       "cd /home/${var.username}",
       "chmod 0755 start_aws_hazelcast_management_center.sh",
-      "./start_aws_hazelcast_management_center.sh ${var.hazelcast_mancenter_version}  ${var.aws_region} ${var.aws_tag_key} ${var.aws_tag_value} ",
-      "sleep 5",
+      "./start_aws_hazelcast_management_center.sh ${var.hazelcast_mancenter_version}",
     ]
   }
 }
@@ -261,7 +306,7 @@ resource "null_resource" "verify_mancenter" {
     host        = aws_instance.hazelcast_mancenter.public_ip
     timeout     = "180s"
     agent       = false
-    private_key = file("${var.local_key_path}/${var.aws_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
   }
 
 

--- a/.github/terraform/aws/scripts/start_aws_hazelcast_management_center.sh
+++ b/.github/terraform/aws/scripts/start_aws_hazelcast_management_center.sh
@@ -3,9 +3,6 @@
 set -x
 
 MANCENTER_VERSION=$1
-REGION=$2
-TAG_KEY=$3
-TAG_VALUE=$4
 
 mkdir -p ${HOME}/lib
 mkdir -p ${HOME}/logs
@@ -14,7 +11,7 @@ mkdir -p ${HOME}/man
 LOG_DIR=${HOME}/logs
 MAN_CENTER_HOME=${HOME}/man
 
-MANCENTER_JAR_URL=https://download.hazelcast.com/management-center/hazelcast-management-center-${MANCENTER_VERSION}.zip
+MANCENTER_JAR_URL=https://repository.hazelcast.com/download/management-center/hazelcast-management-center-${MANCENTER_VERSION}.zip
 
 pushd ${HOME}/lib
     echo "Downloading JAR..."
@@ -25,20 +22,12 @@ pushd ${HOME}/lib
         exit 1;
     fi
     unzip hazelcast-management-center-${MANCENTER_VERSION}.zip
-    cp -R hazelcast-management-center-${MANCENTER_VERSION}/* ./
+    cp -R hazelcast-management-center-*/* ./
 popd
-
-
-sed -i -e "s/REGION/${REGION}/g" ${HOME}/hazelcast-client.yaml
-sed -i -e "s/TAG-KEY/${TAG_KEY}/g" ${HOME}/hazelcast-client.yaml
-sed -i -e "s/TAG-VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast-client.yaml
-
  
-java -cp ${HOME}/lib/hazelcast-management-center-${MANCENTER_VERSION}.jar com.hazelcast.webmonitor.cli.MCConfCommandLine  cluster add -H ${MAN_CENTER_HOME} --client-config ${HOME}/hazelcast-client.yaml \
+lib/bin/hz-mc conf cluster add --client-config=${HOME}/hazelcast-client.yaml \
                        >> $LOG_DIR/mancenter.conf.stdout.log 2>> $LOG_DIR/mancenter.conf.stderr.log
 
-
-nohup java  -Dhazelcast.mc.home=${MAN_CENTER_HOME} \
-             -jar ${HOME}/lib/hazelcast-management-center-${MANCENTER_VERSION}.jar >> $LOG_DIR/mancenter.stdout.log 2>> $LOG_DIR/mancenter.stderr.log &
+nohup lib/bin/hz-mc start >> $LOG_DIR/mancenter.stdout.log 2>> $LOG_DIR/mancenter.stderr.log &
 
 sleep 5

--- a/.github/terraform/aws/scripts/start_aws_hazelcast_member.sh
+++ b/.github/terraform/aws/scripts/start_aws_hazelcast_member.sh
@@ -2,15 +2,6 @@
 
 set -x
 
-REGION=$1
-TAG_KEY=$2
-TAG_VALUE=$3
-
-
-sed -i -e "s/REGION/${REGION}/g" ${HOME}/hazelcast.yaml
-sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast.yaml
-sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast.yaml
-
 CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/hazelcast.yaml"
 
 nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter >> ${HOME}/logs/hazelcast.stderr.log 2>> ${HOME}/logs/hazelcast.stdout.log &

--- a/.github/terraform/aws/scripts/verify_mancenter.sh
+++ b/.github/terraform/aws/scripts/verify_mancenter.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
     for i in `seq 1 6`; do
-        local MEMBER_COUNT=$(cat ~/logs/mancenter.stdout.log | grep -E " Started communication with (a new )?member" | wc -l) 
+        local MEMBER_COUNT=$(grep -cE " Started communication with (a new )?member" ~/logs/mancenter.stdout.log)
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then
             echo "Hazelcast cluster size equal to ${EXPECTED_SIZE}"

--- a/.github/terraform/aws/scripts/verify_member_count.sh
+++ b/.github/terraform/aws/scripts/verify_member_count.sh
@@ -6,7 +6,7 @@ EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 6`; do
+    for i in `seq 1 10`; do
         local MEMBER_COUNT=$( curl -sS http://127.0.0.1:5701/hazelcast/health/cluster-size )
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then

--- a/.github/terraform/aws/terraform.tfvars
+++ b/.github/terraform/aws/terraform.tfvars
@@ -1,14 +1,8 @@
-prefix = SET_PREFIX
-
-aws_key_name = "id_rsa"
-local_key_path = "~/.ssh"
-
-member_count           = "2"
-aws_instance_type      = "t2.micro"
-aws_region             = "eu-central-1"
-aws_tag_key            = "Category"
-aws_tag_value          = "hazelcast-aws-discovery"
-
-hazelcast_mancenter_version = "4.2020.08"
-
-username = "ubuntu"
+member_count                = "2"
+aws_instance_type           = "t2.micro"
+aws_region                  = "eu-central-1"
+aws_tag_key                 = "Category"
+aws_tag_value               = "hazelcast-aws-discovery"
+username                    = "ubuntu"
+hazelcast_mancenter_version = "5.1.2" # last known working version, tests use latest-snapshot
+hazelcast_path              = "~/lib/hazelcast.jar"

--- a/.github/terraform/aws/variables.tf
+++ b/.github/terraform/aws/variables.tf
@@ -1,15 +1,3 @@
-# existing key pair name to be assigned to EC2 instance
-variable "aws_key_name" {
-  type    = string
-  default = "id_rsa"
-}
-
-# local path of pem file for SSH connection - local_key_path/aws_key_name.pem
-variable "local_key_path" {
-  type    = string
-  default = "~/.ssh/"
-}
-
 variable "username" {
   default = "ubuntu"
 }
@@ -40,9 +28,8 @@ variable "aws_tag_value" {
 
 variable "hazelcast_mancenter_version" {
   type    = string
-  default = "4.2020.08"
 }
 
-variable "prefix" {
-  type = string
+variable "hazelcast_path" {
+  type    = string
 }

--- a/.github/terraform/azure/.gitignore
+++ b/.github/terraform/azure/.gitignore
@@ -1,0 +1,6 @@
+.terraform.lock.hcl
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+private_key.pem
+

--- a/.github/terraform/azure/cloud-init.yaml
+++ b/.github/terraform/azure/cloud-init.yaml
@@ -1,0 +1,6 @@
+#cloud-config
+# Install additional packages on first boot
+packages:
+  - openjdk-8-jre-headless
+  - wget
+  - unzip

--- a/.github/terraform/azure/hazelcast-client.yaml
+++ b/.github/terraform/azure/hazelcast-client.yaml
@@ -2,4 +2,4 @@ hazelcast-client:
   network:
     azure:
       enabled: true
-      tag: TAG_KEY=TAG_VALUE
+      tag: ${TAG_KEY}=${TAG_VALUE}

--- a/.github/terraform/azure/hazelcast.yaml
+++ b/.github/terraform/azure/hazelcast.yaml
@@ -5,6 +5,6 @@ hazelcast:
         enabled: false
       azure:
         enabled: true
-        tag: TAG_KEY=TAG_VALUE
+        tag: ${TAG_KEY}=${TAG_VALUE}
     rest-api:
       enabled: true

--- a/.github/terraform/azure/main.tf
+++ b/.github/terraform/azure/main.tf
@@ -13,15 +13,60 @@ provider "azurerm" {
   features {}
 }
 
+resource "random_pet" "prefix" {
+  prefix    = "test"
+  length    = 2
+  separator = "-"
+}
+
+data "template_file" "hazelcast" {
+  template = file("${path.module}/hazelcast.yaml")
+  vars = {
+    TAG_KEY   = var.azure_tag_key
+    TAG_VALUE = var.azure_tag_value
+  }
+}
+
+data "template_file" "hazelcast_client" {
+  template = file("${path.module}/hazelcast-client.yaml")
+  vars = {
+    TAG_KEY   = var.azure_tag_key
+    TAG_VALUE = var.azure_tag_value
+  }
+}
+
+data "template_file" "cloud_init" {
+  template = file("${path.module}/cloud-init.yaml")
+}
+data "template_cloudinit_config" "config" {
+  gzip          = true
+  base64_encode = true
+  part {
+    content_type = "text/cloud-config"
+    content      = "${data.template_file.cloud_init.rendered}"
+  }
+}
+
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+resource "local_file" "private_key" {
+  content         = tls_private_key.ssh.private_key_pem
+  filename        = "private_key.pem"
+  file_permission = "0600"
+}
+
 # Create a resource group
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.prefix}_rg"
+  name     = "${random_pet.prefix.id}_rg"
   location = var.location
 }
 
 # Create virtual network
 resource "azurerm_virtual_network" "vnet" {
-  name                = "${var.prefix}_vnet"
+  name                = "${random_pet.prefix.id}_vnet"
   address_space       = ["10.0.0.0/16"]
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
@@ -29,7 +74,7 @@ resource "azurerm_virtual_network" "vnet" {
 
 # Create subnet
 resource "azurerm_subnet" "subnet" {
-  name                 = "${var.prefix}_subnet"
+  name                 = "${random_pet.prefix.id}_subnet"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
   address_prefixes     = ["10.0.1.0/24"]
@@ -38,7 +83,7 @@ resource "azurerm_subnet" "subnet" {
 # Create public IP(s)
 resource "azurerm_public_ip" "publicip" {
   count               = var.member_count + 1
-  name                = "${var.prefix}_publicip_${count.index}"
+  name                = "${random_pet.prefix.id}_publicip_${count.index}"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   allocation_method   = "Static"
@@ -51,12 +96,12 @@ data "azurerm_subscription" "primary" {}
 resource "azurerm_user_assigned_identity" "hazelcast_reader" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
-  name                = "${var.prefix}_reader_identity"
+  name                = "${random_pet.prefix.id}_reader_identity"
 }
 
 
 resource "azurerm_role_definition" "reader" {
-  name  = "${var.prefix}_reader_role_definition"
+  name  = "${random_pet.prefix.id}_reader_role_definition"
   scope = data.azurerm_subscription.primary.id
 
   permissions {
@@ -82,7 +127,7 @@ resource "azurerm_role_assignment" "reader" {
 # Create network interface(s)
 resource "azurerm_network_interface" "nic" {
   count               = var.member_count + 1
-  name                = "${var.prefix}_nic_${count.index}"
+  name                = "${random_pet.prefix.id}_nic_${count.index}"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
 
@@ -90,7 +135,7 @@ resource "azurerm_network_interface" "nic" {
     "${var.azure_tag_key}" = var.azure_tag_value
   }
   ip_configuration {
-    name                          = "${var.prefix}_nicconfig_${count.index}"
+    name                          = "${random_pet.prefix.id}_nicconfig_${count.index}"
     subnet_id                     = azurerm_subnet.subnet.id
     private_ip_address_allocation = "Static"
     private_ip_address            = "10.0.1.${count.index + 10}"
@@ -101,7 +146,7 @@ resource "azurerm_network_interface" "nic" {
 # Create Hazelcast member instances
 resource "azurerm_linux_virtual_machine" "hazelcast_member" {
   count                 = var.member_count
-  name                  = "${var.prefix}-member-${count.index}"
+  name                  = "${random_pet.prefix.id}-member-${count.index}"
   location              = var.location
   resource_group_name   = azurerm_resource_group.rg.name
   network_interface_ids = [azurerm_network_interface.nic[count.index].id]
@@ -116,14 +161,15 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
 
   admin_ssh_key {
     username   = var.azure_ssh_user
-    public_key = file("${var.local_key_path}/${var.azure_key_name}.pub")
+    public_key = tls_private_key.ssh.public_key_openssh
   }
 
+  custom_data = data.template_cloudinit_config.config.rendered
 
   source_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    sku       = "18.04-LTS"
     version   = "latest"
   }
 
@@ -138,7 +184,7 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
     host        = azurerm_public_ip.publicip[count.index].ip_address
     user        = var.azure_ssh_user
     type        = "ssh"
-    private_key = file("${var.local_key_path}/${var.azure_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
     timeout     = "120"
     agent       = false
   }
@@ -147,9 +193,7 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
     inline = [
       "mkdir -p /home/${var.azure_ssh_user}/jars",
       "mkdir -p /home/${var.azure_ssh_user}/logs",
-      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "sudo apt-get update",
-      "sudo apt-get -y install openjdk-8-jdk wget",
+      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 10; done",
     ]
   }
 
@@ -164,12 +208,12 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
   }
 
   provisioner "file" {
-    source      = "~/lib/hazelcast.jar"
+    source      = var.hazelcast_path
     destination = "/home/${var.azure_ssh_user}/jars/hazelcast.jar"
   }
 
   provisioner "file" {
-    source      = "hazelcast.yaml"
+    content     = data.template_file.hazelcast.rendered
     destination = "/home/${var.azure_ssh_user}/hazelcast.yaml"
   }
 
@@ -184,16 +228,16 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
 }
 
 resource "null_resource" "verify_members" {
-  count = var.member_count
-  depends_on = [ azurerm_linux_virtual_machine.hazelcast_member ]
+  count      = var.member_count
+  depends_on = [azurerm_linux_virtual_machine.hazelcast_member]
 
   connection {
-    type = "ssh"
-    user = var.azure_ssh_user
-    host = azurerm_linux_virtual_machine.hazelcast_member[count.index].public_ip_address
-    timeout = "180s"
-    agent = false
-    private_key = file("${var.local_key_path}/${var.azure_key_name}")
+    type        = "ssh"
+    user        = var.azure_ssh_user
+    host        = azurerm_linux_virtual_machine.hazelcast_member[count.index].public_ip_address
+    timeout     = "180s"
+    agent       = false
+    private_key = tls_private_key.ssh.private_key_pem
   }
 
   provisioner "remote-exec" {
@@ -209,7 +253,7 @@ resource "null_resource" "verify_members" {
 
 # Create Hazelcast Management Center
 resource "azurerm_linux_virtual_machine" "hazelcast_mancenter" {
-  name                  = "${var.prefix}-mancenter"
+  name                  = "${random_pet.prefix.id}-mancenter"
   location              = var.location
   resource_group_name   = azurerm_resource_group.rg.name
   network_interface_ids = [azurerm_network_interface.nic[var.member_count].id]
@@ -224,14 +268,15 @@ resource "azurerm_linux_virtual_machine" "hazelcast_mancenter" {
 
   admin_ssh_key {
     username   = var.azure_ssh_user
-    public_key = file("${var.local_key_path}/${var.azure_key_name}.pub")
+    public_key = tls_private_key.ssh.public_key_openssh
   }
 
+  custom_data = data.template_cloudinit_config.config.rendered
 
   source_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    sku       = "18.04-LTS"
     version   = "latest"
   }
 
@@ -246,7 +291,7 @@ resource "azurerm_linux_virtual_machine" "hazelcast_mancenter" {
     host        = azurerm_public_ip.publicip[var.member_count].ip_address
     user        = var.azure_ssh_user
     type        = "ssh"
-    private_key = file("${var.local_key_path}/${var.azure_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
     timeout     = "120"
     agent       = false
   }
@@ -262,15 +307,13 @@ resource "azurerm_linux_virtual_machine" "hazelcast_mancenter" {
   }
 
   provisioner "file" {
-    source      = "hazelcast-client.yaml"
+    content     = data.template_file.hazelcast_client.rendered
     destination = "/home/${var.azure_ssh_user}/hazelcast-client.yaml"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "sudo apt-get update",
-      "sudo apt-get -y install openjdk-8-jdk wget unzip",
+      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 10; done",
     ]
   }
 
@@ -293,7 +336,7 @@ resource "null_resource" "verify_mancenter" {
     host        = azurerm_linux_virtual_machine.hazelcast_mancenter.public_ip_address
     timeout     = "180s"
     agent       = false
-    private_key = file("${var.local_key_path}/${var.azure_key_name}")
+    private_key = tls_private_key.ssh.private_key_pem
   }
 
 

--- a/.github/terraform/azure/scripts/start_azure_hazelcast_management_center.sh
+++ b/.github/terraform/azure/scripts/start_azure_hazelcast_management_center.sh
@@ -3,8 +3,6 @@
 set -x
 
 MANCENTER_VERSION=$1
-TAG_KEY=$2
-TAG_VALUE=$3
 
 mkdir -p ${HOME}/lib
 mkdir -p ${HOME}/logs
@@ -13,7 +11,7 @@ mkdir -p ${HOME}/man
 LOG_DIR=${HOME}/logs
 MAN_CENTER_HOME=${HOME}/man
 
-MANCENTER_JAR_URL=https://download.hazelcast.com/management-center/hazelcast-management-center-${MANCENTER_VERSION}.zip
+MANCENTER_JAR_URL=https://repository.hazelcast.com/download/management-center/hazelcast-management-center-${MANCENTER_VERSION}.zip
 
 pushd ${HOME}/lib
     echo "Downloading JAR..."
@@ -24,17 +22,12 @@ pushd ${HOME}/lib
         exit 1;
     fi
     unzip hazelcast-management-center-${MANCENTER_VERSION}.zip
-    cp -R hazelcast-management-center-${MANCENTER_VERSION}/* ./
+    cp -R hazelcast-management-center-*/* ./
 popd
-
-sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast-client.yaml
-sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast-client.yaml
-
-java -cp ${HOME}/lib/hazelcast-management-center-${MANCENTER_VERSION}.jar com.hazelcast.webmonitor.cli.MCConfCommandLine  cluster add -H ${MAN_CENTER_HOME} --client-config ${HOME}/hazelcast-client.yaml \
+ 
+lib/bin/hz-mc conf cluster add --client-config=${HOME}/hazelcast-client.yaml \
                        >> $LOG_DIR/mancenter.conf.stdout.log 2>> $LOG_DIR/mancenter.conf.stderr.log
 
-
-nohup java  -Dhazelcast.mc.home=${MAN_CENTER_HOME} \
-             -jar ${HOME}/lib/hazelcast-management-center-${MANCENTER_VERSION}.jar >> $LOG_DIR/mancenter.stdout.log 2>> $LOG_DIR/mancenter.stderr.log &
+nohup lib/bin/hz-mc start >> $LOG_DIR/mancenter.stdout.log 2>> $LOG_DIR/mancenter.stderr.log &
 
 sleep 5

--- a/.github/terraform/azure/scripts/start_azure_hazelcast_member.sh
+++ b/.github/terraform/azure/scripts/start_azure_hazelcast_member.sh
@@ -2,14 +2,8 @@
 
 set -x
 
-TAG_KEY=$1
-TAG_VALUE=$2
-
-sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast.yaml
-sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast.yaml
-
 CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/hazelcast.yaml"
 
-nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
+nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter >> ${HOME}/logs/hazelcast.stderr.log 2>> ${HOME}/logs/hazelcast.stdout.log &
 
 sleep 5

--- a/.github/terraform/azure/scripts/verify_mancenter.sh
+++ b/.github/terraform/azure/scripts/verify_mancenter.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 6`; do
-        local MEMBER_COUNT=$(cat ~/logs/mancenter.stdout.log | grep -E " Started communication with (a new )?member" | wc -l)
+    for i in `seq 1 30`; do
+        local MEMBER_COUNT=$(grep -cE " Started communication with (a new )?member" ~/logs/mancenter.stdout.log)
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then
             echo "Hazelcast cluster size equal to ${EXPECTED_SIZE}"

--- a/.github/terraform/azure/scripts/verify_member_count.sh
+++ b/.github/terraform/azure/scripts/verify_member_count.sh
@@ -6,7 +6,7 @@ EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 6`; do
+    for i in `seq 1 10`; do
         local MEMBER_COUNT=$( curl -sS http://127.0.0.1:5701/hazelcast/health/cluster-size )
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then

--- a/.github/terraform/azure/terraform.tfvars
+++ b/.github/terraform/azure/terraform.tfvars
@@ -1,15 +1,8 @@
-prefix = SET_PREFIX
-
-azure_key_name = "id_rsa"
-local_key_path = "~/.ssh"
-
-member_count        = "2"
-location            = "central us"
-azure_instance_type = "Standard_B1ms"
-azure_tag_key       = "integration-test"
-azure_tag_value     = "terraform"
-
-hazelcast_mancenter_version = "4.2020.08"
-
-azure_ssh_user = "ubuntu"
-
+member_count                = "2"
+location                    = "central us"
+azure_instance_type         = "Standard_B1ms"
+azure_tag_key               = "integration-test"
+azure_tag_value             = "terraform"
+hazelcast_mancenter_version = "5.1.2" # last known working version, tests use latest-snapshot
+azure_ssh_user              = "ubuntu"
+hazelcast_path              = "~/lib/hazelcast.jar"

--- a/.github/terraform/azure/variables.tf
+++ b/.github/terraform/azure/variables.tf
@@ -1,19 +1,3 @@
-variable "prefix" {
-  type    = string
-}
-
-# key name to be assigned to Azure Compute instances
-variable "azure_key_name" {
-  type    = string
-  default = "id_rsa"
-}
-
-# local path of private and public key file for SSH connection - local_key_path/azure_key_name
-variable "local_key_path" {
-  type    = string
-  default = "~/.ssh"
-}
-
 variable "location" {
   type    = string
   default = "central us"
@@ -26,7 +10,6 @@ variable "member_count" {
 
 variable "hazelcast_mancenter_version" {
   type    = string
-  default = "4.2020.08"
 }
 
 variable "azure_ssh_user" {
@@ -47,4 +30,8 @@ variable "azure_tag_key" {
 variable "azure_tag_value" {
   type    = string
   default = "terraform"
+}
+
+variable "hazelcast_path" {
+  type    = string
 }

--- a/.github/terraform/gcp/.gitignore
+++ b/.github/terraform/gcp/.gitignore
@@ -1,0 +1,6 @@
+.terraform.lock.hcl
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+private_key.pem
+

--- a/.github/terraform/gcp/cloud-init.yaml
+++ b/.github/terraform/gcp/cloud-init.yaml
@@ -1,0 +1,6 @@
+#cloud-config
+# Install additional packages on first boot
+packages:
+  - openjdk-8-jre-headless
+  - wget
+  - unzip

--- a/.github/terraform/gcp/hazelcast-client.yaml
+++ b/.github/terraform/gcp/hazelcast-client.yaml
@@ -2,4 +2,4 @@ hazelcast-client:
   network:
     gcp:
       enabled: true
-      label: LABEL_KEY=LABEL_VALUE
+      label: ${LABEL_KEY}=${LABEL_VALUE}

--- a/.github/terraform/gcp/hazelcast.yaml
+++ b/.github/terraform/gcp/hazelcast.yaml
@@ -5,6 +5,6 @@ hazelcast:
         enabled: false
       gcp:
         enabled: true
-        label: LABEL_KEY=LABEL_VALUE
+        label: ${LABEL_KEY}=${LABEL_VALUE}
     rest-api:
       enabled: true

--- a/.github/terraform/gcp/scripts/start_gcp_hazelcast_management_center.sh
+++ b/.github/terraform/gcp/scripts/start_gcp_hazelcast_management_center.sh
@@ -3,8 +3,6 @@
 set -x
 
 MANCENTER_VERSION=$1
-LABEL_KEY=$2
-LABEL_VALUE=$3
 
 mkdir -p ${HOME}/lib
 mkdir -p ${HOME}/logs
@@ -13,7 +11,7 @@ mkdir -p ${HOME}/man
 LOG_DIR=${HOME}/logs
 MAN_CENTER_HOME=${HOME}/man
 
-MANCENTER_JAR_URL=https://download.hazelcast.com/management-center/hazelcast-management-center-${MANCENTER_VERSION}.zip
+MANCENTER_JAR_URL=https://repository.hazelcast.com/download/management-center/hazelcast-management-center-${MANCENTER_VERSION}.zip
 
 pushd ${HOME}/lib
     echo "Downloading JAR..."
@@ -24,17 +22,12 @@ pushd ${HOME}/lib
         exit 1;
     fi
     unzip hazelcast-management-center-${MANCENTER_VERSION}.zip
-    cp -R hazelcast-management-center-${MANCENTER_VERSION}/* ./
+    cp -R hazelcast-management-center-*/* ./
 popd
-
-sed -i -e "s/LABEL_KEY/${LABEL_KEY}/g" ${HOME}/hazelcast-client.yaml
-sed -i -e "s/LABEL_VALUE/${LABEL_VALUE}/g" ${HOME}/hazelcast-client.yaml
  
-java -cp ${HOME}/lib/hazelcast-management-center-${MANCENTER_VERSION}.jar com.hazelcast.webmonitor.cli.MCConfCommandLine  cluster add -H ${MAN_CENTER_HOME} --client-config ${HOME}/hazelcast-client.yaml \
+lib/bin/hz-mc conf cluster add --client-config=${HOME}/hazelcast-client.yaml \
                        >> $LOG_DIR/mancenter.conf.stdout.log 2>> $LOG_DIR/mancenter.conf.stderr.log
 
-
-nohup java  -Dhazelcast.mc.home=${MAN_CENTER_HOME} \
-             -jar ${HOME}/lib/hazelcast-management-center-${MANCENTER_VERSION}.jar >> $LOG_DIR/mancenter.stdout.log 2>> $LOG_DIR/mancenter.stderr.log &
+nohup lib/bin/hz-mc start >> $LOG_DIR/mancenter.stdout.log 2>> $LOG_DIR/mancenter.stderr.log &
 
 sleep 5

--- a/.github/terraform/gcp/scripts/start_gcp_hazelcast_member.sh
+++ b/.github/terraform/gcp/scripts/start_gcp_hazelcast_member.sh
@@ -2,14 +2,8 @@
 
 set -x
 
-LABEL_KEY=$1
-LABEL_VALUE=$2
-
-sed -i -e "s/LABEL_KEY/${LABEL_KEY}/g" ${HOME}/hazelcast.yaml
-sed -i -e "s/LABEL_VALUE/${LABEL_VALUE}/g" ${HOME}/hazelcast.yaml
-
 CLASSPATH="${HOME}/jars/hazelcast.jar:${HOME}/hazelcast.yaml"
 
-nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
+nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter >> ${HOME}/logs/hazelcast.stderr.log 2>> ${HOME}/logs/hazelcast.stdout.log &
 
 sleep 5

--- a/.github/terraform/gcp/scripts/verify_mancenter.sh
+++ b/.github/terraform/gcp/scripts/verify_mancenter.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 6`; do
-        local MEMBER_COUNT=$(cat ~/logs/mancenter.stdout.log | grep -E " Started communication with (a new )?member" | wc -l)
+    for i in `seq 1 30`; do
+        local MEMBER_COUNT=$(grep -cE " Started communication with (a new )?member" ~/logs/mancenter.stdout.log)
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then
             echo "Hazelcast cluster size equal to ${EXPECTED_SIZE}"

--- a/.github/terraform/gcp/scripts/verify_member_count.sh
+++ b/.github/terraform/gcp/scripts/verify_member_count.sh
@@ -6,7 +6,7 @@ EXPECTED_SIZE=$1
 
 verify_hazelcast_cluster_size() {
     EXPECTED_SIZE=$1
-    for i in `seq 1 6`; do
+    for i in `seq 1 10`; do
         local MEMBER_COUNT=$( curl -sS http://127.0.0.1:5701/hazelcast/health/cluster-size )
 
         if [ "$MEMBER_COUNT" == "$EXPECTED_SIZE" ] ; then
@@ -22,4 +22,3 @@ verify_hazelcast_cluster_size() {
 
 echo "Checking Hazelcast cluster size"
 verify_hazelcast_cluster_size $EXPECTED_SIZE
-

--- a/.github/terraform/gcp/terraform.tfvars
+++ b/.github/terraform/gcp/terraform.tfvars
@@ -1,18 +1,11 @@
-project_id = SET_PROJECT_ID
-prefix     = SET_PREFIX
-
-gcp_key_name = "id_rsa"
-local_key_path = "~/.ssh"
-
-region = "us-central1"
-zone   = "us-central1-c"
-
-member_count      = "2"
-gcp_instance_type = "f1-micro"
-gcp_label_key = "integration-test"
-gcp_label_value = "terraform"
-
-hazelcast_mancenter_version = "4.2020.08"
-
-gcp_ssh_user = "ubuntu"
-
+project_id                  = "hazelcast-33"
+region                      = "us-central1"
+zone                        = "us-central1-c"
+member_count                = "2"
+gcp_instance_type           = "f1-micro"
+gcp_label_key               = "integration-test"
+gcp_label_value             = "terraform"
+hazelcast_mancenter_version = "5.1.2" # last known working version, tests use latest-snapshot
+gcp_ssh_user                = "ubuntu"
+hazelcast_path              = "~/lib/hazelcast.jar"
+gcp_key_file                = "gcp_key_file.json"

--- a/.github/terraform/gcp/variables.tf
+++ b/.github/terraform/gcp/variables.tf
@@ -1,20 +1,6 @@
-variable "prefix" {
-  type    = string
-}
-
 # ID of the project you want to use
 variable "project_id" {
   type    = string
-}
-
-variable "gcp_key_name" {
-  type = string
-  default = "id_rsa"
-}
-
-variable "local_key_path" {
-  type = string
-  default = "~/.ssh/"
 }
 
 variable "region" {
@@ -39,7 +25,6 @@ variable "gcp_ssh_user" {
 
 variable "hazelcast_mancenter_version" {
   type    = string
-  default = "4.2020.08"
 }
 
 variable "gcp_instance_type" {
@@ -55,4 +40,12 @@ variable "gcp_label_key" {
 variable "gcp_label_value" {
   type = string
   default = "terraform"
+}
+
+variable "hazelcast_path" {
+  type    = string
+}
+
+variable "gcp_key_file" {
+  type    = string
 }

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -16,8 +16,6 @@ jobs:
     env:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     runs-on: ubuntu-latest
     if: github.repository_owner == 'hazelcast'
     strategy:
@@ -36,8 +34,6 @@ jobs:
 
       - run: java -version
 
-      - run : mkdir ~/lib
-
       # BUILD HAZELCAST AWS SNAPSHOT
       - uses: actions/checkout@v2.4.0
         with:
@@ -48,58 +44,23 @@ jobs:
           cd hazelcast
           mvn clean install -DskipTests -Dcheckstyle.skip
           echo "Hazelcast jar is: " hazelcast/target/hazelcast-*-SNAPSHOT.jar
-          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/lib/hazelcast.jar
+          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/hazelcast.jar
 
-      #BUILD TERRAFORM
+      # INSTALL TERRAFORM
       - name : Set-up Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 0.13.0
-
-      - name: Create unique prefix for resources
-        run: |
-          sed -i -e "s/SET_PREFIX/${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}/g" hazelcast/.github/terraform/aws/hazelcast.yaml
-          sed -i -e "s/SET_PREFIX/\"${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}\"/g" hazelcast/.github/terraform/aws/terraform.tfvars
+          terraform_version: 1.1.8
 
       - name: Terraform Init
-        run: cd hazelcast/.github/terraform/aws && terraform init
-
-      - name: Terraform Format
-        run: cd hazelcast/.github/terraform/aws  && terraform fmt
-
-      - name: Generate SSH keys
-        id: ssh
-        run: |
-          ssh-keygen -t rsa -b 4096 -C "devOpsHazelcast@hazelcast.com" -f id_rsa -P "" 1>/dev/null
-          ssh_key=$(cat id_rsa)
-          echo 'SSH_KEY<<EOF' >> $GITHUB_ENV
-          echo "$ssh_key" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-
-          ssh_key_public=$(cat id_rsa.pub)
-          echo 'SSH_KEY_PUBLIC<<EOF' >> $GITHUB_ENV
-          echo "$ssh_key_public" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-
-      - name: Install private key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ env.SSH_KEY }}
-          name: id_rsa
-          known_hosts: " "
-
-      - name: Install public key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ env.SSH_KEY_PUBLIC }}
-          name: id_rsa.pub
-          known_hosts: " "
+        working-directory: hazelcast/.github/terraform/aws
+        run: terraform init
 
       - name: Terraform Apply
-        run: |
-          cd hazelcast/.github/terraform/aws  && terraform apply -auto-approve
+        working-directory: hazelcast/.github/terraform/aws
+        run: terraform apply -var="hazelcast_mancenter_version=latest-snapshot" -var="hazelcast_path=~/hazelcast.jar" -auto-approve
 
       - name: Terraform Destroy
         if: ${{ always() }}
-        run: |
-          cd hazelcast/.github/terraform/aws  && terraform destroy -auto-approve
+        working-directory: hazelcast/.github/terraform/aws
+        run: terraform destroy -auto-approve

--- a/.github/workflows/azure-terraform-integration-tests.yml
+++ b/.github/workflows/azure-terraform-integration-tests.yml
@@ -19,8 +19,6 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     runs-on: ubuntu-latest
     if: github.repository_owner == 'hazelcast'
     strategy:
@@ -39,10 +37,6 @@ jobs:
 
       - run: java -version
 
-      - run: mvn --version
-
-      - run : mkdir ~/lib
-
       # BUILD HAZELCAST AZURE SNAPSHOT
       - uses: actions/checkout@v2.4.0
         with:
@@ -53,57 +47,23 @@ jobs:
           cd hazelcast
           mvn clean install -DskipTests -Dcheckstyle.skip
           echo "Hazelcast jar is: " hazelcast/target/hazelcast-*-SNAPSHOT.jar
-          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/lib/hazelcast.jar
+          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/hazelcast.jar
 
-      #BUILD TERRAFORM
+      # INSTALL TERRAFORM
       - name : Set-up Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 0.13.0
-
-      - name: Create unique prefix for resources
-        run: |
-          sed -i -e "s/SET_PREFIX/\"${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}\"/g" hazelcast/.github/terraform/azure/terraform.tfvars
+          terraform_version: 1.1.8
 
       - name: Terraform Init
-        run: cd hazelcast/.github/terraform/azure && terraform init
-
-      - name: Terraform Format
-        run: cd hazelcast/.github/terraform/azure  && terraform fmt
-
-      - name: Generate SSH keys
-        id: ssh
-        run: |
-          ssh-keygen -t rsa -b 4096 -C "devOpsHazelcast@hazelcast.com" -f id_rsa -P "" 1>/dev/null
-          ssh_key=$(cat id_rsa)
-          echo 'SSH_KEY<<EOF' >> $GITHUB_ENV
-          echo "$ssh_key" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-
-          ssh_key_public=$(cat id_rsa.pub)
-          echo 'SSH_KEY_PUBLIC<<EOF' >> $GITHUB_ENV
-          echo "$ssh_key_public" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-
-      - name: Install private key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ env.SSH_KEY }}
-          name: id_rsa
-          known_hosts: " "
-
-      - name: Install public key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ env.SSH_KEY_PUBLIC }}
-          name: id_rsa.pub
-          known_hosts: " "
+        working-directory: hazelcast/.github/terraform/azure
+        run: terraform init
 
       - name: Terraform Apply
-        run: |
-          cd hazelcast/.github/terraform/azure && terraform apply -auto-approve
+        working-directory: hazelcast/.github/terraform/azure
+        run: terraform apply -var="hazelcast_mancenter_version=latest-snapshot" -var="hazelcast_path=~/hazelcast.jar" -auto-approve
 
       - name: Terraform Destroy
         if: ${{ always() }}
-        run: |
-          cd hazelcast/.github/terraform/azure && terraform destroy -auto-approve
+        working-directory: hazelcast/.github/terraform/azure
+        run: terraform destroy -auto-approve

--- a/.github/workflows/gcp-terraform-integration-tests.yml
+++ b/.github/workflows/gcp-terraform-integration-tests.yml
@@ -15,8 +15,6 @@ jobs:
         shell: bash
     env:
       GCP_KEY_FILE: ${{ secrets.GCP_KEY_FILE }}
-      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     runs-on: ubuntu-latest
     if: github.repository_owner == 'hazelcast'
     strategy:
@@ -35,10 +33,6 @@ jobs:
 
       - run: java -version
 
-      - run: mvn --version
-
-      - run : mkdir ~/lib
-
       # BUILD HAZELCAST GCP SNAPSHOT
       - uses: actions/checkout@v2.4.0
         with:
@@ -49,67 +43,30 @@ jobs:
           cd hazelcast
           mvn clean install -DskipTests -Dcheckstyle.skip
           echo "Hazelcast jar is: " hazelcast/target/hazelcast-*-SNAPSHOT.jar
-          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/lib/hazelcast.jar
-
-      #BUILD TERRAFORM
-      - name : Set-up Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
-        with:
-          terraform_version: 0.13.0
-
-      - name: Create unique prefix for resources
-        run: |
-          sed -i -e "s/SET_PREFIX/\"${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}\"/g" hazelcast/.github/terraform/gcp/terraform.tfvars
-
-      - name: Add project ID terraform.tfvars
-        run: |
-          project_id=$(echo $GCP_KEY_FILE | grep -Po '"project_id":\s"\K[-a-zA-Z0-9]+')
-          sed -i -e "s~SET_PROJECT_ID~\"${project_id}\"~g"  hazelcast/.github/terraform/gcp/terraform.tfvars
+          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/hazelcast.jar
 
       - name: Create GCP credentials file
         run: |
-          touch hazelcast/.github/terraform/gcp/gcp_key_file.json
-          echo $GCP_KEY_FILE > hazelcast/.github/terraform/gcp/gcp_key_file.json
+          touch gcp_key_file.json
+          echo $GCP_KEY_FILE > gcp_key_file.json
+
+      # INSTALL TERRAFORM
+      - name : Set-up Terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 1.1.8
 
       - name: Terraform Init
-        run: cd hazelcast/.github/terraform/gcp && terraform init
-
-      - name: Terraform Format
-        run: cd hazelcast/.github/terraform/gcp  && terraform fmt
-
-      - name: Generate SSH keys
-        id: ssh
-        run: |
-          ssh-keygen -t rsa -b 4096 -C "devOpsHazelcast@hazelcast.com" -f id_rsa -P "" 1>/dev/null
-          ssh_key=$(cat id_rsa)
-          echo 'SSH_KEY<<EOF' >> $GITHUB_ENV
-          echo "$ssh_key" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-
-          ssh_key_public=$(cat id_rsa.pub)
-          echo 'SSH_KEY_PUBLIC<<EOF' >> $GITHUB_ENV
-          echo "$ssh_key_public" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-
-      - name: Install private key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ env.SSH_KEY }}
-          name: id_rsa
-          known_hosts: " "
-
-      - name: Install public key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ env.SSH_KEY_PUBLIC }}
-          name: id_rsa.pub
-          known_hosts: " "
+        working-directory: hazelcast/.github/terraform/gcp
+        run: terraform init
 
       - name: Terraform Apply
+        working-directory: hazelcast/.github/terraform/gcp
         run: |
-          cd hazelcast/.github/terraform/gcp  && terraform apply -auto-approve
+          project_id=$(echo $GCP_KEY_FILE | grep -Po '"project_id":\s"\K[-a-zA-Z0-9]+')
+          terraform apply -var="hazelcast_mancenter_version=latest-snapshot" -var="hazelcast_path=~/hazelcast.jar" -var="gcp_key_file=~/gcp_key_file.json" -var="project_id=${project_id}" -auto-approve
 
       - name: Terraform Destroy
         if: ${{ always() }}
-        run: |
-          cd hazelcast/.github/terraform/gcp  && terraform destroy -auto-approve
+        working-directory: hazelcast/.github/terraform/gcp
+        run: terraform destroy -auto-approve


### PR DESCRIPTION
We update terraform and use providers to:
- generate ssh key
- generate configs from yaml file templates
- add random names to resources to avoid collisions

Thanks to this change we no longer need to use ssh-keygen and sed in github workflow files.