### PR TITLE
Don't use the remote address in the TcpServerConnection.hashCode()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -232,7 +232,7 @@ public class TcpServerConnection implements ServerConnection {
 
     @Override
     public int hashCode() {
-        return Objects.hash(acceptorSide, connectionId, remoteAddress);
+        return Objects.hash(acceptorSide, connectionId);
     }
 
     @Override


### PR DESCRIPTION
This is an addition to #21642

The `TcpServerConnectionManager_MemoryLeakTest` discovered problem with mutable remote address in the `TcpServerConnection.hashCode()`. This PR removes the field from `hashCode` computation.

Fixes https://github.com/hazelcast/hazelcast/issues/21662
Fixes https://github.com/hazelcast/hazelcast/issues/21670