### PR TITLE
Extract pipelines to separate methods in common Elastic tests

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -112,13 +112,20 @@ public abstract class BaseElasticTest {
     }
 
     /**
-     * RestHighLevelClient supplier, it is used to
-     * - create a client before each test for use by all methods from this class interacting with elastic
-     * - may be used as as a parameter of {@link ElasticSourceBuilder#clientFn(SupplierEx)}
+     * RestHighLevelClient supplier, it is used to create a client before each
+     * test for use by all methods from this class interacting with elastic
      */
     protected SupplierEx<RestClientBuilder> elasticClientSupplier() {
         return ElasticSupport.elasticClientSupplier();
-    };
+    }
+
+    /**
+     * RestHighLevelClient supplier, it is used to used as a parameter of
+     * {@link ElasticSourceBuilder#clientFn(SupplierEx)}
+     */
+    protected SupplierEx<RestClientBuilder> elasticPipelineClientSupplier() {
+        return ElasticSupport.elasticClientSupplier();
+    }
 
     protected abstract HazelcastInstance createHazelcastInstance();
 

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
@@ -176,7 +176,7 @@ public abstract class CommonElasticSourcesTest extends BaseElasticTest {
                 "non-existing-index", elasticPipelineClientSupplier(), results);
 
         assertThatThrownBy(() -> submitJob(p))
-                .hasRootCauseInstanceOf(ResponseException.class)
+                .hasStackTraceContaining("ResponseException")
                 .hasStackTraceContaining("no such index [non-existing-index]");
     }
 

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
@@ -17,20 +17,19 @@
 package com.hazelcast.jet.elastic;
 
 import com.hazelcast.jet.pipeline.Pipeline;
-import org.elasticsearch.client.ResponseException;
 import org.junit.Test;
 
 import java.io.IOException;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexAsStringEnableSlicingPipeline;
-import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexWithQueryExtractNamePipeline;
 import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexAsStringPipeline;
-import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexExtractNamePipeline;
 import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexAsStringZeroRetriesPipeline;
+import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexExtractNamePipeline;
+import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexUsingScrollAsStringPipeline;
 import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexUsingSourceFactoryMethod1ExtractNamePipeline;
 import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexUsingSourceFactoryMethod2ExtractNamePipeline;
-import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexUsingScrollAsStringPipeline;
+import static com.hazelcast.jet.elastic.pipeline.CommonElasticSourcesPipeline.readFromIndexWithQueryExtractNamePipeline;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSinksPipeline.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSinksPipeline.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet.elastic.pipeline;
+
+import com.hazelcast.function.SupplierEx;
+import com.hazelcast.jet.elastic.CommonElasticSinksTest;
+import com.hazelcast.jet.elastic.ElasticSinkBuilder;
+import com.hazelcast.jet.elastic.ElasticSinks;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sink;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.RestClientBuilder;
+
+public final class CommonElasticSinksPipeline {
+
+    private CommonElasticSinksPipeline() {
+    }
+
+    public static Pipeline given_singleDocument_whenWriteToElasticSink_then_singleDocumentInIndex_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier) {
+        Pipeline p = Pipeline.create();
+
+        Sink<CommonElasticSinksTest.TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticSupplier)
+                .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE))
+                .mapToRequestFn(
+                        (CommonElasticSinksTest.TestItem item) -> new IndexRequest("my-index").source(item.asMap()))
+                .build();
+
+        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem("id", "Frantisek")))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+    public static Pipeline given_batchOfDocuments_whenWriteToElasticSink_then_batchOfDocumentsInIndex_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            CommonElasticSinksTest.TestItem[] items) {
+        Pipeline p = Pipeline.create();
+
+        Sink<CommonElasticSinksTest.TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticSupplier)
+                .mapToRequestFn(
+                        (CommonElasticSinksTest.TestItem item) -> new IndexRequest("my-index").source(item.asMap()))
+                .build();
+
+        p.readFrom(TestSources.items(items))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+    public static Pipeline given_sinkCreatedByFactoryMethod_whenWriteToElasticSink_thenDocumentInIndex_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier) {
+        Pipeline p = Pipeline.create();
+
+        Sink<CommonElasticSinksTest.TestItem> elasticSink = ElasticSinks.elastic(
+                elasticSupplier,
+                item -> new IndexRequest("my-index").source(item.asMap())
+        );
+
+        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem("id", "Frantisek")))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+    public static Pipeline given_documentInIndex_whenWriteToElasticSinkUpdateRequest_then_documentsInIndexUpdated_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            String id) {
+        Pipeline p = Pipeline.create();
+
+        Sink<CommonElasticSinksTest.TestItem> elasticSink = ElasticSinks.elastic(
+                elasticSupplier,
+                item -> new UpdateRequest("my-index", item.getId()).doc(item.asMap())
+        );
+
+        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem(id, "Frantisek")))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+    public static Pipeline given_documentInIndex_whenWriteToElasticSinkDeleteRequest_then_documentIsDeleted_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            String id) {
+        Pipeline p = Pipeline.create();
+
+        Sink<CommonElasticSinksTest.TestItem> elasticSink = ElasticSinks.elastic(
+                elasticSupplier,
+                (item) -> new DeleteRequest("my-index", item.getId())
+        );
+
+        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem(id, "Frantisek")))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+    public static Pipeline given_documentNotInIndex_whenWriteToElasticSinkUpdateRequest_then_jobShouldFail_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier) {
+        Pipeline p = Pipeline.create();
+
+        Sink<CommonElasticSinksTest.TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticSupplier)
+                .mapToRequestFn((CommonElasticSinksTest.TestItem item)
+                        -> new UpdateRequest("my-index", item.getId()).doc(item.asMap()))
+                .retries(0)
+                .build();
+
+        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem("notExist", "Frantisek")))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+    public static Pipeline documentInIndex_writeToElasticSinkDeleteRequestTwice_jobShouldFinishSuccessfully_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            String id) {
+        Pipeline p = Pipeline.create();
+
+        Sink<String> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticSupplier)
+                .mapToRequestFn((String item) -> new DeleteRequest("my-index", item))
+                .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE))
+                .build();
+
+        p.readFrom(TestSources.items(id))
+                .writeTo(elasticSink);
+
+        return p;
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSinksPipeline.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSinksPipeline.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.jet.elastic.pipeline;
 
 import com.hazelcast.function.SupplierEx;
-import com.hazelcast.jet.elastic.CommonElasticSinksTest;
+import com.hazelcast.jet.elastic.CommonElasticSinksTest.TestItem;
 import com.hazelcast.jet.elastic.ElasticSinkBuilder;
 import com.hazelcast.jet.elastic.ElasticSinks;
 import com.hazelcast.jet.pipeline.Pipeline;
@@ -34,119 +35,74 @@ public final class CommonElasticSinksPipeline {
     private CommonElasticSinksPipeline() {
     }
 
-    public static Pipeline given_singleDocument_whenWriteToElasticSink_then_singleDocumentInIndex_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier) {
+    public static Pipeline writeItemsToIndexPipeline(
+            String index,
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            TestItem... items) {
         Pipeline p = Pipeline.create();
 
-        Sink<CommonElasticSinksTest.TestItem> elasticSink = new ElasticSinkBuilder<>()
+        Sink<TestItem> elasticSink = new ElasticSinkBuilder<>()
                 .clientFn(elasticSupplier)
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE))
-                .mapToRequestFn(
-                        (CommonElasticSinksTest.TestItem item) -> new IndexRequest("my-index").source(item.asMap()))
-                .build();
-
-        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem("id", "Frantisek")))
-                .writeTo(elasticSink);
-
-        return p;
-    }
-
-    public static Pipeline given_batchOfDocuments_whenWriteToElasticSink_then_batchOfDocumentsInIndex_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier,
-            CommonElasticSinksTest.TestItem[] items) {
-        Pipeline p = Pipeline.create();
-
-        Sink<CommonElasticSinksTest.TestItem> elasticSink = new ElasticSinkBuilder<>()
-                .clientFn(elasticSupplier)
-                .mapToRequestFn(
-                        (CommonElasticSinksTest.TestItem item) -> new IndexRequest("my-index").source(item.asMap()))
+                .mapToRequestFn((TestItem item) -> new IndexRequest(index).source(item.asMap()))
                 .build();
 
         p.readFrom(TestSources.items(items))
-                .writeTo(elasticSink);
+         .writeTo(elasticSink);
 
         return p;
     }
 
-    public static Pipeline given_sinkCreatedByFactoryMethod_whenWriteToElasticSink_thenDocumentInIndex_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier) {
-        Pipeline p = Pipeline.create();
-
-        Sink<CommonElasticSinksTest.TestItem> elasticSink = ElasticSinks.elastic(
-                elasticSupplier,
-                item -> new IndexRequest("my-index").source(item.asMap())
-        );
-
-        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem("id", "Frantisek")))
-                .writeTo(elasticSink);
-
-        return p;
-    }
-
-    public static Pipeline given_documentInIndex_whenWriteToElasticSinkUpdateRequest_then_documentsInIndexUpdated_pipeline(
+    public static Pipeline writeItemsToIndexUsingSourceFactoryMethodPipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
-            String id) {
+            TestItem... items) {
         Pipeline p = Pipeline.create();
 
-        Sink<CommonElasticSinksTest.TestItem> elasticSink = ElasticSinks.elastic(
+        Sink<TestItem> elasticSink = ElasticSinks.elastic(
                 elasticSupplier,
-                item -> new UpdateRequest("my-index", item.getId()).doc(item.asMap())
+                item -> new IndexRequest(index).source(item.asMap())
         );
 
-        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem(id, "Frantisek")))
-                .writeTo(elasticSink);
+        p.readFrom(TestSources.items(items))
+         .writeTo(elasticSink);
 
         return p;
     }
 
-    public static Pipeline given_documentInIndex_whenWriteToElasticSinkDeleteRequest_then_documentIsDeleted_pipeline(
+    public static Pipeline updateItemsInIndexPipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
-            String id) {
+            TestItem... items) {
         Pipeline p = Pipeline.create();
 
-        Sink<CommonElasticSinksTest.TestItem> elasticSink = ElasticSinks.elastic(
-                elasticSupplier,
-                (item) -> new DeleteRequest("my-index", item.getId())
-        );
-
-        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem(id, "Frantisek")))
-                .writeTo(elasticSink);
-
-        return p;
-    }
-
-    public static Pipeline given_documentNotInIndex_whenWriteToElasticSinkUpdateRequest_then_jobShouldFail_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier) {
-        Pipeline p = Pipeline.create();
-
-        Sink<CommonElasticSinksTest.TestItem> elasticSink = new ElasticSinkBuilder<>()
+        Sink<TestItem> elasticSink = new ElasticSinkBuilder<>()
                 .clientFn(elasticSupplier)
-                .mapToRequestFn((CommonElasticSinksTest.TestItem item)
-                        -> new UpdateRequest("my-index", item.getId()).doc(item.asMap()))
-                .retries(0)
-                .build();
-
-        p.readFrom(TestSources.items(new CommonElasticSinksTest.TestItem("notExist", "Frantisek")))
-                .writeTo(elasticSink);
-
-        return p;
-    }
-
-    public static Pipeline documentInIndex_writeToElasticSinkDeleteRequestTwice_jobShouldFinishSuccessfully_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier,
-            String id) {
-        Pipeline p = Pipeline.create();
-
-        Sink<String> elasticSink = new ElasticSinkBuilder<>()
-                .clientFn(elasticSupplier)
-                .mapToRequestFn((String item) -> new DeleteRequest("my-index", item))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE))
+                .mapToRequestFn((TestItem item) -> new UpdateRequest(index, item.getId()).doc(item.asMap()))
                 .build();
 
-        p.readFrom(TestSources.items(id))
-                .writeTo(elasticSink);
+        p.readFrom(TestSources.items(items))
+         .writeTo(elasticSink);
 
         return p;
     }
 
+    public static Pipeline deleteItemsFromIndexPipeline(
+            String index,
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            TestItem... items) {
+        Pipeline p = Pipeline.create();
+
+        Sink<TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticSupplier)
+                .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE))
+                .mapToRequestFn((TestItem item) -> new DeleteRequest(index, item.getId()))
+                .build();
+
+        p.readFrom(TestSources.items(items))
+         .writeTo(elasticSink);
+
+        return p;
+    }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSourcesPipeline.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSourcesPipeline.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet.elastic.pipeline;
+
+import com.hazelcast.collection.IList;
+import com.hazelcast.function.SupplierEx;
+import com.hazelcast.jet.elastic.ElasticSourceBuilder;
+import com.hazelcast.jet.elastic.ElasticSources;
+import com.hazelcast.jet.pipeline.BatchSource;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+
+public final class CommonElasticSourcesPipeline {
+
+    private CommonElasticSourcesPipeline() {
+    }
+
+    public static Pipeline given_emptyIndex_when_readFromElasticSource_then_finishWithNoResults_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index"))
+                .mapToItemFn(SearchHit::getSourceAsString)
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_indexWithOneDocument_whenReadFromElasticSource_thenFinishWithOneResult_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index"))
+                .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_sourceCreatedByFactoryMethod2_whenReadFromElasticSource_thenFinishWithOneResult_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = ElasticSources.elastic(
+                elasticSupplier,
+                hit -> (String) hit.getSourceAsMap().get("name")
+        );
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_sourceCreatedByFactoryMethod3_whenReadFromElasticSource_thenFinishWithOneResult_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = ElasticSources.elastic(
+                elasticSupplier,
+                () -> new SearchRequest("my-index-1"),
+                hit -> (String) hit.getSourceAsMap().get("name")
+        );
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline multipleDocuments_readFromElasticSourceWithScroll_resultHasAllDocuments_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> {
+                    SearchRequest sr = new SearchRequest("my-index");
+
+                    sr.source().size(10) // needs to scroll 5 times
+                            .query(matchAllQuery());
+                    return sr;
+                })
+                .mapToItemFn(SearchHit::getSourceAsString)
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline multipleIndexes_readFromElasticSourceWithIndexWildcard_resultDocumentsFromAllIndexes_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index-*"))
+                .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline multipleIndexes_readFromElasticSourceWithIndex_resultHasNoDocumentFromOtherIndex_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index-1"))
+                .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_documents_when_readFromElasticSourceWithQuery_then_resultHasMatchingDocuments_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index")
+                        .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("name", "Frantisek"))))
+                .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_documents_whenReadFromElasticSourceWithSlicing_then_resultHasAllDocuments_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index"))
+                .mapToItemFn(SearchHit::getSourceAsString)
+                .enableSlicing()
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline documentsInMultipleIndexes_readFromElasticSourceWithSlicing_resultHasAllDocuments_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index-*"))
+                .mapToItemFn(SearchHit::getSourceAsString)
+                .enableSlicing()
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_nonExistingIndex_whenReadFromElasticSource_thenThrowException_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("non-existing-index"))
+                .mapToItemFn(SearchHit::getSourceAsString)
+                .retries(0) // we expect the exception -> faster test
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+    public static Pipeline given_aliasMatchingNoIndex_whenReadFromElasticSource_thenReturnNoResults_pipeline(
+            SupplierEx<RestClientBuilder> elasticSupplier,
+            IList<String> resultsList) {
+        Pipeline p = Pipeline.create();
+
+        BatchSource<String> source = new ElasticSourceBuilder<>()
+                .clientFn(elasticSupplier)
+                .searchRequestFn(() -> new SearchRequest("my-index-*"))
+                .mapToItemFn(SearchHit::getSourceAsString)
+                .build();
+
+        p.readFrom(source)
+                .writeTo(Sinks.list(resultsList));
+
+        return p;
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSourcesPipeline.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSourcesPipeline.java
@@ -35,14 +35,15 @@ public final class CommonElasticSourcesPipeline {
     private CommonElasticSourcesPipeline() {
     }
 
-    public static Pipeline given_emptyIndex_when_readFromElasticSource_then_finishWithNoResults_pipeline(
+    public static Pipeline readFromIndexAsStringPipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
 
         BatchSource<String> source = new ElasticSourceBuilder<>()
                 .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index"))
+                .searchRequestFn(() -> new SearchRequest(index))
                 .mapToItemFn(SearchHit::getSourceAsString)
                 .build();
 
@@ -52,14 +53,15 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline given_indexWithOneDocument_whenReadFromElasticSource_thenFinishWithOneResult_pipeline(
+    public static Pipeline readFromIndexExtractNamePipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
 
         BatchSource<String> source = new ElasticSourceBuilder<>()
                 .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index"))
+                .searchRequestFn(() -> new SearchRequest(index))
                 .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
                 .build();
 
@@ -69,7 +71,7 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline given_sourceCreatedByFactoryMethod2_whenReadFromElasticSource_thenFinishWithOneResult_pipeline(
+    public static Pipeline readFromIndexUsingSourceFactoryMethod1ExtractNamePipeline(
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
@@ -85,14 +87,15 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline given_sourceCreatedByFactoryMethod3_whenReadFromElasticSource_thenFinishWithOneResult_pipeline(
+    public static Pipeline readFromIndexUsingSourceFactoryMethod2ExtractNamePipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
 
         BatchSource<String> source = ElasticSources.elastic(
                 elasticSupplier,
-                () -> new SearchRequest("my-index-1"),
+                () -> new SearchRequest(index),
                 hit -> (String) hit.getSourceAsMap().get("name")
         );
 
@@ -102,7 +105,8 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline multipleDocuments_readFromElasticSourceWithScroll_resultHasAllDocuments_pipeline(
+    public static Pipeline readFromIndexUsingScrollAsStringPipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
@@ -110,7 +114,7 @@ public final class CommonElasticSourcesPipeline {
         BatchSource<String> source = new ElasticSourceBuilder<>()
                 .clientFn(elasticSupplier)
                 .searchRequestFn(() -> {
-                    SearchRequest sr = new SearchRequest("my-index");
+                    SearchRequest sr = new SearchRequest(index);
 
                     sr.source().size(10) // needs to scroll 5 times
                             .query(matchAllQuery());
@@ -125,48 +129,15 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline multipleIndexes_readFromElasticSourceWithIndexWildcard_resultDocumentsFromAllIndexes_pipeline(
+    public static Pipeline readFromIndexWithQueryExtractNamePipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
 
         BatchSource<String> source = new ElasticSourceBuilder<>()
                 .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index-*"))
-                .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
-                .build();
-
-        p.readFrom(source)
-                .writeTo(Sinks.list(resultsList));
-
-        return p;
-    }
-
-    public static Pipeline multipleIndexes_readFromElasticSourceWithIndex_resultHasNoDocumentFromOtherIndex_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier,
-            IList<String> resultsList) {
-        Pipeline p = Pipeline.create();
-
-        BatchSource<String> source = new ElasticSourceBuilder<>()
-                .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index-1"))
-                .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
-                .build();
-
-        p.readFrom(source)
-                .writeTo(Sinks.list(resultsList));
-
-        return p;
-    }
-
-    public static Pipeline given_documents_when_readFromElasticSourceWithQuery_then_resultHasMatchingDocuments_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier,
-            IList<String> resultsList) {
-        Pipeline p = Pipeline.create();
-
-        BatchSource<String> source = new ElasticSourceBuilder<>()
-                .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index")
+                .searchRequestFn(() -> new SearchRequest(index)
                         .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("name", "Frantisek"))))
                 .mapToItemFn(hit -> (String) hit.getSourceAsMap().get("name"))
                 .build();
@@ -177,14 +148,15 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline given_documents_whenReadFromElasticSourceWithSlicing_then_resultHasAllDocuments_pipeline(
+    public static Pipeline readFromIndexAsStringEnableSlicingPipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
 
         BatchSource<String> source = new ElasticSourceBuilder<>()
                 .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index"))
+                .searchRequestFn(() -> new SearchRequest(index))
                 .mapToItemFn(SearchHit::getSourceAsString)
                 .enableSlicing()
                 .build();
@@ -195,51 +167,17 @@ public final class CommonElasticSourcesPipeline {
         return p;
     }
 
-    public static Pipeline documentsInMultipleIndexes_readFromElasticSourceWithSlicing_resultHasAllDocuments_pipeline(
+    public static Pipeline readFromIndexAsStringZeroRetriesPipeline(
+            String index,
             SupplierEx<RestClientBuilder> elasticSupplier,
             IList<String> resultsList) {
         Pipeline p = Pipeline.create();
 
         BatchSource<String> source = new ElasticSourceBuilder<>()
                 .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index-*"))
-                .mapToItemFn(SearchHit::getSourceAsString)
-                .enableSlicing()
-                .build();
-
-        p.readFrom(source)
-                .writeTo(Sinks.list(resultsList));
-
-        return p;
-    }
-
-    public static Pipeline given_nonExistingIndex_whenReadFromElasticSource_thenThrowException_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier,
-            IList<String> resultsList) {
-        Pipeline p = Pipeline.create();
-
-        BatchSource<String> source = new ElasticSourceBuilder<>()
-                .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("non-existing-index"))
+                .searchRequestFn(() -> new SearchRequest(index))
                 .mapToItemFn(SearchHit::getSourceAsString)
                 .retries(0) // we expect the exception -> faster test
-                .build();
-
-        p.readFrom(source)
-                .writeTo(Sinks.list(resultsList));
-
-        return p;
-    }
-
-    public static Pipeline given_aliasMatchingNoIndex_whenReadFromElasticSource_thenReturnNoResults_pipeline(
-            SupplierEx<RestClientBuilder> elasticSupplier,
-            IList<String> resultsList) {
-        Pipeline p = Pipeline.create();
-
-        BatchSource<String> source = new ElasticSourceBuilder<>()
-                .clientFn(elasticSupplier)
-                .searchRequestFn(() -> new SearchRequest("my-index-*"))
-                .mapToItemFn(SearchHit::getSourceAsString)
                 .build();
 
         p.readFrom(source)


### PR DESCRIPTION
Extract pipelines to separate methods in common Elastic tests. It's needed for "[HZ-683] Migrate elasticsearch tests from HZ QE TS to integration module" since those pipelines need to be added through `JobConfig.addClass`. By extracting them we can avoid to adding all classes from integration test.

[HZ-683]: https://hazelcast.atlassian.net/browse/HZ-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ