### PR TITLE
Fix a typo in CompactWriter.writeTimestampWithTimezone

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactWriter.java
@@ -131,7 +131,7 @@ public interface CompactWriter {
     void writeTimestamp(@Nonnull String fieldName, @Nonnull LocalDateTime value);
 
     /**
-     * Reads a timestamp with timezone consisting of date, time and timezone offset.
+     * Writes a timestamp with timezone consisting of date, time and timezone offset.
      *
      * @param fieldName name of the field.
      * @param value     to be written.


### PR DESCRIPTION
Fixes just a typo

Breaking changes (list specific methods/types/messages):

NONE

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
