### PR TITLE
Use ConcurrentReferenceHashMap instead of CHM to cache serializers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -36,6 +36,8 @@ import com.hazelcast.internal.serialization.impl.compact.SchemaService;
 import com.hazelcast.internal.serialization.impl.defaultserializers.ConstantSerializers;
 import com.hazelcast.internal.serialization.impl.portable.PortableGenericRecord;
 import com.hazelcast.internal.usercodedeployment.impl.ClassLocator;
+import com.hazelcast.internal.util.ConcurrentReferenceHashMap;
+import com.hazelcast.internal.util.ConcurrentReferenceHashMap.ReferenceType;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
@@ -86,7 +88,8 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     private final IdentityHashMap<Class, SerializerAdapter> constantTypesMap;
     private final SerializerAdapter[] constantTypeIds;
-    private final ConcurrentMap<Class, SerializerAdapter> typeMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class, SerializerAdapter> typeMap =
+            new ConcurrentReferenceHashMap<>(ReferenceType.WEAK, ReferenceType.STRONG);
     private final ConcurrentMap<Integer, SerializerAdapter> idMap = new ConcurrentHashMap<>();
     private final AtomicReference<SerializerAdapter> global = new AtomicReference<SerializerAdapter>();
 


### PR DESCRIPTION
When we deserialize Externalizable/Serializable we store the
Class->SerializerAdapter in AbstractSerializationService#typeMap.

When the Serializable comes from a Jet job, e.g. a lambda in a Jet
pipeline, the Class instance is different for each instance of the job.
The typeMap keeps the references indefinitely and prevents unloading of
the Jet job's classloader, creating a memory leak.

Also, see https://hazelcast.atlassian.net/browse/HZ-914.

Using ConcurrentReferenceHashMap with a weak reference type for the key
allows the class, together with the JetClassloader, to be garbage
collected once the job is finished and the JetClassloader is no longer
strongly referenced.

For the duration of the job the weak reference to the Class will never
be cleared, because there is another strong reference to the class from
the classloader. The same holds for Class objects from Hazelcast's
classloader, so this will not introduce any misses in the `typeMap`
cache.

Tested locally with metaspace limited to 64m with a simple job with a
lambda. On master we get OOM exception before submitting 1000 jobs, with
the fix I was able to submit more than 20 000 jobs without any issue.
Didn't add a test to the test suite,
because it is covered by Jet soak test suite, where this issue was
originally discovered.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

Will send backports to `5.1.z` and `5.0.z` once reviewed