### PR TITLE
Disable hadoop tests on IBM JDK17 #20754 HZ-980 [5.1.z]

### DIFF
--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
@@ -32,6 +32,11 @@ public abstract class HadoopTestSupport extends SimpleTestInClusterSupport {
             // Tests fail on windows without an extra setup. If you want to run them, comment out this
             // line and follow instructions here: https://stackoverflow.com/a/35652866/952135
             assumeThatNoWindowsOS();
+
+            // Tests will fail on IBM JDK17 with error:
+            // No LoginModule found for com.ibm.security.auth.module.JAASLoginModule
+            // see https://github.com/hazelcast/hazelcast/issues/20754
+            assumeThatNotIBMJDK17();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -118,6 +118,7 @@ public abstract class HazelcastTestSupport {
 
     public static final String JAVA_VERSION = System.getProperty("java.version");
     public static final String JVM_NAME = System.getProperty("java.vm.name");
+    public static final String JAVA_VENDOR = System.getProperty("java.vendor");
 
     public static final int ASSERT_TRUE_EVENTUALLY_TIMEOUT;
     public static final int ASSERT_COMPLETES_STALL_TOLERANCE;
@@ -1606,6 +1607,10 @@ public abstract class HazelcastTestSupport {
 
     public static void assumeThatNotZingJDK6() {
         assumeFalse("Zing JDK6 used", JAVA_VERSION.startsWith("1.6.") && JVM_NAME.startsWith("Zing"));
+    }
+
+    public static void assumeThatNotIBMJDK17() {
+        assumeFalse("Skipping on IBM JDK 17", JAVA_VERSION.startsWith("17.") && JAVA_VENDOR.contains("IBM"));
     }
 
     public static void assumeThatNoWindowsOS() {


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/21068

Fixes: https://github.com/hazelcast/hazelcast/issues/20754
Relates to: https://hazelcast.atlassian.net/browse/HZ-980

Hadoop tests fail due to lack of removed `com.ibm.security.auth.module.JAASLoginModule` class from IBM JDK:
https://github.com/n-marion/hadoop/blob/a0e4acbe7a0820a2f2069adfa33857034ee21ba4/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java#L433-L438 

The funny thing is that it works on IBM JDK 11 because of the bug in the IBM JDK detection. Hadoop checks if the vendor contains "IBM" while JDK 11 reports itself as `International Business Machines Corporation`:
<img width="426" alt="image" src="https://user-images.githubusercontent.com/1242724/160247682-8c7fd402-4176-4e68-a877-d7f4a0cbb6d6.png">
This way Hadoop uses generic `com.sun.security.auth.module.UnixLoginModule` which works.

We can't do anything about it, it has to be fixed by Hadoop. To overcome this I've ignored Hadoop tests when run on IBM JDK17


