### PR TITLE
Remove parameter from the Rest and Memcached tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedDirectBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedDirectBufferTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_BUFFER_DIRECT;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemcachedDirectBufferTest extends MemcachedTest {
+
+    @Override
+    protected Config createConfig() {
+        Config config = super.createConfig();
+        config.setProperty(SOCKET_BUFFER_DIRECT.getName(), "true");
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
@@ -23,10 +23,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.MemcacheEntry;
-import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,7 +38,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -53,33 +50,19 @@ import java.util.ConcurrentModificationException;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static com.hazelcast.test.MemcacheTestUtil.shutdownQuietly;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParametrizedRunner.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MemcachedTest extends HazelcastTestSupport {
-
-    @Parameterized.Parameter
-    public boolean useDirectBuffer;
-
-    @Parameterized.Parameters(name = "useDirectBuffer:{0}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {true},
-                {false},
-        });
-    }
 
     protected HazelcastInstance instance;
     protected MemcachedClient client;
 
     protected Config createConfig() {
         Config config = smallInstanceConfig();
-        config.setProperty(ClusterProperty.SOCKET_BUFFER_DIRECT.getName(), Boolean.toString(useDirectBuffer));
         config.getNetworkConfig().getMemcacheProtocolConfig().setEnabled(true);
         // Join is disabled intentionally. will start standalone HazelcastInstances.
         JoinConfig join = config.getNetworkConfig().getJoin();

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestDirectBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestDirectBufferTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_BUFFER_DIRECT;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RestDirectBufferTest extends RestTest {
+
+    @Override
+    public Config getConfig() {
+        Config config = super.getConfig();
+        config.setProperty(SOCKET_BUFFER_DIRECT.getName(), "true");
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -29,9 +29,7 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.map.IMap;
-import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,14 +39,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.Collection;
 
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
@@ -63,7 +58,6 @@ import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastSeconds;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -71,21 +65,9 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests HTTP REST API.
  */
-@RunWith(HazelcastParametrizedRunner.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RestTest {
-
-    @Parameterized.Parameter
-    public boolean useDirectBuffer;
-
-    @Parameterized.Parameters(name = "useDirectBuffer:{0}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {true},
-                {false},
-        });
-    }
 
     private static final String MAP_WITH_TTL = "mapWithTtl";
 
@@ -108,7 +90,6 @@ public class RestTest {
 
     public Config getConfig() {
         Config config = new Config();
-        config.setProperty(ClusterProperty.SOCKET_BUFFER_DIRECT.getName(), Boolean.toString(useDirectBuffer));
         RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
         config.getNetworkConfig().setRestApiConfig(restApiConfig);
         config.getMapConfig(MAP_WITH_TTL).setTimeToLiveSeconds(2);


### PR DESCRIPTION
In a former PR to fix use cases where direct buffers are enabled,
we have added a new parameter to these tests.

However, there were some subclasses of these tests, where the
new parameter was unexpected.

I believe, we don't need to test direct buffer enabled for all
the subclasses of these tests. Therefore, I have removed the
parameter from the `MemcachedTest` and `RestTest` and instead
added new subclasses for them where we run the tests with
direct buffers enabled.

closes https://github.com/hazelcast/hazelcast-enterprise/issues/5084