### PR TITLE
Rename method and classes for better clarity in partitioning and clus…

### DIFF
--- a/docs/design/partitioning/02-graceful-shutdown-improvements.md
+++ b/docs/design/partitioning/02-graceful-shutdown-improvements.md
@@ -134,7 +134,7 @@ Here is the proposed solution for the new graceful shutdown process:
 -   Migration system has the following modifications to handle the
     shutdown requests:
 
-    -   `RepartitioningTask` removes shutdown-requested nodes from the
+    -   `RedoPartitioningTask` removes shutdown-requested nodes from the
         member groups that is provided to the repartitioning algorithm
         and a new partition table is produced with the given limited
         member groups. Then, migration decision algorithm schedules a
@@ -143,7 +143,7 @@ Here is the proposed solution for the new graceful shutdown process:
         property: shutdown-requested nodes can be only source of these
         migrations. So once all of these migrations are completed,
         partition table will not contain any node that requested to shut
-        down. To verify this, RepartitioningTask schedules a new task,
+        down. To verify this, RedoPartitioningTask schedules a new task,
         `ProcessShutdownRequestsTask`,  at the end of the queue after
         the migrations.
 

--- a/docs/design/partitioning/07-parallel-migrations.md
+++ b/docs/design/partitioning/07-parallel-migrations.md
@@ -100,8 +100,8 @@ _Other usages of partition table stamp will be explained in [Other Changes](#3--
 
 #### 2.1 - Current Migration Mechanism
 
-When a new member joins or an existing member leaves the cluster, eventually a `RepartitioningTask` is scheduled on 
-migration thread. `RepartitioningTask` prepares the new partition table and schedules the individual `MigrationTask`s
+When a new member joins or an existing member leaves the cluster, eventually a `RedoPartitioningTask` is scheduled on 
+migration thread. `RedoPartitioningTask` prepares the new partition table and schedules the individual `MigrationTask`s
 to reach the target partition table. These `MigrationTask`s are executed serially by migration thread and they submit 
 migration operations to the migration participants. After each migration completion, migration is committed to the 
 destination, and partition table is updated. All of these steps are executed serially.
@@ -109,7 +109,7 @@ destination, and partition table is updated. All of these steps are executed ser
  
 #### 2.2 - Parallel Migrations Mechanism
 
-With parallel migrations, most the mechanism remains the same. `RepartitioningTask` prepares the migration plan using 
+With parallel migrations, most the mechanism remains the same. `RedoPartitioningTask` prepares the migration plan using 
 the target partition table. Instead of individual `MigrationTask`s, a single `MigrationPlanTask` will be scheduled. 
 `MigrationPlanTask` will submit parallel migration tasks and keep track of started/completed tasks. 
 
@@ -118,7 +118,7 @@ and safety guarantees while migrating/replicating partition data. For instance, 
 in the plan. Or replication to a missing backup replica is more important than a migration that is just to rebalance the load.
 _For more info please see [Avoid Data Loss on Migration](01-avoid-data-loss-on-migration.md)._   
 
-To achieve this, `RepartitioningTask` creates migration plan with a consistent order. And `MigrationPlanTask` will 
+To achieve this, `RedoPartitioningTask` creates migration plan with a consistent order. And `MigrationPlanTask` will 
 parallelize only migrations belonging to different partitions. Migrations belonging to the same partition will still be 
 executed serially. That's the upper limit of migration parallelization. But still we may want to limit parallel 
 migrations to keep heap memory usage under control and to avoid overload of network resources.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -73,7 +73,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static com.hazelcast.cluster.impl.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
@@ -87,8 +89,6 @@ import static com.hazelcast.internal.util.Preconditions.checkFalse;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static java.lang.String.format;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public class ClusterServiceImpl implements ClusterService, ConnectionListener, ManagedService,
@@ -116,7 +116,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private final ClusterJoinManager clusterJoinManager;
     private final ClusterStateManager clusterStateManager;
     private final ClusterHeartbeatManager clusterHeartbeatManager;
-    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock clusterServiceLock = new ReentrantLock();
     private final AtomicReference<JoinHolder> joined =
             new AtomicReference<>(new JoinHolder(false));
 
@@ -141,10 +141,10 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         logger = node.getLogger(ClusterService.class.getName());
         clusterClock = new ClusterClockImpl(logger);
 
-        membershipManager = new MembershipManager(node, this, lock);
-        clusterStateManager = new ClusterStateManager(node, lock);
-        clusterJoinManager = new ClusterJoinManager(node, this, lock);
-        clusterHeartbeatManager = new ClusterHeartbeatManager(node, this, lock);
+        membershipManager = new MembershipManager(node, this, clusterServiceLock);
+        clusterStateManager = new ClusterStateManager(node, clusterServiceLock);
+        clusterJoinManager = new ClusterJoinManager(node, this, clusterServiceLock);
+        clusterHeartbeatManager = new ClusterHeartbeatManager(node, this, clusterServiceLock);
 
         node.getServer().getConnectionManager(MEMBER).addConnectionListener(this);
         ExecutionService executionService = nodeEngine.getExecutionService();
@@ -196,7 +196,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     public void suspectAddressIfNotConnected(Address address) {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             MemberImpl member = getMember(address);
             if (member == null) {
@@ -217,7 +217,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             }
             suspectMember(member, "No connection", false);
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
@@ -261,7 +261,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         checkNotNull(candidateUuid);
         checkFalse(getThisAddress().equals(candidateAddress), "cannot accept my own mastership claim!");
 
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             checkTrue(isJoined(), candidateAddress + " claims mastership but this node is not joined!");
             checkFalse(isMaster(),
@@ -292,14 +292,14 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
             return response;
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
     // called under cluster service lock
     // mastership is accepted when all members before the candidate is suspected
     private boolean shouldAcceptMastership(MemberMap memberMap, MemberImpl candidate) {
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         for (MemberImpl member : memberMap.headMemberSet(candidate, false)) {
             if (!membershipManager.isMemberSuspected(member)) {
                 if (logger.isFineEnabled()) {
@@ -321,19 +321,19 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public void reset() {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             resetJoinState();
             resetLocalMemberUuid();
             resetClusterId();
             clearInternalState();
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
     private void resetLocalMemberUuid() {
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         assert !isJoined() : "Cannot reset local member UUID when joined.";
 
         Map<EndpointQualifier, Address> addressMap = localMember.getAddressMap();
@@ -355,12 +355,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     public void resetJoinState() {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             setMasterAddress(null);
             setJoined(false);
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
@@ -368,7 +368,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     public boolean finalizeJoin(MembersView membersView, Address callerAddress, UUID callerUuid, UUID targetUuid,
                                 UUID clusterId, ClusterState clusterState, Version clusterVersion, long clusterStartTime,
                                 long masterTime, OnJoinOp preJoinOp) {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             if (!checkValidMaster(callerAddress)) {
                 if (logger.isFineEnabled()) {
@@ -421,12 +421,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 .log();
             return true;
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
     public boolean updateMembers(MembersView membersView, Address callerAddress, UUID callerUuid, UUID targetUuid) {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             if (!isJoined()) {
                 logger.warning("Not updating members received from caller: " + callerAddress + " because node is not joined! ");
@@ -453,7 +453,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             membershipManager.updateMembers(membersView);
             return true;
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
@@ -548,11 +548,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     public void notifyForRemovedMember(MemberImpl member) {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             membershipManager.onMemberRemove(member);
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
@@ -611,7 +611,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     private void clearInternalState() {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             membershipManager.reset();
             clusterHeartbeatManager.reset();
@@ -619,12 +619,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             clusterJoinManager.reset();
             resetJoinState();
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
     public boolean setMasterAddressToJoin(final Address master) {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             if (isJoined()) {
                 Address currentMasterAddress = getMasterAddress();
@@ -640,13 +640,13 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             setMasterAddress(master);
             return true;
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
     // should be called under lock
     void setMasterAddress(Address master) {
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         if (logger.isFineEnabled()) {
             logger.fine("Setting master address to " + master);
         }
@@ -684,7 +684,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     // should be called under lock
     void setJoined(boolean val) {
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         joined.getAndUpdate(holder -> new JoinHolder(val)).latch.countDown();
     }
 
@@ -729,14 +729,14 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     // called under cluster service lock
     void setClusterId(UUID newClusterId) {
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         assert clusterId == null : "Cluster ID should be null: " + clusterId;
         clusterId = newClusterId;
     }
 
     // called under cluster service lock
     private void resetClusterId() {
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         clusterId = null;
     }
 
@@ -747,12 +747,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         EventService eventService = nodeEngine.getEventService();
         EventRegistration registration;
         if (listener instanceof InitialMembershipListener) {
-            lock.lock();
+            clusterServiceLock.lock();
             try {
                 ((InitialMembershipListener) listener).init(new InitialMembershipEvent(this, getMembers()));
                 registration = eventService.registerLocalListener(SERVICE_NAME, SERVICE_NAME, listener);
             } finally {
-                lock.unlock();
+                clusterServiceLock.unlock();
             }
         } else {
             registration = eventService.registerLocalListener(SERVICE_NAME, SERVICE_NAME, listener);
@@ -879,7 +879,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public int getMemberListJoinVersion() {
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             if (!isJoined()) {
                 throw new IllegalStateException("Member list join version is not available when not joined");
@@ -893,7 +893,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             }
             return joinVersion;
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
@@ -1024,7 +1024,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 nodeEngine.getOperationService().invokeOnTarget(SERVICE_NAME, op, master.getAddress());
         MembersView view = future.joinInternal();
 
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             if (!member.getAddress().equals(master.getAddress())) {
                 updateMembers(view, master.getAddress(), master.getUuid(), getThisUuid());
@@ -1042,14 +1042,14 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                         + ", Current master is: " + getMasterAddress());
             }
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
     }
 
     MemberImpl promoteAndGetLocalMember() {
         MemberImpl member = getLocalMember();
         assert member.isLiteMember() : "Local member is not lite member!";
-        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
 
         localMember = new MemberImpl.Builder(member.getAddressMap())
                 .version(member.getVersion())
@@ -1070,7 +1070,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     private MemberImpl getMasterMember() {
         MemberImpl master;
-        lock.lock();
+        clusterServiceLock.lock();
         try {
             Address masterAddress = getMasterAddress();
             if (masterAddress == null) {
@@ -1079,7 +1079,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
             master = getMember(masterAddress);
         } finally {
-            lock.unlock();
+            clusterServiceLock.unlock();
         }
         return master;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -631,12 +631,12 @@ public class MigrationManager {
 
     void onShutdownRequest(Member member) {
         if (!partitionStateManager.isInitialized()) {
-            sendShutdownOperation(member.getAddress());
+            sendShutdownResponseOperation(member.getAddress());
             return;
         }
         ClusterState clusterState = node.getClusterService().getClusterState();
         if (!clusterState.isMigrationAllowed() && clusterState != ClusterState.IN_TRANSITION) {
-            sendShutdownOperation(member.getAddress());
+            sendShutdownResponseOperation(member.getAddress());
             return;
         }
         if (shutdownRequestedMembers.add(member)) {
@@ -749,7 +749,7 @@ public class MigrationManager {
     /**
      * Sends a {@link ShutdownResponseOperation} to the {@code address} or takes a shortcut if shutdown is local.
      */
-    private void sendShutdownOperation(Address address) {
+    private void sendShutdownResponseOperation(Address address) {
         if (node.getThisAddress().equals(address)) {
             assert !node.isRunning() : "Node state: " + node.getState();
             partitionService.onShutdownResponse();
@@ -822,7 +822,7 @@ public class MigrationManager {
      * this task has been scheduled, schedules migrations and syncs the partition state.
      * Also schedules a {@link ProcessShutdownRequestsTask}. Acquires partition service lock.
      */
-    class RepartitioningTask implements MigrationRunnable {
+    class RedoPartitioningTask implements MigrationRunnable {
         @Override
         public void run() {
             if (!partitionService.isLocalMemberMaster()) {
@@ -919,7 +919,7 @@ public class MigrationManager {
                 return;
             }
 
-            logger.fine("Cluster state doesn't allow repartitioning. RepartitioningTask will only assign lost partitions.");
+            logger.fine("Cluster state doesn't allow repartitioning. RedoPartitioningTask will only assign lost partitions.");
             InternalPartition[] partitions = partitionStateManager.getPartitions();
             PartitionIdSet partitionIds = Arrays.stream(partitions)
                     .filter(p -> InternalPartition.replicaIndices().allMatch(i -> p.getReplica(i) == null))
@@ -967,7 +967,7 @@ public class MigrationManager {
         private void processNewPartitionState(PartitionReplica[][] newState) {
             int migrationCount = 0;
             // List of migration queues per-partition
-            List<Queue<MigrationInfo>> migrationQs = new ArrayList<>(newState.length);
+            List<Queue<MigrationInfo>> listOfPartitionMigrationQueues = new ArrayList<>(newState.length);
             Int2ObjectHashMap<PartitionReplica> lostPartitions = new Int2ObjectHashMap<>();
 
             for (int partitionId = 0; partitionId < newState.length; partitionId++) {
@@ -987,7 +987,7 @@ public class MigrationManager {
                     lostPartitions.put(partitionId, migrationCollector.lostPartitionDestination);
                 }
                 if (!migrationCollector.migrations.isEmpty()) {
-                    migrationQs.add(migrationCollector.migrations);
+                    listOfPartitionMigrationQueues.add(migrationCollector.migrations);
                     migrationCount += migrationCollector.migrations.size();
                 }
             }
@@ -1009,7 +1009,7 @@ public class MigrationManager {
             partitionService.publishPartitionRuntimeState();
 
             if (migrationCount > 0) {
-                scheduleMigrations(migrationQs);
+                scheduleMigrations(listOfPartitionMigrationQueues);
                 // Schedule a task to publish completed migrations after all migrations tasks are completed.
                 schedule(new PublishCompletedMigrationsTask());
             }
@@ -1019,8 +1019,8 @@ public class MigrationManager {
         /**
          * Schedules all migrations.
          */
-        private void scheduleMigrations(List<Queue<MigrationInfo>> migrationQs) {
-            schedule(new MigrationPlanTask(migrationQs));
+        private void scheduleMigrations(List<Queue<MigrationInfo>> listOfPartitionMigrationQueues) {
+            schedule(new MigrationPlanTask(listOfPartitionMigrationQueues));
         }
 
         private void logMigrationStatistics(int migrationCount) {
@@ -1116,7 +1116,7 @@ public class MigrationManager {
         /**
          * List of migration queues per-partition
          */
-        private final List<Queue<MigrationInfo>> migrationQs;
+        private final List<Queue<MigrationInfo>> listOfPartitionMigrationQueues;
         /**
          * Queue for completed migrations.
          * It will be processed concurrently while migrations are running.
@@ -1137,16 +1137,18 @@ public class MigrationManager {
         private boolean failed;
         private volatile boolean aborted;
 
-        MigrationPlanTask(List<Queue<MigrationInfo>> migrationQs) {
-            this.migrationQs = migrationQs;
-            this.completed = new ArrayBlockingQueue<>(migrationQs.size());
+        MigrationPlanTask(List<Queue<MigrationInfo>> listOfPartitionMigrationQueues) {
+            this.listOfPartitionMigrationQueues = listOfPartitionMigrationQueues;
+            this.completed = new ArrayBlockingQueue<>(listOfPartitionMigrationQueues.size());
             this.migratingPartitions
-                    = new IntHashSet(migrationQs.stream().mapToInt(Collection::size).sum(), -1);
+                    = new IntHashSet(listOfPartitionMigrationQueues
+                    .stream().mapToInt(Collection::size).sum(), -1);
         }
 
         @Override
         public void run() {
-            migrationCount.set(migrationQs.stream().mapToInt(Collection::size).sum());
+            migrationCount.set(listOfPartitionMigrationQueues
+                    .stream().mapToInt(Collection::size).sum());
 
             while (true) {
                 MigrationInfo migration = next();
@@ -1185,7 +1187,7 @@ public class MigrationManager {
                         + ". Ignoring remaining migrations. Will recalculate the new migration plan. ("
                         + stats.formatToString(logger.isFineEnabled()) + ")");
                 migrationCount.set(0);
-                migrationQs.clear();
+                listOfPartitionMigrationQueues.clear();
             } else {
                 logger.info("All migration tasks have been completed. (" + stats.formatToString(logger.isFineEnabled()) + ")");
             }
@@ -1239,7 +1241,7 @@ public class MigrationManager {
         private MigrationInfo next() {
             MigrationInfo m;
             while ((m = next0()) == null) {
-                if (migrationQs.isEmpty()) {
+                if (listOfPartitionMigrationQueues.isEmpty()) {
                     break;
                 }
 
@@ -1261,7 +1263,7 @@ public class MigrationManager {
         }
 
         private MigrationInfo next0() {
-            Iterator<Queue<MigrationInfo>> iter = migrationQs.iterator();
+            Iterator<Queue<MigrationInfo>> iter = listOfPartitionMigrationQueues.iterator();
             while (iter.hasNext()) {
                 Queue<MigrationInfo> q = iter.next();
                 if (q.isEmpty()) {
@@ -1360,7 +1362,7 @@ public class MigrationManager {
                     && migration.getDestinationNewReplicaIndex() == 0) {
 
                 throw new IllegalStateException("Promotion migrations must be handled by "
-                        + RepairPartitionTableTask.class.getSimpleName() + " -> " + migration);
+                        + FixPartitionTableTask.class.getSimpleName() + " -> " + migration);
             }
 
             Member partitionOwner = checkMigrationParticipantsAndGetPartitionOwner();
@@ -1538,7 +1540,7 @@ public class MigrationManager {
             // Pause migration process for a small amount of time, if a migration attempt is failed.
             // Otherwise, migration failures can do a busy spin until migration problem is resolved.
             // Migration can fail either a node's just joined and not completed start yet or it's just left the cluster.
-            // Re-execute RepartitioningTask when all other migration tasks are done,
+            // Re-execute RedoPartitioningTask when all other migration tasks are done,
             // an imbalance may occur because of this failure.
             partitionServiceLock.lock();
             try {
@@ -1632,12 +1634,12 @@ public class MigrationManager {
      * <li>Remove unknown addresses from the partition table</li>
      * <li>Promote the partition replicas if necessary (the partition owner is missing)</li>
      * </ul>
-     * If the promotions are successful, schedules the {@link RepartitioningTask}. If the process was not successful
+     * If the promotions are successful, schedules the {@link RedoPartitioningTask}. If the process was not successful
      * it will trigger a {@link ControlTask} to restart the partition table repair process.
      * <p>
      * Invoked on the master node. Acquires partition service lock when scheduling the tasks on the migration queue.
      */
-    private class RepairPartitionTableTask implements MigrationRunnable {
+    private class FixPartitionTableTask implements MigrationRunnable {
         @Override
         public void run() {
             if (!partitionStateManager.isInitialized()) {
@@ -1673,9 +1675,9 @@ public class MigrationManager {
             try {
                 if (success) {
                     if (logger.isFinestEnabled()) {
-                        logger.finest("RepartitioningTask scheduled");
+                        logger.finest("RedoPartitioningTask scheduled");
                     }
-                    migrationQueue.add(new RepartitioningTask());
+                    migrationQueue.add(new RedoPartitioningTask());
                 } else {
                     triggerControlTask();
                 }
@@ -1914,7 +1916,7 @@ public class MigrationManager {
      * Task scheduled on the master node to fetch and repair the latest partition table.
      * It will first check if we need to fetch the new partition table and schedule a task to do so, along with a new
      * {@link ControlTask} to be executed afterwards. If we don't need to fetch the partition table it will send a
-     * {@link RepairPartitionTableTask} to repair the existing partition table.
+     * {@link FixPartitionTableTask} to repair the existing partition table.
      * Invoked on the master node. It will acquire the partition service lock.
      *
      * @see InternalPartitionServiceImpl#isFetchMostRecentPartitionTableTaskRequired()
@@ -1933,9 +1935,9 @@ public class MigrationManager {
                     return;
                 }
                 if (logger.isFinestEnabled()) {
-                    logger.finest("RepairPartitionTableTask scheduled");
+                    logger.finest("FixPartitionTableTask scheduled");
                 }
-                migrationQueue.add(new RepairPartitionTableTask());
+                migrationQueue.add(new FixPartitionTableTask());
             } finally {
                 partitionServiceLock.unlock();
             }
@@ -1960,13 +1962,13 @@ public class MigrationManager {
                 if (shutdownRequestCount > 0) {
                     if (shutdownRequestCount == nodeEngine.getClusterService().getSize(DATA_MEMBER_SELECTOR)) {
                         for (Member member : shutdownRequestedMembers) {
-                            sendShutdownOperation(member.getAddress());
+                            sendShutdownResponseOperation(member.getAddress());
                         }
                     } else {
                         boolean present = false;
                         for (Member member : shutdownRequestedMembers) {
                             if (partitionStateManager.isAbsentInPartitionTable(member)) {
-                                sendShutdownOperation(member.getAddress());
+                                sendShutdownResponseOperation(member.getAddress());
                             } else {
                                 logger.warning(member + " requested to shutdown but still in partition table");
                                 present = true;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationManagerTest.java
@@ -69,13 +69,13 @@ public class MigrationManagerTest {
     PartitionStateManager partitionStateManager;
     ClusterServiceImpl clusterService;
     Lock lock = new ReentrantLock();
-    MigrationManager.RepartitioningTask task;
+    MigrationManager.RedoPartitioningTask task;
 
     @Before
     public void setup() {
         setupMocks();
         MigrationManager migrationManager = new MigrationManager(node, partitionService, lock);
-        task = migrationManager.new RepartitioningTask();
+        task = migrationManager.new RedoPartitioningTask();
     }
 
     @Test


### PR DESCRIPTION
…ter system

**Reasoning: **
Some class or method names are not clear to eyes and this makes code reading harder, encountered this during investigations of https://github.com/hazelcast/hazelcast/issues/20220