### PR TITLE
Revert of commit responsible for perf regression HZ-1120

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/string/ConcatWSFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/string/ConcatWSFunctionIntegrationTest.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.jet.sql.impl.expression.string;
 
+import com.hazelcast.jet.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionBiValue;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionType;
 import com.hazelcast.jet.sql.impl.support.expressions.ExpressionTypes;
 import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlColumnType;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
-import com.hazelcast.jet.sql.impl.expression.ExpressionTestSupport;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.string.ConcatWSFunction;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -44,6 +44,7 @@ public class ConcatWSFunctionIntegrationTest extends ExpressionTestSupport {
     @Test
     public void testColumn() {
         ExpressionType<?>[] allTypes = ExpressionTypes.all();
+
         for (int i = 0; i < allTypes.length; i++) {
             for (int j = i; j < allTypes.length; j++) {
                 ExpressionType<?> type1 = allTypes[i];

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastReaders.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastReaders.java
@@ -58,7 +58,6 @@ import java.io.IOException;
 import java.security.Permission;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.forceTotalParallelismOne;
 import static com.hazelcast.jet.impl.util.ImdgUtil.asXmlString;
@@ -175,7 +174,7 @@ public final class HazelcastReaders {
     @Nonnull
     public static ProcessorMetaSupplier readLocalMapSupplier(@Nonnull String mapName) {
         return new LocalProcessorMetaSupplier<
-                CompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>>(
+                InternalCompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>>(
                 new LocalMapReaderFunction(mapName)
         ) {
             @Override
@@ -186,7 +185,7 @@ public final class HazelcastReaders {
     }
 
     public static class LocalMapReaderFunction implements BiFunctionEx<HazelcastInstance, InternalSerializationService,
-            ReadMapOrCacheP.Reader<CompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>>>,
+            ReadMapOrCacheP.Reader<InternalCompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>>>,
             IdentifiedDataSerializable {
         private String mapName;
 
@@ -198,7 +197,7 @@ public final class HazelcastReaders {
         }
 
         @Override
-        public ReadMapOrCacheP.Reader<CompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>>
+        public ReadMapOrCacheP.Reader<InternalCompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>>
         applyEx(HazelcastInstance instance, InternalSerializationService serializationService) throws Exception {
             return new LocalMapReader(instance, serializationService, mapName);
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -30,7 +30,6 @@ import com.hazelcast.client.impl.proxy.ClientMapProxy;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.cluster.Address;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
@@ -48,9 +47,6 @@ import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcSupplierCtx;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.map.impl.LazyMapEntry;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.iterator.AbstractCursor;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.operation.MapOperation;
@@ -60,7 +56,6 @@ import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.map.impl.query.ResultSegment;
-import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -68,7 +63,6 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 
@@ -76,14 +70,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.security.Permission;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -96,7 +88,6 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.impl.util.ImdgUtil.asClientConfig;
 import static com.hazelcast.jet.impl.util.Util.distributeObjects;
-import static com.hazelcast.jet.impl.util.Util.getNodeEngine;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -136,6 +127,7 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
     private ReadMapOrCacheP(@Nonnull Reader<F, B, R> reader, @Nonnull int[] partitionIds) {
         this.reader = reader;
         this.partitionIds = partitionIds;
+
         maxParallelRead = Math.min(partitionIds.length, MAX_PARALLEL_READ);
         readPointers = new IterationPointer[partitionIds.length][];
         Arrays.fill(readPointers, new IterationPointer[]{new IterationPointer(Integer.MAX_VALUE, -1)});
@@ -509,14 +501,9 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
     }
 
     static class LocalMapReader
-            extends Reader<CompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>> {
+            extends Reader<InternalCompletableFuture<MapEntriesWithCursor>, MapEntriesWithCursor, Entry<Data, Data>> {
 
-        private static final int RETRY_DELAY = 100;
         private final MapProxyImpl mapProxyImpl;
-        private final MapServiceContext mapServiceContext;
-        private final NodeEngineImpl nodeEngine;
-        private final boolean isHD;
-
 
         LocalMapReader(@Nonnull HazelcastInstance hzInstance,
                        @Nonnull InternalSerializationService serializationService,
@@ -524,78 +511,15 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
             super(mapName,
                     AbstractCursor::getIterationPointers,
                     AbstractCursor::getBatch);
-            this.serializationService = serializationService;
             this.mapProxyImpl = (MapProxyImpl) hzInstance.getMap(mapName);
-            nodeEngine = getNodeEngine(hzInstance);
-            MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
-            mapServiceContext = service.getMapServiceContext();
-            isHD = mapProxyImpl.getMapConfig().getInMemoryFormat().equals(InMemoryFormat.NATIVE);
+            this.serializationService = serializationService;
         }
 
         @Nonnull @Override
-        public CompletableFuture<MapEntriesWithCursor> readBatch(int partitionId, IterationPointer[] pointers) {
-            if (isHD) {
-                return readWithOperationService(partitionId, pointers);
-            }
-
-            CompletableFuture<MapEntriesWithCursor> f = new CompletableFuture<>();
-            read0(f, partitionId, pointers);
-            return f;
-        }
-
-        private void read0(CompletableFuture<MapEntriesWithCursor> f, int partitionId, IterationPointer[] pointers) {
-            try {
-                boolean isOwned = mapServiceContext.getOrInitCachedMemberPartitions().contains(partitionId);
-
-                if (isOwned) {
-                    int migrationStamp = mapServiceContext.getService().getMigrationStamp();
-
-                    MapEntriesWithCursor result = readFromRecordStore(partitionId, pointers);
-
-                    if (validateMigrationStamp(migrationStamp)) {
-                        f.complete(result);
-                    } else {
-                        scheduleForLater(f, partitionId, pointers);
-                    }
-                } else {
-                    CompletableFuture<MapEntriesWithCursor> f1 = readWithOperationService(partitionId, pointers);
-                    f1.whenComplete((r, t) -> {
-                        if (t != null) {
-                            f.completeExceptionally(t);
-                        } else {
-                            f.complete(r);
-                        }
-                    });
-                }
-            } catch (Throwable t) {
-                f.completeExceptionally(t);
-            }
-        }
-
-        private void scheduleForLater(CompletableFuture<MapEntriesWithCursor> f, int partitionId, IterationPointer[] pointers) {
-            nodeEngine.getExecutionService().schedule(() -> read0(f, partitionId, pointers), RETRY_DELAY, TimeUnit.MILLISECONDS);
-        }
-
-        private MapEntriesWithCursor readFromRecordStore(int partitionId, IterationPointer[] pointers) {
-            PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
-            RecordStore recordStore = partitionContainer.getExistingRecordStore(mapProxyImpl.getName());
-
-            if (recordStore != null) {
-                //Fetch entries using recordStore
-                return recordStore.fetchEntries(pointers, MAX_FETCH_SIZE);
-            }
-            //Partition is empty
-            return new MapEntriesWithCursor(new ArrayList<>(), new IterationPointer[]{new IterationPointer(-1, -1)});
-        }
-
-        private CompletableFuture<MapEntriesWithCursor> readWithOperationService(int partitionId, IterationPointer[] pointers) {
+        public InternalCompletableFuture<MapEntriesWithCursor> readBatch(int partitionId, IterationPointer[] pointers) {
             MapOperationProvider operationProvider = mapProxyImpl.getOperationProvider();
             Operation op = operationProvider.createFetchEntriesOperation(objectName, pointers, MAX_FETCH_SIZE);
             return mapProxyImpl.getOperationService().invokeOnPartition(mapProxyImpl.getServiceName(), op, partitionId);
-        }
-
-        private boolean validateMigrationStamp(int migrationStamp) {
-            return mapServiceContext.getService().validateMigrationStamp(migrationStamp);
         }
 
         @Nullable @Override


### PR DESCRIPTION
Change https://github.com/hazelcast/hazelcast/pull/19474/files#diff-cc94457e7642f7e1cc3a4ed0ca7c2189e347805b13a334f9fff806c93bb48d1bR522-R530

made a cooperative thread to scan local partitions single threaded, which performed degradation in most of the benchmarks.

Two approaches were tested:
- increasing the default parallelism
- revert of the change responsible for the degradation

Red line - current masterBlue line - multithreaded executionGreen line - increasing the default parallelism

![image](https://user-images.githubusercontent.com/57556371/165474869-2d86bc65-69d7-4d82-9587-514325e6bc84.png)
![image](https://user-images.githubusercontent.com/57556371/165474906-382a0e1b-897b-4fdb-b0ad-c6c7eab58bde.png)
![image](https://user-images.githubusercontent.com/57556371/165474924-06313b6b-f296-4c0a-85dd-e01ed204fa1e.png)
![image](https://user-images.githubusercontent.com/57556371/165474947-8c12184b-73fd-409b-88fe-81f07417a4c2.png)
![image](https://user-images.githubusercontent.com/57556371/165474973-c987eab4-bba6-47af-9323-70541eac9b22.png)
![image](https://user-images.githubusercontent.com/57556371/165474991-3a196dc6-7516-4d51-986d-0a38097303fe.png)
![image](https://user-images.githubusercontent.com/57556371/165475006-608b2a86-8ab9-4cde-a4a1-f4d81bab7e99.png)
![image](https://user-images.githubusercontent.com/57556371/165475031-9d3711a3-c053-40df-ae28-1100803faba5.png)
![image](https://user-images.githubusercontent.com/57556371/165475052-98991602-5112-4ac5-a270-6eb98d10b4aa.png)
![image](https://user-images.githubusercontent.com/57556371/165475077-e4a5cc15-7751-4997-a382-453f9ae0873e.png)


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
