### PR TITLE
Upgrade Postgres to 42.3.6 to fix detected vulnerability [5.1.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <osgi.version>4.2.0</osgi.version>
         <parquet.version>1.12.3</parquet.version>
         <picocli.version>4.4.0</picocli.version>
-        <postgresql.version>42.2.25</postgresql.version>
+        <postgresql.version>42.3.6</postgresql.version>
         <prometheus.version>0.14.0</prometheus.version>
         <protobuf.version>3.19.4</protobuf.version>
         <scala.version>2.12</scala.version>


### PR DESCRIPTION
Upgrade Postgres to 42.3.6 to fix detected vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-26520

Fixes #21567

Backport of: https://github.com/hazelcast/hazelcast/pull/21535

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
