### PR TITLE
Fix conditionally wrong information in error messages in CompactUtil

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -98,19 +98,16 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private final int variableOffsetsPosition;
     private final CompactStreamSerializer serializer;
     private final boolean schemaIncludedInBinary;
-    private final boolean isCompactReader;
     private final @Nullable
     Class associatedClass;
 
     protected CompactInternalGenericRecord(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
-                                           @Nullable Class associatedClass, boolean schemaIncludedInBinary,
-                                           boolean isCompactReader) {
+                                           @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
         this.in = in;
         this.serializer = serializer;
         this.schema = schema;
         this.associatedClass = associatedClass;
         this.schemaIncludedInBinary = schemaIncludedInBinary;
-        this.isCompactReader = isCompactReader;
         try {
             int finalPosition;
             int numberOfVariableLengthFields = schema.getNumberOfVariableSizeFields();
@@ -140,6 +137,11 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
         } catch (IOException e) {
             throw illegalStateException(e);
         }
+    }
+
+    @Nonnull
+    public String getMethodPrefixForErrorMessages() {
+        return "get";
     }
 
     @Nullable
@@ -358,7 +360,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                                            Reader<T> reader, String methodSuffix) {
         T value = getVariableSize(fieldDescriptor, reader);
         if (value == null) {
-            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix, isCompactReader);
+            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix, getMethodPrefixForErrorMessages());
         }
         return value;
     }
@@ -560,7 +562,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
             for (int i = 0; i < itemCount; i++) {
                 int offset = offsetReader.getOffset(in, offsetsPosition, i);
                 if (offset == NULL_ARRAY_LENGTH) {
-                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix, isCompactReader);
+                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix, getMethodPrefixForErrorMessages());
                 }
             }
             in.position(dataStartPosition - INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -140,7 +140,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     @Nonnull
-    public String getMethodPrefixForErrorMessages() {
+    protected String getMethodPrefixForErrorMessages() {
         return "get";
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -98,16 +98,18 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private final int variableOffsetsPosition;
     private final CompactStreamSerializer serializer;
     private final boolean schemaIncludedInBinary;
+    private final boolean isCompactReader;
     private final @Nullable
     Class associatedClass;
 
     protected CompactInternalGenericRecord(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
-                                           @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
+                                           @Nullable Class associatedClass, boolean schemaIncludedInBinary, boolean isCompactReader) {
         this.in = in;
         this.serializer = serializer;
         this.schema = schema;
         this.associatedClass = associatedClass;
         this.schemaIncludedInBinary = schemaIncludedInBinary;
+        this.isCompactReader = isCompactReader;
         try {
             int finalPosition;
             int numberOfVariableLengthFields = schema.getNumberOfVariableSizeFields();
@@ -355,7 +357,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                                            Reader<T> reader, String methodSuffix) {
         T value = getVariableSize(fieldDescriptor, reader);
         if (value == null) {
-            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix);
+            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix, isCompactReader);
         }
         return value;
     }
@@ -557,7 +559,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
             for (int i = 0; i < itemCount; i++) {
                 int offset = offsetReader.getOffset(in, offsetsPosition, i);
                 if (offset == NULL_ARRAY_LENGTH) {
-                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix);
+                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix, isCompactReader);
                 }
             }
             in.position(dataStartPosition - INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -360,7 +360,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                                            Reader<T> reader, String methodSuffix) {
         T value = getVariableSize(fieldDescriptor, reader);
         if (value == null) {
-            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix, getMethodPrefixForErrorMessages());
+            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix,
+                    getMethodPrefixForErrorMessages());
         }
         return value;
     }
@@ -562,7 +563,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
             for (int i = 0; i < itemCount; i++) {
                 int offset = offsetReader.getOffset(in, offsetsPosition, i);
                 if (offset == NULL_ARRAY_LENGTH) {
-                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix, getMethodPrefixForErrorMessages());
+                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix,
+                            getMethodPrefixForErrorMessages());
                 }
             }
             in.position(dataStartPosition - INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -103,7 +103,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     Class associatedClass;
 
     protected CompactInternalGenericRecord(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
-                                           @Nullable Class associatedClass, boolean schemaIncludedInBinary, boolean isCompactReader) {
+                                           @Nullable Class associatedClass, boolean schemaIncludedInBinary,
+                                           boolean isCompactReader) {
         this.in = in;
         this.serializer = serializer;
         this.schema = schema;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -360,8 +360,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                                            Reader<T> reader, String methodSuffix) {
         T value = getVariableSize(fieldDescriptor, reader);
         if (value == null) {
-            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix,
-                    getMethodPrefixForErrorMessages());
+            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), getMethodPrefixForErrorMessages(),
+                    methodSuffix);
         }
         return value;
     }
@@ -563,8 +563,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
             for (int i = 0; i < itemCount; i++) {
                 int offset = offsetReader.getOffset(in, offsetsPosition, i);
                 if (offset == NULL_ARRAY_LENGTH) {
-                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix,
-                            getMethodPrefixForErrorMessages());
+                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), getMethodPrefixForErrorMessages(),
+                            methodSuffix);
                 }
             }
             in.position(dataStartPosition - INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -234,7 +234,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
 
     private GenericRecord readGenericRecord(BufferObjectDataInput input, Schema schema, boolean schemaIncludedInBinary) {
         CompactInternalGenericRecord record =
-                new CompactInternalGenericRecord(this, input, schema, null, schemaIncludedInBinary);
+                new CompactInternalGenericRecord(this, input, schema, null, schemaIncludedInBinary, false);
         Collection<FieldDescriptor> fields = schema.getFields();
         DeserializedSchemaBoundGenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
         for (FieldDescriptor fieldDescriptor : fields) {
@@ -254,7 +254,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     public InternalGenericRecord readAsInternalGenericRecord(ObjectDataInput in) throws IOException {
         Schema schema = getOrReadSchema(in, false);
         BufferObjectDataInput input = (BufferObjectDataInput) in;
-        return new CompactInternalGenericRecord(this, input, schema, null, false);
+        return new CompactInternalGenericRecord(this, input, schema, null, false, false);
     }
 
     //Should be deleted with removing Beta tags

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -234,7 +234,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
 
     private GenericRecord readGenericRecord(BufferObjectDataInput input, Schema schema, boolean schemaIncludedInBinary) {
         CompactInternalGenericRecord record =
-                new CompactInternalGenericRecord(this, input, schema, null, schemaIncludedInBinary, false);
+                new CompactInternalGenericRecord(this, input, schema, null, schemaIncludedInBinary);
         Collection<FieldDescriptor> fields = schema.getFields();
         DeserializedSchemaBoundGenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
         for (FieldDescriptor fieldDescriptor : fields) {
@@ -254,7 +254,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     public InternalGenericRecord readAsInternalGenericRecord(ObjectDataInput in) throws IOException {
         Schema schema = getOrReadSchema(in, false);
         BufferObjectDataInput input = (BufferObjectDataInput) in;
-        return new CompactInternalGenericRecord(this, input, schema, null, false, false);
+        return new CompactInternalGenericRecord(this, input, schema, null, false);
     }
 
     //Should be deleted with removing Beta tags

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -31,8 +31,7 @@ public final class CompactUtil {
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValue(@Nonnull String fieldName,
                                                                            @Nonnull String methodSuffix,
-                                                                           boolean isCompactReader) {
-        String methodPrefix = isCompactReader ? "read" : "get";
+                                                                           @Nonnull String methodPrefix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
                 + "null value can not be read via " + methodPrefix + methodSuffix + " methods. "
                 + "Use " + methodPrefix + "Nullable" + methodSuffix + " instead.");
@@ -41,8 +40,7 @@ public final class CompactUtil {
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValueInArray(@Nonnull String fieldName,
                                                                                   @Nonnull String methodSuffix,
-                                                                                  boolean isCompactReader) {
-        String methodPrefix = isCompactReader ? "read" : "get";
+                                                                                  @Nonnull String methodPrefix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
                 + "null value can not be read via " + methodPrefix + "ArrayOf" + methodSuffix + " methods. "
                 + "Use " + methodPrefix + "ArrayOfNullable" + methodSuffix + " instead.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -32,16 +32,16 @@ public final class CompactUtil {
     static HazelcastSerializationException exceptionForUnexpectedNullValue(@Nonnull String fieldName,
                                                                            @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via get" + methodSuffix + " methods. "
-                + "Use getNullable" + methodSuffix + " instead.");
+                + "null value can not be read via read" + methodSuffix + " methods. "
+                + "Use readNullable" + methodSuffix + " instead.");
     }
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValueInArray(@Nonnull String fieldName,
                                                                                   @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via getArrayOf" + methodSuffix + " methods. "
-                + "Use getArrayOfNullable" + methodSuffix + " instead.");
+                + "null value can not be read via readArrayOf" + methodSuffix + " methods. "
+                + "Use readArrayOfNullable" + methodSuffix + " instead.");
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -30,18 +30,22 @@ public final class CompactUtil {
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValue(@Nonnull String fieldName,
-                                                                           @Nonnull String methodSuffix) {
+                                                                           @Nonnull String methodSuffix,
+                                                                           boolean isCompactReader) {
+        String methodPrefix = isCompactReader ? "read" : "get";
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via read" + methodSuffix + " methods. "
-                + "Use readNullable" + methodSuffix + " instead.");
+                + "null value can not be read via " + methodPrefix + methodSuffix + " methods. "
+                + "Use " + methodPrefix + "Nullable" + methodSuffix + " instead.");
     }
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValueInArray(@Nonnull String fieldName,
-                                                                                  @Nonnull String methodSuffix) {
+                                                                                  @Nonnull String methodSuffix,
+                                                                                  boolean isCompactReader) {
+        String methodPrefix = isCompactReader ? "read" : "get";
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via readArrayOf" + methodSuffix + " methods. "
-                + "Use readArrayOfNullable" + methodSuffix + " instead.");
+                + "null value can not be read via " + methodPrefix + "ArrayOf" + methodSuffix + " methods. "
+                + "Use " + methodPrefix + "ArrayOfNullable" + methodSuffix + " instead.");
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -30,8 +30,8 @@ public final class CompactUtil {
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValue(@Nonnull String fieldName,
-                                                                           @Nonnull String methodSuffix,
-                                                                           @Nonnull String methodPrefix) {
+                                                                           @Nonnull String methodPrefix,
+                                                                           @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
                 + "null value can not be read via " + methodPrefix + methodSuffix + " methods. "
                 + "Use " + methodPrefix + "Nullable" + methodSuffix + " instead.");
@@ -39,8 +39,8 @@ public final class CompactUtil {
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValueInArray(@Nonnull String fieldName,
-                                                                                  @Nonnull String methodSuffix,
-                                                                                  @Nonnull String methodPrefix) {
+                                                                                  @Nonnull String methodPrefix,
+                                                                                  @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
                 + "null value can not be read via " + methodPrefix + "ArrayOf" + methodSuffix + " methods. "
                 + "Use " + methodPrefix + "ArrayOfNullable" + methodSuffix + " instead.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -80,7 +80,7 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
 
     public DefaultCompactReader(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
                                 @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
-        super(serializer, in, schema, associatedClass, schemaIncludedInBinary);
+        super(serializer, in, schema, associatedClass, schemaIncludedInBinary, true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -80,7 +80,12 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
 
     public DefaultCompactReader(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
                                 @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
-        super(serializer, in, schema, associatedClass, schemaIncludedInBinary, true);
+        super(serializer, in, schema, associatedClass, schemaIncludedInBinary);
+    }
+
+    @Nonnull
+    public String getMethodPrefixForErrorMessages() {
+        return "read";
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -220,7 +220,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             boolean[] result = new boolean[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", false);
                 }
                 result[i] = array[i];
             }
@@ -238,7 +238,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             byte[] result = new byte[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", false);
                 }
                 result[i] = array[i];
             }
@@ -262,7 +262,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             double[] result = new double[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", false);
                 }
                 result[i] = array[i];
             }
@@ -280,7 +280,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             float[] result = new float[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", false);
                 }
                 result[i] = array[i];
             }
@@ -298,7 +298,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             int[] result = new int[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", false);
                 }
                 result[i] = array[i];
             }
@@ -316,7 +316,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             long[] result = new long[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", false);
                 }
                 result[i] = array[i];
             }
@@ -334,7 +334,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             short[] result = new short[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", false);
                 }
                 result[i] = array[i];
             }
@@ -529,7 +529,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         check(fieldName, primitiveFieldKind, nullableFieldKind);
         T t = (T) objects.get(fieldName);
         if (t == null) {
-            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix);
+            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, false);
         }
         return t;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -86,6 +86,8 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     private final TreeMap<String, Object> objects;
     private final Schema schema;
 
+    private static final String methodPrefixForErrorMessages = "get";
+
     public DeserializedGenericRecord(Schema schema, TreeMap<String, Object> objects) {
         this.schema = schema;
         this.objects = objects;
@@ -220,7 +222,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             boolean[] result = new boolean[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -238,7 +240,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             byte[] result = new byte[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -262,7 +264,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             double[] result = new double[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -280,7 +282,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             float[] result = new float[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -298,7 +300,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             int[] result = new int[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -316,7 +318,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             long[] result = new long[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -334,7 +336,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             short[] result = new short[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", false);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", methodPrefixForErrorMessages);
                 }
                 result[i] = array[i];
             }
@@ -529,7 +531,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         check(fieldName, primitiveFieldKind, nullableFieldKind);
         T t = (T) objects.get(fieldName);
         if (t == null) {
-            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, false);
+            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, methodPrefixForErrorMessages);
         }
         return t;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -222,7 +222,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             boolean[] result = new boolean[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Boolean");
                 }
                 result[i] = array[i];
             }
@@ -240,7 +240,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             byte[] result = new byte[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Int8");
                 }
                 result[i] = array[i];
             }
@@ -264,7 +264,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             double[] result = new double[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Float64");
                 }
                 result[i] = array[i];
             }
@@ -282,7 +282,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             float[] result = new float[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Float32");
                 }
                 result[i] = array[i];
             }
@@ -300,7 +300,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             int[] result = new int[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Int32");
                 }
                 result[i] = array[i];
             }
@@ -318,7 +318,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             long[] result = new long[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Int64");
                 }
                 result[i] = array[i];
             }
@@ -336,7 +336,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             short[] result = new short[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", METHOD_PREFIX_FOR_ERROR_MESSAGES);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, "Int16");
                 }
                 result[i] = array[i];
             }
@@ -531,7 +531,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         check(fieldName, primitiveFieldKind, nullableFieldKind);
         T t = (T) objects.get(fieldName);
         if (t == null) {
-            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, METHOD_PREFIX_FOR_ERROR_MESSAGES);
+            throw exceptionForUnexpectedNullValue(fieldName, METHOD_PREFIX_FOR_ERROR_MESSAGES, methodSuffix);
         }
         return t;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -83,10 +83,10 @@ import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
  */
 public class DeserializedGenericRecord extends CompactGenericRecord {
 
+    private static final String METHOD_PREFIX_FOR_ERROR_MESSAGES = "get";
+
     private final TreeMap<String, Object> objects;
     private final Schema schema;
-
-    private static final String methodPrefixForErrorMessages = "get";
 
     public DeserializedGenericRecord(Schema schema, TreeMap<String, Object> objects) {
         this.schema = schema;
@@ -222,7 +222,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             boolean[] result = new boolean[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -240,7 +240,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             byte[] result = new byte[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -264,7 +264,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             double[] result = new double[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -282,7 +282,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             float[] result = new float[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -300,7 +300,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             int[] result = new int[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -318,7 +318,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             long[] result = new long[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -336,7 +336,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             short[] result = new short[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", methodPrefixForErrorMessages);
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", METHOD_PREFIX_FOR_ERROR_MESSAGES);
                 }
                 result[i] = array[i];
             }
@@ -531,7 +531,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         check(fieldName, primitiveFieldKind, nullableFieldKind);
         T t = (T) objects.get(fieldName);
         if (t == null) {
-            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, methodPrefixForErrorMessages);
+            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, METHOD_PREFIX_FOR_ERROR_MESSAGES);
         }
         return t;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -228,17 +228,18 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         Data data = serializationService.toData(a1);
         // Reading compact with serializer case
         assertThatThrownBy(() -> serializationService.toObject(data))
-                .hasRootCauseExactlyInstanceOf(HazelcastSerializationException.class)
+                .isInstanceOf(HazelcastSerializationException.class)
                 .hasMessageContaining("Use readNullable");
         // Reading array field with null value
         A a2 = new A(1, new Integer[]{1, null, 3});
         Data data2 = serializationService.toData(a2);
         // Reading compact with serializer case
         assertThatThrownBy(() -> serializationService.toObject(data2))
-                .hasRootCauseExactlyInstanceOf(HazelcastSerializationException.class)
+                .isInstanceOf(HazelcastSerializationException.class)
                 .hasMessageContaining("Use readArrayOfNullable");
     }
 
+    @Test
     public void testWriteNullReadPrimitiveThrowsExceptionWithCorrectMethodPrefixGenericRecord() {
         SerializationService serializationService = createSerializationService();
         GenericRecordBuilder builder = compact("genericRecord");
@@ -249,7 +250,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         GenericRecord obj = serializationService.toObject(data);
         // Read null value with non-nullable reader method
         assertThatThrownBy(() -> obj.getInt32("aField"))
-                .hasRootCauseExactlyInstanceOf(HazelcastSerializationException.class)
+                .isInstanceOf(HazelcastSerializationException.class)
                 .hasMessageContaining("Use getNullable");
 
         GenericRecordBuilder builder2 = compact("genericRecord2");
@@ -260,7 +261,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         GenericRecord obj2 = serializationService.toObject(data2);
         // Read an array with null value with non-nullable array reader method
         assertThatThrownBy(() -> obj2.getArrayOfInt32("aField"))
-                .hasRootCauseExactlyInstanceOf(HazelcastSerializationException.class)
+                .isInstanceOf(HazelcastSerializationException.class)
                 .hasMessageContaining("Use getArrayOfNullable");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -264,10 +264,6 @@ public class CompactNullablePrimitiveInteroperabilityTest {
                 .hasMessageContaining("Use getArrayOfNullable");
     }
 
-    private <T extends Throwable> void assertThatErrorMessageIncludes(T e, String expected) {
-        assertTrue(e.getMessage().contains(expected));
-    }
-
     private void assertReadNullAsPrimitiveThrowsException(GenericRecord record) {
         assertThrows(HazelcastSerializationException.class, () -> record.getBoolean("boolean"));
         assertThrows(HazelcastSerializationException.class, () -> record.getInt8("byte"));

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -220,27 +220,40 @@ public class CompactNullablePrimitiveInteroperabilityTest {
     }
 
     @Test
-    public void testWriteNullReadPrimitiveThrowsExceptionWithCorrectMethodPrefix() {
+    public void testWriteNullReadPrimitiveThrowsExceptionWithCorrectMethodPrefixCompactReader() {
         SerializationService serializationService = createSerializationServiceWithASerializer();
+        SerializationService serializationService2 = createSerializationService();
 
+        // Reading null value with non-nullable reader method
         A a1 = new A(null, new Integer[]{1, 2, 3});
         Data data = serializationService.toData(a1);
+        // Reading compact with serializer case
         errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> serializationService.toObject(data)), "Use readNullable");
 
+        GenericRecord genericRecord = serializationService2.toObject(data);
+        // Reading compact without serializer case
+        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> genericRecord.getInt32("age")), "Use getNullable");
+
+        // Reading array field with null value
         A a2 = new A(1, new Integer[]{1, null, 3});
         Data data2 = serializationService.toData(a2);
+        // Reading compact with serializer case
         errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> serializationService.toObject(data2)), "Use readArrayOfNullable");
+
+        GenericRecord genericRecord2 = serializationService2.toObject(data2);
+        // Reading compact without serializer case
+        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> genericRecord2.getArrayOfInt32("ids")), "Use getArrayOfNullable");
     }
 
     public void testWriteNullReadPrimitiveThrowsExceptionWithCorrectMethodPrefixGenericRecord() {
         SerializationService serializationService = createSerializationService();
-
         GenericRecordBuilder builder = compact("genericRecord");
         builder.setNullableInt32("aField", null);
         GenericRecord record = builder.build();
 
         Data data = serializationService.toData(record);
         GenericRecord obj = serializationService.toObject(data);
+        // Read null value with non-nullable reader method
         errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> obj.getInt32("aField")), "Use getNullable");
 
         GenericRecordBuilder builder2 = compact("genericRecord2");
@@ -249,6 +262,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
 
         Data data2 = serializationService.toData(record2);
         GenericRecord obj2 = serializationService.toObject(data2);
+        // Read an array with null value with non-nullable array reader method
         errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> obj2.getArrayOfInt32("aField")), "Use getArrayOfNullable");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -228,21 +228,21 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         A a1 = new A(null, new Integer[]{1, 2, 3});
         Data data = serializationService.toData(a1);
         // Reading compact with serializer case
-        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> serializationService.toObject(data)), "Use readNullable");
+        assertThatErrorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> serializationService.toObject(data)), "Use readNullable");
 
         GenericRecord genericRecord = serializationService2.toObject(data);
         // Reading compact without serializer case
-        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> genericRecord.getInt32("age")), "Use getNullable");
+        assertThatErrorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> genericRecord.getInt32("age")), "Use getNullable");
 
         // Reading array field with null value
         A a2 = new A(1, new Integer[]{1, null, 3});
         Data data2 = serializationService.toData(a2);
         // Reading compact with serializer case
-        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> serializationService.toObject(data2)), "Use readArrayOfNullable");
+        assertThatErrorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> serializationService.toObject(data2)), "Use readArrayOfNullable");
 
         GenericRecord genericRecord2 = serializationService2.toObject(data2);
         // Reading compact without serializer case
-        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> genericRecord2.getArrayOfInt32("ids")), "Use getArrayOfNullable");
+        assertThatErrorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> genericRecord2.getArrayOfInt32("ids")), "Use getArrayOfNullable");
     }
 
     public void testWriteNullReadPrimitiveThrowsExceptionWithCorrectMethodPrefixGenericRecord() {
@@ -254,7 +254,7 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         Data data = serializationService.toData(record);
         GenericRecord obj = serializationService.toObject(data);
         // Read null value with non-nullable reader method
-        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> obj.getInt32("aField")), "Use getNullable");
+        assertThatErrorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> obj.getInt32("aField")), "Use getNullable");
 
         GenericRecordBuilder builder2 = compact("genericRecord2");
         builder2.setArrayOfNullableInt32("aField",  new Integer[]{1, null, 3});
@@ -263,10 +263,10 @@ public class CompactNullablePrimitiveInteroperabilityTest {
         Data data2 = serializationService.toData(record2);
         GenericRecord obj2 = serializationService.toObject(data2);
         // Read an array with null value with non-nullable array reader method
-        errorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> obj2.getArrayOfInt32("aField")), "Use getArrayOfNullable");
+        assertThatErrorMessageIncludes(assertThrows(HazelcastSerializationException.class, () -> obj2.getArrayOfInt32("aField")), "Use getArrayOfNullable");
     }
 
-    private <T extends Throwable> void errorMessageIncludes(T e, String expected) {
+    private <T extends Throwable> void assertThatErrorMessageIncludes(T e, String expected) {
         assertTrue(e.getMessage().contains(expected));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -40,39 +40,39 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-class A {
-    public Integer[] ids;
-    public Integer age;
-
-    public A(Integer age, Integer[] ids) {
-        this.age = age;
-        this.ids = ids;
-    }
-}
-
-class ASerializer implements CompactSerializer<A> {
-    @NotNull
-    @Override
-    public A read(@NotNull CompactReader in) {
-        int age = in.readInt32("age");
-        int[] ids = in.readArrayOfInt32("ids");
-        Integer[] boxedIds = new Integer[ids.length];
-        for (int i = 0; i < ids.length; i++) {
-            boxedIds[i] = ids[i];
-        }
-        return new A(age, boxedIds);
-    }
-
-    @Override
-    public void write(@NotNull CompactWriter out, @NotNull A object) {
-        out.writeNullableInt32("age", object.age);
-        out.writeArrayOfNullableInt32("ids", object.ids);
-    }
-}
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CompactNullablePrimitiveInteroperabilityTest {
+
+    class A {
+        public Integer[] ids;
+        public Integer age;
+
+        A(Integer age, Integer[] ids) {
+            this.age = age;
+            this.ids = ids;
+        }
+    }
+
+    class ASerializer implements CompactSerializer<A> {
+        @NotNull
+        @Override
+        public A read(@NotNull CompactReader in) {
+            int age = in.readInt32("age");
+            int[] ids = in.readArrayOfInt32("ids");
+            Integer[] boxedIds = new Integer[ids.length];
+            for (int i = 0; i < ids.length; i++) {
+                boxedIds[i] = ids[i];
+            }
+            return new A(age, boxedIds);
+        }
+
+        @Override
+        public void write(@NotNull CompactWriter out, @NotNull A object) {
+            out.writeNullableInt32("age", object.age);
+            out.writeArrayOfNullableInt32("ids", object.ids);
+        }
+    }
 
     SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
 


### PR DESCRIPTION
Uses `get${MethodSuffix}` and `read${MethodSuffix}` conditionally depending on user is using a generic record or a compact reader

Breaking changes (list specific methods/types/messages):

**None**

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
