### PR TITLE
Bump hadoop.version from 3.3.1 to 3.3.3 (#21443) [5.1.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <classgraph.version>4.8.139</classgraph.version>
         <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
-        <hadoop.version>3.3.1</hadoop.version>
+        <hadoop.version>3.3.3</hadoop.version>
         <jackson.version>2.12.6</jackson.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jline.version>3.21.0</jline.version>
@@ -1532,8 +1532,12 @@
                 <exclusions>
                     <!-- The following dependencies are not needed for our use of Hadoop -->
                     <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
+                        <groupId>ch.qos.reload4j</groupId>
+                        <artifactId>reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.eclipse.jetty</groupId>
@@ -1670,11 +1674,6 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.htrace</groupId>
-                <artifactId>htrace-core4</artifactId>
-                <version>4.2.0-incubating.hazelcast-2</version>
             </dependency>
             <!-- NOTE: httpcore and httpclient versions are not in sync -->
             <dependency>


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/21443

Relates to: https://github.com/hazelcast/hazelcast/issues/21346

Bump hadoop.version from 3.3.1 to 3.3.3

Bumps `hadoop.version` from 3.3.1 to 3.3.3.

Updates `hadoop-client` from 3.3.1 to 3.3.3

Updates `hadoop-minicluster` from 3.3.1 to 3.3.3

Updates `hadoop-common` from 3.3.1 to 3.3.3

Updates `hadoop-azure` from 3.3.1 to 3.3.3

Updates `hadoop-azure-datalake` from 3.3.1 to 3.3.3

Updates `hadoop-aws` from 3.3.1 to 3.3.3

---
updated-dependencies:
- dependency-name: org.apache.hadoop:hadoop-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-minicluster
  dependency-type: direct:development
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-common
  dependency-type: direct:development
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-azure
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-azure-datalake
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-aws
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* Avoid convergence error with reload4j dependency

* Remove not needed dependency

* Remove exclusion of not present log4j dependency

* Exclude slf4j-reload4j

* Ignore also reload4j

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Łukasz Dziedziul <lukasz.dziedziul@hazelcast.com>
Co-authored-by: Frantisek Hartman <frant.hartm@gmail.com>
(cherry picked from commit 0f8436f24aec9467cc60e882d5a5589c2fe0cb36)

