### PR TITLE
Fix cluster cleanup in Kinesis IT [HZ-1185]

### DIFF
--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
@@ -90,12 +90,16 @@ public abstract class AbstractKinesisTest extends JetTestSupport {
 
     @After
     public void after() {
-        cleanUpCluster(cluster);
+        if (cluster != null) {
+            cleanUpCluster(cluster);
+        }
 
         helper.deleteStream();
 
-        results.clear();
-        results.destroy();
+        if (results != null) {
+            results.clear();
+            results.destroy();
+        }
     }
 
     protected HazelcastInstance hz() {


### PR DESCRIPTION
Fix cluster cleanup in KinesisIntegrationTest - if for some reason before() failed (e.g. Docker had problems), after() won't throw misleading errors.

Fixes #21142 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
