### PR TITLE
Fix warn log in the address registry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/LocalAddressRegistry.java
@@ -129,9 +129,10 @@ public class LocalAddressRegistry {
                 }
             }
             linkedAddresses.getAllAddresses().forEach(address -> {
-                if (addressToUuid.containsKey(address)) {
+                UUID oldMemberUuid = addressToUuid.get(address);
+                if (oldMemberUuid != null && !oldMemberUuid.equals(instanceUuid)) {
                     logger.warning("Address: " + address + " is previously registered with the member uuid: "
-                            + addressToUuid.get(address) + " to our addressToMemberUuid map, now registered with"
+                            + oldMemberUuid + " to our addressToMemberUuid map, now registered with"
                             + "/overridden by a new member uuid: " + instanceUuid + ". In the case, the overridden"
                             + " member uuid belongs to an old member that is recently restarted, this override is"
                             + " expected and it does not create any harm as it will delete the entry of old stale"


### PR DESCRIPTION
Previously, we were printing this warning log even if the new and
old member UUID's for the registered address is actually same. This
PR adds a check for avoiding this. 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
