### PR TITLE
[5.0.z] Correctly handle the buffer copies when the dst is a direct buffer in the text protocols

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
 
-import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 
 public class BulkGetCommand extends AbstractTextCommand {
 
@@ -46,7 +46,7 @@ public class BulkGetCommand extends AbstractTextCommand {
 
     @Override
     public boolean writeTo(ByteBuffer dst) {
-        copyToHeapBuffer(byteBuffer, dst);
+        copyFromHeapBuffer(byteBuffer, dst);
         return !byteBuffer.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
@@ -26,7 +26,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.ERROR;
 import static com.hazelcast.internal.ascii.TextCommandConstants.SERVER_ERROR;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_SERVER;
-import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class ErrorCommand extends AbstractTextCommand {
@@ -68,7 +68,7 @@ public class ErrorCommand extends AbstractTextCommand {
 
     @Override
     public boolean writeTo(ByteBuffer dst) {
-        copyToHeapBuffer(response, dst);
+        copyFromHeapBuffer(response, dst);
         return !response.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
@@ -22,7 +22,7 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.GET;
-import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 
 public class GetCommand extends AbstractTextCommand {
 
@@ -58,9 +58,9 @@ public class GetCommand extends AbstractTextCommand {
     @Override
     public boolean writeTo(ByteBuffer dst) {
         if (value != null) {
-            copyToHeapBuffer(value, dst);
+            copyFromHeapBuffer(value, dst);
         }
-        copyToHeapBuffer(endMarker, dst);
+        copyFromHeapBuffer(endMarker, dst);
         return !((value != null && value.hasRemaining())
                 || endMarker.hasRemaining());
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -18,7 +18,9 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.AbstractTextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
-import com.hazelcast.internal.nio.IOUtil;
+
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
 
 import java.nio.ByteBuffer;
 
@@ -57,15 +59,11 @@ public class SetCommand extends AbstractTextCommand {
         return false;
     }
 
-    void copy(ByteBuffer cb) {
-        if (cb.isDirect()) {
-            int n = Math.min(cb.remaining(), bbValue.remaining());
-            if (n > 0) {
-                cb.get(bbValue.array(), bbValue.position(), n);
-                bbValue.position(bbValue.position() + n);
-            }
+    void copy(ByteBuffer src) {
+        if (src.isDirect()) {
+            copyToHeapBuffer(src, bbValue);
         } else {
-            IOUtil.copyToHeapBuffer(cb, bbValue);
+            copyFromHeapBuffer(src, bbValue);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.AbstractTextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 
-import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
 
 import java.nio.ByteBuffer;
@@ -46,7 +45,7 @@ public class SetCommand extends AbstractTextCommand {
 
     @Override
     public boolean readFrom(ByteBuffer src) {
-        copy(src);
+        copyToHeapBuffer(src, bbValue);
         if (!bbValue.hasRemaining()) {
             while (src.hasRemaining()) {
                 char c = (char) src.get();
@@ -57,14 +56,6 @@ public class SetCommand extends AbstractTextCommand {
             }
         }
         return false;
-    }
-
-    void copy(ByteBuffer src) {
-        if (src.isDirect()) {
-            copyToHeapBuffer(src, bbValue);
-        } else {
-            copyFromHeapBuffer(src, bbValue);
-        }
     }
 
     public void setResponse(byte[] value) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class StatsCommand extends AbstractTextCommand {
@@ -100,7 +100,7 @@ public class StatsCommand extends AbstractTextCommand {
         if (response == null) {
             response = ByteBuffer.allocate(0);
         }
-        copyToHeapBuffer(response, dst);
+        copyFromHeapBuffer(response, dst);
         return !response.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -33,7 +33,7 @@ import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_403;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_404;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_500;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_503;
-import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 @SuppressFBWarnings({"EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT"})
@@ -267,7 +267,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
 
     @Override
     public boolean writeTo(ByteBuffer dst) {
-        copyToHeapBuffer(response, dst);
+        copyFromHeapBuffer(response, dst);
         return !response.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.NoOpCommand;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.nio.ascii.TextDecoder;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.util.StringUtil;
@@ -27,6 +26,8 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_100;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
+import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class HttpPostCommand extends HttpCommand {
@@ -80,17 +81,17 @@ public class HttpPostCommand extends HttpCommand {
         return complete;
     }
 
-    private boolean doActualRead(ByteBuffer cb) {
-        setReadyToReadData(cb);
+    private boolean doActualRead(ByteBuffer src) {
+        setReadyToReadData(src);
         if (!readyToReadData) {
             return false;
         }
         if (!isSpaceForData()) {
             if (chunked) {
-                if (data != null && cb.hasRemaining()) {
-                    readCRLFOrPositionChunkSize(cb);
+                if (data != null && src.hasRemaining()) {
+                    readCRLFOrPositionChunkSize(src);
                 }
-                if (readChunkSize(cb)) {
+                if (readChunkSize(src)) {
                     return true;
                 }
             } else {
@@ -98,7 +99,11 @@ public class HttpPostCommand extends HttpCommand {
             }
         }
         if (data != null) {
-            IOUtil.copyToHeapBuffer(cb, data);
+            if (src.isDirect()) {
+                copyToHeapBuffer(src, data);
+            } else {
+                copyFromHeapBuffer(src, data);
+            }
         }
         return !chunked && !isSpaceForData();
     }
@@ -107,11 +112,11 @@ public class HttpPostCommand extends HttpCommand {
         return data != null && data.hasRemaining();
     }
 
-    private void setReadyToReadData(ByteBuffer cb) {
-        while (!readyToReadData && cb.hasRemaining()) {
-            byte b = cb.get();
+    private void setReadyToReadData(ByteBuffer src) {
+        while (!readyToReadData && src.hasRemaining()) {
+            byte b = src.get();
             if (b == CARRIAGE_RETURN) {
-                readLF(cb);
+                readLF(src);
                 processLine(StringUtil.lowerCaseInternal(toStringAndClear(lineBuffer)));
                 if (nextLine) {
                     readyToReadData = true;
@@ -141,19 +146,19 @@ public class HttpPostCommand extends HttpCommand {
         }
     }
 
-    private void readCRLFOrPositionChunkSize(ByteBuffer cb) {
-        byte b = cb.get();
+    private void readCRLFOrPositionChunkSize(ByteBuffer src) {
+        byte b = src.get();
         if (b == CARRIAGE_RETURN) {
-            readLF(cb);
+            readLF(src);
         } else {
-            cb.position(cb.position() - 1);
+            src.position(src.position() - 1);
         }
     }
 
-    private void readLF(ByteBuffer cb) {
-        assert cb.hasRemaining() : "'\\n' must follow '\\r'";
+    private void readLF(ByteBuffer src) {
+        assert src.hasRemaining() : "'\\n' must follow '\\r'";
 
-        byte b = cb.get();
+        byte b = src.get();
         if (b != LINE_FEED) {
             throw new IllegalStateException("'\\n' must follow '\\r', but got '" + (char) b + "'");
         }
@@ -173,12 +178,12 @@ public class HttpPostCommand extends HttpCommand {
         return result;
     }
 
-    private boolean readChunkSize(ByteBuffer cb) {
+    private boolean readChunkSize(ByteBuffer src) {
         boolean hasLine = false;
-        while (cb.hasRemaining()) {
-            byte b = cb.get();
+        while (src.hasRemaining()) {
+            byte b = src.get();
             if (b == CARRIAGE_RETURN) {
-                readLF(cb);
+                readLF(src);
                 hasLine = true;
                 break;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_100;
-import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
@@ -99,11 +98,7 @@ public class HttpPostCommand extends HttpCommand {
             }
         }
         if (data != null) {
-            if (src.isDirect()) {
-                copyToHeapBuffer(src, data);
-            } else {
-                copyFromHeapBuffer(src, data);
-            }
+            copyToHeapBuffer(src, data);
         }
         return !chunked && !isSpaceForData();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -321,6 +321,18 @@ public final class IOUtil {
         };
     }
 
+    /**
+     * Copies the contents of the {@code src} backed by an on-heap buffer to
+     * {@code dst}. The {@code dst} can be backed by either on-heap or
+     * off-heap buffer.
+     * <p>
+     * Number of bytes to copy is calculated by taking the minimum of the
+     * remaining bytes of {@code src} and {@code dst}.
+     *
+     * @param src source buffer
+     * @param dst destination buffer
+     * @return the number of bytes copied
+     */
     public static int copyFromHeapBuffer(ByteBuffer src, ByteBuffer dst) {
         if (src == null) {
             return 0;
@@ -333,6 +345,18 @@ public final class IOUtil {
         return n;
     }
 
+    /**
+     * Copies the contents of the {@code src} to {@code dst} backed by an
+     * on-heap buffer. The {@code src} can be backed by either on-heap or
+     * off-heap buffer.
+     * <p>
+     * Number of bytes to copy is calculated by taking the minimum of the
+     * remaining bytes of {@code src} and {@code dst}.
+     *
+     * @param src source buffer
+     * @param dst destination buffer
+     * @return the number of bytes copied
+     */
     public static int copyToHeapBuffer(ByteBuffer src, ByteBuffer dst) {
         if (src == null) {
             return 0;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -321,24 +321,27 @@ public final class IOUtil {
         };
     }
 
+    public static int copyFromHeapBuffer(ByteBuffer src, ByteBuffer dst) {
+        if (src == null) {
+            return 0;
+        }
+
+        int n = Math.min(src.remaining(), dst.remaining());
+        int srcPosition = src.position();
+        dst.put(src.array(), srcPosition, n);
+        upcast(src).position(srcPosition + n);
+        return n;
+    }
+
     public static int copyToHeapBuffer(ByteBuffer src, ByteBuffer dst) {
         if (src == null) {
             return 0;
         }
+
         int n = Math.min(src.remaining(), dst.remaining());
-        if (n > 0) {
-            if (n < 16) {
-                for (int i = 0; i < n; i++) {
-                    dst.put(src.get());
-                }
-            } else {
-                int srcPosition = src.position();
-                int destPosition = dst.position();
-                System.arraycopy(src.array(), srcPosition, dst.array(), destPosition, n);
-                src.position(srcPosition + n);
-                dst.position(destPosition + n);
-            }
-        }
+        int dstPosition = dst.position();
+        src.get(dst.array(), dstPosition, n);
+        dst.position(dstPosition + n);
         return n;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -341,7 +341,7 @@ public final class IOUtil {
         int n = Math.min(src.remaining(), dst.remaining());
         int srcPosition = src.position();
         dst.put(src.array(), srcPosition, n);
-        upcast(src).position(srcPosition + n);
+        src.position(srcPosition + n);
         return n;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedDirectBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedDirectBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedDirectBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedDirectBufferTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_BUFFER_DIRECT;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemcachedDirectBufferTest extends MemcachedTest {
+
+    @Override
+    protected Config createConfig() {
+        Config config = super.createConfig();
+        config.setProperty(SOCKET_BUFFER_DIRECT.getName(), "true");
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
@@ -23,9 +23,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.MemcacheEntry;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -37,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -49,19 +53,33 @@ import java.util.ConcurrentModificationException;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static com.hazelcast.test.MemcacheTestUtil.shutdownQuietly;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class MemcachedTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean useDirectBuffer;
+
+    @Parameterized.Parameters(name = "useDirectBuffer:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true},
+                {false},
+        });
+    }
 
     protected HazelcastInstance instance;
     protected MemcachedClient client;
 
     protected Config createConfig() {
         Config config = smallInstanceConfig();
+        config.setProperty(ClusterProperty.SOCKET_BUFFER_DIRECT.getName(), Boolean.toString(useDirectBuffer));
         config.getNetworkConfig().getMemcacheProtocolConfig().setEnabled(true);
         // Join is disabled intentionally. will start standalone HazelcastInstances.
         JoinConfig join = config.getNetworkConfig().getJoin();

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
@@ -23,10 +23,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.MemcacheEntry;
-import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,7 +38,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -53,33 +50,19 @@ import java.util.ConcurrentModificationException;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static com.hazelcast.test.MemcacheTestUtil.shutdownQuietly;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParametrizedRunner.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MemcachedTest extends HazelcastTestSupport {
-
-    @Parameterized.Parameter
-    public boolean useDirectBuffer;
-
-    @Parameterized.Parameters(name = "useDirectBuffer:{0}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {true},
-                {false},
-        });
-    }
 
     protected HazelcastInstance instance;
     protected MemcachedClient client;
 
     protected Config createConfig() {
         Config config = smallInstanceConfig();
-        config.setProperty(ClusterProperty.SOCKET_BUFFER_DIRECT.getName(), Boolean.toString(useDirectBuffer));
         config.getNetworkConfig().getMemcacheProtocolConfig().setEnabled(true);
         // Join is disabled intentionally. will start standalone HazelcastInstances.
         JoinConfig join = config.getNetworkConfig().getJoin();

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestDirectBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestDirectBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestDirectBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestDirectBufferTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_BUFFER_DIRECT;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RestDirectBufferTest extends RestTest {
+
+    @Override
+    public Config getConfig() {
+        Config config = super.getConfig();
+        config.setProperty(SOCKET_BUFFER_DIRECT.getName(), "true");
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -29,9 +29,7 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.map.IMap;
-import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
-import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestAwareInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,14 +39,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.Collection;
 
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
@@ -63,7 +58,6 @@ import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastSeconds;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -71,21 +65,9 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests HTTP REST API.
  */
-@RunWith(HazelcastParametrizedRunner.class)
-@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class RestTest {
-
-    @Parameterized.Parameter
-    public boolean useDirectBuffer;
-
-    @Parameterized.Parameters(name = "useDirectBuffer:{0}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {true},
-                {false},
-        });
-    }
 
     private static final String MAP_WITH_TTL = "mapWithTtl";
 
@@ -108,7 +90,6 @@ public class RestTest {
 
     public Config getConfig() {
         Config config = new Config();
-        config.setProperty(ClusterProperty.SOCKET_BUFFER_DIRECT.getName(), Boolean.toString(useDirectBuffer));
         RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
         config.getNetworkConfig().setRestApiConfig(restApiConfig);
         config.getMapConfig(MAP_WITH_TTL).setTimeToLiveSeconds(2);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -29,8 +29,11 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.TestAwareInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -38,11 +41,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.Collection;
 
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
@@ -57,6 +63,7 @@ import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastSeconds;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -64,9 +71,21 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests HTTP REST API.
  */
-@RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParametrizedRunner.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class RestTest {
+
+    @Parameterized.Parameter
+    public boolean useDirectBuffer;
+
+    @Parameterized.Parameters(name = "useDirectBuffer:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true},
+                {false},
+        });
+    }
 
     private static final String MAP_WITH_TTL = "mapWithTtl";
 
@@ -89,6 +108,7 @@ public class RestTest {
 
     public Config getConfig() {
         Config config = new Config();
+        config.setProperty(ClusterProperty.SOCKET_BUFFER_DIRECT.getName(), Boolean.toString(useDirectBuffer));
         RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
         config.getNetworkConfig().setRestApiConfig(restApiConfig);
         config.getMapConfig(MAP_WITH_TTL).setTimeToLiveSeconds(2);

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -60,6 +60,7 @@ import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.IOUtil.compress;
 import static com.hazelcast.internal.nio.IOUtil.copy;
 import static com.hazelcast.internal.nio.IOUtil.copyFile;
+import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.internal.nio.IOUtil.decompress;
 import static com.hazelcast.internal.nio.IOUtil.delete;
@@ -694,6 +695,45 @@ public class IOUtilTest extends HazelcastTestSupport {
         buffer.put((byte) 0xFF);
         compactOrClear(buffer);
         assertEquals("Buffer position invalid", 0, buffer.position());
+    }
+
+    @Test
+    public void testCopyFromHeapBuffer_whenDestinationIsHeapBuffer() {
+        ByteBuffer src = ByteBuffer.wrap(new byte[SIZE]);
+        ByteBuffer dst = ByteBuffer.wrap(new byte[SIZE]);
+
+        assertEquals(SIZE, copyFromHeapBuffer(src, dst));
+    }
+
+    @Test
+    public void testCopyFromHeapBuffer_whenDestinationIsDirectBuffer() {
+        ByteBuffer src = ByteBuffer.wrap(new byte[SIZE]);
+        ByteBuffer dst = ByteBuffer.allocateDirect(SIZE);
+
+        assertEquals(SIZE, copyFromHeapBuffer(src, dst));
+    }
+
+    @Test
+    public void testCopyFromHeapBuffer_whenSourceIsNull() {
+        ByteBuffer dst = ByteBuffer.wrap(new byte[SIZE]);
+
+        assertEquals(0, copyFromHeapBuffer(null, dst));
+    }
+
+    @Test
+    public void testCopyToHeapBuffer_whenSourceIsHeapBuffer() {
+        ByteBuffer src = ByteBuffer.wrap(new byte[SIZE]);
+        ByteBuffer dst = ByteBuffer.wrap(new byte[SIZE]);
+
+        assertEquals(SIZE, copyToHeapBuffer(src, dst));
+    }
+
+    @Test
+    public void testCopyToHeapBuffer_whenSourceIsDirectBuffer() {
+        ByteBuffer src = ByteBuffer.allocateDirect(SIZE);
+        ByteBuffer dst = ByteBuffer.wrap(new byte[SIZE]);
+
+        assertEquals(SIZE, copyToHeapBuffer(src, dst));
     }
 
     @Test


### PR DESCRIPTION
Backports #21624 and #21685.

We have a configuration element called `hazelcast.socket.buffer.direct`,
which enables us to use direct buffers when set to true.

However, in our text protocol implementations(both the REST and Memcached
protocols) we were using `IOUtil#copyToHeapBuffer` which does not
expect the `dst` to be direct buffer and uses an operation (`#array()`)
which is not supported in direct buffers. It might be very well the
case that the `dst` is a direct buffer in that method if the aforementioned
property is set to `true`.

To fix that, instead of `System.arraycopy`, we will be using the bulk
`put`/`get` methods defined in the `ByteBuffer` interface. We
will also have separate methods to copy from and to
heap buffers(not direct), as there are some places where we might
copy from heap buffers to direct and vice versa.

I have performed measurements on the lab machines comparing the
old implementation to the new one, and here are the results.

As can be seen there, there is no measurable difference for
various input sizes between old `IOUtil#copyToHeapBuffer` and
new `IOUtil#copyFromHeapBuffer` (I know the naming is confusing
but the old method was using the toHeapBuffer suffix mistakenly.
Most of the time src was a heap buffer and dst was a direct buffer
when that property is set. I corrected the naming as well).

```
Benchmark                          (bufferSize)   Mode  Cnt         Score         Error  Units
ByteBufferWriterBenchmark.testNew             8  thrpt   25  31094780.531 ±  129879.214  ops/s
ByteBufferWriterBenchmark.testNew           128  thrpt   25  28547422.040 ±  171893.673  ops/s
ByteBufferWriterBenchmark.testNew           512  thrpt   25  17061190.322 ±   74973.135  ops/s
ByteBufferWriterBenchmark.testNew          1024  thrpt   25  18182480.918 ± 1732035.183  ops/s
ByteBufferWriterBenchmark.testNew          8196  thrpt   25   5003421.975 ±   26035.544  ops/s
ByteBufferWriterBenchmark.testNew         32784  thrpt   25    701275.637 ±    3618.819  ops/s
ByteBufferWriterBenchmark.testOld             8  thrpt   25  24234316.694 ±  462187.521  ops/s
ByteBufferWriterBenchmark.testOld           128  thrpt   25  29826577.844 ±  179080.558  ops/s
ByteBufferWriterBenchmark.testOld           512  thrpt   25  19522970.689 ± 2491823.986  ops/s
ByteBufferWriterBenchmark.testOld          1024  thrpt   25  17370524.842 ±  104985.291  ops/s
ByteBufferWriterBenchmark.testOld          8196  thrpt   25   5033606.115 ±   21938.263  ops/s
ByteBufferWriterBenchmark.testOld         32784  thrpt   25    713670.609 ±   14394.146  ops/s
```

Here is the benchmark code

```java
package org.example;

import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Param;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.infra.Blackhole;

import java.nio.Buffer;
import java.nio.ByteBuffer;

@State(Scope.Benchmark)
public class ByteBufferWriterBenchmark {

    @Param({"8", "128", "512", "1024", "8196", "32784"})
    public int bufferSize;

    public ByteBuffer dst;
    public ByteBuffer src;

    @Setup
    public void setUpBuffers() {
        dst = ByteBuffer.allocate(bufferSize);
        src = ByteBuffer.allocate(bufferSize);
    }

    @Setup(Level.Invocation)
    public void setUpBufferPositions() {
        dst.position(0);
        src.position(0);
    }

    @Benchmark
    public void testOld(Blackhole blackhole) {
        blackhole.consume(copyOld(src, dst));
    }

    @Benchmark
    public void testNew(Blackhole blackhole) {
        blackhole.consume(copyNew(src, dst));
    }

    public static int copyOld(ByteBuffer src, ByteBuffer dst) {
        if (src == null) {
            return 0;
        }
        int n = Math.min(src.remaining(), dst.remaining());
        if (n > 0) {
            if (n < 16) {
                for (int i = 0; i < n; i++) {
                    dst.put(src.get());
                }
            } else {
                int srcPosition = src.position();
                int destPosition = dst.position();
                System.arraycopy(src.array(), srcPosition, dst.array(), destPosition, n);
                upcast(src).position(srcPosition + n);
                upcast(dst).position(destPosition + n);
            }
        }
        return n;
    }

    public static int copyNew(ByteBuffer src, ByteBuffer dst) {
        if (src == null) {
            return 0;
        }

        int n = Math.min(src.remaining(), dst.remaining());
        int srcPosition = src.position();
        dst.put(src.array(), srcPosition, n);
        upcast(src).position(srcPosition + n);
        return n;
    }

    public static Buffer upcast(Buffer buf) {
        return buf;
    }
}
```