### PR TITLE
Fix for the test data in nightly tests #21630 [HZ-1251]

### DIFF
--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcWhiteBlackListIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcWhiteBlackListIntegrationTest.java
@@ -347,13 +347,13 @@ public class MySqlCdcWhiteBlackListIntegrationTest extends AbstractMySqlCdcInteg
         int id3 = 1000 * dbSuffix + 3;
         int id4 = 1000 * dbSuffix + 4;
         return Arrays.asList(
-                id1 + "/0:INSERT:TableRow {id=" + id1 + ", value1=" + db + "_table0_val1_0, "
+                id1 + "/0:SYNC:TableRow {id=" + id1 + ", value1=" + db + "_table0_val1_0, "
                         + "value2=" + db + "_table0_val2_0, value3=" + db + "_table0_val3_0}",
                 id1 + "/1:UPDATE:TableRow {id=" + id1 + ", value1=new_" + db + "_table0_val1_0, "
                         + "value2=" + db + "_table0_val2_0, value3=" + db + "_table0_val3_0}",
-                id2 + "/0:INSERT:TableRow {id=" + id2 + ", value1=" + db + "_table0_val1_1, "
+                id2 + "/0:SYNC:TableRow {id=" + id2 + ", value1=" + db + "_table0_val1_1, "
                         + "value2=" + db + "_table0_val2_1, value3=" + db + "_table0_val3_1}",
-                id3 + "/0:INSERT:TableRow {id=" + id3 + ", value1=" + db + "_table0_val1_2, "
+                id3 + "/0:SYNC:TableRow {id=" + id3 + ", value1=" + db + "_table0_val1_2, "
                         + "value2=" + db + "_table0_val2_2, value3=" + db + "_table0_val3_2}",
                 id4 + "/0:INSERT:TableRow {id=" + id4 + ", value1=" + db + "_table0_val1_3, "
                         + "value2=" + db + "_table0_val2_3, value3=" + db + "_table0_val3_3}",
@@ -369,13 +369,13 @@ public class MySqlCdcWhiteBlackListIntegrationTest extends AbstractMySqlCdcInteg
         int id3 = 1000 * dbSuffix + 103;
         int id4 = 1000 * dbSuffix + 104;
         return Arrays.asList(
-                id1 + "/0:INSERT:TableRow {id=" + id1 + ", value1=" + db + "_table1_val1_0, "
+                id1 + "/0:SYNC:TableRow {id=" + id1 + ", value1=" + db + "_table1_val1_0, "
                         + "value2=" + db + "_table1_val2_0, value3=" + db + "_table1_val3_0}",
-                id2 + "/0:INSERT:TableRow {id=" + id2 + ", value1=" + db + "_table1_val1_1, "
+                id2 + "/0:SYNC:TableRow {id=" + id2 + ", value1=" + db + "_table1_val1_1, "
                         + "value2=" + db + "_table1_val2_1, value3=" + db + "_table1_val3_1}",
                 id2 + "/1:UPDATE:TableRow {id=" + id2 + ", value1=" + db + "_table1_val1_1, "
                         + "value2=new_" + db + "_table1_val2_1, value3=" + db + "_table1_val3_1}",
-                id3 + "/0:INSERT:TableRow {id=" + id3 + ", value1=" + db + "_table1_val1_2, "
+                id3 + "/0:SYNC:TableRow {id=" + id3 + ", value1=" + db + "_table1_val1_2, "
                         + "value2=" + db + "_table1_val2_2, value3=" + db + "_table1_val3_2}",
                 id4 + "/0:INSERT:TableRow {id=" + id4 + ", value1=" + db + "_table1_val1_3, "
                         + "value2=" + db + "_table1_val2_3, value3=" + db + "_table1_val3_3}",
@@ -391,11 +391,11 @@ public class MySqlCdcWhiteBlackListIntegrationTest extends AbstractMySqlCdcInteg
         int id3 = 1000 * dbSuffix + 203;
         int id4 = 1000 * dbSuffix + 204;
         return Arrays.asList(
-                id1 + "/0:INSERT:TableRow {id=" + id1 + ", value1=" + db + "_table2_val1_0, "
+                id1 + "/0:SYNC:TableRow {id=" + id1 + ", value1=" + db + "_table2_val1_0, "
                         + "value2=" + db + "_table2_val2_0, value3=" + db + "_table2_val3_0}",
-                id2 + "/0:INSERT:TableRow {id=" + id2 + ", value1=" + db + "_table2_val1_1, "
+                id2 + "/0:SYNC:TableRow {id=" + id2 + ", value1=" + db + "_table2_val1_1, "
                         + "value2=" + db + "_table2_val2_1, value3=" + db + "_table2_val3_1}",
-                id3 + "/0:INSERT:TableRow {id=" + id3 + ", value1=" + db + "_table2_val1_2, "
+                id3 + "/0:SYNC:TableRow {id=" + id3 + ", value1=" + db + "_table2_val1_2, "
                         + "value2=" + db + "_table2_val2_2, value3=" + db + "_table2_val3_2}",
                 id3 + "/1:UPDATE:TableRow {id=" + id3 + ", value1=" + db + "_table2_val1_2, "
                         + "value2=" + db + "_table2_val2_2, value3=new_" + db + "_table2_val3_2}",

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -1250,9 +1250,10 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     // received a response, but before it cleans up itself, it receives a HazelcastInstanceNotActiveException
     private void warnIfSuspiciousDoubleCompletion(Object s0, Object s1) {
         if (s0 != s1 && !(isStateCancelled(s0)) && !(isStateCancelled(s1))) {
-            logger.warning(String.format("Future.complete(Object) on completed future. "
+            String message = String.format("Future.complete(Object) on completed future. "
                             + "Request: %s, current value: %s, offered value: %s",
-                    invocationToString(), s0, s1), new Exception());
+                    invocationToString(), s0, s1);
+            logger.warning(message, new Exception(message));
         }
     }
 


### PR DESCRIPTION
Fixes test data in the MySQL Debezium nightly tests.

Fixes #21630

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
