### PR TITLE
[CN-399] Change Kubernetes client behavior for token refresh

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/FileReaderTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/FileReaderTokenProvider.java
@@ -1,0 +1,16 @@
+package com.hazelcast.kubernetes;
+
+public class FileReaderTokenProvider implements KubernetesTokenProvider {
+    private final String tokenPath;
+    private final KubernetesConfig.FileContentsReader fileContentsReader;
+
+    public FileReaderTokenProvider(String tokenPath) {
+        this.tokenPath = tokenPath;
+        this.fileContentsReader = new KubernetesConfig.DefaultFileContentsReader();
+    }
+
+    @Override
+    public String getToken() {
+        return fileContentsReader.readFileContents(tokenPath);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/FileReaderTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/FileReaderTokenProvider.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.kubernetes;
 
-public class FileReaderTokenProvider implements KubernetesTokenProvider {
+class FileReaderTokenProvider implements KubernetesTokenProvider {
     private final String tokenPath;
     private final KubernetesConfig.FileContentsReader fileContentsReader;
 
-    public FileReaderTokenProvider(String tokenPath) {
+    FileReaderTokenProvider(String tokenPath) {
         this.tokenPath = tokenPath;
         this.fileContentsReader = new KubernetesConfig.DefaultFileContentsReader();
     }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -58,7 +58,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     }
 
     private static KubernetesClient buildKubernetesClient(KubernetesConfig config) {
-        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getKubernetesApiToken(),
+        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getTokenProvider(),
                 config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.getExposeExternallyMode(),
                 config.isUseNodeNameAsExternalAddress(), config.getServicePerPodLabelName(), config.getServicePerPodLabelValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -66,9 +66,10 @@ class KubernetesClient {
     private boolean isNoPublicIpAlreadyLogged;
     private boolean isKnownExceptionAlreadyLogged;
 
-    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider, String caCertificate, int retries,
-                     ExposeExternallyMode exposeExternallyMode, boolean useNodeNameAsExternalAddress,
-                     String servicePerPodLabelName, String servicePerPodLabelValue) {
+    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
+                     String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
+                     boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
+                     String servicePerPodLabelValue) {
         this.namespace = namespace;
         this.kubernetesMaster = kubernetesMaster;
         this.tokenProvider = tokenProvider;
@@ -81,10 +82,10 @@ class KubernetesClient {
         this.apiProvider =  buildKubernetesApiUrlProvider();
     }
 
-    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider, String caCertificate, int retries,
-                     ExposeExternallyMode exposeExternallyMode, boolean useNodeNameAsExternalAddress,
-                     String servicePerPodLabelName, String servicePerPodLabelValue,
-                     KubernetesApiProvider apiProvider) {
+    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
+                     String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
+                     boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
+                     String servicePerPodLabelValue, KubernetesApiProvider apiProvider) {
         this.namespace = namespace;
         this.kubernetesMaster = kubernetesMaster;
         this.tokenProvider = tokenProvider;

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesTokenProvider.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.kubernetes;
 
-public interface KubernetesTokenProvider {
+interface KubernetesTokenProvider {
     String getToken();
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesTokenProvider.java
@@ -1,0 +1,6 @@
+package com.hazelcast.kubernetes;
+
+public interface KubernetesTokenProvider {
+    String getToken();
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/StaticTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/StaticTokenProvider.java
@@ -1,0 +1,14 @@
+package com.hazelcast.kubernetes;
+
+public class StaticTokenProvider implements KubernetesTokenProvider {
+    private final String token;
+
+    public StaticTokenProvider(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String getToken() {
+        return token;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/StaticTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/StaticTokenProvider.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.kubernetes;
 
-public class StaticTokenProvider implements KubernetesTokenProvider {
+class StaticTokenProvider implements KubernetesTokenProvider {
     private final String token;
 
-    public StaticTokenProvider(String token) {
+    StaticTokenProvider(String token) {
         this.token = token;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -49,7 +49,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class KubernetesClientTest {
     private static final String KUBERNETES_MASTER_IP = "localhost";

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -101,7 +101,6 @@ public class KubernetesConfigTest {
         assertEquals(serviceDns, config.getServiceDns());
         assertEquals(serviceDnsTimeout, config.getServiceDnsTimeout());
         assertEquals(servicePort, config.getServicePort());
-        assertNull(config.getKubernetesApiToken());
         assertNull(config.getKubernetesCaCertificate());
     }
 
@@ -118,7 +117,7 @@ public class KubernetesConfigTest {
         assertEquals("test", config.getNamespace());
         assertEquals(true, config.isResolveNotReadyAddresses());
         assertEquals(false, config.isUseNodeNameAsExternalAddress());
-        assertEquals(TEST_API_TOKEN, config.getKubernetesApiToken());
+        assertEquals(TEST_API_TOKEN, config.getTokenProvider().getToken());
         assertEquals(TEST_CA_CERTIFICATE, config.getKubernetesCaCertificate());
         assertEquals(ExposeExternallyMode.AUTO, config.getExposeExternallyMode());
     }
@@ -187,8 +186,6 @@ public class KubernetesConfigTest {
         // given
         KubernetesConfig.FileContentsReader dummyFileContentsReader = fileName -> {
             switch (fileName) {
-                case "/var/run/secrets/kubernetes.io/serviceaccount/token":
-                    return "token-xyz";
                 case "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt":
                     return "certificate-xyz";
                 case "/var/run/secrets/kubernetes.io/serviceaccount/namespace":
@@ -202,7 +199,6 @@ public class KubernetesConfigTest {
 
         // then
         assertEquals("certificate-xyz", config.getKubernetesCaCertificate());
-        assertEquals("token-xyz", config.getKubernetesApiToken());
         assertEquals("namespace-xyz", config.getNamespace());
     }
 


### PR DESCRIPTION
Kubernetes token which is read from the file was static in the
beginning. With the recent changes, it is time bound and its content
is periodically refreshed.

To incorporate new behavior:
* Introduced a new token reader which gets the value by reading the file
  every time.
* Introduced a second token reader which imitates the original
  behavior.

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
