### PR TITLE
[HZ-1140] Added a CPMember UUID check to distinguish a rejoined node and a restarted one

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
@@ -174,8 +174,8 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeObject(groupId);
-            out.writeString(name);
+        out.writeObject(groupId);
+        out.writeString(name);
         synchronized (waitKeys) {
             out.writeInt(waitKeys.size());
             for (Entry<Object, WaitKeyContainer<W>> e : waitKeys.entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -39,6 +39,8 @@ import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.cp.event.CPGroupAvailabilityListener;
 import com.hazelcast.cp.event.CPMembershipListener;
+import com.hazelcast.cp.internal.CPMemberInfo;
+import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
@@ -795,9 +797,17 @@ public class Node {
         final Set<UUID> excludedMemberUuids = nodeExtension.getInternalHotRestartService().getExcludedMemberUuids();
 
         MemberImpl localMember = getLocalMember();
+        CPMemberInfo localCPMember = getLocalCPMember();
+        UUID cpMemberUUID = localCPMember != null ? localCPMember.getUuid() : null;
         return new JoinRequest(Packet.VERSION, buildInfo.getBuildNumber(), version, address,
                 localMember.getUuid(), localMember.isLiteMember(), createConfigCheck(), credentials,
-                localMember.getAttributes(), excludedMemberUuids, localMember.getAddressMap());
+                localMember.getAttributes(), excludedMemberUuids, localMember.getAddressMap(), cpMemberUUID);
+    }
+
+    private CPMemberInfo getLocalCPMember() {
+        RaftService raftService = nodeEngine.getService(RaftService.SERVICE_NAME);
+        CPMemberInfo localCPMember = raftService.getLocalCPMember();
+        return localCPMember;
     }
 
     public ConfigCheck createConfigCheck() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
@@ -64,8 +64,9 @@ public final class MembersView implements IdentifiedDataSerializable {
         list.addAll(source.getMembers());
         int newVersion = max(source.version, source.size());
         for (MemberInfo newMember : newMembers) {
-            MemberInfo m = new MemberInfo(newMember.getAddress(), newMember.getUuid(), newMember.getAttributes(),
-                    newMember.isLiteMember(), newMember.getVersion(), ++newVersion, newMember.getAddressMap());
+            MemberInfo m = new MemberInfo(newMember.getAddress(), newMember.getUuid(), newMember.getCPMemberUUID(),
+                    newMember.getAttributes(), newMember.isLiteMember(), newMember.getVersion(), ++newVersion,
+                    newMember.getAddressMap());
             list.add(m);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -22,6 +22,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.operations.FetchMembersViewOp;
@@ -361,6 +362,7 @@ public class MembershipManager {
         sendMembershipEvents(currentMemberMap.getMembers(), addedMembers, !clusterService.isJoined());
 
         removeFromMissingMembers(members);
+        removeFromCPMissingMembers(membersView);
 
         clusterHeartbeatManager.heartbeat();
         clusterService.printMemberList();
@@ -1067,6 +1069,12 @@ public class MembershipManager {
             }
         }
         missingMembersRef.set(unmodifiableMap(m));
+    }
+
+    private void removeFromCPMissingMembers(MembersView membersView) {
+        RaftService raftService = nodeEngine.getService(RaftService.SERVICE_NAME);
+        List<MemberInfo> membersInfo = membersView.getMembers();
+        raftService.removeFromMissingMembers(membersInfo);
     }
 
     private boolean isHotRestartEnabled() {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
@@ -16,14 +16,13 @@
 
 package com.hazelcast.cp.internal;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.cp.CPMember;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,10 +31,9 @@ import java.util.Collection;
 
 import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
 import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -54,8 +52,29 @@ public class CPMemberAutoRemoveTest extends HazelcastRaftTestSupport {
         assertTrueEventually(() -> {
             Collection<CPMemberInfo> activeMembers = getRaftService(instances[0]).getMetadataGroupManager()
                                                                                  .getActiveMembers();
-            assertThat(activeMembers, not(hasItem(terminatedMember)));
-            assertThat(getRaftService(instances[0]).getMissingMembers(), Matchers.empty());
+            assertThat(activeMembers).doesNotContain(terminatedMember);
+            assertThat(getRaftService(instances[0]).getMissingMembers()).isEmpty();
+        });
+    }
+
+    @Test
+    public void when_missingCPNodeReplacedByNewNode_then_itIsAutomaticallyRemoved() {
+        missingRaftMemberRemovalSeconds = 10;
+        HazelcastInstance[] instances = newInstances(3, 3, 0);
+
+        CPMemberInfo terminatedMember = (CPMemberInfo) instances[2].getCPSubsystem().getLocalCPMember();
+        Address address = terminatedMember.getAddress();
+        instances[2].getLifecycleService().terminate();
+
+        Config config = createConfig(3, 3);
+        HazelcastInstance instance = factory.newHazelcastInstance(address, config);
+        waitUntilCPDiscoveryCompleted(instance);
+
+        assertTrueEventually(() -> {
+            Collection<CPMemberInfo> activeMembers = getRaftService(instances[0]).getMetadataGroupManager()
+                    .getActiveMembers();
+            assertThat(activeMembers).doesNotContain(terminatedMember);
+            assertThat(getRaftService(instances[0]).getMissingMembers()).isEmpty();
         });
     }
 
@@ -64,9 +83,9 @@ public class CPMemberAutoRemoveTest extends HazelcastRaftTestSupport {
         missingRaftMemberRemovalSeconds = 300;
         HazelcastInstance[] instances = newInstances(3, 3, 0);
 
-        CPMember cpMember0 = instances[0].getCPSubsystem().getLocalCPMember();
-        CPMember cpMember1 = instances[1].getCPSubsystem().getLocalCPMember();
-        CPMember cpMember2 = instances[2].getCPSubsystem().getLocalCPMember();
+        CPMemberInfo cpMember0 = (CPMemberInfo) instances[0].getCPSubsystem().getLocalCPMember();
+        CPMemberInfo cpMember1 = (CPMemberInfo) instances[1].getCPSubsystem().getLocalCPMember();
+        CPMemberInfo cpMember2 = (CPMemberInfo) instances[2].getCPSubsystem().getLocalCPMember();
 
         assertTrueEventually(() -> {
             for (HazelcastInstance instance : instances) {
@@ -84,10 +103,9 @@ public class CPMemberAutoRemoveTest extends HazelcastRaftTestSupport {
         assertClusterSizeEventually(1, instances[2]);
 
         assertTrueEventually(() -> {
-            assertThat(getRaftService(instances[0]).getMissingMembers(), hasItem((CPMemberInfo) cpMember2));
-            assertThat(getRaftService(instances[1]).getMissingMembers(), hasItem((CPMemberInfo) cpMember2));
-            assertThat(getRaftService(instances[2]).getMissingMembers(), hasItem((CPMemberInfo) cpMember0));
-            assertThat(getRaftService(instances[2]).getMissingMembers(), hasItem((CPMemberInfo) cpMember1));
+            assertThat(getRaftService(instances[0]).getMissingMembers()).contains(cpMember2);
+            assertThat(getRaftService(instances[1]).getMissingMembers()).contains(cpMember2);
+            assertThat(getRaftService(instances[2]).getMissingMembers()).contains(cpMember0, cpMember1);
         });
 
         unblockCommunicationBetween(instances[1], instances[2]);
@@ -96,9 +114,9 @@ public class CPMemberAutoRemoveTest extends HazelcastRaftTestSupport {
         assertClusterSizeEventually(3, instances);
 
         assertTrueEventually(() -> {
-            assertThat(getRaftService(instances[0]).getMissingMembers(), Matchers.empty());
-            assertThat(getRaftService(instances[1]).getMissingMembers(), Matchers.empty());
-            assertThat(getRaftService(instances[2]).getMissingMembers(), Matchers.empty());
+            assertThat(getRaftService(instances[0]).getMissingMembers()).isEmpty();
+            assertThat(getRaftService(instances[1]).getMissingMembers()).isEmpty();
+            assertThat(getRaftService(instances[2]).getMissingMembers()).isEmpty();
         });
     }
 


### PR DESCRIPTION
In addition to comparing IP addresses, we also need to check the UUID of the CP Member to distinguish between a new (or restarted) node and a node that has been rejoined after split-brain healing.

A new `cpMemberUUID` field has been added to `MemberInfo` and `JoinRequest` objects.

Fixes https://hazelcast.atlassian.net/browse/HZ-1140

Breaking changes (list specific methods/types/messages):
- added a new field to `MemberInfo` and `JoinRequest` classes


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
