### PR TITLE
Ignore flaky JobSubmissionSlownessRegressionTest [HZ-1066] [5.1.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.jet.test.IgnoredForCoverage;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -44,8 +45,15 @@ import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * This test is ignored due to being flaky - it tries to submit as many jobs as
+ * possible and checks if the rate doesn't go down.
+ * Any larger GC pause or noisy neighbor on the build machine can cause the test to fail.
+ * We keep the test so we can run it on demand when required.
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({SlowTest.class, IgnoredForCoverage.class})
+@Ignore
 public final class JobSubmissionSlownessRegressionTest extends JetTestSupport {
 
     private static final int DURATION_SECS = 10;


### PR DESCRIPTION
Ignoring as agreed with Ondrej. See the comment on the test.

Closes #19658
Backport of #21298

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
