### PR TITLE
Handle max integer expiry configuration [HZ-1170] 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
@@ -18,13 +18,8 @@ package com.hazelcast.internal.nearcache;
 
 import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.Expirable;
-import com.hazelcast.map.impl.record.Record;
 
 import java.util.UUID;
-
-import static com.hazelcast.internal.util.TimeUtil.zeroOutMs;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * An expirable and evictable data object
@@ -38,22 +33,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @see com.hazelcast.internal.eviction.Evictable
  */
 public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
-
-    /**
-     * Base time to be used for storing time values as diffs
-     * (int) rather than full blown epoch based vals (long)
-     * This allows for a space in seconds, of roughly 68 years.
-     *
-     * Reference value (1514764800000) -
-     * Monday, January 1, 2018 12:00:00 AM
-     *
-     * The fixed time in the past (instead of {@link
-     * System#currentTimeMillis()} prevents any time
-     * discrepancies among nodes, mis-translated as diffs
-     * of -1 ie. {@link Record#UNSET} values. (see.
-     * https://github.com/hazelcast/hazelcast-enterprise/issues/2527)
-     */
-    long EPOCH_TIME = zeroOutMs(1514764800000L);
 
     int TIME_NOT_SET = -1;
 
@@ -97,7 +76,7 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
     /**
      * It can have 2 different value:
      *
-     *  1. {@link #READ_PERMITTED} if no
+     * 1. {@link #READ_PERMITTED} if no
      * update is happening on this record.
      *
      * 2. A `long` reservation id to indicate
@@ -151,25 +130,9 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
 
     void setCachedAsNull(boolean valueCachedAsNull);
 
-    default int stripBaseTime(long timeInMillis) {
-        if (timeInMillis > 0) {
-            return (int) MILLISECONDS.toSeconds(timeInMillis - EPOCH_TIME);
-        } else {
-            return TIME_NOT_SET;
-        }
-    }
-
-    default long recomputeWithBaseTime(int trimmedTime) {
-        if (trimmedTime == TIME_NOT_SET) {
-            return TIME_NOT_SET;
-        }
-        long exploded = SECONDS.toMillis(trimmedTime);
-        return exploded + EPOCH_TIME;
-    }
-
     default boolean isExpiredAt(long now) {
         long expirationTime = getExpirationTime();
-        return (expirationTime > TIME_NOT_SET) && (expirationTime <= now);
+        return (expirationTime > 0L) && (expirationTime <= now);
     }
 
     /**
@@ -187,7 +150,7 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
         }
 
         long lastAccessTime = getLastAccessTime();
-        return lastAccessTime > TIME_NOT_SET
+        return lastAccessTime > 0L
                 ? lastAccessTime + maxIdleMilliSeconds < now
                 : getCreationTime() + maxIdleMilliSeconds < now;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/AbstractNearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/AbstractNearCacheRecord.java
@@ -22,6 +22,9 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+import static com.hazelcast.internal.util.TimeStripUtil.recomputeWithBaseTime;
+import static com.hazelcast.internal.util.TimeStripUtil.stripBaseTime;
+
 /**
  * Abstract implementation of {@link NearCacheRecord}
  * with value and expiration time as internal state.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/TimeStripUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/TimeStripUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.map.impl.record.Record;
+
+import static com.hazelcast.internal.util.TimeUtil.zeroOutMs;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Contains millis to seconds, second to millis
+ * conversions based on a fixed epoch time.
+ */
+public final class TimeStripUtil {
+
+    /**
+     * Base time to be used for storing time values as diffs
+     * (int) rather than full-blown epoch based values (long)
+     * This allows for a space in seconds, of roughly 68 years.
+     * <p>
+     * Reference value (1514764800000) -
+     * Monday, January 1, 2018 12:00:00 AM
+     * <p>
+     * The fixed time in the past (instead of {@link
+     * System#currentTimeMillis()} prevents any time
+     * discrepancies among nodes, mis-translated as
+     * diffs of -1 ie. {@link Record#UNSET} values.
+     * <p>
+     * (see:
+     * https://github.com/hazelcast/hazelcast-enterprise/issues/2527)
+     */
+    private static final long EPOCH_TIME_MILLIS = zeroOutMs(1514764800000L);
+    private static final int UNSET = -1;
+
+    private TimeStripUtil() {
+    }
+
+    public static int stripBaseTime(long millis) {
+        if (millis == Long.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+
+        if (millis > 0) {
+            long toSeconds = MILLISECONDS.toSeconds(millis - EPOCH_TIME_MILLIS);
+            return toSeconds >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) toSeconds;
+        }
+
+        return UNSET;
+    }
+
+    public static long recomputeWithBaseTime(int seconds) {
+        if (seconds == UNSET) {
+            return 0L;
+        }
+
+        if (seconds == Integer.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+
+        return EPOCH_TIME_MILLIS + SECONDS.toMillis(seconds);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/TimeStripUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/TimeStripUtil.java
@@ -44,7 +44,7 @@ public final class TimeStripUtil {
      * (see:
      * https://github.com/hazelcast/hazelcast-enterprise/issues/2527)
      */
-    private static final long EPOCH_TIME_MILLIS = zeroOutMs(1514764800000L);
+    public static final long EPOCH_TIME_MILLIS = zeroOutMs(1514764800000L);
     private static final int UNSET = -1;
 
     private TimeStripUtil() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
@@ -78,11 +78,6 @@ public final class ExpirationTimeSetter {
      * @return time in millis
      */
     private static long pickRightTimeInMillis(int secondsFromMapConfig, long millisFromOperation) {
-        if (millisFromOperation < 0
-                && (secondsFromMapConfig == 0 || secondsFromMapConfig == Integer.MAX_VALUE)) {
-            return Long.MAX_VALUE;
-        }
-
         if (millisFromOperation > 0) {
             // if user set millisFromOperation when calling operation, use it
             return millisFromOperation;
@@ -92,7 +87,7 @@ public final class ExpirationTimeSetter {
             return Long.MAX_VALUE;
         }
 
-        if (secondsFromMapConfig > 0) {
+        if (secondsFromMapConfig > 0 && secondsFromMapConfig < Integer.MAX_VALUE) {
             // if this is the first creation of entry, try to get expiry value from mapConfig
             return SECONDS.toMillis(secondsFromMapConfig);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.config.MapConfig;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -97,5 +98,19 @@ public final class ExpirationTimeSetter {
         }
         // if we are here, entry should live forever
         return Long.MAX_VALUE;
+    }
+
+    public static int toSeconds(long millis) {
+        long seconds = MILLISECONDS.toSeconds(millis);
+        if (seconds == 0 && millis != 0) {
+            seconds = 1;
+        }
+        return seconds > Integer.MAX_VALUE
+                ? Integer.MAX_VALUE : (int) seconds;
+    }
+
+    public static long toMillis(int seconds) {
+        return seconds == Integer.MAX_VALUE
+                ? Long.MAX_VALUE : SECONDS.toMillis(seconds);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -20,6 +20,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.util.JVMUtil.OBJECT_HEADER_SIZE;
+import static com.hazelcast.internal.util.TimeStripUtil.recomputeWithBaseTime;
+import static com.hazelcast.internal.util.TimeStripUtil.stripBaseTime;
 import static com.hazelcast.map.impl.record.RecordReaderWriter.DATA_RECORD_WITH_STATS_READER_WRITER;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/CachedSimpleRecordWithLRUEviction.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/CachedSimpleRecordWithLRUEviction.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.serialization.Data;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.internal.util.TimeStripUtil.recomputeWithBaseTime;
+import static com.hazelcast.internal.util.TimeStripUtil.stripBaseTime;
 import static com.hazelcast.map.impl.record.RecordReaderWriter.SIMPLE_DATA_RECORD_WITH_LRU_EVICTION_READER_WRITER;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
@@ -18,30 +18,11 @@ package com.hazelcast.map.impl.record;
 
 import com.hazelcast.internal.util.Clock;
 
-import static com.hazelcast.internal.util.TimeUtil.zeroOutMs;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 /**
  * @param <V> the type of value which is in the Record
  */
 @SuppressWarnings("checkstyle:methodcount")
 public interface Record<V> {
-    /**
-     * Base time to be used for storing time values as diffs
-     * (int) rather than full blown epoch based vals (long)
-     * This allows for a space in seconds, of roughly 68 years.
-     *
-     * Reference value (1514764800000) -
-     * Monday, January 1, 2018 12:00:00 AM
-     *
-     * The fixed time in the past (instead of {@link
-     * System#currentTimeMillis()} prevents any time
-     * discrepancies among nodes, mis-translated as
-     * diffs of -1 ie. {@link Record#UNSET} values. (see.
-     * https://github.com/hazelcast/hazelcast-enterprise/issues/2527)
-     */
-    long EPOCH_TIME = zeroOutMs(1514764800000L);
 
     /**
      * Represents an unset value. This is the default
@@ -145,24 +126,6 @@ public interface Record<V> {
     }
 
     default void setLastStoredTime(long lastStoredTime) {
-    }
-
-    default long recomputeWithBaseTime(int value) {
-        if (value == UNSET) {
-            return 0L;
-        }
-
-        long exploded = SECONDS.toMillis(value);
-        return exploded + EPOCH_TIME;
-    }
-
-    default int stripBaseTime(long value) {
-        int diff = UNSET;
-        if (value > 0) {
-            diff = (int) MILLISECONDS.toSeconds(value - EPOCH_TIME);
-        }
-
-        return diff;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/SimpleRecordWithLRUEviction.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/SimpleRecordWithLRUEviction.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.internal.serialization.Data;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.internal.util.TimeStripUtil.recomputeWithBaseTime;
+import static com.hazelcast.internal.util.TimeStripUtil.stripBaseTime;
 import static com.hazelcast.map.impl.record.RecordReaderWriter.SIMPLE_DATA_RECORD_WITH_LRU_EVICTION_READER_WRITER;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
@@ -169,7 +169,8 @@ public interface ExpiryMetadata {
     default int stripBaseTime(long value) {
         int diff = UNSET;
         if (value > 0) {
-            diff = (int) MILLISECONDS.toSeconds(value - EPOCH_TIME);
+            long toSeconds = MILLISECONDS.toSeconds(value - EPOCH_TIME);
+            return toSeconds >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) toSeconds;
         }
 
         return diff;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
@@ -21,11 +21,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
-import static com.hazelcast.map.impl.record.Record.EPOCH_TIME;
-import static com.hazelcast.map.impl.record.Record.UNSET;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 public interface ExpiryMetadata {
 
     @SuppressWarnings("checkstyle:anoninnerlength")
@@ -164,24 +159,5 @@ public interface ExpiryMetadata {
         setRawMaxIdle(in.readInt());
         setRawExpirationTime(in.readInt());
         setRawLastUpdateTime(in.readInt());
-    }
-
-    default int stripBaseTime(long value) {
-        int diff = UNSET;
-        if (value > 0) {
-            long toSeconds = MILLISECONDS.toSeconds(value - EPOCH_TIME);
-            return toSeconds >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) toSeconds;
-        }
-
-        return diff;
-    }
-
-    default long recomputeWithBaseTime(int value) {
-        if (value == UNSET) {
-            return 0L;
-        }
-
-        long exploded = SECONDS.toMillis(value);
-        return exploded + EPOCH_TIME;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadataImpl.java
@@ -51,13 +51,7 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public ExpiryMetadata setTtl(long ttl) {
-        long ttlSeconds = MILLISECONDS.toSeconds(ttl);
-        if (ttlSeconds == 0 && ttl != 0) {
-            ttlSeconds = 1;
-        }
-
-        this.ttl = ttlSeconds > Integer.MAX_VALUE
-                ? Integer.MAX_VALUE : (int) ttlSeconds;
+        this.ttl = toSeconds(ttl);
         return this;
     }
 
@@ -80,13 +74,17 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public ExpiryMetadata setMaxIdle(long maxIdle) {
-        long maxIdleSeconds = MILLISECONDS.toSeconds(maxIdle);
-        if (maxIdleSeconds == 0 && maxIdle != 0) {
-            maxIdleSeconds = 1;
-        }
-        this.maxIdle = maxIdleSeconds > Integer.MAX_VALUE
-                ? Integer.MAX_VALUE : (int) maxIdleSeconds;
+        this.maxIdle = toSeconds(maxIdle);
         return this;
+    }
+
+    private static int toSeconds(long millis) {
+        long seconds = MILLISECONDS.toSeconds(millis);
+        if (seconds == 0 && millis != 0) {
+            seconds = 1;
+        }
+        return seconds > Integer.MAX_VALUE
+                ? Integer.MAX_VALUE : (int) seconds;
     }
 
     @Override
@@ -115,9 +113,7 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public ExpiryMetadata setExpirationTime(long expirationTime) {
-        this.expirationTime = expirationTime == Long.MAX_VALUE
-                ? Integer.MAX_VALUE
-                : stripBaseTime(expirationTime);
+        this.expirationTime = toStrippedSeconds(expirationTime);
         return this;
     }
 
@@ -147,10 +143,16 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public ExpiryMetadata setLastUpdateTime(long lastUpdateTime) {
-        this.lastUpdateTime = lastUpdateTime == Long.MAX_VALUE
-                ? Integer.MAX_VALUE
-                : stripBaseTime(lastUpdateTime);
+        this.lastUpdateTime = toStrippedSeconds(lastUpdateTime);
         return this;
+    }
+
+    private int toStrippedSeconds(long millis) {
+        if (millis == Long.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+
+        return stripBaseTime(millis);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadataImpl.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.map.impl.recordstore.expiry;
 
-import static com.hazelcast.map.impl.record.Record.UNSET;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static com.hazelcast.internal.util.TimeStripUtil.recomputeWithBaseTime;
+import static com.hazelcast.internal.util.TimeStripUtil.stripBaseTime;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.toMillis;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.toSeconds;
 
 public class ExpiryMetadataImpl implements ExpiryMetadata {
 
@@ -40,8 +41,7 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public long getTtl() {
-        return ttl == Integer.MAX_VALUE
-                ? Long.MAX_VALUE : SECONDS.toMillis(ttl);
+        return toMillis(ttl);
     }
 
     @Override
@@ -63,8 +63,7 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public long getMaxIdle() {
-        return maxIdle == Integer.MAX_VALUE
-                ? Long.MAX_VALUE : SECONDS.toMillis(maxIdle);
+        return toMillis(maxIdle);
     }
 
     @Override
@@ -78,15 +77,6 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
         return this;
     }
 
-    private static int toSeconds(long millis) {
-        long seconds = MILLISECONDS.toSeconds(millis);
-        if (seconds == 0 && millis != 0) {
-            seconds = 1;
-        }
-        return seconds > Integer.MAX_VALUE
-                ? Integer.MAX_VALUE : (int) seconds;
-    }
-
     @Override
     public ExpiryMetadata setRawMaxIdle(int maxIdle) {
         this.maxIdle = maxIdle;
@@ -95,14 +85,6 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public long getExpirationTime() {
-        if (expirationTime == UNSET) {
-            return 0L;
-        }
-
-        if (expirationTime == Integer.MAX_VALUE) {
-            return Long.MAX_VALUE;
-        }
-
         return recomputeWithBaseTime(expirationTime);
     }
 
@@ -113,7 +95,7 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public ExpiryMetadata setExpirationTime(long expirationTime) {
-        this.expirationTime = toStrippedSeconds(expirationTime);
+        this.expirationTime = stripBaseTime(expirationTime);
         return this;
     }
 
@@ -125,14 +107,6 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public long getLastUpdateTime() {
-        if (lastUpdateTime == UNSET) {
-            return 0L;
-        }
-
-        if (lastUpdateTime == Integer.MAX_VALUE) {
-            return Long.MAX_VALUE;
-        }
-
         return recomputeWithBaseTime(lastUpdateTime);
     }
 
@@ -143,16 +117,8 @@ public class ExpiryMetadataImpl implements ExpiryMetadata {
 
     @Override
     public ExpiryMetadata setLastUpdateTime(long lastUpdateTime) {
-        this.lastUpdateTime = toStrippedSeconds(lastUpdateTime);
+        this.lastUpdateTime = stripBaseTime(lastUpdateTime);
         return this;
-    }
-
-    private int toStrippedSeconds(long millis) {
-        if (millis == Long.MAX_VALUE) {
-            return Integer.MAX_VALUE;
-        }
-
-        return stripBaseTime(millis);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -675,6 +675,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public abstract void testMapExpiryConfig();
+
+    @Test
     public abstract void testIntegrityCheckerConfig();
 
     protected abstract Config buildAuditlogConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -848,6 +848,24 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(2342, mergePolicyConfig.getBatchSize());
     }
 
+
+    @Override
+    @Test
+    public void testMapExpiryConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "<map name=\"expiry\">"
+                + "    <time-to-live-seconds>2147483647</time-to-live-seconds>"
+                + "    <max-idle-seconds>2147483647</max-idle-seconds>    "
+                + "</map>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        MapConfig mapConfig = config.getMapConfig("expiry");
+
+        assertEquals(Integer.MAX_VALUE, mapConfig.getTimeToLiveSeconds());
+        assertEquals(Integer.MAX_VALUE, mapConfig.getMaxIdleSeconds());
+    }
+
     @Override
     @Test
     public void readRingbuffer() {
@@ -3058,14 +3076,14 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testAllowOverrideDefaultSerializers() {
         String xml = HAZELCAST_START_TAG
-          + "  <serialization>\n"
-          + "      <allow-override-default-serializers>true</allow-override-default-serializers>\n"
-          + "  </serialization>\n"
-          + HAZELCAST_END_TAG;
+                + "  <serialization>\n"
+                + "      <allow-override-default-serializers>true</allow-override-default-serializers>\n"
+                + "  </serialization>\n"
+                + HAZELCAST_END_TAG;
 
         final Config config = new InMemoryXmlConfig(xml);
         final boolean isAllowOverrideDefaultSerializers
-          = config.getSerializationConfig().isAllowOverrideDefaultSerializers();
+                = config.getSerializationConfig().isAllowOverrideDefaultSerializers();
         assertTrue(isAllowOverrideDefaultSerializers);
     }
 
@@ -3965,7 +3983,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         PersistentMemoryConfig pmemConfig = xmlConfig.getNativeMemoryConfig()
                 .getPersistentMemoryConfig();
         List<PersistentMemoryDirectoryConfig> directoryConfigs = pmemConfig
-                                                                          .getDirectoryConfigs();
+                .getDirectoryConfigs();
         assertFalse(pmemConfig.isEnabled());
         assertEquals(MOUNTED, pmemConfig.getMode());
         assertEquals(2, directoryConfigs.size());
@@ -4322,10 +4340,10 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Test
     public void testSqlConfig() {
         String xml = HAZELCAST_START_TAG
-            + "<sql>\n"
-            + "  <statement-timeout-millis>30</statement-timeout-millis>\n"
-            + "</sql>"
-            + HAZELCAST_END_TAG;
+                + "<sql>\n"
+                + "  <statement-timeout-millis>30</statement-timeout-millis>\n"
+                + "</sql>"
+                + HAZELCAST_END_TAG;
         Config config = new InMemoryXmlConfig(xml);
         SqlConfig sqlConfig = config.getSqlConfig();
         assertEquals(30L, sqlConfig.getStatementTimeoutMillis());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3156,7 +3156,7 @@ public class YamlConfigBuilderTest
         String yaml = ""
                 + "hazelcast:\n"
                 + "  dynamic-configuration:\n"
-                + "    persistence-enabled: " +  persistenceEnabled + "\n"
+                + "    persistence-enabled: " + persistenceEnabled + "\n"
                 + "    backup-dir: " + backupDir + "\n"
                 + "    backup-count: " + backupCount + "\n";
 
@@ -3170,7 +3170,7 @@ public class YamlConfigBuilderTest
         yaml = ""
                 + "hazelcast:\n"
                 + "  dynamic-configuration:\n"
-                + "    persistence-enabled: " +  persistenceEnabled + "\n";
+                + "    persistence-enabled: " + persistenceEnabled + "\n";
 
         config = new InMemoryYamlConfig(yaml);
         dynamicConfigurationConfig = config.getDynamicConfigurationConfig();
@@ -4407,5 +4407,21 @@ public class YamlConfigBuilderTest
         Config config = buildConfig(yaml);
 
         assertFalse(config.getIntegrityCheckerConfig().isEnabled());
+    }
+
+    @Override
+    public void testMapExpiryConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    expiry:\n"
+                + "      time-to-live-seconds: 2147483647\n"
+                + "      max-idle-seconds: 2147483647\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("expiry");
+
+        assertEquals(Integer.MAX_VALUE, mapConfig.getTimeToLiveSeconds());
+        assertEquals(Integer.MAX_VALUE, mapConfig.getMaxIdleSeconds());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -599,6 +599,72 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void no_expiration_happens_when_max_idle_is_int_max() {
+        IMap<Integer, Integer> map = createMapWithMaxIdleSeconds(Integer.MAX_VALUE);
+
+        map.set(1, 1);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        assertEquals(Long.MAX_VALUE, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void no_expiration_happens_when_max_idle_is_zero() {
+        IMap<Integer, Integer> map = createMapWithMaxIdleSeconds(0);
+
+        map.set(1, 1);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        assertEquals(Long.MAX_VALUE, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void no_expiration_happens_when_max_idle_is_close_to_int_max() {
+        IMap<Integer, Integer> map = createMapWithMaxIdleSeconds(Integer.MAX_VALUE - 100);
+
+        map.set(1, 1);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        assertEquals(Long.MAX_VALUE, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void no_expiration_happens_when_ttl_is_int_max() {
+        IMap<Integer, Integer> map = createMapWithTTLSeconds(Integer.MAX_VALUE);
+
+        map.set(1, 1);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        assertEquals(Long.MAX_VALUE, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void no_expiration_happens_when_ttl_is_zero() {
+        IMap<Integer, Integer> map = createMapWithTTLSeconds(0);
+
+        map.set(1, 1);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        assertEquals(Long.MAX_VALUE, expirationTimeAfterPut);
+    }
+
+    @Test
+    public void no_expiration_happens_when_ttl_is_close_to_int_max() {
+        IMap<Integer, Integer> map = createMapWithTTLSeconds(Integer.MAX_VALUE - 100);
+
+        map.set(1, 1);
+
+        long expirationTimeAfterPut = getExpirationTime(map, 1);
+
+        assertEquals(Long.MAX_VALUE, expirationTimeAfterPut);
+    }
+
     protected InMemoryFormat inMemoryFormat() {
         return BINARY;
     }


### PR DESCRIPTION
ee: https://github.com/hazelcast/hazelcast-enterprise/pull/5002

closes https://github.com/hazelcast/hazelcast/issues/21330

**Issue:**
- We are not treating `Integer.MAX_VALUE` as infinity for ttl and maxIdle configuration, this is not in line with docs.

**Modifications:**
- Created a `TimeStripUtil` class and used it in everywhere where it is needed.
- Refactored methods in `ExpirationTimeSetter` class and put common functionality into `pickRightTimeInMillis` method.
- These lines include the main fixes: 
  In `pickRightTimeInMillis`:
 ```
   (secondsFromMapConfig == 0 || secondsFromMapConfig == Integer.MAX_VALUE)
```
   and in `TimeStripUtil` https://github.com/hazelcast/hazelcast/pull/21409/files#diff-47ff3996597dbec216711eec776f0abc5ca20f92f49fe920d96c8f9bf527d10bR60 , this change is required otherwise casting to int can cause negative values and this results with immediate entry removals. 