### PR TITLE
Add uuid to shutdown request and response operations [HZ-1055]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -919,7 +919,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                 if (node.getThisAddress().equals(masterAddress)) {
                     onShutdownRequest(node.getLocalMember());
                 } else {
-                    operationService.send(new ShutdownRequestOperation(), masterAddress);
+                    UUID memberUuid = node.getLocalMember().getUuid();
+                    operationService.send(new ShutdownRequestOperation(memberUuid), masterAddress);
                 }
                 if (latch.await(awaitStep, TimeUnit.MILLISECONDS)) {
                     return true;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -58,7 +58,8 @@ public class ShutdownRequestOperation
                 if (logger.isFinestEnabled()) {
                     logger.finest("Received shutdown request from " + caller);
                 }
-                if (member.getUuid().equals(uuid)) {
+                // RU_COMPAT 5.1
+                 if (isClusterVersionLessThanV52() || member.getUuid().equals(uuid)) {
                     partitionService.onShutdownRequest(member);
                 } else {
                     logger.warning("Ignoring shutdown request from " + uuid + " because it is not a member");
@@ -69,6 +70,12 @@ public class ShutdownRequestOperation
         } else {
             logger.warning("Received shutdown request from " + caller + " but this node is not master.");
         }
+    }
+
+    // RU_COMPAT 5.1
+    private boolean isClusterVersionLessThanV52() {
+        return getNodeEngine().getClusterService()
+                .getClusterVersion().isLessThan(Versions.V5_2);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -19,15 +19,30 @@ package com.hazelcast.internal.partition.operation;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
-public class ShutdownRequestOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
+import java.io.IOException;
+import java.util.UUID;
+
+public class ShutdownRequestOperation
+        extends AbstractPartitionOperation implements MigrationCycleOperation, Versioned {
+
+    private UUID uuid;
 
     public ShutdownRequestOperation() {
+    }
+
+    public ShutdownRequestOperation(UUID uuid) {
+        this.uuid = uuid;
     }
 
     @Override
@@ -43,7 +58,11 @@ public class ShutdownRequestOperation extends AbstractPartitionOperation impleme
                 if (logger.isFinestEnabled()) {
                     logger.finest("Received shutdown request from " + caller);
                 }
-                partitionService.onShutdownRequest(member);
+                if (member.getUuid().equals(uuid)) {
+                    partitionService.onShutdownRequest(member);
+                } else {
+                    logger.warning("Ignoring shutdown request from " + uuid + " because it is not a member");
+                }
             } else {
                 logger.warning("Ignoring shutdown request from " + caller + " because it is not a member");
             }
@@ -65,5 +84,25 @@ public class ShutdownRequestOperation extends AbstractPartitionOperation impleme
     @Override
     public int getClassId() {
         return PartitionDataSerializerHook.SHUTDOWN_REQUEST;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+
+        // RU_COMPAT 5.1
+        if (out.getVersion().isGreaterThan(Versions.V5_1)) {
+            UUIDSerializationUtil.writeUUID(out, uuid);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+
+        // RU_COMPAT 5.1
+        if (in.getVersion().isGreaterThan(Versions.V5_1)) {
+            uuid = UUIDSerializationUtil.readUUID(in);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
@@ -17,16 +17,31 @@
 package com.hazelcast.internal.partition.operation;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.NodeEngine;
 
-public class ShutdownResponseOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
+import java.io.IOException;
+import java.util.UUID;
+
+public class ShutdownResponseOperation
+        extends AbstractPartitionOperation implements MigrationCycleOperation, Versioned {
+
+    private UUID uuid;
 
     public ShutdownResponseOperation() {
+    }
+
+    public ShutdownResponseOperation(UUID uuid) {
+        this.uuid = uuid;
     }
 
     @Override
@@ -45,7 +60,12 @@ public class ShutdownResponseOperation extends AbstractPartitionOperation implem
             if (logger.isFinestEnabled()) {
                 logger.finest("Received shutdown response from " + caller);
             }
-            partitionService.onShutdownResponse();
+
+            if (nodeEngine.getLocalMember().getUuid().equals(uuid)) {
+                partitionService.onShutdownResponse();
+            } else {
+                logger.warning("Ignoring shutdown response for " + uuid + " since it's not the expected member");
+            }
         } else {
             logger.warning("Received shutdown response from " + caller + " but it's not the known master");
         }
@@ -64,5 +84,25 @@ public class ShutdownResponseOperation extends AbstractPartitionOperation implem
     @Override
     public int getClassId() {
         return PartitionDataSerializerHook.SHUTDOWN_RESPONSE;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+
+        // RU_COMPAT 5.1
+        if (out.getVersion().isGreaterThan(Versions.V5_1)) {
+            UUIDSerializationUtil.writeUUID(out, uuid);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+
+        // RU_COMPAT 5.1
+        if (in.getVersion().isGreaterThan(Versions.V5_1)) {
+            uuid = UUIDSerializationUtil.readUUID(in);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
@@ -61,7 +61,8 @@ public class ShutdownResponseOperation
                 logger.finest("Received shutdown response from " + caller);
             }
 
-            if (nodeEngine.getLocalMember().getUuid().equals(uuid)) {
+            if (isClusterVersionLessThanV52()
+                    || nodeEngine.getLocalMember().getUuid().equals(uuid)) {
                 partitionService.onShutdownResponse();
             } else {
                 logger.warning("Ignoring shutdown response for " + uuid + " since it's not the expected member");
@@ -69,6 +70,12 @@ public class ShutdownResponseOperation
         } else {
             logger.warning("Received shutdown response from " + caller + " but it's not the known master");
         }
+    }
+
+    // RU_COMPAT 5.1
+    private boolean isClusterVersionLessThanV52() {
+        return getNodeEngine().getClusterService()
+                .getClusterVersion().isLessThan(Versions.V5_2);
     }
 
     @Override


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/20220

**Issue:**
**Short:**
Data loss happens in graceful shutdown with zero backup if a node restarts on same address, reason is, we signal gracefully closing node early so migrations fail on this node.
**Detailed:**
During graceful shutdown, there can be more than one shutdown-request operation sent while waiting migrations finish.
Lets think this possible execution: Between first and second shutdown requests, migrations are finished and node is stopped and master removed shutdown-requested-member, after a suspectMember call, from its `shutDownRequestedMembers` registry(= so 2nd shutDownRequest can run).  Then second shutdown request is placed to run on master. And in parallel there is a new node on the <strong>same address</strong> started and immediately request for shutdown and at the same time the previous shutdown response operation is executed. For this reason, this new node's shutdown is completed early without waiting migrations finish, this effectively makes graceful shutdown a non-graceful shutdown hence we see data lost. 

**Modification:**
Add uuid to shutdown request and response operations, so they will only be executed for the intended members.