### PR TITLE
[4.2.z] Check for the minimum size of the bytes read only once per frame

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
@@ -34,8 +34,8 @@ public final class ClientMessageReader {
     private int sumUntrustedMessageLength;
     private final int maxMessageLength;
 
-    public ClientMessageReader(int maxMessageLenth) {
-        this.maxMessageLength = maxMessageLenth > 0 ? maxMessageLenth : Integer.MAX_VALUE;
+    public ClientMessageReader(int maxMessageLength) {
+        this.maxMessageLength = maxMessageLength > 0 ? maxMessageLength : Integer.MAX_VALUE;
     }
 
     public boolean readFrom(ByteBuffer src, boolean trusted) {
@@ -62,13 +62,15 @@ public final class ClientMessageReader {
     }
 
     private boolean readFrame(ByteBuffer src, boolean trusted) {
-        // init internal buffer
-        int remaining = src.remaining();
-        if (remaining < SIZE_OF_FRAME_LENGTH_AND_FLAGS) {
-            // we don't have even the frame length and flags ready
-            return false;
-        }
         if (readOffset == -1) {
+            // Check for the minimum buffer size only if we
+            // haven't read the frame length and flags.
+            int remaining = src.remaining();
+            if (remaining < SIZE_OF_FRAME_LENGTH_AND_FLAGS) {
+                // we don't have even the frame length and flags ready
+                return false;
+            }
+
             int frameLength = Bits.readIntL(src, src.position());
             if (frameLength < SIZE_OF_FRAME_LENGTH_AND_FLAGS) {
                 throw new IllegalArgumentException(format(

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageReaderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.util;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.ClientMessageReader;
+import com.hazelcast.client.impl.protocol.ClientMessageWriter;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static com.hazelcast.internal.util.JVMUtil.upcast;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientMessageReaderTest {
+
+    private final Random random = new Random();
+
+    @Test
+    public void testReadSingleFrameMessage() {
+        ClientMessage.Frame frame = createFrameWithRandomBytes(42);
+
+        ClientMessage message = ClientMessage.createForEncode();
+        message.add(frame);
+
+        ByteBuffer buffer = writeToBuffer(message);
+
+        ClientMessageReader reader = new ClientMessageReader(-1);
+        assertTrue(reader.readFrom(buffer, true));
+
+        ClientMessage messageRead = reader.getClientMessage();
+        ClientMessage.ForwardFrameIterator iterator = messageRead.frameIterator();
+
+        assertTrue(iterator.hasNext());
+        ClientMessage.Frame frameRead = iterator.next();
+        assertArrayEquals(frame.content, frameRead.content);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testReadMultiFrameMessage() {
+        ClientMessage.Frame frame1 = createFrameWithRandomBytes(10);
+        ClientMessage.Frame frame2 = createFrameWithRandomBytes(20);
+        ClientMessage.Frame frame3 = createFrameWithRandomBytes(30);
+
+        ClientMessage message = ClientMessage.createForEncode();
+        message.add(frame1);
+        message.add(frame2);
+        message.add(frame3);
+
+        ByteBuffer buffer = writeToBuffer(message);
+
+        ClientMessageReader reader = new ClientMessageReader(-1);
+        assertTrue(reader.readFrom(buffer, true));
+
+        ClientMessage messageRead = reader.getClientMessage();
+        ClientMessage.ForwardFrameIterator iterator = messageRead.frameIterator();
+
+        assertTrue(iterator.hasNext());
+        ClientMessage.Frame frameRead = iterator.next();
+        assertArrayEquals(frame1.content, frameRead.content);
+
+        assertTrue(iterator.hasNext());
+        frameRead = iterator.next();
+        assertArrayEquals(frame2.content, frameRead.content);
+
+        assertTrue(iterator.hasNext());
+        frameRead = iterator.next();
+        assertArrayEquals(frame3.content, frameRead.content);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testReadFramesInMultipleCallsToReadFrom() {
+        ClientMessage.Frame frame = createFrameWithRandomBytes(1000);
+
+        ClientMessage message = ClientMessage.createForEncode();
+        message.add(frame);
+
+        ByteBuffer buffer = writeToBuffer(message);
+
+        byte[] part1 = new byte[750];
+        buffer.get(part1, 0, 750);
+        byte[] part2 = new byte[buffer.remaining()];
+        buffer.get(part2);
+
+        ByteBuffer part1Buffer = ByteBuffer.wrap(part1);
+        ByteBuffer part2Buffer = ByteBuffer.wrap(part2);
+
+        ClientMessageReader reader = new ClientMessageReader(-1);
+        assertFalse(reader.readFrom(part1Buffer, true));
+        assertTrue(reader.readFrom(part2Buffer, true));
+
+        ClientMessage messageRead = reader.getClientMessage();
+        ClientMessage.ForwardFrameIterator iterator = messageRead.frameIterator();
+
+        assertTrue(iterator.hasNext());
+        ClientMessage.Frame frameRead = iterator.next();
+        assertArrayEquals(frame.content, frameRead.content);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testReadFramesInMultipleCallsToReadFrom_whenLastPieceIsSmall() {
+        ClientMessage.Frame frame = createFrameWithRandomBytes(1000);
+
+        ClientMessage message = ClientMessage.createForEncode();
+        message.add(frame);
+
+        ByteBuffer buffer = writeToBuffer(message);
+
+        byte[] part1 = new byte[750];
+        buffer.get(part1, 0, 750);
+        byte[] part2 = new byte[252];
+        buffer.get(part2, 0, 252);
+
+        // Message Length = 1000 + 6 bytes
+        // part1 = 750, part2 = 250, part3 = 4 bytes
+        byte[] part3 = new byte[buffer.remaining()];
+        buffer.get(part3);
+
+        ByteBuffer part1Buffer = ByteBuffer.wrap(part1);
+        ByteBuffer part2Buffer = ByteBuffer.wrap(part2);
+        ByteBuffer part3Buffer = ByteBuffer.wrap(part3);
+
+        ClientMessageReader reader = new ClientMessageReader(-1);
+        assertFalse(reader.readFrom(part1Buffer, true));
+        assertFalse(reader.readFrom(part2Buffer, true));
+        assertTrue(reader.readFrom(part3Buffer, true));
+
+        ClientMessage messageRead = reader.getClientMessage();
+        ClientMessage.ForwardFrameIterator iterator = messageRead.frameIterator();
+
+        assertTrue(iterator.hasNext());
+        ClientMessage.Frame frameRead = iterator.next();
+        assertArrayEquals(frame.content, frameRead.content);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    private ClientMessage.Frame createFrameWithRandomBytes(int contentLength) {
+        byte[] content = new byte[contentLength];
+        random.nextBytes(content);
+        return new ClientMessage.Frame(content);
+    }
+
+    private ByteBuffer writeToBuffer(ClientMessage message) {
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[message.getFrameLength()]);
+        ClientMessageWriter writer = new ClientMessageWriter();
+        writer.writeTo(buffer, message);
+        upcast(buffer).flip();
+        return buffer;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageWriterTest.java
@@ -48,7 +48,7 @@ public class ClientMessageWriterTest {
     }
 
     @Test
-    public void testWriteAttemptToInsufficentSpaceRemaining_spaceLeftIsLessThanFrameLengthAndFlags() {
+    public void testWriteAttemptToInsufficientSpaceRemaining_spaceLeftIsLessThanFrameLengthAndFlags() {
         ClientMessage.Frame frame = new ClientMessage.Frame(new byte[100], DEFAULT_FLAGS);
         ClientMessage message = createForDecode(frame);
         ByteBuffer buffer = ByteBuffer.allocate(SIZE_OF_FRAME_LENGTH_AND_FLAGS - 1);


### PR DESCRIPTION
Before this fix, while reading a message frame, we were mistakenly
checking that the bytes we haven't read yet are less than 6 bytes
each time the ClientMessageReader#readFrame is called.

This is problematic for frames that are read in multiple calls,
as the size of the last piece of the frame we are reading might be
actually less than 6 bytes and that is definitely valid. However,
in that case, we were not able to read the remaining part and
continue.

This PR aims to fix this problem by having that check only at the
beginning for each frame, only once per frame. Once we read the frame
length and flags, we will be able to read any number of bytes no
matter how small it is.

backport of https://github.com/hazelcast/hazelcast/pull/21502