### PR TITLE
[5.1.z] Add more logging to DynamicMapConfigTest

### DIFF
--- a/hazelcast/src/test/resources/log4j2-trace-dynamic-map-config-update.xml
+++ b/hazelcast/src/test/resources/log4j2-trace-dynamic-map-config-update.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.map.impl" level="trace"/>
+        <Logger name="com.hazelcast.spi.impl.operationservice" level="trace"/>
+        <Logger name="com.hazelcast.map.impl.recordstore.expiry" level="trace"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Previously, I was thinking that this test only fails in 5.0.z, but it also
failed in the current master so created the forward-ports for it. 

Forwardport of #20926 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

