### PR TITLE
Improve encryption related sections in hazelcast-full-example.xml

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -834,10 +834,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertFalse(tcp.isEnabled());
         SymmetricEncryptionConfig symmetricEncryptionConfig = networkConfig.getSymmetricEncryptionConfig();
         assertFalse(symmetricEncryptionConfig.isEnabled());
-        assertEquals("PBEWithMD5AndDES", symmetricEncryptionConfig.getAlgorithm());
-        assertEquals("thesalt", symmetricEncryptionConfig.getSalt());
-        assertEquals("thepass", symmetricEncryptionConfig.getPassword());
-        assertEquals(19, symmetricEncryptionConfig.getIterationCount());
 
         List<String> members = tcp.getMembers();
         assertEquals(members.toString(), 2, members.size());
@@ -1120,7 +1116,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         SSLConfig sslConfig = config.getNetworkConfig().getSSLConfig();
         assertNotNull(sslConfig);
         assertFalse(sslConfig.isEnabled());
-        assertEquals(sslContextFactory, sslConfig.getFactoryImplementation());
+        assertNotNull(sslContextFactory);
     }
 
     @Test
@@ -1387,7 +1383,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         SSLConfig sslConfig = vaultConfig.getSSLConfig();
         assertNotNull(sslConfig);
         assertTrue(sslConfig.isEnabled());
-        assertEquals(sslContextFactory, sslConfig.getFactoryImplementation());
+        assertNotNull(sslContextFactory);
         assertEquals(60, vaultConfig.getPollingInterval());
         assertEquals(240, persistenceConfig.getRebalanceDelaySeconds());
     }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -105,7 +105,6 @@ import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SplitBrainProtectionConfig;
 import com.hazelcast.config.SqlConfig;
-import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TieredStoreConfig;
 import com.hazelcast.config.TopicConfig;
@@ -832,8 +831,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         TcpIpConfig tcp = networkConfig.getJoin().getTcpIpConfig();
         assertNotNull(tcp);
         assertFalse(tcp.isEnabled());
-        SymmetricEncryptionConfig symmetricEncryptionConfig = networkConfig.getSymmetricEncryptionConfig();
-        assertFalse(symmetricEncryptionConfig.isEnabled());
 
         List<String> members = tcp.getMembers();
         assertEquals(members.toString(), 2, members.size());

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -177,16 +177,24 @@
                     <hz:interface>10.10.1.*</hz:interface>
                 </hz:interfaces>
 
-
-                <hz:ssl enabled="false" factory-class-name="com.hazelcast.spring.DummySSLContextFactory"
-                        factory-implementation="dummySSLContextFactory"/>
+                <hz:ssl enabled="false" factory-class-name="com.hazelcast.nio.ssl.BasicSSLContextFactory">
+                    <hz:properties>
+                        <hz:property name="protocol">TLS</hz:property>
+                        <hz:property name="mutualAuthentication">REQUIRED</hz:property>
+                        <hz:property name="keyStore">/opt/hazelcast.keystore</hz:property>
+                        <hz:property name="keyStorePassword">secret.97531</hz:property>
+                        <hz:property name="keyStoreType">PKCS12</hz:property>
+                        <hz:property name="trustStore">/opt/hazelcast.truststore</hz:property>
+                        <hz:property name="trustStorePassword">changeit</hz:property>
+                        <hz:property name="trustStoreType">PKCS12</hz:property>
+                    </hz:properties>
+                </hz:ssl>
                 <hz:socket-interceptor enabled="false" class-name="com.hazelcast.spring.DummySocketInterceptor"
                                        implementation="dummySocketInterceptor"/>
-                <hz:symmetric-encryption enabled="false"
-                                         algorithm="PBEWithMD5AndDES"
-                                         salt="thesalt"
-                                         password="thepass"
-                                         iteration-count="19"/>
+                <!--
+                The symmetric-encryption is deprecated since Hazelcast 4.2. Consider using TLS instead.
+                 -->
+                <hz:symmetric-encryption enabled="false"/>
                 <hz:reuse-address>true</hz:reuse-address>
                 <hz:member-address-provider enabled="false" class-name="com.hazelcast.spring.DummyMemberAddressProvider">
                     <hz:properties>

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -177,7 +177,7 @@
                     <hz:interface>10.10.1.*</hz:interface>
                 </hz:interfaces>
 
-                <hz:ssl enabled="false" factory-class-name="com.hazelcast.nio.ssl.BasicSSLContextFactory">
+                <hz:ssl enabled="false">
                     <hz:properties>
                         <hz:property name="protocol">TLS</hz:property>
                         <hz:property name="mutualAuthentication">REQUIRED</hz:property>
@@ -193,8 +193,12 @@
                                        implementation="dummySocketInterceptor"/>
                 <!--
                 The symmetric-encryption is deprecated since Hazelcast 4.2. Consider using TLS instead.
+                <hz:symmetric-encryption enabled="false"
+                                         algorithm="PBEWithMD5AndDES"
+                                         salt="thesalt"
+                                         password="thepass"
+                                         iteration-count="19"/>
                  -->
-                <hz:symmetric-encryption enabled="false"/>
                 <hz:reuse-address>true</hz:reuse-address>
                 <hz:member-address-provider enabled="false" class-name="com.hazelcast.spring.DummyMemberAddressProvider">
                     <hz:properties>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.xml
@@ -187,21 +187,18 @@
                 </properties>
             </socket-interceptor>
         * <ssl>:
-            Lets you configure SSL using the SSL context factory. This feature is available only in Hazelcast
-            Enterprise. To be able to use it, encryption should NOT be enabled and you should first implement
-            your SSLContextFactory class. Its configuration contains the factory class and SSL properties.
-            By default, it is disabled. The following is an example:
+            Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast Enterprise.
+            The default configuration usually uses JSSE engine available in Java.
+            Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines.
             <ssl enabled="true">
                 <factory-class-name>
-                    com.hazelcast.nio.ssl.BasicSSLContextFactory
+                    com.hazelcast.nio.ssl.OpenSSLEngineFactory
                 </factory-class-name>
                 <properties>
-                    <property name="keyStore">keyStore</property>
-                    <property name="keyStorePassword">keyStorePassword</property>
-                    <property name="keyManagerAlgorithm">SunX509</property>
-                    <property name="trustManagerAlgorithm">SunX509</property>
-                    <property name="protocol">TLS</property>
-                    <property name="mutualAuthentication">REQUIRED</property>
+                    <property name="protocol">TLSv1.2</property>
+                    <property name="trustCertCollectionFile">/opt/hazelcast/trusted-certs.pem</property>
+                    <property name="keyFile">/opt/hazelcast/privkey.pem</property>
+                    <property name="keyCertChainFile">/opt/hazelcast/chain.pem</property>
                 </properties>
             </ssl>
         * <aws>:
@@ -291,18 +288,17 @@
         </socket-interceptor>
 
         <ssl enabled="false">
-            <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>
             <properties>
                 <property name="protocol">TLS</property>
 
                 <property name="trustStore">/opt/hazelcast-client.truststore</property>
                 <property name="trustStorePassword">secret.123456</property>
-                <property name="trustStoreType">JKS</property>
+                <property name="trustStoreType">PKCS12</property>
 
                 <!-- Following properties are only needed when the mutual authentication is used. -->
                 <property name="keyStore">/opt/hazelcast-client.keystore</property>
                 <property name="keyStorePassword">keystorePassword123</property>
-                <property name="keyStoreType">JKS</property>
+                <property name="keyStoreType">PKCS12</property>
             </properties>
         </ssl>
         <auto-detection enabled="false"/>

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -256,18 +256,17 @@ hazelcast-client:
 
     ssl:
       enabled: false
-      factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory
       properties:
         protocol: TLS
 
         trustStore: /opt/hazelcast-client.truststore
         trustStorePassword: secret.123456
-        trustStoreType: JKS
+        trustStoreType: PKCS12
 
         # Following properties are only needed when the mutual authentication is used.
         keyStore: /opt/hazelcast-client.keystore
         keyStorePassword: keystorePassword123
-        keyStoreType: JKS
+        keyStoreType: PKCS12
 
     auto-detection:
       enabled: false

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -162,20 +162,18 @@ hazelcast-client:
   #         kerberos-host: kerb-host-name
   #         kerberos-config-file: kerb.conf
   # * "ssl":
-  #     Lets you configure SSL using the SSL context factory. This feature is available only in Hazelcast
-  #     Enterprise. To be able to use it, encryption should NOT be enabled and you should first implement
-  #     your SSLContextFactory class. Its configuration contains the factory class and SSL properties.
-  #     By default, it is disabled. The following is an example:
+  #     Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast
+  #      Enterprise.
+  #      The default configuration usually uses JSSE engine available in Java.
+  #      Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines.
   #     ssl:
   #       enabled: true
-  #       factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory
+  #       factory-class-name: com.hazelcast.nio.ssl.OpenSSLEngineFactory
   #       properties:
-  #         keyStore: keyStore
-  #         keyStorePassword: keyStorePassword
-  #         keyManagerAlgorithm: SunX509
-  #         trustManagerAlgorithm: SunX509
-  #         protocol: TLS
-  #         mutualAuthentication: REQUIRED
+  #         protocol: TLSv1.2
+  #         trustCertCollectionFile: /opt/hazelcast/trusted-certs.pem
+  #         keyFile: /opt/hazelcast/privkey.pem
+  #         keyCertChainFile: /opt/hazelcast/chain.pem
   # * "aws":
   #     Set its "enabled" sub-element to true for discovery within Amazon EC2.
   #     Please refer to https://github.com/hazelcast/hazelcast-aws/#configuration for the configuration details.

--- a/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-full-example.yaml
@@ -163,9 +163,9 @@ hazelcast-client:
   #         kerberos-config-file: kerb.conf
   # * "ssl":
   #     Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast
-  #      Enterprise.
-  #      The default configuration usually uses JSSE engine available in Java.
-  #      Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines.
+  #     Enterprise.
+  #     The default configuration usually uses JSSE engine available in Java.
+  #     Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines.
   #     ssl:
   #       enabled: true
   #       factory-class-name: com.hazelcast.nio.ssl.OpenSSLEngineFactory

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -544,18 +544,15 @@
         * <ssl>:
         Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast
         Enterprise.
-        The default configuration uses JSSE engine available in Java.
+        The default configuration usually uses JSSE engine available in Java.
+        Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines. E.g.
         <ssl enabled="true">
-            <factory-class-name>
-                com.hazelcast.nio.ssl.BasicSSLContextFactory
-            </factory-class-name>
+            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>
             <properties>
-                <property name="keyStore">keyStore</property>
-                <property name="keyStorePassword">keyStorePassword</property>
-                <property name="keyManagerAlgorithm">SunX509</property>
-                <property name="trustManagerAlgorithm">SunX509</property>
-                <property name="protocol">TLS</property>
-                <property name="mutualAuthentication">REQUIRED</property>
+                <property name="protocol">TLSv1.2</property>
+                <property name="trustCertCollectionFile">/opt/hazelcast/trusted-certs.pem</property>
+                <property name="keyFile">/opt/hazelcast/privkey.pem</property>
+                <property name="keyCertChainFile">/opt/hazelcast/chain.pem</property>
             </properties>
         </ssl>
         * <socket-interceptor>:

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -545,7 +545,7 @@
         Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast
         Enterprise.
         The default configuration usually uses JSSE engine available in Java.
-        Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines. E.g.
+        Consult the Hazelcast documentation on how to integrate with OpenSSL/BoringSSL engines.
         <ssl enabled="true">
             <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>
             <properties>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -735,7 +735,6 @@
             </properties>
         </ssl>
         <socket-interceptor enabled="false"/>
-        <symmetric-encryption enabled="false"/>
         <member-address-provider enabled="false">
             <class-name>com.hazelcast.MemberAddressProviderImpl</class-name>
             <properties>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -542,10 +542,9 @@
         to true to be able to use your defined interfaces. You can define multiple interfaces
         using its <interface> sub-element. By default, it is disabled.
         * <ssl>:
-        Lets you configure SSL using the SSL context factory. This feature is available only in Hazelcast
-        Enterprise. To be able to use it, encryption should NOT be enabled and you should first implement
-        your SSLContextFactory class. Its configuration contains the factory class and SSL properties.
-        By default, it is disabled. The following is an example:
+        Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast
+        Enterprise.
+        The default configuration uses JSSE engine available in Java.
         <ssl enabled="true">
             <factory-class-name>
                 com.hazelcast.nio.ssl.BasicSSLContextFactory
@@ -575,10 +574,7 @@
             </properties>
         </socket-interceptor>
         * <symmetric-encryption>:
-        Lets you encrypt the entire socket level communication among all Hazelcast members.
-        This feature is available only in Hazelcast Enterprise.  Its configuration contains the encryption
-        properties and the same configuration must be placed to all members. By default, it is disabled.
-        The following is an example:
+        The symmetric-encryption is deprecated since Hazelcast 4.2. Consider using TLS instead.
         <symmetric-encryption enabled="true">
             <algorithm>PBEWithMD5AndDES</algorithm>
             <salt>thesalt</salt>
@@ -726,26 +722,20 @@
             <interface>10.10.1.*</interface>
         </interfaces>
         <ssl enabled="false">
-            <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>
             <properties>
                 <property name="protocol">TLS</property>
 
                 <property name="mutualAuthentication">REQUIRED</property>
                 <property name="keyStore">/opt/hazelcast.keystore</property>
                 <property name="keyStorePassword">secret.97531</property>
-                <property name="keyStoreType">JKS</property>
+                <property name="keyStoreType">PKCS12</property>
                 <property name="trustStore">/opt/hazelcast.truststore</property>
                 <property name="trustStorePassword">changeit</property>
-                <property name="trustStoreType">JKS</property>
+                <property name="trustStoreType">PKCS12</property>
             </properties>
         </ssl>
         <socket-interceptor enabled="false"/>
-        <symmetric-encryption enabled="false">
-            <algorithm>PBEWithMD5AndDES</algorithm>
-            <password>...</password>
-            <salt>...</salt>
-            <iteration-count>7</iteration-count>
-        </symmetric-encryption>
+        <symmetric-encryption enabled="false"/>
         <member-address-provider enabled="false">
             <class-name>com.hazelcast.MemberAddressProviderImpl</class-name>
             <properties>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -524,10 +524,9 @@ hazelcast:
   # Specifies which network interfaces Hazelcast should use. You need to set its "enabled" attribute
   # to true to be able to use your defined interfaces. You can define multiple interfaces. By default, it is disabled.
   # * "ssl":
-  # Lets you configure SSL using the SSL context factory. This feature is available only in Hazelcast
-  # Enterprise. To be able to use it, encryption should NOT be enabled and you should first implement
-  # your SSLContextFactory class. Its configuration contains the factory class and SSL properties.
-  # By default, it is disabled. The following is an example:
+  # Allows configuring TLS/SSL communication encryption. This feature is available only in Hazelcast
+  # Enterprise.
+  # The default configuration uses JSSE engine available in Java.
   # ssl:
   #   enabled: true
   #   factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory
@@ -551,10 +550,7 @@ hazelcast:
   #     property1: value1
   #     property2: value2
   # * "symmetric-encryption":
-  # Lets you encrypt the entire socket level communication among all Hazelcast members.
-  # This feature is available only in Hazelcast Enterprise.  Its configuration contains the encryption
-  # properties and the same configuration must be placed to all members. By default, it is disabled.
-  # The following is an example:
+  # The symmetric-encryption is deprecated since Hazelcast 4.2. Consider using TLS instead.
   # symmetric-encryption:
   #   enabled: true
   #   algorithm: PBEWithMD5AndDES
@@ -703,25 +699,20 @@ hazelcast:
         - 10.10.1.*
     ssl:
       enabled: false
-      factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory
       properties:
         protocol: TLS
 
         mutualAuthentication: REQUIRED
         keyStore: /opt/hazelcast.keystore
         keyStorePassword: secret.97531
-        keyStoreType: JKS
+        keyStoreType: PKCS12
         trustStore: /opt/hazelcast.truststore
         trustStorePassword: changeit
-        trustStoreType: JKS
+        trustStoreType: PKCS12
     socket-interceptor:
       enabled: false
     symmetric-encryption:
       enabled: false
-      algorithm: PBEWithMD5AndDES
-      password: ...
-      salt: ...
-      iteration-count: 7
     member-address-provider:
       enabled: false
       class-name: com.hazelcast.MemberAddressProviderImpl

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -711,8 +711,6 @@ hazelcast:
         trustStoreType: PKCS12
     socket-interceptor:
       enabled: false
-    symmetric-encryption:
-      enabled: false
     member-address-provider:
       enabled: false
       class-name: com.hazelcast.MemberAddressProviderImpl


### PR DESCRIPTION
This PR should simplify the network encryption configuration and make it more real-world like in `hazelcast-full-example.xml`

It mainly:
* adds deprecation info to `symmetric-encryption` config;
* uses `PKCS12` as the sample keystore type;
* removes the default factory name from the `ssl` config.