### PR TITLE
JavaDoc more precise about the need of defensive copy or (flat)mapStateful

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -132,6 +132,10 @@ public interface GeneralStage<T> extends Stage {
      * the object's state. The state object will be included in the state
      * snapshot, so it survives job restarts. For this reason it must be
      * serializable.
+     * If you want to return the state variable from {@code mapFn},
+     * then the return value must be a copy of state variable to avoid
+     * situations in which the result of {@code mapFn} is modified by other processor
+     * after being emitted.
      * <p>
      * This sample takes a stream of {@code long} numbers representing request
      * latencies, computes the cumulative latency of all requests so far, and
@@ -205,6 +209,10 @@ public interface GeneralStage<T> extends Stage {
      * the object's state. The state object will be included in the state
      * snapshot, so it survives job restarts. For this reason it must be
      * serializable.
+     * If you want to return the state variable from {@code flatMapFn},
+     * then the return value must be a copy of state variable to avoid
+     * situations in which the result of {@code mapFn} is modified by other processor
+     * after being emitted.
      * <p>
      * This sample inserts a punctuation mark (a special string) after every
      * 10th input string:

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -134,8 +134,8 @@ public interface GeneralStage<T> extends Stage {
      * serializable.
      * If you want to return the state variable from {@code mapFn},
      * then the return value must be a copy of state variable to avoid
-     * situations in which the result of {@code mapFn} is modified by other processor
-     * after being emitted.
+     * situations in which the result of {@code mapFn} is modified
+     * after being emitted or where the state is modified by downstream processors.
      * <p>
      * This sample takes a stream of {@code long} numbers representing request
      * latencies, computes the cumulative latency of all requests so far, and
@@ -209,10 +209,10 @@ public interface GeneralStage<T> extends Stage {
      * the object's state. The state object will be included in the state
      * snapshot, so it survives job restarts. For this reason it must be
      * serializable.
-     * If you want to return the state variable from {@code flatMapFn},
+     * If you want to return the state variable from {@code mapFn},
      * then the return value must be a copy of state variable to avoid
-     * situations in which the result of {@code mapFn} is modified by other processor
-     * after being emitted.
+     * situations in which the result of {@code mapFn} is modified
+     * after being emitted or where the state is modified by downstream processors.
      * <p>
      * This sample inserts a punctuation mark (a special string) after every
      * 10th input string:

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -157,7 +157,7 @@ public interface GeneralStageWithKey<T, K> {
      * separate state object. The state object will be included in the state
      * snapshot, so it survives job restarts. For this reason it must be
      * serializable.
-     * If you want to return the state variable from {@code mapFn},
+     * If you want to return the state variable from {@code flatMapStateful},
      * then the return value must be a copy of state variable to avoid
      * situations in which the result of {@code mapFn} is modified
      * after being emitted or where the state is modified by downstream processors.

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -68,6 +68,10 @@ public interface GeneralStageWithKey<T, K> {
      * can update the object's state. For each grouping key there's a separate
      * state object. The state object will be included in the state snapshot,
      * so it survives job restarts. For this reason it must be serializable.
+     * If you want to return the state variable from {@code mapFn},
+     * then the return value must be a copy of state variable to avoid
+     * situations in which the result of {@code mapFn} is modified
+     * after being emitted or where the state is modified by downstream processors.
      * <p>
      * This sample takes a stream of pairs {@code (serverId, latency)}
      * representing the latencies of serving individual requests and outputs
@@ -153,6 +157,10 @@ public interface GeneralStageWithKey<T, K> {
      * separate state object. The state object will be included in the state
      * snapshot, so it survives job restarts. For this reason it must be
      * serializable.
+     * If you want to return the state variable from {@code mapFn},
+     * then the return value must be a copy of state variable to avoid
+     * situations in which the result of {@code mapFn} is modified
+     * after being emitted or where the state is modified by downstream processors.
      * <p>
      * This sample groups a stream of strings by length and inserts punctuation
      * (a special string) after every 10th string in each group:


### PR DESCRIPTION
Small JavaDoc improvements to state clearly, that the result of (flat)mapStateful must be copied to avoid problems when other processor will change the state value and not-copied result from mapFn will be changed after being emitted.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
