### PR TITLE
[HZ-1149] make the UpdatePermissionConfigOperation retryable (4.1.z)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdatePermissionConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdatePermissionConfigOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
@@ -50,7 +51,11 @@ public class UpdatePermissionConfigOperation extends AbstractManagementOperation
     @Override
     public void run() throws Exception {
         Node node = ((NodeEngineImpl) getNodeEngine()).getNode();
-        node.securityContext.refreshPermissions(permissionConfigs);
+        try {
+            node.securityContext.refreshPermissions(permissionConfigs);
+        } catch (IllegalStateException e) {
+            throw new RetryableHazelcastException("Permission refresh was not allowed at this time", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backports #21440.

Internal JIRA: https://hazelcast.atlassian.net/browse/HZ-1149

When the `on-join-operation=SEND` is used in the client permissions config and more Hazelcast members start simultaneously, they can hit a point where permissions are locked for change and can't be refreshed. This PR makes the refresh permissions operation retryable to solve the issue.