### PR TITLE
#20044 Log requests to help identify cause of flaky test

### DIFF
--- a/hazelcast/src/test/resources/log4j2-debug.xml
+++ b/hazelcast/src/test/resources/log4j2-debug.xml
@@ -27,6 +27,7 @@
         </Root>
         <Logger name="com.hazelcast.instance" level="debug"/>
         <Logger name="com.hazelcast.cluster" level="debug"/>
+        <Logger name="com.hazelcast.internal.ascii" level="debug"/>
         <Logger name="com.hazelcast.internal.cluster" level="debug"/>
         <Logger name="com.hazelcast.internal.partition" level="debug"/>
         <Logger name="com.hazelcast.internal.hotrestart.cluster" level="debug"/>

--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -32,6 +32,7 @@
         <!--<Logger name="com.hazelcast.internal.hotrestart.cluster" level="debug"/>-->
         <!--<Logger name="com.hazelcast.test.mocknetwork" level="debug"/>-->
         <!--<Logger name="com.hazelcast.cp.internal" level="trace"/>-->
+        <Logger name="com.hazelcast.internal.ascii" level="debug"/>
         <Logger name="com.hazelcast.client.impl.protocol.task" level="debug"/>
         <Logger name="com.hazelcast.client.impl.operations" level="debug"/>
         <Logger name="com.hazelcast.client.impl.spi.ClientListenerService" level="trace"/>


### PR DESCRIPTION
Add request log to help identify reason of the flaky test

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
