### PR TITLE
Make TcpIpConnection.equals more robust [HZ-1202] (4.0.z)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnection.java
@@ -193,20 +193,24 @@ public class TcpIpConnection implements Connection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TcpIpConnection)) {
-            return false;
-        }
-        TcpIpConnection that = (TcpIpConnection) o;
-        return connectionId == that.getConnectionId();
+    public int hashCode() {
+        return Objects.hash(channel.isClientMode(), connectionId, endPoint);
     }
 
     @Override
-    public int hashCode() {
-        return connectionId;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TcpIpConnection other = (TcpIpConnection) obj;
+        return channel.isClientMode() == other.channel.isClientMode() && connectionId == other.connectionId
+                && Objects.equals(endPoint, other.endPoint);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/tcp/TcpIpConnection.java
@@ -194,7 +194,7 @@ public class TcpIpConnection implements Connection {
 
     @Override
     public int hashCode() {
-        return Objects.hash(channel.isClientMode(), connectionId, endPoint);
+        return Objects.hash(channel.isClientMode(), connectionId);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpConnection_AbstractBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nio/tcp/TcpIpConnection_AbstractBasicTest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.internal.nio.tcp;
 
+import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.nio.ConnectionLifecycleListener;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.test.AssertTask;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -43,6 +46,9 @@ public abstract class TcpIpConnection_AbstractBasicTest extends TcpIpConnection_
     private static final int MARGIN_OF_ERROR_MS = 3000;
 
     private List<Packet> packetsB;
+
+    @Mock
+    private ConnectionLifecycleListener<TcpIpConnection> mockedListener;
 
     @Before
     public void setup() throws Exception {
@@ -235,5 +241,19 @@ public abstract class TcpIpConnection_AbstractBasicTest extends TcpIpConnection_
         assertNotEquals(connAB, connAC);
         assertNotEquals(connAC, connAB);
         assertNotEquals(connAB, "foo");
+
+        // don't mock if you don't need to
+        TcpIpEndpointManager em = connAB.getEndpointManager();
+        Channel channel = connAB.getChannel();
+        TcpIpConnection conn1 = new TcpIpConnection(em, mockedListener, 0, channel);
+        TcpIpConnection conn2 = new TcpIpConnection(em, mockedListener, 0, channel);
+        assertEquals(conn1, conn2);
+        conn1.setEndPoint(addressA);
+        assertNotEquals(conn1, conn2);
+        conn2.setEndPoint(addressB);
+        assertNotEquals(conn1, conn2);
+        conn2.setEndPoint(addressA);
+        assertEquals(conn1, conn2);
     }
+
 }


### PR DESCRIPTION
Backports #21631

The change improves the `TcpIpConnection.equals` method by adding more fields to compare.