### PR TITLE
Don't print the JAVA/JAVA_OPTS/CLASSPATH details when "hz -V"

### DIFF
--- a/distribution/src/bin-filemode-755/hz
+++ b/distribution/src/bin-filemode-755/hz
@@ -99,10 +99,12 @@ if [ -z "$LOGGING_PATTERN" ]; then
   fi
 fi
 
-echo "########################################"
-echo "# JAVA=$JAVA"
-echo "# JAVA_OPTS=${JAVA_OPTS_ARRAY[*]}"
-echo "# CLASSPATH=$CLASSPATH"
-echo "########################################"
+if [[ "$1" != "--version" ]] && [[ "$1" != "-V" ]]; then
+  echo "########################################"
+  echo "# JAVA=$JAVA"
+  echo "# JAVA_OPTS=${JAVA_OPTS_ARRAY[*]}"
+  echo "# CLASSPATH=$CLASSPATH"
+  echo "########################################"
+fi
 
 exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS_ARRAY[*]} com.hazelcast.commandline.HazelcastServerCommandLine "$@"


### PR DESCRIPTION
Do not print the  JAVA, JAVA_OPTS and CLASSPATH variables if `hz -V` or `hz --version` is called

Fixes https://github.com/hazelcast/hazelcast-packaging/issues/144

