### PR TITLE
Fix non-deterministic order of UNION ALL output

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlUnionTest.java
@@ -227,7 +227,7 @@ public class SqlUnionTest extends SqlTestSupport {
         expected.add(new Row(timestampTz(14L), 3));
 
         String query = sql + " UNION ALL " + sql;
-        assertTipOfStream(query, expected);
+        assertRowsEventuallyInAnyOrder(query, expected);
     }
 
     private static String createTable(Object[]... values) {


### PR DESCRIPTION
The UNION ALL of streams doesn't provide deterministic order, the test shouldn't
assert that.

Fixes #21218