### PR TITLE
Fix concurrency issues while checking Raft sessions [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/Lock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/Lock.java
@@ -252,7 +252,8 @@ public class Lock extends BlockingResource<LockInvocationKey> implements Identif
      */
     @Override
     protected Collection<Long> getActivelyAttachedSessions() {
-        return owner != null ? Collections.singleton(owner.sessionId()) : Collections.emptyList();
+        LockInvocationKey ownerCopy = owner;
+        return ownerCopy != null ? Collections.singleton(ownerCopy.sessionId()) : Collections.emptyList();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/Lock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/Lock.java
@@ -191,21 +191,23 @@ public class Lock extends BlockingResource<LockInvocationKey> implements Identif
     private Collection<LockInvocationKey> setNewLockOwner() {
         Collection<LockInvocationKey> newOwnerWaitKeys;
         Iterator<WaitKeyContainer<LockInvocationKey>> iter = waitKeyContainersIterator();
-        if (iter.hasNext()) {
-            WaitKeyContainer<LockInvocationKey> container = iter.next();
-            LockInvocationKey newOwner = container.key();
-            newOwnerWaitKeys = container.keyAndRetries();
+        synchronized (waitKeys) {
+            if (iter.hasNext()) {
+                WaitKeyContainer<LockInvocationKey> container = iter.next();
+                LockInvocationKey newOwner = container.key();
+                newOwnerWaitKeys = container.keyAndRetries();
 
-            iter.remove();
-            owner = newOwner;
-            lockCount = 1;
-            ownerInvocationRefUids.put(BiTuple.of(owner.endpoint(), owner.invocationUid()), lockOwnershipState());
-        } else {
-            owner = null;
-            newOwnerWaitKeys = Collections.emptyList();
+                iter.remove();
+                owner = newOwner;
+                lockCount = 1;
+                ownerInvocationRefUids.put(BiTuple.of(owner.endpoint(), owner.invocationUid()), lockOwnershipState());
+            } else {
+                owner = null;
+                newOwnerWaitKeys = Collections.emptyList();
+            }
+
+            return newOwnerWaitKeys;
         }
-
-        return newOwnerWaitKeys;
     }
 
     LockOwnershipState lockOwnershipState() {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/Semaphore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/Semaphore.java
@@ -240,17 +240,19 @@ public class Semaphore extends BlockingResource<AcquireInvocationKey> implements
     private Collection<AcquireInvocationKey> assignPermitsToWaitKeys() {
         List<AcquireInvocationKey> assigned = new ArrayList<>();
         Iterator<WaitKeyContainer<AcquireInvocationKey>> iterator = waitKeyContainersIterator();
-        while (iterator.hasNext() && available > 0) {
-            WaitKeyContainer<AcquireInvocationKey> container = iterator.next();
-            AcquireInvocationKey key = container.key();
-            if (key.permits() <= available) {
-                iterator.remove();
-                assigned.addAll(container.keyAndRetries());
-                assignPermitsToInvocation(key.endpoint(), key.invocationUid(), key.permits());
+        synchronized (waitKeys) {
+            while (iterator.hasNext() && available > 0) {
+                WaitKeyContainer<AcquireInvocationKey> container = iterator.next();
+                AcquireInvocationKey key = container.key();
+                if (key.permits() <= available) {
+                    iterator.remove();
+                    assigned.addAll(container.keyAndRetries());
+                    assignPermitsToInvocation(key.endpoint(), key.invocationUid(), key.permits());
+                }
             }
-        }
 
-        return assigned;
+            return assigned;
+        }
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,10 +42,10 @@ import java.util.UUID;
  */
 public abstract class BlockingResource<W extends WaitKey> implements DataSerializable {
 
+    // Should be an insertion ordered map to ensure fairness
+    protected final Map<Object, WaitKeyContainer<W>> waitKeys = Collections.synchronizedMap(new LinkedHashMap<>());
     private CPGroupId groupId;
     private String name;
-    // Should be an insertion ordered map to ensure fairness
-    private final Map<Object, WaitKeyContainer<W>> waitKeys = new LinkedHashMap<>();
 
     protected BlockingResource() {
     }
@@ -98,23 +99,27 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
     }
 
     protected final Collection<W> getAllWaitKeys() {
-        List<W> all = new ArrayList<>(waitKeys.size());
-        for (WaitKeyContainer<W> container : waitKeys.values()) {
-            all.addAll(container.keyAndRetries());
-        }
+        synchronized (waitKeys) {
+            List<W> all = new ArrayList<>(waitKeys.size());
+            for (WaitKeyContainer<W> container : waitKeys.values()) {
+                all.addAll(container.keyAndRetries());
+            }
 
-        return all;
+            return all;
+        }
     }
 
     final void expireWaitKeys(UUID invocationUid, List<W> expired) {
         Iterator<WaitKeyContainer<W>> iter = waitKeys.values().iterator();
-        while (iter.hasNext()) {
-            WaitKeyContainer<W> container = iter.next();
-            if (container.invocationUid().equals(invocationUid)) {
-                expired.addAll(container.keyAndRetries());
-                iter.remove();
-                onWaitKeyExpire(container.key());
-                return;
+        synchronized (waitKeys) {
+            while (iter.hasNext()) {
+                WaitKeyContainer<W> container = iter.next();
+                if (container.invocationUid().equals(invocationUid)) {
+                    expired.addAll(container.keyAndRetries());
+                    iter.remove();
+                    onWaitKeyExpire(container.key());
+                    return;
+                }
             }
         }
     }
@@ -122,6 +127,10 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
     protected void onWaitKeyExpire(W waitKey) {
     }
 
+    /**
+     * To prevent a {@link java.util.ConcurrentModificationException}, all iterator operations
+     * should be synchronized on the {@code waitKeys} object
+     */
     protected final Iterator<WaitKeyContainer<W>> waitKeyContainersIterator() {
         return waitKeys.values().iterator();
     }
@@ -132,14 +141,16 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
 
     final void closeSession(long sessionId, List<Long> expiredWaitKeys, Map<Long, Object> result) {
         Iterator<WaitKeyContainer<W>> iter = waitKeys.values().iterator();
-        while (iter.hasNext()) {
-            WaitKeyContainer<W> container = iter.next();
-            if (container.sessionId() == sessionId) {
-                for (W retry : container.keyAndRetries()) {
-                    expiredWaitKeys.add(retry.commitIndex());
-                }
+        synchronized (waitKeys) {
+            while (iter.hasNext()) {
+                WaitKeyContainer<W> container = iter.next();
+                if (container.sessionId() == sessionId) {
+                    for (W retry : container.keyAndRetries()) {
+                        expiredWaitKeys.add(retry.commitIndex());
+                    }
 
-                iter.remove();
+                    iter.remove();
+                }
             }
         }
 
@@ -148,8 +159,10 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
 
     final void collectAttachedSessions(Collection<Long> sessions) {
         sessions.addAll(getActivelyAttachedSessions());
-        for (WaitKeyContainer<W> key : waitKeys.values()) {
-            sessions.add(key.sessionId());
+        synchronized (waitKeys) {
+            for (WaitKeyContainer<W> key : waitKeys.values()) {
+                sessions.add(key.sessionId());
+            }
         }
     }
 
@@ -163,10 +176,12 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(groupId);
         out.writeString(name);
-        out.writeInt(waitKeys.size());
-        for (Entry<Object, WaitKeyContainer<W>> e : waitKeys.entrySet()) {
-            out.writeObject(e.getKey());
-            out.writeObject(e.getValue());
+        synchronized (waitKeys) {
+            out.writeInt(waitKeys.size());
+            for (Entry<Object, WaitKeyContainer<W>> e : waitKeys.entrySet()) {
+                out.writeObject(e.getKey());
+                out.writeObject(e.getValue());
+            }
         }
     }
 


### PR DESCRIPTION
In a high-load environment, periodically running the `CheckInactiveSessions` task in `RaftSessionService` can cause concurrency issues if the list of sessions changes at the same time.

Backport of: https://github.com/hazelcast/hazelcast/pull/21334, https://github.com/hazelcast/hazelcast/pull/21266
