### PR TITLE
Update TestContainers, so that they work fine on Mac M1 CPUs

### DIFF
--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -48,10 +48,10 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.kinesis.KinesisSinks.MAXIMUM_KEY_LENGTH;
 import static com.hazelcast.jet.kinesis.KinesisSinks.MAX_RECORD_SIZE;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
+import static com.hazelcast.test.TestStringUtils.repeat;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.repeat;
 import static org.testcontainers.utility.DockerImageName.parse;
 
 public class KinesisFailureTest extends AbstractKinesisTest {

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <mockito.version>3.6.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
-        <testcontainers.version>1.15.3</testcontainers.version>
+        <testcontainers.version>1.17.1</testcontainers.version>
         <archunit.version>0.22.0</archunit.version>
         <errorprone.version>2.11.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>


### PR DESCRIPTION
TestContainers need to be upgraded to work with the newest Docker.

For more context, please see https://github.com/testcontainers/testcontainers-java/issues/3834 - dependency mentioned there is a standard dependency in the newest TestContainers and it fixes the problem.

EE PR: [#5001](https://github.com/hazelcast/hazelcast-enterprise/pull/5001)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
