### PR TITLE
[API-1427] Fix race in the TestHazelcastFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig;
@@ -67,7 +68,7 @@ import static com.hazelcast.internal.util.SetUtil.createHashSet;
 public final class HazelcastClient {
 
     private static final AtomicInteger CLIENT_ID_GEN = new AtomicInteger();
-    private static final ConcurrentHashMap<String, InstanceFuture<HazelcastClientProxy>> CLIENTS = new ConcurrentHashMap<>(5);
+    private static final ConcurrentMap<String, InstanceFuture<HazelcastClientProxy>> CLIENTS = new ConcurrentHashMap<>(5);
 
     static {
         OutOfMemoryErrorDispatcher.setClientHandler(new ClientOutOfMemoryHandler());

--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig;
@@ -68,7 +67,7 @@ import static com.hazelcast.internal.util.SetUtil.createHashSet;
 public final class HazelcastClient {
 
     private static final AtomicInteger CLIENT_ID_GEN = new AtomicInteger();
-    private static final ConcurrentMap<String, InstanceFuture<HazelcastClientProxy>> CLIENTS = new ConcurrentHashMap<>(5);
+    private static final ConcurrentHashMap<String, InstanceFuture<HazelcastClientProxy>> CLIENTS = new ConcurrentHashMap<>(5);
 
     static {
         OutOfMemoryErrorDispatcher.setClientHandler(new ClientOutOfMemoryHandler());
@@ -116,7 +115,7 @@ public final class HazelcastClient {
      * @see #getHazelcastClientByName(String) (String)
      */
     public static HazelcastInstance newHazelcastClient() {
-        return newHazelcastClientInternal(null, resolveClientConfig(null), null);
+        return newHazelcastClientInternal(resolveClientConfig(null), null, null, null);
     }
 
     /**
@@ -133,7 +132,7 @@ public final class HazelcastClient {
      * @see #getHazelcastClientByName(String) (String)
      */
     public static HazelcastInstance newHazelcastClient(ClientConfig config) {
-        return newHazelcastClientInternal(null, resolveClientConfig(config), null);
+        return newHazelcastClientInternal(resolveClientConfig(config), null, null, null);
     }
 
     /**
@@ -158,7 +157,7 @@ public final class HazelcastClient {
      * @throws InvalidConfigurationException if the loaded failover configuration is not valid
      */
     public static HazelcastInstance newHazelcastFailoverClient() {
-        return newHazelcastClientInternal(null, null, resolveClientFailoverConfig());
+        return newHazelcastClientInternal(null, resolveClientFailoverConfig(), null, null);
     }
 
     /**
@@ -185,7 +184,7 @@ public final class HazelcastClient {
      * @throws InvalidConfigurationException if the provided or the loaded failover configuration is not valid
      */
     public static HazelcastInstance newHazelcastFailoverClient(ClientFailoverConfig clientFailoverConfig) {
-        return newHazelcastClientInternal(null, null, resolveClientFailoverConfig(clientFailoverConfig));
+        return newHazelcastClientInternal(null, resolveClientFailoverConfig(clientFailoverConfig), null, null);
     }
 
     /**
@@ -402,10 +401,14 @@ public final class HazelcastClient {
         OutOfMemoryErrorDispatcher.setClientHandler(outOfMemoryHandler);
     }
 
-    static HazelcastInstance newHazelcastClientInternal(AddressProvider addressProvider, ClientConfig clientConfig,
-                                                        ClientFailoverConfig failoverConfig) {
-        checkConfigs(clientConfig, failoverConfig);
-        String instanceName = getInstanceName(clientConfig, failoverConfig);
+    static HazelcastInstance newHazelcastClientInternal(
+            ClientConfig config,
+            ClientFailoverConfig failoverConfig,
+            ClientConnectionManagerFactory connectionManagerFactory,
+            AddressProvider addressProvider
+    ) {
+        checkConfigs(config, failoverConfig);
+        String instanceName = getInstanceName(config, failoverConfig);
 
         InstanceFuture<HazelcastClientProxy> future = new InstanceFuture<>();
         if (CLIENTS.putIfAbsent(instanceName, future) != null) {
@@ -413,7 +416,8 @@ public final class HazelcastClient {
         }
 
         try {
-            return constructHazelcastClient(addressProvider, clientConfig, failoverConfig, instanceName, future);
+            return constructHazelcastClient(instanceName, config, failoverConfig,
+                    connectionManagerFactory, addressProvider, future);
         } catch (Throwable t) {
             CLIENTS.remove(instanceName, future);
             future.setFailure(t);
@@ -439,7 +443,7 @@ public final class HazelcastClient {
         }
 
         try {
-            return constructHazelcastClient(null, config, null, instanceName, future);
+            return constructHazelcastClient(instanceName, config, null, null, null, future);
         } catch (Throwable t) {
             CLIENTS.remove(instanceName, future);
             future.setFailure(t);
@@ -447,38 +451,43 @@ public final class HazelcastClient {
         }
     }
 
-    private static HazelcastInstance constructHazelcastClient(AddressProvider addressProvider, ClientConfig clientConfig,
-                                                              ClientFailoverConfig failoverConfig, String instanceName,
-                                                              InstanceFuture<HazelcastClientProxy> future) {
+    private static HazelcastInstance constructHazelcastClient(
+            String instanceName,
+            ClientConfig config,
+            ClientFailoverConfig failoverConfig,
+            ClientConnectionManagerFactory connectionManagerFactory,
+            AddressProvider addressProvider,
+            InstanceFuture<HazelcastClientProxy> future
+    ) {
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         HazelcastClientProxy proxy;
         try {
             Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
-            ClientConnectionManagerFactory factory = new DefaultClientConnectionManagerFactory();
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(instanceName, clientConfig,
-                    failoverConfig, factory, addressProvider);
+            if (connectionManagerFactory == null) {
+                connectionManagerFactory = new DefaultClientConnectionManagerFactory();
+            }
+            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(instanceName, config,
+                    failoverConfig, connectionManagerFactory, addressProvider);
             client.start();
             OutOfMemoryErrorDispatcher.registerClient(client);
             proxy = new HazelcastClientProxy(client);
             future.set(proxy);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
         }
         return proxy;
     }
 
-    private static void checkConfigs(ClientConfig clientConfig, ClientFailoverConfig clientFailoverConfig) {
-        assert clientConfig != null || clientFailoverConfig != null : "At most one type of config can be provided";
-        assert clientConfig == null || clientFailoverConfig == null : "At least one config should be provided ";
+    private static void checkConfigs(ClientConfig config, ClientFailoverConfig failoverConfig) {
+        assert config != null || failoverConfig != null : "At most one type of config can be provided";
+        assert config == null || failoverConfig == null : "At least one config should be provided ";
     }
 
-    static String getInstanceName(ClientConfig clientConfig, ClientFailoverConfig failoverConfig) {
+    private static String getInstanceName(ClientConfig config, ClientFailoverConfig failoverConfig) {
         int instanceNum = CLIENT_ID_GEN.incrementAndGet();
         String instanceName;
-        if (clientConfig != null) {
-            instanceName = clientConfig.getInstanceName();
+        if (config != null) {
+            instanceName = config.getInstanceName();
         } else {
             instanceName = failoverConfig.getClientConfigs().get(0).getInstanceName();
         }
@@ -486,9 +495,5 @@ public final class HazelcastClient {
             instanceName = "hz.client_" + instanceNum;
         }
         return instanceName;
-    }
-
-    static ConcurrentMap<String, InstanceFuture<HazelcastClientProxy>> getClients() {
-        return CLIENTS;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -246,7 +246,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         };
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(addressProvider, clientConfig);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, addressProvider);
 
 
         HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();

--- a/hazelcast/src/test/java/com/hazelcast/client/ClusterNameTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClusterNameTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -31,12 +32,11 @@ import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ClusterNameTest {
+public class ClusterNameTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
@@ -50,7 +50,7 @@ public class ClusterNameTest {
         hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        String name = "aClient";
+        String name = randomString();
         clientConfig.setInstanceName(name);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
@@ -62,7 +62,7 @@ public class ClusterNameTest {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        String name = "aClient";
+        String name = randomString();
         clientConfig.setInstanceName(name);
         hazelcastFactory.newHazelcastClient(clientConfig);
 
@@ -91,7 +91,7 @@ public class ClusterNameTest {
         });
 
         ClientConfig clientConfig = new ClientConfig();
-        String name = "aClient";
+        String name = randomString();
         clientConfig.setInstanceName(name);
         hazelcastFactory.newHazelcastClient(clientConfig);
 
@@ -119,7 +119,7 @@ public class ClusterNameTest {
         });
 
         ClientConfig clientConfig = new ClientConfig();
-        String name = "aClient";
+        String name = randomString();
         clientConfig.setInstanceName(name);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         client.shutdown();

--- a/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
@@ -17,28 +17,23 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.connection.AddressProvider;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 
 public class HazelcastClientUtil {
 
-    public static HazelcastInstance newHazelcastClient(AddressProvider addressProvider, ClientConfig clientConfig) {
-        return HazelcastClient.newHazelcastClientInternal(addressProvider, clientConfig, null);
+    public static HazelcastInstance newHazelcastClient(ClientConfig config, AddressProvider addressProvider) {
+        return HazelcastClient.newHazelcastClientInternal(config, null, null, addressProvider);
     }
 
-    public static String getInstanceName(ClientConfig config) {
-        return HazelcastClient.getInstanceName(config, null);
-    }
-
-    public static void registerProxyFuture(String instanceName,
-                                           HazelcastInstanceFactory.InstanceFuture future) {
-        HazelcastClient.getClients().put(instanceName, future);
-    }
-
-    public static boolean hasRegisteredClientWithName(String instanceName) {
-        return HazelcastClient.getClients().containsKey(instanceName);
+    public static HazelcastInstance newHazelcastClient(
+            ClientConfig config,
+            ClientConnectionManagerFactory connectionManagerFactory,
+            AddressProvider addressProvider
+    ) {
+        return HazelcastClient.newHazelcastClientInternal(config, null, connectionManagerFactory, addressProvider);
     }
 
     public static ClientMessage.Frame fastForwardToEndFrame(ClientMessage.ForwardFrameIterator iterator) {

--- a/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -110,6 +110,6 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
                     clientInstanceImpl != registeredClient);
         }
 
-        assertFalse(HazelcastClientUtil.hasRegisteredClientWithName(instanceName));
+        assertNull(HazelcastClient.getHazelcastClientByName(instanceName));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManagerTranslateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManagerTranslateTest.java
@@ -76,7 +76,7 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
         // given
         ClientConfig config = new ClientConfig();
         config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(1000);
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(new TestAddressProvider(true), config);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(config, new TestAddressProvider(true));
         TcpClientConnectionManager clientConnectionManager =
                 new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
 
@@ -91,7 +91,7 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
     public void testTranslateIsNotUsedOnGettingExistingConnection() {
         // given
         TestAddressProvider provider = new TestAddressProvider(false);
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(provider, new ClientConfig());
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(new ClientConfig(), provider);
         TcpClientConnectionManager clientConnectionManager =
                 new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
 
@@ -114,7 +114,7 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.getName(), "true");
 
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(null, clientConfig);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, null);
         TcpClientConnectionManager clientConnectionManager =
                 new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
         clientConnectionManager.start();
@@ -138,7 +138,7 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.getName(), "false");
 
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(null, clientConfig);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, null);
         TcpClientConnectionManager clientConnectionManager =
                 new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
         clientConnectionManager.start();
@@ -162,7 +162,7 @@ public class TcpClientConnectionManagerTranslateTest extends ClientTestSupport {
         clientConfig.setProperty(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED.getName(), "true");
 
         TestAddressProvider provider = new TestAddressProvider(false);
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(provider, clientConfig);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, provider);
         TcpClientConnectionManager clientConnectionManager =
                 new TcpClientConnectionManager(getHazelcastClientInstanceImpl(client));
         clientConnectionManager.start();

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.config.impl.ClientAliasedDiscoveryConfigUtils;
+import com.hazelcast.client.impl.clientside.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.impl.connection.AddressProvider;
@@ -30,10 +31,7 @@ import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.DiscoveryStrategyConfig;
-import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.impl.HazelcastInstanceFactory;
-import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.TestEnvironment;
@@ -44,7 +42,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.client.HazelcastClientUtil.getInstanceName;
 
 public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
@@ -85,32 +82,13 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
             config = new XmlClientConfigBuilder().build();
         }
 
-        Thread currentThread = Thread.currentThread();
-        ClassLoader tccl = currentThread.getContextClassLoader();
-        try {
-            if (tccl == ClassLoader.getSystemClassLoader()) {
-                currentThread.setContextClassLoader(HazelcastClient.class.getClassLoader());
-            }
-            String instanceName = getInstanceName(config);
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(instanceName, config,
-                    null, clientRegistry.createClientServiceFactory(sourceIp), createAddressProvider(config));
-            registerJvmNameAndPidMetric(client);
-            client.start();
-            if (clients.putIfAbsent(client.getName(), client) != null) {
-                throw new InvalidConfigurationException("HazelcastClientInstance with name '" + client.getName()
-                        + "' already exists!");
-            }
-
-            HazelcastInstanceFactory.InstanceFuture future = new HazelcastInstanceFactory.InstanceFuture<>();
-            HazelcastClientUtil.registerProxyFuture(instanceName, future);
-
-            OutOfMemoryErrorDispatcher.registerClient(client);
-            HazelcastClientProxy proxy = new HazelcastClientProxy(client);
-            future.set(proxy);
-            return proxy;
-        } finally {
-            currentThread.setContextClassLoader(tccl);
-        }
+        ClientConnectionManagerFactory connectionManagerFactory = clientRegistry.createClientServiceFactory(sourceIp);
+        AddressProvider addressProvider = createAddressProvider(config);
+        HazelcastInstance proxy = HazelcastClientUtil.newHazelcastClient(config, connectionManagerFactory, addressProvider);
+        HazelcastClientInstanceImpl client = ((HazelcastClientProxy) proxy).client;
+        registerJvmNameAndPidMetric(client);
+        clients.put(client.getName(), client);
+        return proxy;
     }
 
     private void registerJvmNameAndPidMetric(HazelcastClientInstanceImpl client) {


### PR DESCRIPTION
Formerly, we were creating the client instance and after that
registering an instance future for it to the static `CLIENTS` map.

This is fine for the happy path, both under some scenarios, this
implementation is open to dangling client references in the
aforementioned map.

For example, the call to the `client.start()` can return successfully,
but just before we add an instance future to the `CLIENTS` map,
the client might be shutdown by an external thread. That shutdown
process tries to remove the instance future associated with
that client from that map, in
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java#L367

If the code that adds that future to that map runs after
the code that removes it, we would end up with a dangling
reference to a shutdown client.

To solve this problem, I have refactored
`TestHazelcastFactory#newHazelcastClient` to use the code we already
have, that deals with the lifecycle of the client and the instance
future correctly. This is also good for getting rid of the duplication
in that method.

This was the reason behind the recent failures of https://github.com/hazelcast/hazelcast/issues/15739.

Closes https://github.com/hazelcast/hazelcast/issues/15739