### PR TITLE
Update parquet-jackson to 1.12.3 [HZ-1172]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <netty.version>4.1.74.Final</netty.version>
         <objenesis.version>3.2</objenesis.version>
         <osgi.version>4.2.0</osgi.version>
-        <parquet.version>1.12.2</parquet.version>
+        <parquet.version>1.12.3</parquet.version>
         <picocli.version>4.4.0</picocli.version>
         <postgresql.version>42.2.25</postgresql.version>
         <prometheus.version>0.14.0</prometheus.version>


### PR DESCRIPTION
Fixes shaded jackson-databind vulnerability reported in #21045

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases

Will send backports to 5.1.z and 5.0.z after review.