### PR TITLE
Clear JMX metrics when starting tests looking at them HZ-1092 #21245 [4.1.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientJmxMetricsTest.java
@@ -49,7 +49,7 @@ public class ClientJmxMetricsTest extends HazelcastTestSupport {
 
     @Test
     public void testNoMBeanLeak() {
-        helper.assertNoMBeans();
+        helper.clearMBeans();
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getMetricsConfig()
@@ -62,11 +62,6 @@ public class ClientJmxMetricsTest extends HazelcastTestSupport {
         assertTrueEventually(() -> helper.assertMBeanContains(expectedObjectName));
 
         client.shutdown();
-        // if failing, grep for "test-jvm"
-        // there should be a Metric[com.hazelcast:type=Metrics,instance=$CLIENT_NAME,prefix=test-jvm-$JVM_NAME] metric if the
-        // client was created with TestHazelcastFactory
-        // $JVM_NAME contains the PID, so $CLIENT_NAME + $JVM_NAME together helps identifying the test left the given metric
-        // around
         helper.assertNoMBeans();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTestHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTestHelper.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.metrics.jmx;
 
 import com.hazelcast.internal.metrics.jmx.MetricsMBean.Type;
 import com.hazelcast.internal.util.BiTuple;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.TriTuple;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -49,6 +50,20 @@ public class JmxPublisherTestHelper {
         objectNameNoModule = new ObjectName(domainPrefix + ":*");
         objectNameWithModule = new ObjectName(domainPrefix + "." + MODULE_NAME + ":*");
         platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+    }
+
+    public void clearMBeans() {
+        queryOurInstances().forEach(this::clearMBean);
+        assertNoMBeans();
+    }
+
+    private void clearMBean(ObjectInstance instance) {
+        try {
+            ObjectName name = instance.getObjectName();
+            platformMBeanServer.unregisterMBean(name);
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        }
     }
 
     public void assertNoMBeans() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/MemberJmxMetricsTest.java
@@ -50,7 +50,7 @@ public class MemberJmxMetricsTest {
 
     @Test
     public void testNoMBeanLeak() {
-        helper.assertNoMBeans();
+        helper.clearMBeans();
 
         Config config = smallInstanceConfig();
         config.getMetricsConfig()


### PR DESCRIPTION
Fix brittle tests by cleaning up garbage before they start.

Fixes #21245

Backport of: #18528 