### PR TITLE
Shorten startup log line for Integrity Checker

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/IntegrityChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/IntegrityChecker.java
@@ -33,14 +33,8 @@ import static java.lang.String.format;
 public final class IntegrityChecker {
     private static final String FACTORY_ID = "com.hazelcast.DataSerializerHook";
     private static final String INTEGRITY_CHECKER_IS_DISABLED = "Integrity Checker is disabled. "
-            + "Fail-fast on corrupted executables will not be performed.\n"
-            + "To enable integrity checker do one of the following: \n"
-            + format(CONFIG_CHANGE_TEMPLATE,
-            "config.setIntegrityCheckerEnabled(true);",
-            "hazelcast.integrity-checker.enabled to true",
-            "-Dhz.integritychecker.enabled=true",
-            "HZ_INTEGRITYCHECKER_ENABLED=true"
-    );
+            + "Fail-fast on corrupted executables will not be performed. "
+            + "For more information, see the documentation for Integrity Checker.";
     private static final String INTEGRITY_CHECKER_IS_ENABLED = "Starting Integrity Check scan. "
             + "This is a costly operation and it can be disabled if startup time is important. \n"
             + "To disable Integrity Checker do one of the following: \n"


### PR DESCRIPTION
The current, full-blown logging for enabling integrity checker is very noisy given that it's not expected that a majority of people will actually use it (my assumption). 
This PR is reducing the noise while keeping a clear "next steps" path.

Related discussion: https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1644847169035399
