### PR TITLE
Add `classloading.jet.extensions.<extension-name>` metrics MC-1537

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -748,5 +748,12 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast.jet</groupId>
+            <artifactId>hazelcast-jet-avro</artifactId>
+            <version>5.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -52,6 +52,7 @@ public final class MetricDescriptorConstants {
     public static final String CLASSLOADING_FULL_METRIC_LOADED_CLASSES_COUNT = "classloading.loadedClassesCount";
     public static final String CLASSLOADING_FULL_METRIC_TOTAL_LOADED_CLASSES_COUNT = "classloading.totalLoadedClassesCount";
     public static final String CLASSLOADING_FULL_METRIC_UNLOADED_CLASSES_COUNT = "classloading.unloadedClassesCount";
+    public static final String CLASSLOADING_JET_EXTENSIONS_PREFIX = "classloading.jet.extensions";
     // ===[/CLASS LOADING]==============================================
 
     // ===[CLIENT]======================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
@@ -16,21 +16,44 @@
 
 package com.hazelcast.internal.metrics.metricsets;
 
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
 
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLASSLOADING_FULL_METRIC_LOADED_CLASSES_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLASSLOADING_FULL_METRIC_TOTAL_LOADED_CLASSES_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLASSLOADING_FULL_METRIC_UNLOADED_CLASSES_COUNT;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLASSLOADING_JET_EXTENSIONS_PREFIX;
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.internal.metrics.ProbeUnit.BOOLEAN;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
- * A Metric set for exposing {@link java.lang.management.ClassLoadingMXBean} metrics.
+ * A Metric set for exposing {@link java.lang.management.ClassLoadingMXBean} metrics and Jet extensions' availability.
  */
 public final class ClassLoadingMetricSet {
+
+    public static final Map<String, String> JET_EXTENSION_TO_CLASS_MAPPING = new HashMap<>();
+
+    static {
+        JET_EXTENSION_TO_CLASS_MAPPING.put("kafka", "com.hazelcast.jet.kafka.KafkaSinks");
+
+        JET_EXTENSION_TO_CLASS_MAPPING.put("csv", "com.hazelcast.jet.csv.impl.CsvReadFileFnProvider");
+        JET_EXTENSION_TO_CLASS_MAPPING.put("avro", "com.hazelcast.jet.avro.AvroSources");
+        JET_EXTENSION_TO_CLASS_MAPPING.put("parquet", "org.apache.parquet.avro.AvroParquetInputFormat");
+
+        JET_EXTENSION_TO_CLASS_MAPPING.put("hadoop", "com.hazelcast.jet.hadoop.HadoopProcessors");
+        JET_EXTENSION_TO_CLASS_MAPPING.put("files-s3", "org.apache.hadoop.fs.s3a.S3A");
+        JET_EXTENSION_TO_CLASS_MAPPING.put("files-gcs", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
+        JET_EXTENSION_TO_CLASS_MAPPING.put("files-azure", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+    }
 
     private ClassLoadingMetricSet() {
     }
@@ -53,5 +76,12 @@ public final class ClassLoadingMetricSet {
 
         metricsRegistry.registerStaticProbe(mxBean, CLASSLOADING_FULL_METRIC_UNLOADED_CLASSES_COUNT, MANDATORY,
                 ClassLoadingMXBean::getUnloadedClassCount);
+
+        MetricDescriptor extensionsJetDescriptor = metricsRegistry.newMetricDescriptor()
+                .withPrefix(CLASSLOADING_JET_EXTENSIONS_PREFIX);
+        JET_EXTENSION_TO_CLASS_MAPPING.forEach((extensionName, fqdn) -> metricsRegistry.registerStaticProbe(
+                "classpath", extensionsJetDescriptor, extensionName, INFO, BOOLEAN,
+                (LongProbeFunction<?>) ignored -> ClassLoaderUtil.isClassDefined(fqdn) ? 1L : 0L)
+        );
     }
 }


### PR DESCRIPTION
These metrics allow the Management Center to identify which connectors/serialization options/filesystems are available to members.
Also, we can provide inconsistency alerts in MC if some extensions are missing from some members' classpath.

Fixes [MC-1537](https://hazelcast.atlassian.net/browse/MC-1537)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set

