### PR TITLE
Use dynamicPort for WireMockRule [HZ-1156]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/PhoneHomeIntegrationTest.java
@@ -59,6 +59,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.test.Accessors.getNode;
 import static org.mockito.Mockito.when;
@@ -72,7 +73,7 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
     }
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     private Node node;
     private PhoneHome phoneHome;
@@ -94,11 +95,12 @@ public class PhoneHomeIntegrationTest extends HazelcastTestSupport {
         when(dockerPath.toRealPath()).thenReturn(Paths.get(System.getProperty("user.dir")));
         when(kubernetesTokenPath.toRealPath()).thenReturn(Paths.get(System.getProperty("user.dir")));
 
-        cloudInfoCollector = new CloudInfoCollector("http://localhost:8080/latest/meta-data",
-                "http://localhost:8080/metadata/instance/compute?api-version=2018-02-01",
-                "http://localhost:8080/metadata.google.internal", kubernetesTokenPath, dockerPath);
+        int port = wireMockRule.port();
+        cloudInfoCollector = new CloudInfoCollector("http://localhost:" + port + "/latest/meta-data",
+                "http://localhost:" + port + "/metadata/instance/compute?api-version=2018-02-01",
+                "http://localhost:" + port + "/metadata.google.internal", kubernetesTokenPath, dockerPath);
 
-        phoneHome = new PhoneHome(node, "http://localhost:8080/ping", cloudInfoCollector);
+        phoneHome = new PhoneHome(node, "http://localhost:" + port + "/ping", cloudInfoCollector);
         stubUrls("200", "4XX", "4XX", "4XX");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/RESTClientPhoneHomeTest.java
@@ -41,6 +41,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_MAPS;
 import static com.hazelcast.internal.ascii.HTTPCommunicator.URI_QUEUES;
 import static com.hazelcast.internal.util.phonehome.PhoneHomeIntegrationTest.containingParam;
@@ -60,13 +61,14 @@ public class RESTClientPhoneHomeTest {
     }
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     private HazelcastInstance instance;
 
     private HTTPCommunicator http;
 
     private Config config;
+    private int port;
 
     @Before
     public void setUp() {
@@ -74,6 +76,7 @@ public class RESTClientPhoneHomeTest {
         instance = factory.newHazelcastInstance(config);
         http = new HTTPCommunicator(instance);
         stubFor(post(urlPathEqualTo("/ping")).willReturn(aResponse().withStatus(200)));
+        port = wireMockRule.port();
     }
 
     @After
@@ -103,7 +106,7 @@ public class RESTClientPhoneHomeTest {
         assertEquals(400, http.doGet(http.getUrl(URI_MAPS)).responseCode);
         assertEquals(200, http.mapDelete("my-map", "key"));
 
-        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
+        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:" + port + "/ping");
         phoneHome.phoneHome(false);
 
         verify(1, postRequestedFor(urlPathEqualTo("/ping"))
@@ -134,7 +137,7 @@ public class RESTClientPhoneHomeTest {
         assertEquals(204, http.doDelete(http.getUrl(URI_QUEUES) + "my-queue/10").responseCode);
         assertEquals(400, http.doDelete(http.getUrl(URI_QUEUES) + "my-queue").responseCode);
 
-        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
+        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:" + port + "/ping");
         phoneHome.phoneHome(false);
 
         verify(1, postRequestedFor(urlPathEqualTo("/ping"))
@@ -157,7 +160,7 @@ public class RESTClientPhoneHomeTest {
         http.configReload(config.getClusterName(), "");
         http.configUpdate(config.getClusterName(), "", "hazelcast:\n");
 
-        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:8080/ping");
+        PhoneHome phoneHome = new PhoneHome(getNode(instance), "http://localhost:" + port + "/ping");
         phoneHome.phoneHome(false);
 
         verify(1, postRequestedFor(urlPathEqualTo("/ping"))


### PR DESCRIPTION
In #20034 wiremock failed to bind to the port 8080, because it was
already in use. I wasn't able to reproduce it, but it's likely that
these 2 tests interfere with each other, or possibly REST interface in
other test open on port 8080.

This changes the PhoneHomeIntegrationTest and RESTClientPhoneHomeTest,
which use port 8080, to use `dynamicPort()` (random port).

Fixes #20034

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
