### PR TITLE
Priority-based leadership rebalancing for CP subsystem [HZ-1062]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
@@ -280,6 +280,12 @@ public class CPSubsystemConfig {
     private int dataLoadTimeoutSeconds = DEFAULT_DATA_LOAD_TIMEOUT_SECONDS;
 
     /**
+     * The CP member priority. The Raft leader's role eventually will be transferred to members with
+     * higher priorities within the CP group.
+     */
+    private int cpMemberPriority;
+
+    /**
      * Contains configuration options for Hazelcast's Raft consensus algorithm
      * implementation.
      */
@@ -311,6 +317,7 @@ public class CPSubsystemConfig {
         this.persistenceEnabled = config.persistenceEnabled;
         this.baseDir = config.baseDir;
         this.dataLoadTimeoutSeconds = config.dataLoadTimeoutSeconds;
+        this.cpMemberPriority = config.cpMemberPriority;
         for (SemaphoreConfig semaphoreConfig : config.semaphoreConfigs.values()) {
             this.semaphoreConfigs.put(semaphoreConfig.getName(), new SemaphoreConfig(semaphoreConfig));
         }
@@ -540,6 +547,27 @@ public class CPSubsystemConfig {
     }
 
     /**
+     * Sets the CP member priority. CP groups' leadership will be transferred to members with
+     * higher priorities within the CP group.
+     *
+     * @param cpMemberPriority can be any integer number
+     * @return this config instance
+     */
+    public CPSubsystemConfig setCPMemberPriority(int cpMemberPriority) {
+        this.cpMemberPriority = cpMemberPriority;
+        return this;
+    }
+
+    /**
+     * Returns the CP member priority.
+     *
+     * @return the CP member priority
+     */
+    public int getCPMemberPriority() {
+        return cpMemberPriority;
+    }
+
+    /**
      * Returns configuration options for Hazelcast's Raft consensus algorithm
      * implementation
      *
@@ -673,8 +701,9 @@ public class CPSubsystemConfig {
         return "CPSubsystemConfig{" + "cpMemberCount=" + cpMemberCount + ", groupSize=" + groupSize
                 + ", sessionTimeToLiveSeconds=" + sessionTimeToLiveSeconds + ", sessionHeartbeatIntervalSeconds="
                 + sessionHeartbeatIntervalSeconds + ", missingCPMemberAutoRemovalSeconds=" + missingCPMemberAutoRemovalSeconds
-                + ", failOnIndeterminateOperationState=" + failOnIndeterminateOperationState + ", raftAlgorithmConfig="
-                + raftAlgorithmConfig + ", semaphoreConfigs=" + semaphoreConfigs + ", lockConfigs=" + lockConfigs + '}';
+                + ", failOnIndeterminateOperationState=" + failOnIndeterminateOperationState
+                + ", cpMemberPriority=" + cpMemberPriority + ", raftAlgorithmConfig=" + raftAlgorithmConfig
+                + ", semaphoreConfigs=" + semaphoreConfigs + ", lockConfigs=" + lockConfigs + '}';
     }
 
     @Override
@@ -693,6 +722,7 @@ public class CPSubsystemConfig {
                 && missingCPMemberAutoRemovalSeconds == that.missingCPMemberAutoRemovalSeconds
                 && failOnIndeterminateOperationState == that.failOnIndeterminateOperationState
                 && persistenceEnabled == that.persistenceEnabled && dataLoadTimeoutSeconds == that.dataLoadTimeoutSeconds
+                && cpMemberPriority == that.cpMemberPriority
                 && Objects.equals(baseDir, that.baseDir)
                 && Objects.equals(raftAlgorithmConfig, that.raftAlgorithmConfig)
                 && Objects.equals(semaphoreConfigs, that.semaphoreConfigs)
@@ -703,7 +733,7 @@ public class CPSubsystemConfig {
     @Override
     public int hashCode() {
         return Objects.hash(cpMemberCount, groupSize, sessionTimeToLiveSeconds, sessionHeartbeatIntervalSeconds,
-                missingCPMemberAutoRemovalSeconds, failOnIndeterminateOperationState, persistenceEnabled, baseDir,
-                dataLoadTimeoutSeconds, raftAlgorithmConfig, semaphoreConfigs, lockConfigs, configPatternMatcher);
+                missingCPMemberAutoRemovalSeconds, failOnIndeterminateOperationState, persistenceEnabled, cpMemberPriority,
+                baseDir, dataLoadTimeoutSeconds, raftAlgorithmConfig, semaphoreConfigs, lockConfigs, configPatternMatcher);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -53,18 +53,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.hazelcast.cp.internal.RaftService.CP_SUBSYSTEM_MANAGEMENT_EXECUTOR;
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LEADER_LOCAL;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Realizes pending Raft group membership changes and periodically checks
@@ -461,25 +469,137 @@ class RaftGroupMembershipManager {
         }
 
         private void rebalanceLeaderships() {
-            Map<RaftEndpoint, CPMember> members = getMembers();
+            Collection<CPMember> allMembers = getMembers().values();
+            Map<CPMember, Entry<Integer, Collection<CPGroupId>>> leadershipPriorityMap
+                    = getLeadershipPriorityMap(allMembers);
+
             Collection<CPGroupId> groupIds = getCpGroupIds();
+            List<CPGroupSummary> cpGroupSummaries
+                    = groupIds.stream()
+                    .map(this::getCpGroup)
+                    .collect(Collectors.toList());
 
-            final int avgGroupsPerMember = groupIds.size() / members.size();
-            final boolean overAvgAllowed = groupIds.size() % members.size() != 0;
+            // Transferring leaderships from the lowest priority CP members
+            Set<CPMember> priorityCPMembers
+                    = rebalanceLeadershipsByPriority(leadershipPriorityMap, cpGroupSummaries);
 
-            Collection<CPGroupSummary> allGroups = new ArrayList<>(groupIds.size());
-            for (CPGroupId groupId : groupIds) {
-                CPGroupSummary group = getCpGroup(groupId);
-                allGroups.add(group);
+            // If there are several CP members with the same priority level, we should rebalance leadership evenly among them
+            if (priorityCPMembers.size() > 1) {
+                rebalanceLeadershipsEvenly(priorityCPMembers, cpGroupSummaries, allMembers);
+            }
+        }
+
+        private Map<CPMember, Map.Entry<Integer, Collection<CPGroupId>>> getLeadershipPriorityMap(Collection<CPMember> members) {
+            Map<CPMember, Map.Entry<Integer, Collection<CPGroupId>>> leadershipsWithPriorities = new HashMap<>();
+            OperationService operationService = nodeEngine.getOperationService();
+            StringBuilder s = new StringBuilder("Current leadership claims:");
+            for (CPMember member : members) {
+                try {
+                    Map.Entry<Integer, Collection<CPGroupId>> entry =
+                            operationService.<Map.Entry<Integer, Collection<CPGroupId>>>invokeOnTarget(
+                                    RaftService.SERVICE_NAME, new GetLeadedGroupsOp(), member.getAddress())
+                                    .join();
+                        leadershipsWithPriorities.put(member, entry);
+                        int priority = entry.getKey();
+                        Collection<CPGroupId> groups = entry.getValue();
+                        if (logger.isFineEnabled()) {
+                            logger.fine(member + " claims it's leader of " + groups.size() + " groups: " + groups);
+                        }
+                        s.append('\n').append('\t').append(member).append(" priority ").append(priority)
+                                .append(" has ").append(groups.size()).append(",");
+                } catch (Exception e) {
+                    logger.info("Skipped " + member + " for leadership rebalancing due to " + e);
+                }
+            }
+            s.append(" leaderships.");
+            logger.info(s.toString());
+            return leadershipsWithPriorities;
+        }
+
+        private Set<CPMember> rebalanceLeadershipsByPriority(
+                Map<CPMember, Entry<Integer, Collection<CPGroupId>>> leadershipPriorityMap,
+                List<CPGroupSummary> cpGroupSummaries) {
+
+            // CP member(s) in each CP group with the highest priority
+            Map<CPGroupId, List<CPMember>> priorityMembersInAGroup = new HashMap<>();
+            // Priorities eligible for leadership - is a set of the highest priorities taken from each CP group
+            Set<Integer> maxPriorities = new HashSet<>();
+            for (CPGroupSummary cpGroupSummary : cpGroupSummaries) {
+                Collection<CPMember> groupMembers = cpGroupSummary.members();
+                Entry<Integer, List<CPMember>> priorityMembersInAGroupEntry
+                        = getPriorityMembersInAGroup(leadershipPriorityMap, groupMembers);
+                int priority = priorityMembersInAGroupEntry.getKey();
+                List<CPMember> priorityMembers = priorityMembersInAGroupEntry.getValue();
+                maxPriorities.add(priority);
+                priorityMembersInAGroup.put(cpGroupSummary.id(), priorityMembers);
             }
 
-            logger.fine("Searching for leadership imbalance in " + groupIds.size() + " CPGroups, "
+            Map<Boolean, Set<CPMember>> partitionedMembersByPriority = leadershipPriorityMap.entrySet().stream()
+                    .collect(
+                            partitioningBy(
+                                    e -> maxPriorities.contains(e.getValue().getKey()),
+                                    mapping(Entry::getKey, toSet())
+                            ));
+            // CP members with the lowest priorities from which leadership should be transferred
+            Set<CPMember> fromCPMembers = partitionedMembersByPriority.get(false);
+            // CP members having maxPriorities levels. Leadership from these members shouldn't be transferred
+            Set<CPMember> allPriorityMembers = partitionedMembersByPriority.get(true);
+
+            int roundRobinCounter = 0;
+            for (CPMember fromCPMember : fromCPMembers) {
+                Collection<CPGroupId> leadedGroups = leadershipPriorityMap.get(fromCPMember).getValue();
+
+                for (CPGroupId cpGroupId : leadedGroups) {
+                    List<CPMember> priorityMembers = priorityMembersInAGroup.get(cpGroupId);
+                    int roundRobinNumber = (roundRobinCounter++) % priorityMembers.size();
+                    CPMember toCPMember = priorityMembers.get(roundRobinNumber);
+                    logger.info("Transferring leadership for " + cpGroupId.getName() + " group:"
+                            + " from " + fromCPMember + " with priority " + leadershipPriorityMap.get(fromCPMember).getKey()
+                            + " to " + toCPMember + " with priority " + leadershipPriorityMap.get(toCPMember).getKey());
+
+                    if (!transferLeadership(fromCPMember, toCPMember, cpGroupId)) {
+                        // could not transfer leadership
+                        // try next time
+                        return Collections.EMPTY_SET;
+                    }
+                }
+            }
+            return allPriorityMembers;
+        }
+
+        private Entry<Integer, List<CPMember>> getPriorityMembersInAGroup(
+                Map<CPMember, Entry<Integer, Collection<CPGroupId>>> leadershipPriorityMap,
+                Collection<CPMember> cpGroupMembers) {
+            return cpGroupMembers.stream()
+                    .flatMap(m -> leadershipPriorityMap.containsKey(m)
+                            ? Stream.of(BiTuple.of(leadershipPriorityMap.get(m).getKey(), m))
+                            : Stream.empty())
+                    .collect(groupingBy(
+                            BiTuple::element1,
+                            TreeMap::new,
+                            mapping(BiTuple::element2, toList())))
+                    .lastEntry();
+        }
+
+        private void rebalanceLeadershipsEvenly(Set<CPMember> priorityMembers,
+                                                Collection<CPGroupSummary> cpGroupSummaries,
+                                                Collection<CPMember> allMembers) {
+            final int avgGroupsPerMember = cpGroupSummaries.size() / priorityMembers.size();
+            final boolean overAvgAllowed = cpGroupSummaries.size() % priorityMembers.size() != 0;
+
+            logger.fine("Searching for leadership imbalance in " + cpGroupSummaries.size() + " CPGroups, "
                     + "average groups per member is " + avgGroupsPerMember);
 
-            Set<CPMember> handledMembers = new HashSet<>(members.size());
-            Map<CPMember, Collection<CPGroupId>> leaderships = getLeadershipsMap(members);
+            Set<CPMember> handledMembers = new HashSet<>(priorityMembers.size());
 
             for (; ;) {
+                Map<CPMember, Entry<Integer, Collection<CPGroupId>>> leadershipPriorityMap
+                        = getLeadershipPriorityMap(allMembers);
+                // Filtering CP members to evenly rebalance leadership among them
+                Map<CPMember, Collection<CPGroupId>>  leaderships = leadershipPriorityMap.entrySet().stream()
+                        .filter(e -> priorityMembers.contains(e.getKey()))
+                        .collect(Collectors.toMap(Entry::getKey, v -> v.getValue().getValue()));
+
                 BiTuple<CPMember, Integer> from = getEndpointWithMaxLeaderships(leaderships, avgGroupsPerMember, handledMembers);
                 if (from.element1 == null) {
                     // nothing to transfer
@@ -489,7 +609,8 @@ class RaftGroupMembershipManager {
 
                 logger.info("Searching a candidate transfer leadership from "
                         + from.element1 + " with " + from.element2 + " leaderships.");
-                Collection<CPGroupSummary> groups = getLeaderGroupsOf(from.element1, leaderships.get(from.element1), allGroups);
+                Collection<CPGroupSummary> groups
+                        = getLeaderGroupsOf(from.element1, leaderships.get(from.element1), cpGroupSummaries);
 
                 int maxLeaderships;
                 if (overAvgAllowed) {
@@ -519,28 +640,7 @@ class RaftGroupMembershipManager {
                     // try next time
                     return;
                 }
-                leaderships = getLeadershipsMap(members);
             }
-        }
-
-        private Map<CPMember, Collection<CPGroupId>> getLeadershipsMap(Map<RaftEndpoint, CPMember> members) {
-            Map<CPMember, Collection<CPGroupId>> leaderships = new HashMap<>();
-            OperationService operationService = nodeEngine.getOperationService();
-            StringBuilder s = new StringBuilder("Current leadership claims:");
-            for (CPMember member : members.values()) {
-                Collection<CPGroupId> groups =
-                        operationService.<Collection<CPGroupId>>invokeOnTarget(null, new GetLeadedGroupsOp(),
-                                member.getAddress()).join();
-                leaderships.put(member, groups);
-                if (logger.isFineEnabled()) {
-                    logger.fine(member + " claims it's leader of " + groups.size() + " groups: " + groups);
-                }
-                s.append('\n').append('\t').append(member).append(" has ").append(groups.size()).append(",");
-            }
-            s.setLength(s.length() - 1);
-            s.append(" leaderships.");
-            logger.info(s.toString());
-            return leaderships;
         }
 
         private Collection<CPGroupSummary> getLeaderGroupsOf(CPMember member, Collection<CPGroupId> leaderships,
@@ -570,7 +670,10 @@ class RaftGroupMembershipManager {
             for (CPGroupSummary group : groups) {
                 for (CPMember member : group.members()) {
                     Collection<CPGroupId> g = leaderships.get(member);
-                    int k = g != null ? g.size() : 0;
+                    if (g == null) {
+                        continue;
+                    }
+                    int k = g.size();
                     if (k < min) {
                         min = k;
                         to = member;
@@ -629,7 +732,6 @@ class RaftGroupMembershipManager {
         private Collection<CPGroupId> getCpGroupIds() {
             InternalCompletableFuture<Collection<CPGroupId>> future = queryMetadata(new GetActiveRaftGroupIdsOp());
             Collection<CPGroupId> groupIds = future.join();
-            groupIds.remove(raftService.getMetadataGroupId());
             return groupIds;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -190,6 +190,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
     private final boolean cpSubsystemEnabled;
     private final UnsafeModePartitionState[] unsafeModeStates;
     private final Map<CPGroupAvailabilityEventKey, Long> recentAvailabilityEvents = new ConcurrentHashMap<>();
+    private int cpMemberPriority;
 
     public RaftService(NodeEngine nodeEngine) {
         this.nodeEngine = (NodeEngineImpl) nodeEngine;
@@ -200,6 +201,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
         this.cpSubsystemEnabled = config.getCPMemberCount() > 0;
         this.invocationManager = new RaftInvocationManager(nodeEngine, this);
         this.metadataGroupManager = new MetadataRaftGroupManager(this.nodeEngine, this, config);
+        this.cpMemberPriority = config.getCPMemberPriority();
 
         if (cpSubsystemEnabled) {
             this.unsafeModeStates = null;
@@ -1212,10 +1214,6 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
         Collection<CPGroupId> groupIds = new ArrayList<>();
         RaftEndpoint localEndpoint = getLocalCPEndpoint();
         for (RaftNode raftNode : nodes.values()) {
-            if (CPGroup.METADATA_CP_GROUP_NAME.equals(raftNode.getGroupId().getName())) {
-                // Ignore metadata group
-                continue;
-            }
             RaftEndpoint leader = raftNode.getLeader();
             if (leader != null && leader.equals(localEndpoint)) {
                 groupIds.add(raftNode.getGroupId());
@@ -1434,6 +1432,10 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
             return;
         }
         throw new IllegalArgumentException("Unhandled event: " + e);
+    }
+
+    public int getCPMemberPriority() {
+        return cpMemberPriority;
     }
 
     private class InitializeRaftNodeTask implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/GetLeadedGroupsOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/GetLeadedGroupsOp.java
@@ -26,15 +26,18 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 /**
- * Returns the CP groups that this local CP member is the Raft group leader.
+ * Returns member priority and the CP groups that this local CP member is the Raft group leader.
  */
 public class GetLeadedGroupsOp extends Operation implements RaftSystemOperation, IdentifiedDataSerializable {
 
-    private transient Collection<CPGroupId> groups = Collections.emptyList();
+    private transient Map.Entry<Integer, Collection<CPGroupId>> entry =
+        new AbstractMap.SimpleImmutableEntry<>(0, Collections.emptyList());
 
     public GetLeadedGroupsOp() {
     }
@@ -42,12 +45,14 @@ public class GetLeadedGroupsOp extends Operation implements RaftSystemOperation,
     @Override
     public void run() throws Exception {
         RaftService service = getService();
-        groups = service.getLeadedGroups();
+        Collection<CPGroupId> groups = service.getLeadedGroups();
+        int cpMemberPriority = service.getCPMemberPriority();
+        entry = new AbstractMap.SimpleImmutableEntry<>(cpMemberPriority, groups);
     }
 
     @Override
     public Object getResponse() {
-        return groups;
+        return entry;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPGroupRebalanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPGroupRebalanceTest.java
@@ -18,9 +18,12 @@ package com.hazelcast.cp.internal;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.CPGroup;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPMember;
+import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.internal.operation.GetLeadedGroupsOp;
+import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -30,14 +33,18 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.hazelcast.cp.internal.RaftGroupMembershipManager.LEADERSHIP_BALANCE_TASK_PERIOD;
 import static com.hazelcast.test.Accessors.getOperationService;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -51,10 +58,10 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
     }
 
     @Test
-    public void test() throws Exception {
+    public void testDefaultRebalancing() throws Exception {
         int groupSize = 5;
         int leadershipsPerMember = 10;
-        int groupCount = groupSize * leadershipsPerMember;
+        int groupCount = groupSize * leadershipsPerMember - 1;
 
         HazelcastInstance[] instances = newInstances(groupSize, groupSize, 0);
         waitUntilCPDiscoveryCompleted(instances);
@@ -78,7 +85,7 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
                 waitAllForLeaderElection(instances, groupId);
             }
 
-            rebalanceLeaderships(metadataLeader);
+            rebalanceLeadership(instances);
 
             Map<CPMember, Collection<CPGroupId>> leadershipsMap = getLeadershipsMap(metadataLeader, cpMembers);
             for (Entry<CPMember, Collection<CPGroupId>> entry : leadershipsMap.entrySet()) {
@@ -88,7 +95,315 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
         });
     }
 
-    private void rebalanceLeaderships(HazelcastInstance metadataLeader) {
+    @Test
+    public void testRebalancingWhenGroupSizeLessThenCPMembers() {
+        int groupCount = 10;
+
+        Config config = createConfig(5, 3);
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(-1);
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance5 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3, instance4, instance5};
+        waitUntilCPDiscoveryCompleted(instances);
+        List<HazelcastInstance> cpMemberList = Arrays.asList(
+                instance1,
+                instance2,
+                instance3
+        );
+
+        RaftInvocationManager invocationManager = getRaftInvocationManager(instance1);
+
+        Collection<CPGroupId> groupIds = new ArrayList<>();
+        RaftGroupId metadataGroupId = getMetadataGroupId(instance1);
+        groupIds.add(metadataGroupId);
+        for (int i = 0; i < groupCount; i++) {
+            RaftGroupId groupId = invocationManager.createRaftGroup("group-" + i).joinInternal();
+            groupIds.add(groupId);
+            HazelcastInstance leaderInstance = getLeaderInstance(instances, groupId);
+            assertTrueEventually(() -> assertNotNull(leaderInstance));
+        }
+
+        assertTrueEventually(() -> {
+            rebalanceLeadership(instances);
+
+            for (CPGroupId groupId : groupIds) {
+                HazelcastInstance leaderInstance = getLeaderInstance(instances, groupId);
+                assertContains(cpMemberList, leaderInstance);
+            }
+        });
+    }
+
+    @Test
+    public void testRebalancingWithOneNonPriorityMember() throws Exception {
+        int groupSize = 5;
+        int leadershipsPerMember = 12;
+        int groupCount = (groupSize - 1) * leadershipsPerMember - 1;
+
+        Config config = createConfig(5, 5);
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(-1);
+        HazelcastInstance instance5 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3, instance4, instance5};
+        waitUntilCPDiscoveryCompleted(instances);
+
+        Collection<CPGroupId> groupIds = new ArrayList<>(groupCount);
+        RaftInvocationManager invocationManager = getRaftInvocationManager(instance1);
+        for (int i = 0; i < groupCount; i++) {
+            RaftGroupId groupId = invocationManager.createRaftGroup("group-" + i).joinInternal();
+            groupIds.add(groupId);
+        }
+
+        HazelcastInstance metadataLeader = getLeaderInstance(instances, getMetadataGroupId(instance1));
+        Collection<CPMember> cpMembers =
+                metadataLeader.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().toCompletableFuture().get();
+
+        // Assert eventually since during the test
+        // a long pause can cause leadership change unexpectedly.
+        assertTrueEventually(() -> {
+            // Wait for leader election all groups
+            for (CPGroupId groupId : groupIds) {
+                waitAllForLeaderElection(instances, groupId);
+            }
+
+            rebalanceLeadership(instances);
+
+            Map<CPMember, Collection<CPGroupId>> leadershipsMap = getLeadershipsMap(metadataLeader, cpMembers);
+            for (Entry<CPMember, Collection<CPGroupId>> entry : leadershipsMap.entrySet()) {
+                int count = entry.getValue().size();
+                if (entry.getKey().getUuid().equals(instance5.getLocalEndpoint().getUuid())) {
+                    assertEquals(leadershipsString(leadershipsMap), 0, count);
+                } else {
+                    assertEquals(leadershipsString(leadershipsMap), leadershipsPerMember, count);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testRebalancingWithTwoNonPriorityMembers() throws Exception {
+        int groupSize = 5;
+        int leadershipsPerMember = 15;
+        int groupCount = (groupSize - 2) * leadershipsPerMember - 1;
+
+        Config config = createConfig(5, 5);
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(-1);
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance5 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3, instance4, instance5};
+        waitUntilCPDiscoveryCompleted(instances);
+
+        Collection<CPGroupId> groupIds = new ArrayList<>(groupCount);
+        RaftInvocationManager invocationManager = getRaftInvocationManager(instance1);
+        for (int i = 0; i < groupCount; i++) {
+            RaftGroupId groupId = invocationManager.createRaftGroup("group-" + i).joinInternal();
+            groupIds.add(groupId);
+        }
+
+        HazelcastInstance metadataLeader = getLeaderInstance(instances, getMetadataGroupId(instance1));
+        Collection<CPMember> cpMembers =
+                metadataLeader.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().toCompletableFuture().get();
+
+        // Assert eventually since during the test
+        // a long pause can cause leadership change unexpectedly.
+        assertTrueEventually(() -> {
+            // Wait for leader election all groups
+            for (CPGroupId groupId : groupIds) {
+                waitAllForLeaderElection(instances, groupId);
+            }
+
+            rebalanceLeadership(instances);
+
+            Map<CPMember, Collection<CPGroupId>> leadershipsMap = getLeadershipsMap(metadataLeader, cpMembers);
+            for (Entry<CPMember, Collection<CPGroupId>> entry : leadershipsMap.entrySet()) {
+                int count = entry.getValue().size();
+                if (entry.getKey().getUuid().equals(instance4.getLocalEndpoint().getUuid())
+                        || entry.getKey().getUuid().equals(instance5.getLocalEndpoint().getUuid())) {
+                    assertEquals(leadershipsString(leadershipsMap), 0, count);
+                } else {
+                    assertEquals(leadershipsString(leadershipsMap), leadershipsPerMember, count);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testDefaultGroupTransferring() throws Exception {
+        Config config = createConfig(3, 3);
+
+        config.getCPSubsystemConfig().setCPMemberPriority(1);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(2);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(3);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3};
+        waitUntilCPDiscoveryCompleted(instances);
+
+        IAtomicLong atomicLong = instance1.getCPSubsystem().getAtomicLong("atomic-long");
+        assertEquals(1L, atomicLong.incrementAndGet());
+        CPGroup cpGroup = getRaftService(instance1).getCPGroup(CPGroup.DEFAULT_GROUP_NAME).get();
+        waitAllForLeaderElection(instances, cpGroup.id());
+        waitAllForLeaderElection(instances, getMetadataGroupId(instance1));
+
+        rebalanceLeadership(instances);
+
+        RaftNodeImpl metadataGroupLeader = waitAllForLeaderElection(instances, getMetadataGroupId(instance1));
+        HazelcastInstance metadataGroupLeaderIns = getInstance(metadataGroupLeader.getLeader());
+        RaftNodeImpl defaultGroupLeader = waitAllForLeaderElection(instances, cpGroup.id());
+        HazelcastInstance defaultGroupLeaderIns = getInstance(defaultGroupLeader.getLeader());
+
+        assertEquals(instance3, metadataGroupLeaderIns);
+        assertEquals(instance3, defaultGroupLeaderIns);
+    }
+
+    @Test
+    public void testTransferringWithSeveralPriorityMembers() throws Exception {
+        Config config = createConfig(3, 3);
+
+        config.getCPSubsystemConfig().setCPMemberPriority(1);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(2);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(2);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3};
+        waitUntilCPDiscoveryCompleted(instances);
+
+        IAtomicLong atomicLong = instance1.getCPSubsystem().getAtomicLong("atomic-long");
+        assertEquals(1L, atomicLong.incrementAndGet());
+        CPGroup cpGroup = getRaftService(instance1).getCPGroup(CPGroup.DEFAULT_GROUP_NAME).get();
+        waitAllForLeaderElection(instances, cpGroup.id());
+        waitAllForLeaderElection(instances, getMetadataGroupId(instance1));
+
+        rebalanceLeadership(instances);
+
+        RaftNodeImpl metadataGroupLeader = waitAllForLeaderElection(instances, getMetadataGroupId(instance1));
+        HazelcastInstance metadataGroupLeaderIns = getInstance(metadataGroupLeader.getLeader());
+        RaftNodeImpl defaultGroupLeader = waitAllForLeaderElection(instances, cpGroup.id());
+        HazelcastInstance defaultGroupLeaderIns = getInstance(defaultGroupLeader.getLeader());
+
+        assertTrue((metadataGroupLeaderIns.equals(instance2)) || (metadataGroupLeaderIns.equals(instance3)));
+        assertTrue((defaultGroupLeaderIns.equals(instance2)) || (defaultGroupLeaderIns.equals(instance3)));
+    }
+
+    @Test
+    public void testTransferringWhenCPMembersFailed() throws Exception {
+        Config config = createConfig(3, 3);
+
+        config.getCPSubsystemConfig().setCPMemberPriority(1);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(2);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(3);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3};
+        HazelcastInstance[] instances2 = {instance1, instance2};
+        waitUntilCPDiscoveryCompleted(instances);
+
+        IAtomicLong atomicLong = instance1.getCPSubsystem().getAtomicLong("atomic-long");
+        CPGroup cpGroup = getRaftService(instance1).getCPGroup(CPGroup.DEFAULT_GROUP_NAME).get();
+        assertEquals(1L, atomicLong.incrementAndGet());
+
+        instance3.getLifecycleService().terminate();
+        assertClusterSizeEventually(2, instances2);
+
+        waitAllForLeaderElection(instances2, cpGroup.id());
+        waitAllForLeaderElection(instances2, getMetadataGroupId(instance1));
+
+        getRaftService(instance1).transferLeadership(cpGroup.id(), getRaftService(instance1).getLocalCPMember());
+        getRaftService(instance1).transferLeadership(getMetadataGroupId(instance1), getRaftService(instance1).getLocalCPMember());
+
+        waitAllForLeaderElection(instances2, cpGroup.id());
+        waitAllForLeaderElection(instances2, getMetadataGroupId(instance1));
+
+        rebalanceLeadership(instances2);
+
+        RaftNodeImpl metadataGroupLeader = waitAllForLeaderElection(instances2, getMetadataGroupId(instance1));
+        HazelcastInstance metadataGroupLeaderIns = getInstance(metadataGroupLeader.getLeader());
+        RaftNodeImpl defaultGroupLeader = waitAllForLeaderElection(instances2, cpGroup.id());
+        HazelcastInstance defaultGroupLeaderIns = getInstance(defaultGroupLeader.getLeader());
+
+        assertEquals(instance2, metadataGroupLeaderIns);
+        assertEquals(instance2, defaultGroupLeaderIns);
+    }
+
+    @Test
+    public void testTransferringWhenCPMembersChanged() throws Exception {
+        Config config = createConfig(3, 3);
+
+        config.getCPSubsystemConfig().setCPMemberPriority(1);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(2);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        config.getCPSubsystemConfig().setCPMemberPriority(3);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+
+        HazelcastInstance[] instances = {instance1, instance2, instance3};
+        HazelcastInstance[] instances2 = {instance1, instance2};
+        waitUntilCPDiscoveryCompleted(instances);
+
+        IAtomicLong atomicLong = instance1.getCPSubsystem().getAtomicLong("atomic-long");
+        CPGroup cpGroup = getRaftService(instance1).getCPGroup(CPGroup.DEFAULT_GROUP_NAME).get();
+        assertEquals(1L, atomicLong.incrementAndGet());
+
+        instance3.shutdown();
+        assertClusterSizeEventually(2, instances2);
+
+        waitAllForLeaderElection(instances2, cpGroup.id());
+        waitAllForLeaderElection(instances2, getMetadataGroupId(instance1));
+
+        rebalanceLeadership(instances2);
+
+        RaftNodeImpl metadataGroupLeader = waitAllForLeaderElection(instances2, getMetadataGroupId(instance1));
+        HazelcastInstance metadataGroupLeaderIns = getInstance(metadataGroupLeader.getLeader());
+        RaftNodeImpl defaultGroupLeader = waitAllForLeaderElection(instances2, cpGroup.id());
+        HazelcastInstance defaultGroupLeaderIns = getInstance(defaultGroupLeader.getLeader());
+
+        assertEquals(instance2, metadataGroupLeaderIns);
+        assertEquals(instance2, defaultGroupLeaderIns);
+
+        config.getCPSubsystemConfig().setCPMemberPriority(4);
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        HazelcastInstance[] instances3 = {instance1, instance2, instance4};
+
+        instance4.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
+                .toCompletableFuture().get();
+        waitUntilCPDiscoveryCompleted(instances3);
+
+        waitAllForLeaderElection(instances3, cpGroup.id());
+        waitAllForLeaderElection(instances3, getMetadataGroupId(instance1));
+
+        rebalanceLeadership(instances3);
+
+        RaftNodeImpl metadataGroupLeaderNew = waitAllForLeaderElection(instances3, getMetadataGroupId(instance1));
+        HazelcastInstance metadataGroupLeaderInsNew = getInstance(metadataGroupLeaderNew.getLeader());
+        RaftNodeImpl defaultGroupLeaderNew = waitAllForLeaderElection(instances3, cpGroup.id());
+        HazelcastInstance defaultGroupLeaderInsNew = getInstance(defaultGroupLeaderNew.getLeader());
+
+        assertEquals(instance4, metadataGroupLeaderInsNew);
+        assertEquals(instance4, defaultGroupLeaderInsNew);
+    }
+
+    private void rebalanceLeadership(HazelcastInstance[] instances) {
+        HazelcastInstance metadataLeader = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
         getRaftService(metadataLeader).getMetadataGroupManager().rebalanceGroupLeaderships();
     }
 
@@ -105,10 +420,10 @@ public class CPGroupRebalanceTest extends HazelcastRaftTestSupport {
         Map<CPMember, Collection<CPGroupId>> leaderships = new HashMap<>();
 
         for (CPMember member : members) {
-            Collection<CPGroupId> groups =
-                    operationService.<Collection<CPGroupId>>invokeOnTarget(null, new GetLeadedGroupsOp(), member.getAddress())
+            Entry<Integer, Collection<CPGroupId>> entry =
+                    operationService.<Entry<Integer, Collection<CPGroupId>>>invokeOnTarget(RaftService.SERVICE_NAME, new GetLeadedGroupsOp(), member.getAddress())
                             .join();
-            leaderships.put(member, groups);
+            leaderships.put(member, entry.getValue());
         }
         return leaderships;
     }


### PR DESCRIPTION
The following commit introduces the priority-based leadership rebalancing in addition to the evenly rebalancing strategy.

Hazelcast CP Subsystem is based on the Raft protocol, which is a leader-based protocol.
A leader is responsible for client interaction and state replication.
Every CP group has its own leader and any CP member could be elected as a CP group leader.
To have an equal CP members load, the periodically running leadership rebalancing task is trying to distribute CP group leaders among all CP members evenly.
However, there are cases/scenarios when some CP members shouldn't act as a leader. To ensure the availability of the CP subsystem, we cannot prevent some members from being elected as a leader. But we can ask to transfer leadership from the existing leader to any other CP member.
To implement this behaviour, we can introduce priority-based leadership in addition to the existing rebalancing strategy.
Each CP member will be assigned a priority - an integer number. Initially, any CP member with any priority can take the leader's role. But the periodically running leadership rebalancing task should transfer the leadership to members with the highest priority.
So, eventually, all CP groups' leaders will be transferred to CP members with the highest priority.

To use the priority-based leadership strategy, just assign a priority to CP members:
`config.getCPSubsystemConfig().setCPMemberPriority(-1);`

After applying this configuration, every 60 sec (specified in the `LEADERSHIP_BALANCE_TASK_PERIOD` property) will run a `RaftGroupLeadershipBalanceTask`.

If the CP group size is smaller than the number of CP members, the groups may have different sets of CP members, and the highest CP member in each group may not be the same. In that case, we form a set of highest priorities based on the highest priorities taken from each group. For example:
_Group1: {M0-0; M1-1; M2-2} - max priority member is M2 with priority 2_
_Group2: {M1-1; M2-2; M3-3} - max priority member is M3 with priority 3_
The highest priorities set is: _{2, 3}_ 
Based on this highest priority set, we assume all CP members with those priorities are eligible for leadership.

Limitations:
In this PR, we do not address the problem where a CP group can only be formed from CP members with the lowest priority, or later on promoting CP members with the highest priority. To fix this, we should change the logic of how the CP groups are formed. Possibly we should introduce so-called _Light CP Members_. 

Fixes https://hazelcast.atlassian.net/browse/HZ-651

Breaking changes (list specific methods/types/messages):
- the return type for `GetLeadedGroupsOp` has been changed, but we can ignore it since the class cast exception will be caught [here](https://github.com/hazelcast/hazelcast/blob/14a6eec2cd682ad365e03907ad22dfc5da6cb866/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java#L462) and rebalancing will be skipped during the rolling upgrade. 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
