### PR TITLE
Debezium upgrade to 1.9.3.Final [HZ-1147]

### DIFF
--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -33,7 +33,7 @@
     </parent>
 
     <properties>
-        <debezium.version>1.2.5.Final</debezium.version>
+        <debezium.version>1.9.3.Final</debezium.version>
 
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -33,8 +33,6 @@
     </parent>
 
     <properties>
-        <debezium.version>1.9.3.Final</debezium.version>
-
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
     </properties>

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSerializerHooks.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSerializerHooks.java
@@ -29,10 +29,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Hazelcast serializer hooks for data objects involved in processing
  * change data capture streams.
  */
+@SuppressWarnings("NullableProblems")
 public class CdcSerializerHooks {
 
     public static final class ChangeRecordImplHook implements SerializerHook<ChangeRecordImpl> {
@@ -54,16 +57,16 @@ public class CdcSerializerHooks {
                 public void write(ObjectDataOutput out, ChangeRecordImpl record) throws IOException {
                     out.writeLong(record.sequenceSource());
                     out.writeLong(record.sequenceValue());
-                    out.writeUTF(record.getKeyJson());
-                    out.writeUTF(record.getValueJson());
+                    out.writeString(record.getKeyJson());
+                    out.writeString(record.getValueJson());
                 }
 
                 @Override
                 public ChangeRecordImpl read(ObjectDataInput in) throws IOException {
                     long sequenceSource = in.readLong();
                     long sequenceValue = in.readLong();
-                    String keyJson = in.readUTF();
-                    String valueJson = in.readUTF();
+                    String keyJson = requireNonNull(in.readString(), "keyJson cannot be null");
+                    String valueJson = requireNonNull(in.readString(), "valueJson cannot be null");
                     return new ChangeRecordImpl(sequenceSource, sequenceValue, keyJson, valueJson);
                 }
             };
@@ -91,12 +94,12 @@ public class CdcSerializerHooks {
 
                 @Override
                 public void write(ObjectDataOutput out, RecordPartImpl part) throws IOException {
-                    out.writeUTF(part.toJson());
+                    out.writeString(part.toJson());
                 }
 
                 @Override
                 public RecordPartImpl read(ObjectDataInput in) throws IOException {
-                    String json = in.readUTF();
+                    String json = requireNonNull(in.readString(), "RecordPart.json must not be null");
                     return new RecordPartImpl(json);
                 }
             };

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
@@ -172,7 +172,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
                 Map<String, ?> partition = record.sourcePartition();
                 Map<String, ?> offset = record.sourceOffset();
                 state.setOffset(partition, offset);
-                task.commitRecord(record);
+                task.commitRecord(record, null);
             }
 
             if (!snapshotting && commitPeriod == 0) {
@@ -238,6 +238,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
         }
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private SourceConnector startNewConnector() {
         SourceConnector connector = newInstance(properties.getProperty(CONNECTOR_CLASS_PROPERTY), "connector");
         connector.initialize(new JetConnectorContext());
@@ -342,6 +343,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public <V> Map<Map<String, V>, Map<String, Object>> offsets(Collection<Map<String, V>> partitions) {
             Map<Map<String, V>, Map<String, Object>> map = new HashMap<>();
             for (Map<String, V> partition : partitions) {
@@ -363,6 +365,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
         return sb.toString();
     }
 
+    @SuppressWarnings("unchecked")
     protected static <T> T newInstance(String className, String type) throws JetException {
         try {
             Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(className);

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -67,13 +67,12 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
                 .sorted().collect(Collectors.toList());
     }
 
-    @Nonnull
     protected static void assertMatch(List<String> expectedPatterns, List<String> actualValues) {
         assertEquals(expectedPatterns.size(), actualValues.size());
         for (int i = 0; i < expectedPatterns.size(); i++) {
             String pattern = expectedPatterns.get(i);
             String value = actualValues.get(i);
-            assertTrue(value.matches(pattern));
+            assertTrue("\n" + value + " \nmust match \n" + pattern, value.matches(pattern));
         }
     }
 

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -48,33 +48,29 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
+@SuppressWarnings("SqlNoDataSourceInspection")
 @Category({NightlyTest.class})
 @RunWith(HazelcastSerialClassRunner.class)
 public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
-
     private static final DockerImageName MYSQL_IMAGE =
-            DockerImageName.parse("debezium/example-mysql:1.3").asCompatibleSubstituteFor("mysql");
-
+            DockerImageName.parse("debezium/example-mysql:1.9.3.Final").asCompatibleSubstituteFor("mysql");
     private static final DockerImageName POSTGRES_IMAGE =
-            DockerImageName.parse("debezium/example-postgres:1.3").asCompatibleSubstituteFor("postgres");
-
+            DockerImageName.parse("debezium/example-postgres:1.9.3.Final").asCompatibleSubstituteFor("postgres");
     @Test
     public void mysql() throws Exception {
         Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623, " +
                         "https://github.com/hazelcast/hazelcast/issues/18800",
                 System.getProperty("java.version").matches("^1[56].*"));
 
-        MySQLContainer<?> container = mySqlContainer();
-
-        try {
+        try (MySQLContainer<?> container = mySqlContainer()) {
             container.start();
 
             // given
             List<String> expectedRecords = Arrays.asList(
-                    "1001/0:INSERT:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                    "1002/0:INSERT:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                    "1003/0:INSERT:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                    "1004/0:INSERT:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
+                    "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
+                    "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
+                    "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
                     "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
                     "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
                     "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
@@ -124,8 +120,6 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);
             }
-        } finally {
-            container.stop();
         }
     }
 
@@ -151,9 +145,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                         "https://github.com/hazelcast/hazelcast/issues/18800",
                 System.getProperty("java.version").matches("^1[56].*"));
 
-        MySQLContainer<?> container = mySqlContainer();
-
-        try {
+        try (MySQLContainer<?> container = mySqlContainer()) {
             container.start();
 
             // given
@@ -161,35 +153,39 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                     "\\{\"id\":1001}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1001,\"first_name\":\"Sally\",\"last_name\":\"Thomas\"," +
                                 "\"email\":\"sally.thomas@acme.com\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
-                                "\"ts_ms\":0,\"snapshot\":\"true\",\"db\":\"inventory\",\"table\":\"customers\"," +
-                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":154,\"row\":0," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
+                                "\"ts_ms\":[0-9]*,\"snapshot\":\"true\",\"db\":\"inventory\",\"sequence\":null," +
+                            "\"table\":\"customers\"," +
+                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":157,\"row\":0," +
                                 "\"thread\":null,\"query\":null}," +
-                            "\"op\":\"c\",\"ts_ms\":[0-9]*,\"transaction\":null}",
+                            "\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}",
                     "\\{\"id\":1002}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1002,\"first_name\":\"George\",\"last_name\":\"Bailey\"," +
                                 "\"email\":\"gbailey@foobar.com\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
-                                "\"ts_ms\":0,\"snapshot\":\"true\",\"db\":\"inventory\",\"table\":\"customers\"," +
-                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":154,\"row\":0," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
+                                "\"ts_ms\":[0-§9]*,\"snapshot\":\"true\",\"db\":\"inventory\",\"sequence\":null," +
+                            "\"table\":\"customers\"," +
+                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":157,\"row\":0," +
                                 "\"thread\":null,\"query\":null}," +
-                            "\"op\":\"c\",\"ts_ms\":[0-9]*,\"transaction\":null}",
+                            "\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}",
                     "\\{\"id\":1003}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1003,\"first_name\":\"Edward\",\"last_name\":\"Walker\"," +
                                 "\"email\":\"ed@walker.com\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
-                                "\"ts_ms\":0,\"snapshot\":\"true\",\"db\":\"inventory\",\"table\":\"customers\"," +
-                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":154,\"row\":0," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
+                                "\"ts_ms\":[0-9]*,\"snapshot\":\"true\",\"db\":\"inventory\",\"sequence\":null," +
+                            "\"table\":\"customers\"," +
+                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":157,\"row\":0," +
                                 "\"thread\":null,\"query\":null}," +
-                            "\"op\":\"c\",\"ts_ms\":[0-9]*,\"transaction\":null}",
+                            "\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}",
                     "\\{\"id\":1004}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1004,\"first_name\":\"Anne\",\"last_name\":\"Kretchmar\"," +
                                 "\"email\":\"annek@noanswer.org\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
-                                "\"ts_ms\":0,\"snapshot\":\"last\",\"db\":\"inventory\",\"table\":\"customers\"," +
-                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":154,\"row\":0," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"mysql\",\"name\":\"dbserver1\"," +
+                            "\"ts_ms\":[0-9]*,\"snapshot\":\"last\",\"db\":\"inventory\",\"sequence\":null," +
+                            "\"table\":\"customers\"," +
+                                "\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":157,\"row\":0," +
                                 "\"thread\":null,\"query\":null}," +
-                            "\"op\":\"c\",\"ts_ms\":[0-9]*,\"transaction\":null}"
+                            "\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}"
             );
 
             StreamSource<Entry<String, String>> source = DebeziumCdcSources.debeziumJson("mysql",
@@ -221,11 +217,10 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);
             }
-        } finally {
-            container.stop();
         }
     }
 
+    @SuppressWarnings("resource")
     private MySQLContainer<?> mySqlContainer() {
         return namedTestContainer(
                 new MySQLContainer<>(MYSQL_IMAGE)
@@ -236,9 +231,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Test
     public void postgres() throws Exception {
-        PostgreSQLContainer<?> container = postgresContainer();
-
-        try {
+        try (PostgreSQLContainer<?> container = postgresContainer()) {
             container.start();
 
             // given
@@ -306,16 +299,12 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);
             }
-        } finally {
-            container.stop();
         }
     }
 
     @Test
     public void postgres_simpleJson() {
-        PostgreSQLContainer<?> container = postgresContainer();
-
-        try {
+       try (PostgreSQLContainer<?> container = postgresContainer()) {
             container.start();
 
             // given
@@ -323,29 +312,33 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                     "\\{\"id\":1001}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1001,\"first_name\":\"Sally\",\"last_name\":\"Thomas\"," +
                                 "\"email\":\"sally.thomas@acme.com\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"postgresql\"," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"postgresql\"," +
                                 "\"name\":\"dbserver1\",\"ts_ms\":[0-9]*,\"snapshot\":\"true\",\"db\":\"postgres\"," +
+                            "\"sequence\":\"\\[.*]\"," +
                                 "\"schema\":\"inventory\",\"table\":\"customers\",\"txId\":[0-9]*,\"lsn\":[0-9]*," +
                                 "\"xmin\":null},\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}",
                     "\\{\"id\":1002}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1002,\"first_name\":\"George\",\"last_name\":\"Bailey\"," +
                                 "\"email\":\"gbailey@foobar.com\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"postgresql\"," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"postgresql\"," +
                                 "\"name\":\"dbserver1\",\"ts_ms\":[0-9]*,\"snapshot\":\"true\",\"db\":\"postgres\"," +
+                            "\"sequence\":\"\\[.*]\"," +
                                 "\"schema\":\"inventory\",\"table\":\"customers\",\"txId\":[0-9]*,\"lsn\":[0-9]*," +
                                 "\"xmin\":null},\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}",
                     "\\{\"id\":1003}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1003,\"first_name\":\"Edward\",\"last_name\":\"Walker\"," +
                                 "\"email\":\"ed@walker.com\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"postgresql\"," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"postgresql\"," +
                                 "\"name\":\"dbserver1\",\"ts_ms\":[0-9]*,\"snapshot\":\"true\",\"db\":\"postgres\"," +
+                            "\"sequence\":\"\\[.*]\"," +
                                 "\"schema\":\"inventory\",\"table\":\"customers\",\"txId\":[0-9]*,\"lsn\":[0-9]*," +
                                 "\"xmin\":null},\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}",
                     "\\{\"id\":1004}:\\{\"before\":null," +
                             "\"after\":\\{\"id\":1004,\"first_name\":\"Anne\",\"last_name\":\"Kretchmar\"," +
                                 "\"email\":\"annek@noanswer.org\"}," +
-                            "\"source\":\\{\"version\":\"1.2.5.Final\",\"connector\":\"postgresql\"," +
+                            "\"source\":\\{\"version\":\"[\\w\\d\\.]*\",\"connector\":\"postgresql\"," +
                                 "\"name\":\"dbserver1\",\"ts_ms\":[0-9]*,\"snapshot\":\"last\",\"db\":\"postgres\"," +
+                            "\"sequence\":\"\\[.*]\"," +
                                 "\"schema\":\"inventory\",\"table\":\"customers\",\"txId\":[0-9]*,\"lsn\":[0-9]*," +
                                 "\"xmin\":null},\"op\":\"r\",\"ts_ms\":[0-9]*,\"transaction\":null}"
             );
@@ -377,11 +370,10 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);
             }
-        } finally {
-            container.stop();
         }
     }
 
+    @SuppressWarnings("resource")
     private PostgreSQLContainer<?> postgresContainer() {
         return namedTestContainer(
                 new PostgreSQLContainer<>(POSTGRES_IMAGE)

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -55,7 +55,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     private static final DockerImageName MYSQL_IMAGE =
             DockerImageName.parse("debezium/example-mysql:1.9.3.Final").asCompatibleSubstituteFor("mysql");
     private static final DockerImageName POSTGRES_IMAGE =
-            DockerImageName.parse("debezium/example-postgres:1.9.3.Final").asCompatibleSubstituteFor("postgres");
+            DockerImageName.parse("debezium/example-postgres:1.7").asCompatibleSubstituteFor("postgres");
     @Test
     public void mysql() throws Exception {
         Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623, " +

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -33,7 +33,7 @@
     </parent>
 
     <properties>
-        <debezium.version>1.2.5.Final</debezium.version>
+        <debezium.version>1.9.3.Final</debezium.version>
 
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -33,8 +33,6 @@
     </parent>
 
     <properties>
-        <debezium.version>1.9.3.Final</debezium.version>
-
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
     </properties>

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -39,10 +39,11 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.3")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.9.3.Final")
             .asCompatibleSubstituteFor("mysql");
 
     @Rule
+    @SuppressWarnings("resource")
     public MySQLContainer<?> mysql = namedTestContainer(
             new MySQLContainer<>(DOCKER_IMAGE)
                     .withUsername("mysqluser")

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcIntegrationTest.java
@@ -56,10 +56,10 @@ public class MySqlCdcIntegrationTest extends AbstractMySqlCdcIntegrationTest {
     public void customers() throws Exception {
         // given
         List<String> expectedRecords = Arrays.asList(
-                "1001/0:INSERT:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                "1002/0:INSERT:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                "1003/0:INSERT:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                "1004/0:INSERT:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
+                "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
+                "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
+                "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
+                "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
                 "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
                 "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
                 "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
@@ -113,13 +113,13 @@ public class MySqlCdcIntegrationTest extends AbstractMySqlCdcIntegrationTest {
     public void orders() {
         // given
         List<String> expectedRecords = Arrays.asList(
-                "10001/0:INSERT:Order {orderNumber=10001, orderDate=" + new Date(1452902400000L) +
+                "10001/0:SYNC:Order {orderNumber=10001, orderDate=" + new Date(1452902400000L) +
                         ", quantity=1, productId=102}",
-                "10002/0:INSERT:Order {orderNumber=10002, orderDate=" + new Date(1452988800000L) +
+                "10002/0:SYNC:Order {orderNumber=10002, orderDate=" + new Date(1452988800000L) +
                         ", quantity=2, productId=105}",
-                "10003/0:INSERT:Order {orderNumber=10003, orderDate=" + new Date(1455840000000L) +
+                "10003/0:SYNC:Order {orderNumber=10003, orderDate=" + new Date(1455840000000L) +
                         ", quantity=2, productId=106}",
-                "10004/0:INSERT:Order {orderNumber=10004, orderDate=" + new Date(1456012800000L) +
+                "10004/0:SYNC:Order {orderNumber=10004, orderDate=" + new Date(1456012800000L) +
                         ", quantity=1, productId=107}"
         );
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcListenBeforeExistIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcListenBeforeExistIntegrationTest.java
@@ -54,6 +54,7 @@ public class MySqlCdcListenBeforeExistIntegrationTest extends AbstractMySqlCdcIn
 
         StreamSource<ChangeRecord> source = sourceBuilder("cdcMysql")
                 .setDatabaseWhitelist(DATABASE)
+                .setCustomProperty("snapshot.mode", "never")
                 .build();
 
         Pipeline pipeline = pipeline(source);
@@ -88,6 +89,7 @@ public class MySqlCdcListenBeforeExistIntegrationTest extends AbstractMySqlCdcIn
         StreamSource<ChangeRecord> source = sourceBuilder("cdcMysql")
                 .setDatabaseWhitelist(DATABASE)
                 .setTableWhitelist(DATABASE + ".someTable")
+                .setCustomProperty("snapshot.mode", "never")
                 .build();
 
         Pipeline pipeline = pipeline(source);
@@ -117,7 +119,7 @@ public class MySqlCdcListenBeforeExistIntegrationTest extends AbstractMySqlCdcIn
         insertToTable(DATABASE, "someTable", 1001, "someValue1", "someValue2");
 
         List<String> expectedRecords = Arrays.asList(
-                "1001/0:INSERT:TableRow {id=1001, value1=someValue1, value2=someValue2, value3=null}",
+                "1001/0:SYNC:TableRow {id=1001, value1=someValue1, value2=someValue2, value3=null}",
                 "1002/0:INSERT:TableRow {id=1002, value1=someValue4, value2=someValue5, value3=someValue6}"
         );
 
@@ -135,7 +137,7 @@ public class MySqlCdcListenBeforeExistIntegrationTest extends AbstractMySqlCdcIn
 
         try {
             assertEqualsEventually(() -> mapResultsToSortedList(hz.getMap(SINK_MAP_NAME)), Collections.singletonList(
-                    "1001/0:INSERT:TableRow {id=1001, value1=someValue1, value2=someValue2, value3=null}"
+                    "1001/0:SYNC:TableRow {id=1001, value1=someValue1, value2=someValue2, value3=null}"
             ));
             //then
             addColumnToTable(DATABASE, "someTable", "value_3");

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -33,7 +33,7 @@
     </parent>
 
     <properties>
-        <debezium.version>1.2.5.Final</debezium.version>
+        <debezium.version>1.9.3.Final</debezium.version>
 
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -33,8 +33,6 @@
     </parent>
 
     <properties>
-        <debezium.version>1.9.3.Final</debezium.version>
-
         <!-- needed for CheckStyle -->
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
     </properties>

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.9.3.Final")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.7")
             .asCompatibleSubstituteFor("postgres");
 
     protected static final String DATABASE_NAME = "postgres";

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.3")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.9.3.Final")
             .asCompatibleSubstituteFor("postgres");
 
     protected static final String DATABASE_NAME = "postgres";

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <kotlin.version>1.5.32</kotlin.version>
         <log4j.version>1.2.17.redhat-00008</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>
-        <mysql.connector.version>8.0.20</mysql.connector.version>
+        <mysql.connector.version>8.0.29</mysql.connector.version>
         <netty.version>4.1.74.Final</netty.version>
         <objenesis.version>3.2</objenesis.version>
         <osgi.version>4.2.0</osgi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <avro.version>1.11.0</avro.version>
         <aws.sdk.version>1.12.150</aws.sdk.version>
         <classgraph.version>4.8.139</classgraph.version>
+        <debezium.version>1.9.3.Final</debezium.version>
         <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
         <hadoop.version>3.3.3</hadoop.version>


### PR DESCRIPTION
This PR upgrades Debezium to 1.9.3.Final.

Breaking changes (list specific methods/types/messages):
* serialized form - use readString instead of readUTF, etc.
* snapshot format - use readString instead of readUTF, etc.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
