### PR TITLE
Added `cluster-name` for `hazelcast-client-default-assembly` configs.

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-client-default-assembly.xml
+++ b/hazelcast/src/main/resources/hazelcast-client-default-assembly.xml
@@ -33,6 +33,12 @@
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.1.xsd">
 
+    <!--
+    The name of the cluster. All members of a single cluster must have the same cluster name
+    configured and a client connecting to this cluster must use it as well.
+    -->
+    <cluster-name>dev</cluster-name>
+
     <network>
         <cluster-members>
             <!--

--- a/hazelcast/src/main/resources/hazelcast-client-default-assembly.yaml
+++ b/hazelcast/src/main/resources/hazelcast-client-default-assembly.yaml
@@ -22,6 +22,10 @@
 # at https://docs.hazelcast.com/
 
 hazelcast-client:
+  # The name of the cluster. All members of a single cluster must have the
+  # same cluster name configured and a client connecting to this cluster
+  # must use it as well.
+  cluster-name: dev
   network:
     # List of addresses for the client to try to connect to. All members of
     # a Hazelcast cluster accept client connections.


### PR DESCRIPTION
PR closed by Hazelcast automation as no activity (>6 months). Please reopen with comments, if necessary. Thank you for using Hazelcast and your valuable contributions