### PR TITLE
[HZ-1140] Added a CPMember UUID check to distinguish a rejoined node and a restarted one

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftServiceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftServiceDataSerializerHook.java
@@ -20,6 +20,7 @@ import com.hazelcast.cp.internal.MembershipChangeSchedule.CPGroupMembershipChang
 import com.hazelcast.cp.internal.operation.ChangeRaftGroupMembershipOp;
 import com.hazelcast.cp.internal.operation.DefaultRaftReplicateOp;
 import com.hazelcast.cp.internal.operation.DestroyRaftGroupOp;
+import com.hazelcast.cp.internal.operation.GetLocalCPMemberOp;
 import com.hazelcast.cp.internal.operation.GetLeadedGroupsOp;
 import com.hazelcast.cp.internal.operation.RaftQueryOp;
 import com.hazelcast.cp.internal.operation.ResetCPMemberOp;
@@ -124,6 +125,7 @@ public final class RaftServiceDataSerializerHook implements DataSerializerHook {
     public static final int TRIGGER_LEADER_ELECTION_OP = 50;
     public static final int UNSAFE_MODE_PARTITION_STATE = 51;
     public static final int UNSAFE_STATE_REPLICATE_OP = 52;
+    public static final int GET_LOCAL_CP_MEMBER = 53;
 
     @Override
     public int getFactoryId() {
@@ -238,6 +240,8 @@ public final class RaftServiceDataSerializerHook implements DataSerializerHook {
                     return new UnsafeModePartitionState();
                 case UNSAFE_STATE_REPLICATE_OP:
                     return new UnsafeStateReplicationOp();
+                case GET_LOCAL_CP_MEMBER:
+                    return new GetLocalCPMemberOp();
                 default:
                     throw new IllegalArgumentException("Undefined type: " + typeId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/GetLocalCPMemberOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/GetLocalCPMemberOp.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.operation;
+
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.cp.internal.CPMemberInfo;
+import com.hazelcast.cp.internal.RaftService;
+import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
+import com.hazelcast.cp.internal.RaftSystemOperation;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.operationservice.ExceptionAction;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+/**
+ * Returns the CPMemberInfo for the local member if a CP member exists. Otherwise, it returns null.
+ */
+public class GetLocalCPMemberOp extends Operation implements RaftSystemOperation, IdentifiedDataSerializable {
+
+    private transient CPMemberInfo cpMemberInfo;
+
+    public GetLocalCPMemberOp() {
+    }
+
+    @Override
+    public void run() throws Exception {
+        RaftService service = getService();
+        cpMemberInfo = service.getLocalCPMember();
+    }
+
+    @Override
+    public Object getResponse() {
+        return cpMemberInfo;
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
+    }
+
+    @Override
+    public final boolean validatesTarget() {
+        return false;
+    }
+
+    @Override
+    public final String getServiceName() {
+        return RaftService.SERVICE_NAME;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return RaftServiceDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return RaftServiceDataSerializerHook.GET_LOCAL_CP_MEMBER;
+    }
+}


### PR DESCRIPTION
In addition to comparing IP addresses, we also need to check the UUID of the CP Member to distinguish between a new (or restarted) node and a node that has been rejoined after split-brain healing.

A new `GetLocalCPMemberOp` operation has been added to get a `CPMemberInfo` object (with a Raft Member UUID) from a remote node.

Fixes https://hazelcast.atlassian.net/browse/HZ-1140

Breaking changes (list specific methods/types/messages):
* added new operation `GetLocalCPMemberOp` 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
