### PR TITLE
Increase container startup timeout in Elastic tests

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -18,8 +18,6 @@ package com.hazelcast.jet.elastic;
 
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.impl.util.Util;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -63,8 +61,10 @@ public final class ElasticSupport {
     }
 
     public static SupplierEx<RestClientBuilder> elasticClientSupplier() {
-        String address = elastic.get().getHttpHostAddress();
-        return () -> RestClient.builder(HttpHost.create(address));
+        ElasticsearchContainer container = elastic.get();
+        String containerHost = container.getHost();
+        Integer port = container.getMappedPort(PORT);
+        return () -> client(containerHost, port);
     }
 
     public static SupplierEx<RestClientBuilder> secureElasticClientSupplier() {

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSinksPipeline.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/pipeline/CommonElasticSinksPipeline.java
@@ -80,6 +80,7 @@ public final class CommonElasticSinksPipeline {
                 .clientFn(elasticSupplier)
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new UpdateRequest(index, item.getId()).doc(item.asMap()))
+                .retries(0)
                 .build();
 
         p.readFrom(TestSources.items(items))


### PR DESCRIPTION
Elastic tests uses 60 second default container startup timeout. In some cases the container starts in normal way, just way slower due to e.g. host load. 

This PR decreases a lot test time by avoiding retries in pipeline tests (we sometimes expect exceptions, so retries were just waiting without any chance to recover; previously 4m 53s, now under 1m) and increases two times the startup timeout (from 1m to 2m). Even if we loose those additional 2 minutes sometimes, we still be not-slower than before this PR.

Fixes #21430 (rather not directly fixes, but this PR should make such issues not happen so easily)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
