### PR TITLE
Update parquet-jackson to 1.12.3 [5.0.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <classgraph.version>4.8.139</classgraph.version>
         <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
-        <hadoop.version>3.3.1</hadoop.version>
+        <hadoop.version>3.3.3</hadoop.version>
         <jackson.version>2.12.6</jackson.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jline.version>3.21.0</jline.version>
@@ -113,7 +113,7 @@
         <mysql.connector.version>8.0.20</mysql.connector.version>
         <netty.version>4.1.75.Final</netty.version>
         <osgi.version>4.2.0</osgi.version>
-        <parquet.version>1.12.0</parquet.version>
+        <parquet.version>1.12.3</parquet.version>
         <picocli.version>4.4.0</picocli.version>
         <postgresql.version>42.2.25</postgresql.version>
         <prometheus.version>0.14.0</prometheus.version>
@@ -1463,8 +1463,12 @@
                 <exclusions>
                     <!-- The following dependencies are not needed for our use of Hadoop -->
                     <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
+                        <groupId>ch.qos.reload4j</groupId>
+                        <artifactId>reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.eclipse.jetty</groupId>
@@ -1607,11 +1611,6 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.htrace</groupId>
-                <artifactId>htrace-core4</artifactId>
-                <version>4.2.0-incubating.hazelcast-2</version>
             </dependency>
             <!-- NOTE: httpcore and httpclient versions are not in sync -->
             <dependency>


### PR DESCRIPTION
Fixes shaded jackson-databind vulnerability reported in #21045

Backport of #21525

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
