### PR TITLE
[Backport #21232] Reduce metrics sent to MC [HZ-1056]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java
@@ -46,6 +46,7 @@ import java.util.function.Consumer;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLIENT_METRIC_CONNECTION_CLOSED_TIME;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLIENT_METRIC_CONNECTION_CONNECTIONID;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLIENT_METRIC_CONNECTION_EVENT_HANDLER_COUNT;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.StringUtil.timeToStringFriendly;
 
@@ -55,7 +56,7 @@ import static com.hazelcast.internal.util.StringUtil.timeToStringFriendly;
  */
 public class TcpClientConnection implements ClientConnection {
 
-    @Probe(name = CLIENT_METRIC_CONNECTION_CONNECTIONID)
+    @Probe(name = CLIENT_METRIC_CONNECTION_CONNECTIONID, level = DEBUG)
     private final int connectionId;
     private final ILogger logger;
     private final Channel channel;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
@@ -27,6 +27,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLUSTER_M
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLUSTER_METRIC_CLUSTER_CLOCK_CLUSTER_UP_TIME;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLUSTER_METRIC_CLUSTER_CLOCK_LOCAL_CLOCK_TIME;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLUSTER_METRIC_CLUSTER_CLOCK_MAX_CLUSTER_TIME_DIFF;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static java.lang.Math.abs;
@@ -45,7 +46,7 @@ public class ClusterClockImpl implements ClusterClock {
         this.logger = logger;
     }
 
-    @Probe(name = CLUSTER_METRIC_CLUSTER_CLOCK_CLUSTER_TIME, unit = MS)
+    @Probe(name = CLUSTER_METRIC_CLUSTER_CLOCK_CLUSTER_TIME, unit = MS, level = DEBUG)
     @Override
     public long getClusterTime() {
         return Clock.currentTimeMillis() + clusterTimeDiff;
@@ -91,12 +92,12 @@ public class ClusterClockImpl implements ClusterClock {
         }
     }
 
-    @Probe(name = CLUSTER_METRIC_CLUSTER_CLOCK_LOCAL_CLOCK_TIME, unit = MS)
+    @Probe(name = CLUSTER_METRIC_CLUSTER_CLOCK_LOCAL_CLOCK_TIME, unit = MS, level = DEBUG)
     private long getLocalClockTime() {
         return Clock.currentTimeMillis();
     }
 
-    @Probe(name = CLUSTER_METRIC_CLUSTER_CLOCK_CLUSTER_START_TIME, unit = MS)
+    @Probe(name = CLUSTER_METRIC_CLUSTER_CLOCK_CLUSTER_START_TIME, unit = MS, level = DEBUG)
     public long getClusterStartTime() {
         return clusterStartTime;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricTarget.java
@@ -18,15 +18,13 @@ package com.hazelcast.internal.metrics;
 
 import com.hazelcast.internal.util.collection.Int2ObjectHashMap;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableList;
 
 /**
  * Enum representing the target platforms of the metrics collection.
@@ -40,7 +38,7 @@ public enum MetricTarget {
     DIAGNOSTICS,
     JET_JOB;
 
-    public static final List<MetricTarget> ALL_TARGETS = unmodifiableList(asList(values()));
+    public static final Collection<MetricTarget> ALL_TARGETS = EnumSet.copyOf(Arrays.asList(values()));
     public static final Collection<MetricTarget> NONE_OF = EnumSet.noneOf(MetricTarget.class);
     public static final Collection<MetricTarget> ALL_TARGETS_BUT_DIAGNOSTICS;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -113,7 +113,7 @@ class MetricsCollectionCycle {
                         .copy()
                         .withUnit(methodProbe.probe.unit())
                         .withMetric(methodProbe.getProbeName())
-                        .withExcludedTargets(extractExcludedTargets(methodProbe));
+                        .withExcludedTargets(extractExcludedTargets(methodProbe, minimumLevel));
 
                 lookupMetricValueCatcher(descriptorCopy).catchMetricValue(collectionId, source, methodProbe);
                 collect(descriptorCopy, source, methodProbe);
@@ -126,7 +126,7 @@ class MetricsCollectionCycle {
                         .copy()
                         .withUnit(fieldProbe.probe.unit())
                         .withMetric(fieldProbe.getProbeName())
-                        .withExcludedTargets(extractExcludedTargets(fieldProbe));
+                        .withExcludedTargets(extractExcludedTargets(fieldProbe, minimumLevel));
 
                 lookupMetricValueCatcher(descriptorCopy).catchMetricValue(collectionId, source, fieldProbe);
                 collect(descriptorCopy, source, fieldProbe);
@@ -188,7 +188,7 @@ class MetricsCollectionCycle {
                         .copy()
                         .withUnit(unit)
                         .withMetric(name);
-                adjustExclusionsWithLevel(descriptorCopy, level);
+                adjustExclusionsWithLevel(descriptorCopy, level, minimumLevel);
 
                 lookupMetricValueCatcher(descriptorCopy).catchMetricValue(collectionId, value);
                 metricsCollector.collectLong(descriptorCopy, value);
@@ -202,7 +202,7 @@ class MetricsCollectionCycle {
                         .copy()
                         .withUnit(unit)
                         .withMetric(name);
-                adjustExclusionsWithLevel(descriptorCopy, level);
+                adjustExclusionsWithLevel(descriptorCopy, level, minimumLevel);
 
                 lookupMetricValueCatcher(descriptorCopy).catchMetricValue(collectionId, value);
                 metricsCollector.collectDouble(descriptorCopy, value);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -234,7 +234,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
             return;
         }
 
-        descriptor.withExcludedTargets(extractExcludedTargets(function));
+        descriptor.withExcludedTargets(extractExcludedTargets(function, minimumLevel));
 
         MetricDescriptorImpl.LookupView descriptorLookupView = ((MetricDescriptorImpl) descriptor).lookupView();
         ProbeInstance probeInstance = probeInstances

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsUtil.java
@@ -41,8 +41,13 @@ final class MetricsUtil {
      *
      * @param descriptor The descriptor to update
      * @param level      The level of the metric to adjust with
+     * @param minimumLevel      The level of metrics exposed for debugging purposes
      */
-    static void adjustExclusionsWithLevel(MetricDescriptor descriptor, ProbeLevel level) {
+    static void adjustExclusionsWithLevel(MetricDescriptor descriptor, ProbeLevel level, ProbeLevel minimumLevel) {
+        if (DEBUG == minimumLevel) {
+            return;
+        }
+
         if (DEBUG != level) {
             return;
         }
@@ -59,27 +64,33 @@ final class MetricsUtil {
      *
      * @param function The {@link ProbeFunction} the excluded targets to
      *                 be excluded from
+     * @param minimumLevel The level of metrics exposed for debugging purposes
      * @return the excluded targets
      */
-    static Collection<MetricTarget> extractExcludedTargets(ProbeFunction function) {
+    static Collection<MetricTarget> extractExcludedTargets(ProbeFunction function, ProbeLevel minimumLevel) {
         if (function instanceof FieldProbe) {
             FieldProbe fieldProbe = (FieldProbe) function;
-            return extractExcludedTargets(fieldProbe.probe, fieldProbe.sourceMetadata);
+            return extractExcludedTargets(fieldProbe.probe, fieldProbe.sourceMetadata, minimumLevel);
         }
 
         if (function instanceof MethodProbe) {
             MethodProbe methodProbe = (MethodProbe) function;
-            return extractExcludedTargets(methodProbe.probe, methodProbe.sourceMetadata);
+            return extractExcludedTargets(methodProbe.probe, methodProbe.sourceMetadata, minimumLevel);
         }
 
         return emptySet();
     }
 
-    private static Collection<MetricTarget> extractExcludedTargets(CachedProbe probe, SourceMetadata sourceMetadata) {
+    private static Collection<MetricTarget> extractExcludedTargets(CachedProbe probe, SourceMetadata sourceMetadata,
+                                                                   ProbeLevel minimumLevel) {
         ProbeLevel level = probe.level();
         Collection<MetricTarget> excludedTargetsClass = sourceMetadata.excludedTargetsClass();
         Set<MetricTarget> excludedTargetsProbe = asSet(probe.excludedTargets());
         Set<MetricTarget> excludedTargetsUnion = MetricTarget.union(excludedTargetsClass, excludedTargetsProbe);
+
+        if (DEBUG == minimumLevel) {
+            return excludedTargetsUnion;
+        }
 
         if (DEBUG != level) {
             return excludedTargetsUnion;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -36,6 +36,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.NETWORKIN
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.NETWORKING_METRIC_NIO_INBOUND_PIPELINE_IDLE_TIME_MS;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.NETWORKING_METRIC_NIO_INBOUND_PIPELINE_NORMAL_FRAMES_READ;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.NETWORKING_METRIC_NIO_INBOUND_PIPELINE_PRIORITY_FRAMES_READ;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -57,11 +58,11 @@ public final class NioInboundPipeline extends NioPipeline implements InboundPipe
     private InboundHandler[] handlers = new InboundHandler[0];
     private ByteBuffer receiveBuffer;
 
-    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_BYTES_READ, unit = BYTES)
+    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_BYTES_READ, unit = BYTES, level = DEBUG)
     private final SwCounter bytesRead = newSwCounter();
-    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_NORMAL_FRAMES_READ)
+    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_NORMAL_FRAMES_READ, level = DEBUG)
     private final SwCounter normalFramesRead = newSwCounter();
-    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_PRIORITY_FRAMES_READ)
+    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_PRIORITY_FRAMES_READ, level = DEBUG)
     private final SwCounter priorityFramesRead = newSwCounter();
     private volatile long lastReadTime = -1;
 
@@ -100,7 +101,7 @@ public final class NioInboundPipeline extends NioPipeline implements InboundPipe
         }
     }
 
-    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_IDLE_TIME_MS, unit = MS)
+    @Probe(name = NETWORKING_METRIC_NIO_INBOUND_PIPELINE_IDLE_TIME_MS, unit = MS, level = DEBUG)
     private long idleTimeMillis() {
         return Math.max(currentTimeMillis() - lastReadTime, 0);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -59,6 +59,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFI
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX_CONNECTION_OUT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX_INPUTTHREAD;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX_OUTPUTTHREAD;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeUnit.BYTES;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_NOW_STRING;
@@ -128,13 +129,13 @@ public final class NioNetworking implements Networking, DynamicMetricsProvider {
     // Currently, this is a coarse-grained aggregation of the bytes/send received.
     // In the future you probably want to split this up in member and client and potentially
     // wan specific.
-    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_BYTES_SEND, unit = BYTES)
+    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_BYTES_SEND, unit = BYTES, level = DEBUG)
     private volatile long bytesSend;
-    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_BYTES_RECEIVED, unit = BYTES)
+    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_BYTES_RECEIVED, unit = BYTES, level = DEBUG)
     private volatile long bytesReceived;
-    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_PACKETS_SEND)
+    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_PACKETS_SEND, level = DEBUG)
     private volatile long packetsSend;
-    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_PACKETS_RECEIVED)
+    @Probe(name = NETWORKING_METRIC_NIO_NETWORKING_PACKETS_RECEIVED, level = DEBUG)
     private volatile long packetsReceived;
 
     public NioNetworking(Context ctx) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -107,21 +107,21 @@ public final class NioOutboundPipeline
     }
 
     @SuppressWarnings("checkstyle:visibilitymodifier")
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_WRITE_QUEUE_SIZE)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_WRITE_QUEUE_SIZE, level = DEBUG)
     public final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<>();
     @SuppressWarnings("checkstyle:visibilitymodifier")
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_PRIORITY_WRITE_QUEUE_SIZE)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_PRIORITY_WRITE_QUEUE_SIZE, level = DEBUG)
     public final Queue<OutboundFrame> priorityWriteQueue = new ConcurrentLinkedQueue<>();
 
     private OutboundHandler[] handlers = new OutboundHandler[0];
     private ByteBuffer sendBuffer;
 
     private final AtomicReference<State> scheduled = new AtomicReference<>(State.SCHEDULED);
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_BYTES_WRITTEN, unit = BYTES)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_BYTES_WRITTEN, unit = BYTES, level = DEBUG)
     private final SwCounter bytesWritten = newSwCounter();
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_NORMAL_FRAMES_WRITTEN)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_NORMAL_FRAMES_WRITTEN, level = DEBUG)
     private final SwCounter normalFramesWritten = newSwCounter();
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_PRIORITY_FRAMES_WRITTEN)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_PRIORITY_FRAMES_WRITTEN, level = DEBUG)
     private final SwCounter priorityFramesWritten = newSwCounter();
 
     private volatile long lastWriteTime;
@@ -188,12 +188,12 @@ public final class NioOutboundPipeline
         return bytesPending;
     }
 
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_IDLE_TIME_MILLIS, unit = MS)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_IDLE_TIME_MILLIS, unit = MS, level = DEBUG)
     private long idleTimeMillis() {
         return max(currentTimeMillis() - lastWriteTime, 0);
     }
 
-    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_SCHEDULED)
+    @Probe(name = NETWORKING_METRIC_NIO_OUTBOUND_PIPELINE_SCHEDULED, level = DEBUG)
     private long scheduled() {
         return scheduled.get().ordinal();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -50,7 +50,7 @@ public abstract class NioPipeline implements MigratablePipeline, Runnable {
     protected final int loadType = Integer.getInteger("hazelcast.io.load", LOAD_BALANCING_BYTE);
 
     // the number of time the NioPipeline.process() method has been called.
-    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_PROCESS_COUNT)
+    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_PROCESS_COUNT, level = DEBUG)
     protected final SwCounter processCount = newSwCounter();
     protected final ILogger logger;
     protected final NioChannel channel;
@@ -66,12 +66,12 @@ public abstract class NioPipeline implements MigratablePipeline, Runnable {
     private final int initialOps;
     private final IOBalancer ioBalancer;
     private final AtomicReference<TaskNode> delayedTaskStack = new AtomicReference<>();
-    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_OWNER_ID)
+    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_OWNER_ID, level = DEBUG)
     private volatile int ownerId;
     // counts the number of migrations that have happened so far
-    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_STARTED_MIGRATIONS)
+    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_STARTED_MIGRATIONS, level = DEBUG)
     private final SwCounter startedMigrations = newSwCounter();
-    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_COMPLETED_MIGRATIONS)
+    @Probe(name = NETWORKING_METRIC_NIO_PIPELINE_COMPLETED_MIGRATIONS, level = DEBUG)
     private final SwCounter completedMigrations = newSwCounter();
     private volatile NioThread newOwner;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -34,6 +34,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.NETWORKING_METRIC_NIO_IO_BALANCER_IMBALANCE_DETECTED_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.NETWORKING_METRIC_NIO_IO_BALANCER_MIGRATION_COMPLETED_COUNT;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.spi.properties.ClusterProperty.IO_BALANCER_INTERVAL_SECONDS;
@@ -78,11 +79,11 @@ public class IOBalancer {
     private IOBalancerThread ioBalancerThread;
 
     // only IOBalancerThread will write to this field.
-    @Probe(name = NETWORKING_METRIC_NIO_IO_BALANCER_IMBALANCE_DETECTED_COUNT)
+    @Probe(name = NETWORKING_METRIC_NIO_IO_BALANCER_IMBALANCE_DETECTED_COUNT, level = DEBUG)
     private final SwCounter imbalanceDetectedCount = newSwCounter();
 
     // multiple threads can update this field.
-    @Probe(name = NETWORKING_METRIC_NIO_IO_BALANCER_MIGRATION_COMPLETED_COUNT)
+    @Probe(name = NETWORKING_METRIC_NIO_IO_BALANCER_MIGRATION_COMPLETED_COUNT, level = DEBUG)
     private final MwCounter migrationCompletedCount = newMwCounter();
 
     public IOBalancer(NioThread[] inputThreads,

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerAcceptor.java
@@ -45,6 +45,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRI
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ACCEPTOR_IDLE_TIME_MILLIS;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ACCEPTOR_SELECTOR_RECREATE_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX_ACCEPTOR;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_WITH_FIX;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
@@ -73,12 +74,12 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
     private final TcpServer server;
     private final ILogger logger;
     private final ServerContext serverContext;
-    @Probe(name = TCP_METRIC_ACCEPTOR_EVENT_COUNT)
+    @Probe(name = TCP_METRIC_ACCEPTOR_EVENT_COUNT, level = DEBUG)
     private final SwCounter eventCount = newSwCounter();
-    @Probe(name = TCP_METRIC_ACCEPTOR_EXCEPTION_COUNT)
+    @Probe(name = TCP_METRIC_ACCEPTOR_EXCEPTION_COUNT, level = DEBUG)
     private final SwCounter exceptionCount = newSwCounter();
     // count number of times the selector was recreated (if selectWorkaround is enabled)
-    @Probe(name = TCP_METRIC_ACCEPTOR_SELECTOR_RECREATE_COUNT)
+    @Probe(name = TCP_METRIC_ACCEPTOR_SELECTOR_RECREATE_COUNT, level = DEBUG)
     private final SwCounter selectorRecreateCount = newSwCounter();
     private final AcceptorIOThread acceptorThread;
     // last time select returned
@@ -107,7 +108,7 @@ public class TcpServerAcceptor implements DynamicMetricsProvider {
      *
      * @return the idle time in ms.
      */
-    @Probe(name = TCP_METRIC_ACCEPTOR_IDLE_TIME_MILLIS, unit = MS)
+    @Probe(name = TCP_METRIC_ACCEPTOR_IDLE_TIME_MILLIS, unit = MS, level = DEBUG)
     private long idleTimeMillis() {
         return max(currentTimeMillis() - lastSelectTimeMs, 0);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -43,6 +43,7 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_CONNECTION_CONNECTION_TYPE;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeUnit.ENUM;
 import static com.hazelcast.internal.nio.ConnectionType.MEMBER;
 import static com.hazelcast.internal.nio.ConnectionType.NONE;
@@ -132,7 +133,7 @@ public class TcpServerConnection implements ServerConnection {
         return connectionType;
     }
 
-    @Probe(name = TCP_METRIC_CONNECTION_CONNECTION_TYPE, unit = ENUM)
+    @Probe(name = TCP_METRIC_CONNECTION_CONNECTION_TYPE, unit = ENUM, level = DEBUG)
     private int getType() {
         return ConnectionType.getTypeId(connectionType);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManager.java
@@ -63,6 +63,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRI
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_TEXT_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_PREFIX_CONNECTION;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_TAG_ENDPOINT;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static com.hazelcast.internal.nio.ConnectionType.MEMCACHE_CLIENT;
@@ -320,7 +321,7 @@ public class TcpServerConnectionManager extends TcpServerConnectionManagerBase
                 + ", connectionsMap=" + null + '}';
     }
 
-    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_IN_PROGRESS_COUNT)
+    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_IN_PROGRESS_COUNT, level = DEBUG)
     private int connectionsInProgress() {
         int c = 0;
         for (Plane plane : planes) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnectionManagerBase.java
@@ -55,6 +55,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRI
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_CLOSED_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_CONNECTION_LISTENER_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TCP_METRIC_ENDPOINT_MANAGER_OPENED_COUNT;
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
@@ -70,10 +71,10 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
     private static final int RETRY_NUMBER = 5;
     private static final long DELAY_FACTOR = 100L;
 
-    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_OPENED_COUNT)
+    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_OPENED_COUNT, level = DEBUG)
     protected final MwCounter openedCount = newMwCounter();
 
-    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_CLOSED_COUNT)
+    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_CLOSED_COUNT, level = DEBUG)
     protected final MwCounter closedCount = newMwCounter();
 
     protected final ILogger logger;
@@ -94,7 +95,7 @@ abstract class TcpServerConnectionManagerBase implements ServerConnectionManager
     @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_ACCEPTED_SOCKET_COUNT, level = MANDATORY)
     final Set<Channel> acceptedChannels = newSetFromMap(new ConcurrentHashMap<>());
 
-    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_CONNECTION_LISTENER_COUNT)
+    @Probe(name = TCP_METRIC_ENDPOINT_MANAGER_CONNECTION_LISTENER_COUNT, level = DEBUG)
     final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<>();
 
     private final ConstructorFunction<Address, TcpServerConnectionErrorHandler> errorHandlerConstructor;

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -819,8 +819,7 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.mc.executor.thread.count", 2);
 
     /**
-     * Enables collecting debug metrics. Debug metrics are sent to the
-     * diagnostics only.
+     * Enables collecting debug metrics.
      */
     public static final HazelcastProperty METRICS_DEBUG
             = new HazelcastProperty("hazelcast.metrics.debug.enabled");

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsTargetExclusionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsTargetExclusionTest.java
@@ -34,6 +34,8 @@ import java.util.Collection;
 import static com.hazelcast.internal.metrics.MetricTarget.ALL_TARGETS;
 import static com.hazelcast.internal.metrics.MetricTarget.ALL_TARGETS_BUT_DIAGNOSTICS;
 import static com.hazelcast.internal.metrics.MetricTarget.DIAGNOSTICS;
+import static com.hazelcast.internal.metrics.MetricTarget.JET_JOB;
+import static com.hazelcast.internal.metrics.MetricTarget.JMX;
 import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
 import static com.hazelcast.internal.metrics.MetricTarget.NONE_OF;
 import static com.hazelcast.internal.metrics.MetricTarget.asSet;
@@ -105,12 +107,12 @@ public class MetricsTargetExclusionTest {
             MetricDescriptor descriptorValues = descriptor.copy().withPrefix("testValues");
             context.collect(descriptorValues.copy().withMetric("noLevelLong").withUnit(COUNT), 42L);
             context.collect(descriptorValues.copy(), "nonDebugLong", INFO, COUNT, 42L);
-            context.collect(descriptorValues.copy(), "debugLong", DEBUG, COUNT, 42L);
-            context.collect(descriptorValues.copy().withExcludedTarget(DIAGNOSTICS), "debugLongNoDiag", DEBUG, COUNT, 42L);
+            context.collect(descriptorValues.copy().withExcludedTargets(ALL_TARGETS_BUT_DIAGNOSTICS), "debugLong", DEBUG, COUNT, 42L);
+            context.collect(descriptorValues.copy().withExcludedTargets(ALL_TARGETS), "debugLongNoDiag", DEBUG, COUNT, 42L);
             context.collect(descriptorValues.copy().withMetric("noLevelDouble").withUnit(COUNT), 42L);
             context.collect(descriptorValues.copy(), "nonDebugDouble", INFO, COUNT, 42.42D);
-            context.collect(descriptorValues.copy(), "debugDouble", DEBUG, COUNT, 42.42D);
-            context.collect(descriptorValues.copy().withExcludedTarget(DIAGNOSTICS), "debugDoubleNoDiag", DEBUG, COUNT, 42.42D);
+            context.collect(descriptorValues.copy().withExcludedTargets(ALL_TARGETS_BUT_DIAGNOSTICS), "debugDouble", DEBUG, COUNT, 42.42D);
+            context.collect(descriptorValues.copy().withExcludedTargets(ALL_TARGETS), "debugDoubleNoDiag", DEBUG, COUNT, 42.42D);
 
             // object
             context.collect(descriptor.withPrefix("test"), new SomeObject());
@@ -186,15 +188,15 @@ public class MetricsTargetExclusionTest {
 
         @Probe(name = "nonDebugLongField")
         private long nonDebugLongField;
-        @Probe(name = "debugLongField", level = DEBUG)
+        @Probe(name = "debugLongField", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX})
         private long debugLongField;
-        @Probe(name = "debugLongFieldNoDiag", level = DEBUG, excludedTargets = DIAGNOSTICS)
+        @Probe(name = "debugLongFieldNoDiag", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX, DIAGNOSTICS})
         private long debugLongFieldNoDiag;
         @Probe(name = "nonDebugDoubleField")
         private double nonDebugDoubleField;
-        @Probe(name = "debugDoubleField", level = DEBUG)
+        @Probe(name = "debugDoubleField", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX})
         private double debugDoubleField;
-        @Probe(name = "debugDoubleFieldNoDiag", level = DEBUG, excludedTargets = DIAGNOSTICS)
+        @Probe(name = "debugDoubleFieldNoDiag", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX, DIAGNOSTICS})
         private long debugDoubleFieldNoDiag;
 
         @Probe(name = "nonDebugLongMethod")
@@ -202,12 +204,12 @@ public class MetricsTargetExclusionTest {
             return 0;
         }
 
-        @Probe(name = "debugLongMethod", level = DEBUG)
+        @Probe(name = "debugLongMethod", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX})
         private long debugLongMethod() {
             return 0;
         }
 
-        @Probe(name = "debugLongMethodNoDiag", level = DEBUG, excludedTargets = DIAGNOSTICS)
+        @Probe(name = "debugLongMethodNoDiag", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX, DIAGNOSTICS})
         private long debugLongMethodNoDiag() {
             return 0;
         }
@@ -217,12 +219,12 @@ public class MetricsTargetExclusionTest {
             return 0;
         }
 
-        @Probe(name = "debugDoubleMethod", level = DEBUG)
+        @Probe(name = "debugDoubleMethod", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX})
         private double debugDoubleMethod() {
             return 0;
         }
 
-        @Probe(name = "debugDoubleMethodNoDiag", level = DEBUG, excludedTargets = DIAGNOSTICS)
+        @Probe(name = "debugDoubleMethodNoDiag", level = DEBUG, excludedTargets = {MANAGEMENT_CENTER, JET_JOB, JMX, DIAGNOSTICS})
         private long debugDoubleMethodNoDiag() {
             return 0;
         }


### PR DESCRIPTION
Most network-related metrics sent to MC by members are not used by MC. In a case of a large cluster, it can overload the MC.

To decrease the number of metrics sent to MC, their level has been changed to DEBUG.

In case those metrics are used by Prometheus Exporter via MC, the system property `hazelcast.metrics.debug.enabled` enables collecting debug metrics.

Backport of: https://github.com/hazelcast/hazelcast/pull/21232

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
