### PR TITLE
Update schemaLocation to current version

### DIFF
--- a/distribution/src/test/resources/test-hazelcast-user-defined.xml
+++ b/distribution/src/test/resources/test-hazelcast-user-defined.xml
@@ -16,14 +16,14 @@
 
 <!--
     The default Hazelcast configuration. This is used when no hazelcast.xml is present.
-    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.10.xsd
+    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-5.2.xsd
     or the documentation at https://hazelcast.org/documentation/
 -->
 <!--suppress XmlDefaultAttributeValue -->
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://www.hazelcast.com/schema/config"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>hz-xml-configured-cluster</cluster-name>
 </hazelcast>

--- a/docs/design/instance-tracking/instance-tracking.md
+++ b/docs/design/instance-tracking/instance-tracking.md
@@ -25,7 +25,7 @@ The equivalent XML configuration:
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
     
     <instance-tracking enabled="true">
         <file-name>/tmp/hz-tracking.txt</file-name>

--- a/hazelcast/src/main/config-template/hazelcast-assembly.xml
+++ b/hazelcast/src/main/config-template/hazelcast-assembly.xml
@@ -33,7 +33,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <!--
         The name of the cluster. All members of a single cluster must have the same cluster name

--- a/hazelcast/src/main/config-template/hazelcast-assembly.xml
+++ b/hazelcast/src/main/config-template/hazelcast-assembly.xml
@@ -25,7 +25,7 @@
   It's focused on keeping balance between security and usability in the distribution.
 
   To learn how to configure Hazelcast, please see the schema at
-  https://hazelcast.com/schema/config/hazelcast-config-5.1.xsd
+  https://hazelcast.com/schema/config/hazelcast-config-5.2.xsd
   or the Reference Manual at https://docs.hazelcast.com/
 -->
 

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -29,7 +29,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <!--
         The name of the cluster. All members of a single cluster must have the same cluster name

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -21,7 +21,7 @@
   This XML file is used when no hazelcast.xml is present.
 
   To learn how to configure Hazelcast, please see the schema at
-  https://hazelcast.com/schema/config/hazelcast-config-5.1.xsd
+  https://hazelcast.com/schema/config/hazelcast-config-5.2.xsd
   or the Reference Manual at https://docs.hazelcast.com/
 -->
 

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -31,7 +31,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <!--
         You can use the <import> element to load different Hazelcast declarative configuration files you prepared.

--- a/hazelcast/src/main/resources/hazelcast-security-hardened.xml
+++ b/hazelcast/src/main/resources/hazelcast-security-hardened.xml
@@ -19,7 +19,7 @@
 
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <!-- 
       Custom cluster name protects against unintended cluster formation between foreign members.

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
@@ -405,7 +405,7 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
         String mapNameWithStoreAndSize = "MapStoreMaxSize*";
 
         String xml = "<hazelcast xsi:schemaLocation=\"http://www.hazelcast.com/schema/config\n"
-                + "                             http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd\"\n"
+                + "                             http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd\"\n"
                 + "                             xmlns=\"http://www.hazelcast.com/schema/config\"\n"
                 + "                             xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n"
                 + "\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractYamlSchemaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractYamlSchemaTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractYamlSchemaTest {
     private static final ILogger LOGGER = Logger.getLogger(AbstractYamlSchemaTest.class);
 
     public static final Schema SCHEMA = SchemaLoader.builder()
-            .schemaJson(readJSONObject("/hazelcast-config-5.1.json"))
+            .schemaJson(readJSONObject("/hazelcast-config-5.2.json"))
             .draftV6Support()
             .schemaClient(SchemaClient.classPathAwareClient())
             .build()

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -223,7 +223,7 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
         String xmlFileName = "test-hazelcast-discovery-spi.xml";
 
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        URL schemaResource = DiscoverySpiTest.class.getClassLoader().getResource("hazelcast-config-4.0.xsd");
+        URL schemaResource = DiscoverySpiTest.class.getClassLoader().getResource("hazelcast-config-5.2.xsd");
         assertNotNull(schemaResource);
 
         InputStream xmlResource = DiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);

--- a/hazelcast/src/test/resources/aws/test-aws-config.xml
+++ b/hazelcast/src/test/resources/aws/test-aws-config.xml
@@ -15,7 +15,7 @@
   -->
 
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-4.0.xsd"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-5.2.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <properties>

--- a/hazelcast/src/test/resources/azure/test-azure-config-invalid.xml
+++ b/hazelcast/src/test/resources/azure/test-azure-config-invalid.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/azure/test-azure-config.xml
+++ b/hazelcast/src/test/resources/azure/test-azure-config.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>dev</cluster-name>
     <network>

--- a/hazelcast/src/test/resources/com/hazelcast/config/jet/jet-config-and-instance-config.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/jet/jet-config-and-instance-config.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <jet>
         <backup-count>4</backup-count>

--- a/hazelcast/src/test/resources/com/hazelcast/config/jet/just-instance-config.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/jet/just-instance-config.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
     <jet>
         <instance>
             <backup-count>5</backup-count>

--- a/hazelcast/src/test/resources/gcp/test-gcp-config-invalid.xml
+++ b/hazelcast/src/test/resources/gcp/test-gcp-config-invalid.xml
@@ -15,7 +15,7 @@
   -->
 
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-5.2.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <properties>

--- a/hazelcast/src/test/resources/gcp/test-gcp-config.xml
+++ b/hazelcast/src/test/resources/gcp/test-gcp-config.xml
@@ -15,7 +15,7 @@
   -->
 
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-5.2.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <properties>

--- a/hazelcast/src/test/resources/hazelcast-cache-entrylistener-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-cache-entrylistener-test.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cache name="entrylistenertestcache">
         <expiry-policy-factory>

--- a/hazelcast/src/test/resources/hazelcast-composite-index-xml-config-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-composite-index-xml-config-test.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <map name="map">
         <indexes>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.xml
@@ -36,7 +36,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <import resource="hazelcast-fullconfig-without-network.xml"/>
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -39,7 +39,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>my-cluster</cluster-name>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -36,7 +36,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <import resource="hazelcast-fullconfig-without-network.xml"/>
 

--- a/hazelcast/src/test/resources/hazelcast-instance-tracking-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-instance-tracking-test.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <instance-tracking enabled="true">
         <file-name>${instance_tracking_filename}</file-name>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <map name="testQueryCacheXmlConfigWithWildCardMap*">
         <backup-count>1</backup-count>

--- a/hazelcast/src/test/resources/hazelcast-test-executor.xml
+++ b/hazelcast/src/test/resources/hazelcast-test-executor.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <serialization>
         <data-serializable-factories>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
   <properties>
     <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
   <properties>
     <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/test-hazelcast-invalid-cache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-invalid-cache.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>F4D03AC8-B5F7-4542-9BAD-0A94BA48E95D</cluster-name>
     <network>

--- a/hazelcast/src/test/resources/test-hazelcast-jcache-partition-lost-listener.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache-partition-lost-listener.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>test-group1</cluster-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast-jcache-with-split-brain-protection.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache-with-split-brain-protection.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>test-group1</cluster-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <instance-name>test-hazelcast-jcache</instance-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>test-cluster2</cluster-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>test-group1</cluster-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast-variable.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-variable.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <properties>
         <property name="prop">${variable}</property>

--- a/hazelcast/src/test/resources/test-hazelcast.foobar
+++ b/hazelcast/src/test/resources/test-hazelcast.foobar
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>foobar-foobar</cluster-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast.xml
+++ b/hazelcast/src/test/resources/test-hazelcast.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <cluster-name>foobar-xml</cluster-name>
 

--- a/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>


### PR DESCRIPTION
Update schemaLocation to current version to avoid warning messages about wrong schema name.

EE part: [#4991](https://github.com/hazelcast/hazelcast-enterprise/pull/4991)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
