### PR TITLE
Upgrade Protobuf version to make the branch compilable on M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <picocli.version>4.4.0</picocli.version>
         <postgresql.version>42.2.25</postgresql.version>
         <prometheus.version>0.14.0</prometheus.version>
-        <protobuf.version>3.13.0</protobuf.version>
+        <protobuf.version>3.19.4</protobuf.version>
         <scala.version>2.12</scala.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>4.3.0.RELEASE</spring.version>


### PR DESCRIPTION
This PR changes Protobuf version to match the master (5.2 snapshot) version. This is done to enable M1 users to build the 5.0.z branch.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
