### PR TITLE
[HZ-1074] Fix WAN address registration issue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
@@ -129,16 +129,20 @@ public class LocalAddressRegistry {
                 }
             }
             linkedAddresses.getAllAddresses().forEach(address -> {
-                if (!addressToUuid.containsKey(address)) {
-                    addressToUuid.put(address, instanceUuid);
-                } else {
-                    logger.warning("Address: " + address + " cannot be registered for the member uuid: " + instanceUuid
-                            + " to addressToMemberUuid map since this address is previously registered for the instance"
-                            + " uuid: " + addressToUuid.get(address) + ". Please use the different set of addresses in "
-                            + " all connected members. Tip: If you want only the wan addresses of the target cluster"
-                            + " to be registered while using advanced networking, configure your wan publishers with"
-                            + " the wan-endpoint-config.");
+                if (addressToUuid.containsKey(address)) {
+                    logger.warning("Address: " + address + " is previously registered with the member uuid: "
+                            + addressToUuid.get(address) + " to our addressToMemberUuid map, now registered with"
+                            + "/overridden by a new member uuid: " + instanceUuid +". In the case, the overridden member"
+                            +  " uuid belongs to an old member that is recently restarted, this override is expected"
+                            + " and it does not create any harm as it will delete the entry of old stale connections."
+                            + " But, if you use the intersecting set of addresses in the two different members in"
+                            + " your cluster topology, please use the different set of addresses in the connected"
+                            + " members. Tip: We can encounter members using these same addresses in WAN setups"
+                            + " including clusters that are belongs to two private networks. If you want only the"
+                            + " WAN addresses of the target cluster to be registered, Use advanced networking,"
+                            + " configure your wan publishers with an wan-endpoint-config.");
                 }
+                addressToUuid.put(address, instanceUuid);
             });
             if (logger.isFineEnabled()) {
                 logger.fine(linkedAddresses + " registered for the instance uuid=" + instanceUuid

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
@@ -132,15 +132,16 @@ public class LocalAddressRegistry {
                 if (addressToUuid.containsKey(address)) {
                     logger.warning("Address: " + address + " is previously registered with the member uuid: "
                             + addressToUuid.get(address) + " to our addressToMemberUuid map, now registered with"
-                            + "/overridden by a new member uuid: " + instanceUuid +". In the case, the overridden member"
-                            +  " uuid belongs to an old member that is recently restarted, this override is expected"
-                            + " and it does not create any harm as it will delete the entry of old stale connections."
-                            + " But, if you use the intersecting set of addresses in the two different members in"
-                            + " your cluster topology, please use the different set of addresses in the connected"
-                            + " members. Tip: We can encounter members using these same addresses in WAN setups"
-                            + " including clusters that are belongs to two private networks. If you want only the"
-                            + " WAN addresses of the target cluster to be registered, Use advanced networking,"
-                            + " configure your wan publishers with an wan-endpoint-config.");
+                            + "/overridden by a new member uuid: " + instanceUuid + ". In the case, the overridden"
+                            + " member uuid belongs to an old member that is recently restarted, this override is"
+                            + " expected and it does not create any harm as it will delete the entry of old stale"
+                            + " connections. But, if you use the intersecting set of addresses in the two different"
+                            + " members in your cluster topology, please use the different set of addresses in the"
+                            + " connected members. Tip: We can encounter members using these same addresses in WAN"
+                            + " setups including clusters that are belongs to two private networks. If you want only"
+                            + " the WAN addresses of the target cluster to be registered, use advanced networking"
+                            + " in the both clusters, configure your wan server sockets and your wan publishers with"
+                            + " some wan endpoint config.");
                 }
                 addressToUuid.put(address, instanceUuid);
             });

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
@@ -128,7 +128,18 @@ public class LocalAddressRegistry {
                             + " member.");
                 }
             }
-            linkedAddresses.getAllAddresses().forEach(address -> addressToUuid.put(address, instanceUuid));
+            linkedAddresses.getAllAddresses().forEach(address -> {
+                if (!addressToUuid.containsKey(address)) {
+                    addressToUuid.put(address, instanceUuid);
+                } else {
+                    logger.warning("Address: " + address + " cannot be registered for the member uuid: " + instanceUuid
+                            + " to addressToMemberUuid map since this address is previously registered for the instance"
+                            + " uuid: " + addressToUuid.get(address) + ". Please use the different set of addresses in "
+                            + " all connected members. Tip: If you want only the wan addresses of the target cluster"
+                            + " to be registered while using advanced networking, configure your wan publishers with"
+                            + " the wan-endpoint-config.");
+                }
+            });
             if (logger.isFineEnabled()) {
                 logger.fine(linkedAddresses + " registered for the instance uuid=" + instanceUuid
                         + " currently all registered addresses for this instance uuid: "

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
@@ -138,7 +138,7 @@ public class LocalAddressRegistry {
                             + " connections. But, if you use the intersecting set of addresses in the two different"
                             + " members in your cluster topology, please use the different set of addresses in the"
                             + " connected members. Tip: We can encounter members using these same addresses in WAN"
-                            + " setups including clusters that are belongs to two private networks. If you want only"
+                            + " setups including clusters that belong to two private networks. If you want only"
                             + " the WAN addresses of the target cluster to be registered, use advanced networking"
                             + " in the both clusters, configure your wan server sockets and your wan publishers with"
                             + " some wan endpoint config.");

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -611,7 +611,7 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
         if (connection != null) {
             write = context.outboundOperationHandler.send(op, connection);
         } else {
-            write = context.outboundOperationHandler.send(op, targetAddress);
+            write = context.outboundOperationHandler.send(op, targetAddress, connectionManager);
         }
 
         if (!write) {


### PR DESCRIPTION
With this change, we also register the WAN addresses of the remote
member in the connection initiator side when the connections are
created using the connection manager with EndpointQualifier#MEMBER.
Because the connections initiated from `MEMBER` connection manager
can be member or wan connections and we cannot differentiate the type
while processing the member handshake. 

Also, in the previous changes, we were registering the client socket
of the initiator on the acceptor side unnecessarily, removed that
part too. Also, when some member addresses overlap each other in a
cluster topology (A possible case in wan connections in two clusters
using two separate private networks), print a warning log when
overriding the old registered address in this case. In addition, when
connection failures occur during operation invocation, the wrong
connection manager was used to reconnect in some case, fixed that wrong
usage.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/4945