### PR TITLE
[API-1425] Do not try to connect cluster members when the client is not connected to cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1212,16 +1212,13 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             }
 
             for (Member member : client.getClientClusterService().getMemberList()) {
-                if (clientState == ClientState.SWITCHING_CLUSTER) {
-                    // when switching cluster we only want to open a new
-                    // connection via `doConnectToCandidateCluster`
-                    return;
-                }
-
-                if (clientState == ClientState.DISCONNECTED_FROM_CLUSTER) {
-                    // best-effort check to prevent this task from trying to
-                    // connect to all cluster members when the client is not
-                    // connected to any.
+                if (clientState == ClientState.SWITCHING_CLUSTER
+                        || clientState == ClientState.DISCONNECTED_FROM_CLUSTER) {
+                    // Best effort check to prevent this task from attempting to
+                    // open a new connection when the client is either switching
+                    // clusters or is not connected to any of the cluster members.
+                    // In such occasions, only `doConnectToCandidateCluster`
+                    // method should open new connections.
                     return;
                 }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1201,9 +1201,18 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
 
             for (Member member : client.getClientClusterService().getMemberList()) {
                 if (clientState == ClientState.SWITCHING_CLUSTER) {
-                    // when switching cluster we only want to open a new connection via `doConnectToCandidateCluster`
+                    // when switching cluster we only want to open a new
+                    // connection via `doConnectToCandidateCluster`
                     return;
                 }
+
+                if (activeConnections.isEmpty()) {
+                    // best-effort check to prevent this task from trying to
+                    // connect to all cluster members when the client is not
+                    // connected to any.
+                    return;
+                }
+
                 UUID uuid = member.getUuid();
                 if (activeConnections.get(uuid) != null) {
                     continue;

--- a/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientClusterReconnectionRetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cluster/ClientClusterReconnectionRetryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cluster;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.connection.ClientConnectionManager;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class ClientClusterReconnectionRetryTest extends HazelcastTestSupport {
+
+    private static final int ASSERTION_SECONDS = 30;
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testClientShouldNotTryToConnectCluster_whenThereIsNoConnection() {
+        ClientConfig clientConfig = new ClientConfig();
+
+        // Sleep indefinitely after the first connection attempt fails
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
+                .setInitialBackoffMillis(Integer.MAX_VALUE)
+                .setMaxBackoffMillis(Integer.MAX_VALUE);
+
+        HazelcastInstance member = factory.newHazelcastInstance(getMemberConfig());
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+        factory.terminate(member);
+
+        ClientConnectionManager connectionManager = getHazelcastClientInstanceImpl(client)
+                .getConnectionManager();
+
+        // Wait until the client-side connection is closed
+        assertTrueEventually(() -> assertTrue(connectionManager.getActiveConnections().isEmpty()));
+
+        // Wait a bit more to make it more likely that the first reconnection
+        // attempt is made before we restart the instance
+        sleepAtLeastSeconds(ASSERTION_SECONDS);
+
+        // Cleanup the address registry so that the member will re-use the
+        // address it had. This is there to make sure that in the periodic
+        // task, we would try to connect the restarted instance(as it was in
+        // the member list) and fail the test in case of the incorrect behavior
+        factory.cleanup();
+
+        factory.newHazelcastInstance(getMemberConfig());
+
+        // Assert that the client doesn't reconnect to the cluster, as the
+        // configured connection strategy would sleep indefinitely after the
+        // first connection attempt
+        assertTrueAllTheTime(
+                () -> assertTrue(connectionManager.getActiveConnections().isEmpty()),
+                ASSERTION_SECONDS);
+    }
+
+    private Config getMemberConfig() {
+        Config config = smallInstanceConfig();
+        // Jet prints too many logs while the member is idle
+        config.getJetConfig().setEnabled(false);
+        return config;
+    }
+
+}


### PR DESCRIPTION
We run `ConnectToAllClusterMembersTask` periodically to make sure
the client has a connection to all cluster members, in case
smart routing is enabled.

However, the task was missing a check, and was trying to connect
to the last known member list even though the client was disconnected
from the cluster.

This was problematic in the sense that, it was not respecting the
cluster connection retry configuration of the user. In scenarios
where the user configured backoffs during the reconnection attempts
are long, we were trying to connect back to the cluster every second
anyways.

There is no bullet-proof way to prevent the client from doing so in the
current design, but adding a simple check before each connection attempt
on the task will get rid of almost all such attempts.

The added test could also fail under some unlucky scenarios,
where the task submitted to reconnect the cluster would be delayed
more than 30 seconds. There are (ugly) ways to make this test
reliable by mocking the `WaitStrategy` class but I believe 30 second
wait time would be sufficient for the reconnect task to be
executed. If this test fails in the future, we would choose
the ugly way :)

closes https://github.com/hazelcast/hazelcast/issues/21565