### PR TITLE
Bumped kafka test version of Confluent Platform to 7.1.1

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
@@ -28,7 +28,7 @@ import java.util.Properties;
 
 class DockerizedKafkaTestSupport extends KafkaTestSupport {
 
-    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.0.1");
+    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.1.1");
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerizedKafkaTestSupport.class);
 
     private KafkaContainer kafkaContainer;


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Bumped Kafka Confluent Platform version used in tests


Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
