### PR TITLE
Improve destroy of child Hazelcast process in HzStartIT [HZ-1067]

### DIFF
--- a/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/HzStartIT.java
+++ b/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/HzStartIT.java
@@ -19,6 +19,8 @@ package com.hazelcast.it;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -31,12 +33,15 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
 public class HzStartIT extends HazelcastTestSupport {
+
+    private static final ILogger log = Logger.getLogger(HzStartIT.class);
 
     private Process process;
     private HazelcastInstance client;
@@ -62,11 +67,18 @@ public class HzStartIT extends HazelcastTestSupport {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (client != null) {
             client.shutdown();
         }
+        log.info("Destroying Hazelcast process");
         process.destroy();
+        boolean destroyed = process.waitFor(30, TimeUnit.SECONDS);
+        if (!destroyed) {
+            log.info("Hazelcast process not destroyed, trying Process#destroyForcibly()");
+            process.destroyForcibly()
+                   .waitFor();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4425

EE counter-part https://github.com/hazelcast/hazelcast-enterprise/pull/4967.

Backports are not needed (this fails on fips only and we don't have older builds with fips).

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
