### PR TITLE
Lexicographically lesser node should initiate merge when not on member list[HZ-1035]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -483,13 +483,24 @@ public class TcpIpJoiner extends AbstractJoiner {
         SplitBrainJoinMessage request = node.createSplitBrainJoinMessage();
         for (Address address : possibleAddresses) {
             SplitBrainMergeCheckResult result = sendSplitBrainJoinMessageAndCheckResponse(address, request);
-            if (result == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
-                logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
-                setTargetAddress(address);
-                startClusterMerge(address, request.getMemberListVersion());
-                return;
+             if (result == SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE) {
+                String targetAddressStr = address.getHost() + ":" + address.getPort();
+                Address thisAddress = node.address;
+                String thisAddressStr = thisAddress.getHost() + ":" + thisAddress.getPort();
+                if(getMembers().contains(targetAddressStr) && !getMembers().contains(thisAddressStr)) {
+                    startMerge(address, request);
+                }
+            }
+            else if (result == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
+                 startMerge(address, request);
             }
         }
+    }
+
+    private void startMerge(Address address, SplitBrainJoinMessage request) {
+        logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
+        setTargetAddress(address);
+        startClusterMerge(address, request.getMemberListVersion());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -487,11 +487,10 @@ public class TcpIpJoiner extends AbstractJoiner {
                 String targetAddressStr = address.getHost() + ":" + address.getPort();
                 Address thisAddress = node.address;
                 String thisAddressStr = thisAddress.getHost() + ":" + thisAddress.getPort();
-                if(getMembers().contains(targetAddressStr) && !getMembers().contains(thisAddressStr)) {
+                if (getMembers().contains(targetAddressStr) && !getMembers().contains(thisAddressStr)) {
                     startMerge(address, request);
                 }
-            }
-            else if (result == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
+            } else if (result == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                  startMerge(address, request);
             }
         }


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

This PR adds a condition in the `TcpIpJoiner.searchForOtherClusters()` method that even if the local node decides that the remote node should merge, the local node should nevertheless initiate the merge if it (i.e. the local node) is not on the member list in the configuration file. Note that this specifically addresses the issue as described in #20331, where both nodes share the same configuration file.
A possible side effect of this change in the code is that **_both_** nodes in the cluster may sometimes decide to initiate the merge, as opposed to one initiating and the other waiting, especially when Node 1, the lexicographically lesser node, is not in the member list of its own configuration file, while Node 2, the lexicographically higher node, does have Node 1 listed in the member list of its own (i.e. Node 2's) configuration file.

Fixes https://github.com/hazelcast/hazelcast/issues/20331

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
