### PR TITLE
Make TcpServerConnection.equals more robust [HZ-1202] (5.0.z)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -207,7 +207,7 @@ public class TcpServerConnection implements ServerConnection {
 
     @Override
     public int hashCode() {
-        return Objects.hash(channel.isClientMode(), connectionId, remoteAddress);
+        return Objects.hash(channel.isClientMode(), connectionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -206,20 +206,24 @@ public class TcpServerConnection implements ServerConnection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TcpServerConnection)) {
-            return false;
-        }
-        TcpServerConnection that = (TcpServerConnection) o;
-        return connectionId == that.getConnectionId();
+    public int hashCode() {
+        return Objects.hash(channel.isClientMode(), connectionId, remoteAddress);
     }
 
     @Override
-    public int hashCode() {
-        return connectionId;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TcpServerConnection other = (TcpServerConnection) obj;
+        return channel.isClientMode() == other.channel.isClientMode() && connectionId == other.connectionId
+                && Objects.equals(remoteAddress, other.remoteAddress);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/TcpServerConnection_AbstractBasicTest.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.internal.server.tcp;
 
+import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.nio.ConnectionLifecycleListener;
 import com.hazelcast.internal.nio.Packet;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -40,6 +43,9 @@ public abstract class TcpServerConnection_AbstractBasicTest extends TcpServerCon
     private static final int MARGIN_OF_ERROR_MS = 3000;
 
     private List<Packet> packetsB;
+
+    @Mock
+    private ConnectionLifecycleListener<TcpServerConnection> mockedListener;
 
     @Before
     public void setup() throws Exception {
@@ -191,5 +197,19 @@ public abstract class TcpServerConnection_AbstractBasicTest extends TcpServerCon
         assertNotEquals(connAB, connAC);
         assertNotEquals(connAC, connAB);
         assertNotEquals(connAB, "foo");
+
+        //don't mock if you don't need to
+        TcpServerConnectionManager cm = connAB.getConnectionManager();
+        Channel channel = connAB.getChannel();
+        TcpServerConnection conn1 = new TcpServerConnection(cm, mockedListener, 0, channel);
+        TcpServerConnection conn2 = new TcpServerConnection(cm, mockedListener, 0, channel);
+        assertEquals(conn1, conn2);
+        conn1.setRemoteAddress(addressA);
+        assertNotEquals(conn1, conn2);
+        conn2.setRemoteAddress(addressB);
+        assertNotEquals(conn1, conn2);
+        conn2.setRemoteAddress(addressA);
+        assertEquals(conn1, conn2);
     }
+
 }


### PR DESCRIPTION
Backports #21631

The change improves the `TcpServerConnection.equals` method by adding more fields to compare.