### PR TITLE
[HZ-1094] Increase PartitionServiceSafetyCheckTest timeout and log loop time

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
@@ -160,7 +160,7 @@ public class PartitionServiceSafetyCheckTest extends PartitionCorrectnessTestSup
     }
 
     @Category(SlowTest.class)
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     public void clusterSafe_completes_whenInvokedFromCommonPool() throws InterruptedException {
         Config config = getConfig(true, true);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.internal.partition;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.partition.PartitionService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -34,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.internal.partition.AntiEntropyCorrectnessTest.setBackupPacketDropFilter;
 import static org.junit.Assert.assertFalse;
@@ -42,6 +45,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PartitionServiceSafetyCheckTest extends PartitionCorrectnessTestSupport {
+
+    private static final ILogger LOGGER = Logger.getLogger(PartitionCorrectnessTestSupport.class);
 
     private static final float BLOCK_RATIO = 0.95f;
 
@@ -180,28 +185,33 @@ public class PartitionServiceSafetyCheckTest extends PartitionCorrectnessTestSup
         ExecutorService executorService = ForkJoinPool.commonPool();
         // no assertions are actually executed. We only care that isClusterSafe
         // does not hang indefinitely
+        AtomicInteger loopCount = new AtomicInteger();
         assertTrueAllTheTime(() -> {
+            LOGGER.info(">> loop start: " + loopCount.incrementAndGet());
+            long start = System.currentTimeMillis();
             CountDownLatch startQueryClusterSafe = new CountDownLatch(1);
             CountDownLatch completed = new CountDownLatch(threadCount);
             for (int i = 0; i < threadCount; i++) {
                 executorService.submit(() -> {
-                            try {
-                                startQueryClusterSafe.await();
-                                for (HazelcastInstance instance : instances) {
-                                    PartitionService ps = instance.getPartitionService();
-                                    // just invoke isClusterSafe, no need to assert result
-                                    // we only care about the call eventually completing
+                    try {
+                        startQueryClusterSafe.await();
+                        for (HazelcastInstance instance : instances) {
+                            PartitionService ps = instance.getPartitionService();
+                            // just invoke isClusterSafe, no need to assert result
+                            // we only care about the call eventually completing
                                     ps.isClusterSafe();
-                                }
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            } finally {
-                                completed.countDown();
-                            }
-                        });
+                        }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    } finally {
+                        completed.countDown();
+                    }
+                });
             }
             startQueryClusterSafe.countDown();
             completed.await();
+            long end = System.currentTimeMillis();
+            LOGGER.info(">> loop finish: " + TimeUnit.MILLISECONDS.toSeconds(end - start) + "s " + loopCount);
         }, 30);
     }
 


### PR DESCRIPTION
In the thread dump there is no indication that the test is stuck/taking long time. FJP is occupied by some operations and doesn't have an empty thread but this shouldn't be the problem, as I couldn't find anything which uses FJP other than the `SafeStateCheckOperation`. It's likely that test timed out due to natural causes. I add logging for duration of the loop, so if we ever encounter this again, we'll be more certain if this is due to some kind of deadlock or congestion.

I'm also open for suggestions, if you want to see some additional logging.

I will port this after it get's merged.

Fixes https://github.com/hazelcast/hazelcast/issues/21247

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
