### PR TITLE
Fix typo in error messages in CompactUtil [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -95,16 +95,19 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private final int variableOffsetsPosition;
     private final CompactStreamSerializer serializer;
     private final boolean schemaIncludedInBinary;
+    private final boolean isCompactReader;
     private final @Nullable
     Class associatedClass;
 
     public CompactInternalGenericRecord(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
-                                        @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
+                                        @Nullable Class associatedClass, boolean schemaIncludedInBinary,
+                                        boolean isCompactReader) {
         this.in = in;
         this.serializer = serializer;
         this.schema = schema;
         this.associatedClass = associatedClass;
         this.schemaIncludedInBinary = schemaIncludedInBinary;
+        this.isCompactReader = isCompactReader;
         try {
             int finalPosition;
             int numberOfVariableLengthFields = schema.getNumberOfVariableSizeFields();
@@ -348,7 +351,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                                            Reader<T> reader, String methodSuffix) {
         T value = getVariableSize(fieldDescriptor, reader);
         if (value == null) {
-            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix);
+            throw exceptionForUnexpectedNullValue(fieldDescriptor.getFieldName(), methodSuffix, isCompactReader);
         }
         return value;
     }
@@ -548,7 +551,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
             for (int i = 0; i < itemCount; i++) {
                 int offset = offsetReader.getOffset(in, offsetsPosition, i);
                 if (offset == NULL_ARRAY_LENGTH) {
-                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix);
+                    throw exceptionForUnexpectedNullValueInArray(fd.getFieldName(), methodSuffix, isCompactReader);
                 }
             }
             in.position(dataStartPosition - INT_SIZE_IN_BYTES);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -200,11 +200,12 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
 
         if (registration == null) {
             //we have tried to load class via class loader, it did not work. We are returning a GenericRecord.
-            return new DefaultCompactReader(this, input, schema, null, schemaIncludedInBinary);
+            return new DefaultCompactReader(this, input, schema, null, schemaIncludedInBinary,
+                    false);
         }
 
         DefaultCompactReader genericRecord = new DefaultCompactReader(this, input, schema,
-                registration.getClazz(), schemaIncludedInBinary);
+                registration.getClazz(), schemaIncludedInBinary, true);
         Object object = registration.getSerializer().read(genericRecord);
         return managedContext != null ? managedContext.initialize(object) : object;
 
@@ -263,7 +264,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     public GenericRecord readGenericRecord(ObjectDataInput in, boolean schemaIncludedInBinary) throws IOException {
         Schema schema = getOrReadSchema(in, schemaIncludedInBinary);
         BufferObjectDataInput input = (BufferObjectDataInput) in;
-        return new DefaultCompactReader(this, input, schema, null, schemaIncludedInBinary);
+        return new DefaultCompactReader(this, input, schema, null, schemaIncludedInBinary, false);
     }
 
     public InternalGenericRecord readAsInternalGenericRecord(ObjectDataInput input) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -32,16 +32,16 @@ public final class CompactUtil {
     static HazelcastSerializationException exceptionForUnexpectedNullValue(@Nonnull String fieldName,
                                                                            @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via get" + methodSuffix + " methods. "
-                + "Use getNullable" + methodSuffix + " instead.");
+                + "null value can not be read via read" + methodSuffix + " methods. "
+                + "Use readNullable" + methodSuffix + " instead.");
     }
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValueInArray(@Nonnull String fieldName,
                                                                                   @Nonnull String methodSuffix) {
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via getArrayOf" + methodSuffix + " methods. "
-                + "Use getArrayOfNullable" + methodSuffix + " instead.");
+                + "null value can not be read via readArrayOf" + methodSuffix + " methods. "
+                + "Use readArrayOfNullable" + methodSuffix + " instead.");
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -30,18 +30,22 @@ public final class CompactUtil {
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValue(@Nonnull String fieldName,
-                                                                           @Nonnull String methodSuffix) {
+                                                                           @Nonnull String methodSuffix,
+                                                                           boolean isCompactReader) {
+        String methodPrefix = isCompactReader ? "read" : "get";
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via read" + methodSuffix + " methods. "
-                + "Use readNullable" + methodSuffix + " instead.");
+                + "null value can not be read via " + methodPrefix + methodSuffix + " methods. "
+                + "Use " + methodPrefix + "Nullable" + methodSuffix + " instead.");
     }
 
     @Nonnull
     static HazelcastSerializationException exceptionForUnexpectedNullValueInArray(@Nonnull String fieldName,
-                                                                                  @Nonnull String methodSuffix) {
+                                                                                  @Nonnull String methodSuffix,
+                                                                                  boolean isCompactReader) {
+        String methodPrefix = isCompactReader ? "read" : "get";
         return new HazelcastSerializationException("Error while reading " + fieldName + ". "
-                + "null value can not be read via readArrayOf" + methodSuffix + " methods. "
-                + "Use readArrayOfNullable" + methodSuffix + " instead.");
+                + "null value can not be read via " + methodPrefix + "ArrayOf" + methodSuffix + " methods. "
+                + "Use " + methodPrefix + "ArrayOfNullable" + methodSuffix + " instead.");
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -76,8 +76,9 @@ import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
 public class DefaultCompactReader extends CompactInternalGenericRecord implements CompactReader {
 
     public DefaultCompactReader(CompactStreamSerializer serializer, BufferObjectDataInput in, Schema schema,
-                                @Nullable Class associatedClass, boolean schemaIncludedInBinary) {
-        super(serializer, in, schema, associatedClass, schemaIncludedInBinary);
+                                @Nullable Class associatedClass, boolean schemaIncludedInBinary,
+                                boolean isCompactReader) {
+        super(serializer, in, schema, associatedClass, schemaIncludedInBinary, isCompactReader);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -216,7 +216,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             boolean[] result = new boolean[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Boolean", false);
                 }
                 result[i] = array[i];
             }
@@ -234,7 +234,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             byte[] result = new byte[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int8", false);
                 }
                 result[i] = array[i];
             }
@@ -258,7 +258,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             double[] result = new double[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float64", false);
                 }
                 result[i] = array[i];
             }
@@ -276,7 +276,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             float[] result = new float[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Float32", false);
                 }
                 result[i] = array[i];
             }
@@ -294,7 +294,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             int[] result = new int[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int32", false);
                 }
                 result[i] = array[i];
             }
@@ -312,7 +312,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             long[] result = new long[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int64", false);
                 }
                 result[i] = array[i];
             }
@@ -330,7 +330,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
             short[] result = new short[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
-                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16");
+                    throw exceptionForUnexpectedNullValueInArray(fieldName, "Int16", false);
                 }
                 result[i] = array[i];
             }
@@ -525,7 +525,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         check(fieldName, primitiveFieldKind, nullableFieldKind);
         T t = (T) objects.get(fieldName);
         if (t == null) {
-            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix);
+            throw exceptionForUnexpectedNullValue(fieldName, methodSuffix, false);
         }
         return t;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordBuilder.java
@@ -75,7 +75,7 @@ public class SerializingGenericRecordBuilder implements GenericRecordBuilder {
         defaultCompactWriter.end();
         byte[] bytes = defaultCompactWriter.toByteArray();
         return new DefaultCompactReader(serializer, bufferObjectDataInputFunc.apply(bytes), schema,
-                null, false);
+                null, false, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SerializingGenericRecordCloner.java
@@ -94,7 +94,7 @@ public class SerializingGenericRecordCloner implements GenericRecordBuilder {
             byte[] bytes = cw.toByteArray();
             Class associatedClass = genericRecord.getAssociatedClass();
             BufferObjectDataInput dataInput = bufferObjectDataInputFunc.apply(bytes);
-            return new DefaultCompactReader(serializer, dataInput, schema, associatedClass, false);
+            return new DefaultCompactReader(serializer, dataInput, schema, associatedClass, false, false);
         } catch (IOException e) {
             throw new HazelcastSerializationException(e);
         }


### PR DESCRIPTION
Backport of #21543

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
