### PR TITLE
[HZ-1206] Cleanup map partition container on migration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -174,16 +174,17 @@ class MapMigrationAwareService
             depopulateIndexes(event, "commitMigration");
         }
 
+        PartitionContainer partitionContainer
+                = mapServiceContext.getPartitionContainer(event.getPartitionId());
         if (SOURCE == event.getMigrationEndpoint()) {
             // Do not change order of below methods
             removeWbqCountersHavingLesserBackupCountThan(event.getPartitionId(),
                     event.getNewReplicaIndex());
             removeRecordStoresHavingLesserBackupCountThan(event.getPartitionId(),
                     event.getNewReplicaIndex());
+            partitionContainer.cleanUp();
         }
 
-        PartitionContainer partitionContainer
-                = mapServiceContext.getPartitionContainer(event.getPartitionId());
         for (RecordStore recordStore : partitionContainer.getAllRecordStores()) {
             // in case the record store has been created without
             // loading during migration trigger again if loading
@@ -216,6 +217,9 @@ class MapMigrationAwareService
             removeRecordStoresHavingLesserBackupCountThan(event.getPartitionId(),
                     event.getCurrentReplicaIndex());
             getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
+
+            PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(event.getPartitionId());
+            partitionContainer.cleanUp();
         }
 
         mapServiceContext.nullifyOwnedPartitions();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -182,7 +182,10 @@ class MapMigrationAwareService
                     event.getNewReplicaIndex());
             removeRecordStoresHavingLesserBackupCountThan(event.getPartitionId(),
                     event.getNewReplicaIndex());
-            partitionContainer.cleanUp();
+
+            if (event.getNewReplicaIndex() == -1) {
+                partitionContainer.cleanUp();
+            }
         }
 
         for (RecordStore recordStore : partitionContainer.getAllRecordStores()) {
@@ -194,6 +197,7 @@ class MapMigrationAwareService
         mapServiceContext.nullifyOwnedPartitions();
 
         removeOrRegenerateNearCacheUuid(event);
+
     }
 
     private void removeOrRegenerateNearCacheUuid(PartitionMigrationEvent event) {
@@ -218,8 +222,10 @@ class MapMigrationAwareService
                     event.getCurrentReplicaIndex());
             getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
 
-            PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(event.getPartitionId());
-            partitionContainer.cleanUp();
+            if (event.getNewReplicaIndex() == -1) {
+                PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(event.getPartitionId());
+                partitionContainer.cleanUp();
+            }
         }
 
         mapServiceContext.nullifyOwnedPartitions();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -271,7 +271,7 @@ class MapMigrationAwareService
      * @return predicate to find all map partitions which are expected to have
      * fewer backups than given backupCount.
      */
-    private static Predicate<RecordStore> lesserBackupMapsThen(final int backupCount) {
+    static Predicate<RecordStore> lesserBackupMapsThen(final int backupCount) {
         return recordStore -> recordStore.getMapContainer().getTotalBackupCount() < backupCount;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -183,9 +183,7 @@ class MapMigrationAwareService
             removeRecordStoresHavingLesserBackupCountThan(event.getPartitionId(),
                     event.getNewReplicaIndex());
 
-            if (event.getNewReplicaIndex() == -1) {
-                partitionContainer.cleanUp();
-            }
+            partitionContainer.cleanUpOnMigration(event.getNewReplicaIndex());
         }
 
         for (RecordStore recordStore : partitionContainer.getAllRecordStores()) {
@@ -222,10 +220,8 @@ class MapMigrationAwareService
                     event.getCurrentReplicaIndex());
             getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
 
-            if (event.getNewReplicaIndex() == -1) {
-                PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(event.getPartitionId());
-                partitionContainer.cleanUp();
-            }
+            PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(event.getPartitionId());
+            partitionContainer.cleanUpOnMigration(event.getCurrentReplicaIndex());
         }
 
         mapServiceContext.nullifyOwnedPartitions();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -240,10 +240,25 @@ public class PartitionContainer {
     }
 
     /**
-     * Called when this container's enclosing partition is removed from the
-     * member, i.e. during migration.
+     * Cleans up the container's state if the enclosing partition is migrated
+     * off this member. Whether cleanup is needed is decided based on the
+     * provided {@code replicaIndex}.
+     *
+     * @param replicaIndex The replica index to use for deciding per map whether
+     *                     cleanup is necessary or not
      */
-    public void cleanUp() {
+    final void cleanUpOnMigration(int replicaIndex) {
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+
+        mapServiceContext.getMapContainers().keySet().stream()
+                .filter(mapName -> replicaIndex == -1
+                        || replicaIndex > nodeEngine.getConfig().findMapConfig(mapName).getTotalBackupCount())
+                .forEach(this::cleanUpMap);
+    }
+
+    protected void cleanUpMap(String mapName) {
+        // overridden in enterprise
     }
 
     // -------------------------------------------------------------------------------------------------------------

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -239,11 +239,19 @@ public class PartitionContainer {
         this.lastCleanupTimeCopy = lastCleanupTimeCopy;
     }
 
+    /**
+     * Called when this container's enclosing partition is removed from the
+     * member, i.e. during migration.
+     */
+    public void cleanUp() {
+    }
+
     // -------------------------------------------------------------------------------------------------------------
     // IMPORTANT: never use directly! use MapContainer.getIndex() instead.
     // There are cases where a global index is used. In this case, the global-index is stored in the MapContainer.
     // By using this method in the context of global index an exception will be thrown.
     // -------------------------------------------------------------------------------------------------------------
+
     Indexes getIndexes(String name) {
         Indexes ixs = indexes.get(name);
         if (ixs == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 
 import static com.hazelcast.map.impl.MapKeyLoaderUtil.getMaxSizePerNode;
+import static com.hazelcast.map.impl.MapMigrationAwareService.lesserBackupMapsThen;
 
 public class PartitionContainer {
 
@@ -251,7 +252,7 @@ public class PartitionContainer {
         mapService.getMapServiceContext().getMapContainers().keySet()
                 .stream()
                 .filter(mapName -> replicaIndex == -1
-                        || replicaIndex > getRecordStore(mapName).getMapContainer().getTotalBackupCount())
+                        || lesserBackupMapsThen(replicaIndex).test(getRecordStore(mapName)))
                 .forEach(this::cleanUpMap);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -248,12 +248,10 @@ public class PartitionContainer {
      *                     cleanup is necessary or not
      */
     final void cleanUpOnMigration(int replicaIndex) {
-        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-
-        mapServiceContext.getMapContainers().keySet().stream()
+        mapService.getMapServiceContext().getMapContainers().keySet()
+                .stream()
                 .filter(mapName -> replicaIndex == -1
-                        || replicaIndex > nodeEngine.getConfig().findMapConfig(mapName).getTotalBackupCount())
+                        || replicaIndex > getRecordStore(mapName).getMapContainer().getTotalBackupCount())
                 .forEach(this::cleanUpMap);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -251,7 +251,6 @@ public class PartitionContainer {
     // There are cases where a global index is used. In this case, the global-index is stored in the MapContainer.
     // By using this method in the context of global index an exception will be thrown.
     // -------------------------------------------------------------------------------------------------------------
-
     Indexes getIndexes(String name) {
         Indexes ixs = indexes.get(name);
         if (ixs == null) {


### PR DESCRIPTION
This change introduces `PartitionContaier.cleanUp()` called during
migration commit (on source) and rollback (on destination). This lets
the partition containers' states to be cleaned up, such as getting rid
of references to cached objects, like merkle trees and tstore's hybrid
logs.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4932
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5046