### PR TITLE
[API-1250] Rename `cloneWithBuilder` to `newBuilderWithClone` for `GenericRecord`s

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -161,7 +161,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     @Nonnull
-    public GenericRecordBuilder cloneWithBuilder() {
+    public GenericRecordBuilder newBuilderWithClone() {
         TreeMap<String, Object> objects = new TreeMap<>();
         for (String fieldName : getFieldNames()) {
             objects.put(fieldName, readAny(fieldName));

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -104,7 +104,7 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
 
     @Nonnull
     @Override
-    public GenericRecordBuilder cloneWithBuilder() {
+    public GenericRecordBuilder newBuilderWithClone() {
         return new DeserializedGenericRecordCloner(schema, objects);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DeserializedPortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DeserializedPortableGenericRecord.java
@@ -63,7 +63,7 @@ public class DeserializedPortableGenericRecord extends PortableGenericRecord {
 
     @Nonnull
     @Override
-    public GenericRecordBuilder cloneWithBuilder() {
+    public GenericRecordBuilder newBuilderWithClone() {
         return new PortableGenericRecordBuilder(classDefinition, Arrays.copyOf(objects, objects.length));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -343,7 +343,7 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
             if (!isClone) {
                 throw new HazelcastSerializationException("It is illegal to the overwrite the field");
             } else {
-                throw new HazelcastSerializationException("Field can only overwritten once with `cloneWithBuilder`");
+                throw new HazelcastSerializationException("Field can only overwritten once with `newBuilderWithClone`");
             }
         }
         objects[index] = value;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -515,7 +515,7 @@ public class PortableInternalGenericRecord extends PortableGenericRecord impleme
 
     @Nonnull
     @Override
-    public GenericRecordBuilder cloneWithBuilder() {
+    public GenericRecordBuilder newBuilderWithClone() {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -30,40 +30,49 @@ import java.time.OffsetDateTime;
 import java.util.Set;
 
 /**
- * A generic object interface that is returned to the user when the domain class can not be created from any of the distributed
- * hazelcast data structures like {@link IMap}, {@link IQueue} etc.
+ * A generic object interface that is returned to the user when the domain class
+ * can not be created from any of the distributed Hazelcast data structures like
+ * {@link IMap}, {@link IQueue} etc.
  * <p>
- * On remote calls like in the distributed executor service or EntryProcessors, you may need access to the domain object. In
- * case the class of the domain object is not available on the cluster, GenericRecord allows you to read and write the object
- * without the domain class on the classpath. Here is an example with EntryProcessor:
+ * On remote calls like in the distributed executor service or EntryProcessors,
+ * you may need access to the domain object. In case the class of the domain
+ * object is not available on the cluster, GenericRecord allows you to read and
+ * write the object without the domain class on the classpath. Here is an
+ * example with EntryProcessor:
  * <pre>{@code
  * map.executeOnKey(key, (EntryProcessor<Object, Object, Object>) entry -> {
- *             Object value = entry.getValue();
- *             GenericRecord genericRecord = (GenericRecord) value;
+ *     Object value = entry.getValue();
+ *     GenericRecord genericRecord = (GenericRecord) value;
  *
- *             int id = genericRecord.getInt("id");
+ *     int id = genericRecord.getInt32("id");
  *
- *             return null;
- *         });
+ *     return null;
+ * });
  * }</pre>
- * Another example with EntryProcessor to demonstrate how to read, modify and set the value back to the map:
+ * Another example with EntryProcessor to demonstrate how to read, modify and
+ * set the value back to the map:
  * <pre>{@code
  * map.executeOnKey("key", (EntryProcessor<Object, Object, Object>) entry -> {
- *             GenericRecord genericRecord = (GenericRecord) entry.getValue();
- *             GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder()
- *                     .setInt("age",22).build();
- *             entry.setValue(modifiedGenericRecord);
- *             return null;
- *         });
+ *     GenericRecord genericRecord = (GenericRecord) entry.getValue();
+ *     GenericRecord modifiedGenericRecord = genericRecord.newBuilderWithClone()
+ *             .setInt32("age", 22)
+ *             .build();
+ *     entry.setValue(modifiedGenericRecord);
+ *     return null;
+ * });
  * }</pre>
  * <p>
- * GenericRecord also allows reading from a cluster without having the classes on the client side.
- * For {@link Portable}, when {@link PortableFactory} is not provided in the config at the start,
- * a {@link HazelcastSerializationException} was thrown stating that a factory could not be found. Starting from 4.1,
- * the objects will be returned as {@link GenericRecord}. This way, the clients can read and write objects back to
- * the cluster without the need to have the domain classes on the classpath.
+ * GenericRecord also allows reading from a cluster without having the classes
+ * on the client side. For {@link Portable}, when {@link PortableFactory} is not
+ * provided in the config at the start, a
+ * {@link HazelcastSerializationException} was thrown stating that a factory
+ * could not be found. Starting from 4.1, the objects will be returned as
+ * {@link GenericRecord}. This way, the clients can read and write objects back
+ * to the cluster without the need to have the domain classes on the classpath.
  * <p>
- * Currently, this is valid for {@link Portable} and compact serializable objects.
+ * Currently, this is valid for {@link Portable} and
+ * {@link com.hazelcast.config.CompactSerializationConfig Compact} serializable
+ * objects.
  *
  * @since 4.1
  */
@@ -71,46 +80,53 @@ import java.util.Set;
 public interface GenericRecord {
 
     /**
-     * Creates a {@link GenericRecordBuilder} allows to create a new object. This method is a convenience method to get a builder,
-     * without creating the class definition for this type. Here you can see  a  new object is constructed from an existing
-     * GenericRecord with its class definition:
+     * Creates a {@link GenericRecordBuilder} allows to create a new object.
+     * This method is a convenience method to get a builder, without creating
+     * the schema/class definition for this type. Here you can see a new object
+     * is constructed from an existing GenericRecord with its schema:
      *
-     * <pre>
-     *
+     * <pre>{@code
      * GenericRecord newGenericRecord = genericRecord.newBuilder()
      *      .setString("name", "bar")
-     *      .setInt("id", 4).build();
-     *
-     * </pre>
+     *      .setInt32("id", 4)
+     *      .build();
+     * }</pre>
      * <p>
-     * see {@link GenericRecordBuilder#portable(ClassDefinition)} to create a GenericRecord in Portable format
-     * with a different class definition.
+     * See {@link GenericRecordBuilder#portable(ClassDefinition)} to create a
+     * GenericRecord in Portable format with a different class definition and
+     * {@link GenericRecordBuilder#compact(String)} to create a GenericRecord in
+     * Compact format with a different schema.
      *
-     * @return an empty generic record builder with same class definition as this one
+     * @return an empty generic record builder with same class definition as
+     * this one
      */
     @Nonnull
     GenericRecordBuilder newBuilder();
 
     /**
-     * Returned {@link GenericRecordBuilder} can be used to have exact copy and also just to update a couple of fields.
-     * By default, it will copy all the fields.
-     * So instead of following where only the `id` field is updated,
-     * <pre>
-     *     GenericRecord modifiedGenericRecord = genericRecord.newBuilder()
-     *                         .setString("name", genericRecord.getString("name"))
-     *                         .setLong("id", 4)
-     *                         .setString("surname", genericRecord.getString("surname"))
-     *                         .setInt("age", genericRecord.getInt("age")).build();
-     * </pre>
-     * `cloneWithBuilder` used as follows:
-     * <pre>
-     *     GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder().setInt("id", 4).build();
-     * </pre>
+     * Returned {@link GenericRecordBuilder} can be used to have exact copy and
+     * also just to update a couple of fields. By default, it will copy all the
+     * fields. So instead of following where only the `id` field is updated,
+     * <pre>{@code
+     * GenericRecord modifiedGenericRecord = genericRecord.newBuilder()
+     *         .setString("name", genericRecord.getString("name"))
+     *         .setInt64("id", 4)
+     *         .setString("surname", genericRecord.getString("surname"))
+     *         .setInt32("age", genericRecord.getInt32("age"))
+     *         .build();
+     * }</pre>
+     * `newBuilderWithClone` used as follows:
+     * <pre>{@code
+     * GenericRecord modifiedGenericRecord = genericRecord.newBuilderWithClone()
+     *         .setInt32("id", 4)
+     *         .build();
+     * }</pre>
      *
-     * @return a generic record builder with same class definition as this one and populated with same values.
+     * @return a generic record builder with same schema/class definition as
+     * this one and populated with same values.
      */
     @Nonnull
-    GenericRecordBuilder cloneWithBuilder();
+    GenericRecordBuilder newBuilderWithClone();
 
     /**
      * @return set of field names of this GenericRecord
@@ -121,135 +137,183 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return field type for the given field name
-     * @throws IllegalArgumentException if the field name does not exist in the class definition
+     * @throws IllegalArgumentException if the field name does not exist in the
+     *                                  schema/class definition
      */
     @Nonnull
     FieldKind getFieldKind(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return true if field exists in the definition of the class. Note that returns true even if the field is null.
+     * @return true if field exists in the schema/class definition. Note that
+     * returns true even if the field is null.
      */
     boolean hasField(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     boolean getBoolean(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link Portable}. Not applicable for {@link com.hazelcast.config.CompactSerializationConfig Compact}
+     * Supported only for {@link Portable}. Not applicable for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the class definition or the
+     *                                         type of the field does not match
+     *                                         the one in the class definition.
      */
     char getChar(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     byte getInt8(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     short getInt16(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     int getInt32(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     long getInt64(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     float getFloat32(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     double getFloat64(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     String getString(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return decimal which is arbitrary precision and scale floating-point number as BigDecimal
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return decimal which is arbitrary precision and scale floating-point
+     * number as {@link BigDecimal}
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     BigDecimal getDecimal(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return time field consisting of hour, minute, seconds and nanos parts as LocalTime
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return time field consisting of hour, minute, seconds and nanos parts as
+     * {@link LocalTime}
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     LocalTime getTime(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return date field consisting of year, month of the year and day of the month as LocalDate
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return date field consisting of year, month of the year and day of the
+     * month as {@link LocalDate}
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     LocalDate getDate(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return timestamp field consisting of year, month of the year, day of the month, hour, minute, seconds,
-     * nanos parts as LocalDateTime
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return timestamp field consisting of year, month of the year, day of the
+     * month, hour, minute, seconds, nanos parts as {@link LocalDateTime}
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     LocalDateTime getTimestamp(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return timestamp with timezone field consisting of
-     * year, month of the year, day of the month, offset seconds, hour, minute, seconds, nanos parts as OffsetDateTime
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return timestamp with timezone field consisting of year, month of the
+     * year, day of the month, offset seconds, hour, minute, seconds, nanos
+     * parts as {@link OffsetDateTime}
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     OffsetDateTime getTimestampWithTimezone(@Nonnull String fieldName);
@@ -257,8 +321,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     GenericRecord getGenericRecord(@Nonnull String fieldName);
@@ -266,19 +333,25 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     boolean[] getArrayOfBoolean(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link Portable}. Not applicable for {@link com.hazelcast.config.CompactSerializationConfig Compact}
+     * Supported only for {@link Portable}. Not applicable for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the class definition or the
+     *                                         type of the field does not match
+     *                                         the one in the class definition.
      */
     @Nullable
     char[] getArrayOfChar(@Nonnull String fieldName);
@@ -286,8 +359,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     byte[] getArrayOfInt8(@Nonnull String fieldName);
@@ -295,8 +371,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     short[] getArrayOfInt16(@Nonnull String fieldName);
@@ -304,8 +383,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     int[] getArrayOfInt32(@Nonnull String fieldName);
@@ -313,8 +395,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     long[] getArrayOfInt64(@Nonnull String fieldName);
@@ -322,8 +407,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     float[] getArrayOfFloat32(@Nonnull String fieldName);
@@ -331,8 +419,11 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     double[] getArrayOfFloat64(@Nonnull String fieldName);
@@ -340,17 +431,23 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     String[] getArrayOfString(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field
-     * @return array of Decimal's as BigDecimal[]
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      * @see #getDecimal(String)
      */
     @Nullable
@@ -358,9 +455,12 @@ public interface GenericRecord {
 
     /**
      * @param fieldName the name of the field
-     * @return array of Time's as LocalTime[]
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      * @see #getTime(String)
      */
     @Nullable
@@ -368,9 +468,12 @@ public interface GenericRecord {
 
     /**
      * @param fieldName the name of the field
-     * @return array of Date's to LocalDate[]
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      * @see #getDate(String)
      */
     @Nullable
@@ -378,9 +481,12 @@ public interface GenericRecord {
 
     /**
      * @param fieldName the name of the field
-     * @return array of Timestamp's as LocalDateTime[]
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      * @see #getTimestamp(String)
      */
     @Nullable
@@ -388,9 +494,12 @@ public interface GenericRecord {
 
     /**
      * @param fieldName the name of the field
-     * @return array of TimestampWithTimezone's as OffsetDateTime[]
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      * @see #getTimestampWithTimezone(String)
      */
     @Nullable
@@ -399,162 +508,221 @@ public interface GenericRecord {
     /**
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
      */
     @Nullable
     GenericRecord[] getArrayOfGenericRecord(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Boolean getNullableBoolean(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Byte getNullableInt8(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Short getNullableInt16(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Integer getNullableInt32(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Long getNullableInt64(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Float getNullableFloat32(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Double getNullableFloat64(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Boolean[] getArrayOfNullableBoolean(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Byte[] getArrayOfNullableInt8(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Short[] getArrayOfNullableInt16(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Integer[] getArrayOfNullableInt32(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Long[] getArrayOfNullableInt64(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Float[] getArrayOfNullableFloat32(@Nonnull String fieldName);
 
     /**
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
      * @param fieldName the name of the field
      * @return the value of the field
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema.
      */
     @Nullable
     Double[] getArrayOfNullableFloat64(@Nonnull String fieldName);

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecord.java
@@ -83,7 +83,8 @@ public interface GenericRecord {
      * Creates a {@link GenericRecordBuilder} allows to create a new object.
      * This method is a convenience method to get a builder, without creating
      * the schema/class definition for this type. Here you can see a new object
-     * is constructed from an existing GenericRecord with its schema:
+     * is constructed from an existing GenericRecord with its schema/class
+     * definition:
      *
      * <pre>{@code
      * GenericRecord newGenericRecord = genericRecord.newBuilder()

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
@@ -32,22 +32,24 @@ import java.time.OffsetDateTime;
  * Interface for creating {@link GenericRecord} instances.
  */
 @Beta
-public
-interface GenericRecordBuilder {
+public interface GenericRecordBuilder {
 
     /**
-     * Creates a Builder that will build a {@link GenericRecord} in {@link Portable} format with a new class definition:
-     * <pre>
-     *     ClassDefinition classDefinition =
-     *                 new ClassDefinitionBuilder(FACTORY_ID, CLASS_ID)
-     *                         .addStringField("name").addIntField("id").build();
+     * Creates a Builder that will build a {@link GenericRecord} in
+     * {@link Portable} format with a new class definition:
+     * <pre>{@code
+     * ClassDefinition classDefinition = new ClassDefinitionBuilder(FACTORY_ID, CLASS_ID)
+     *         .addStringField("name")
+     *         .addIntField("id")
+     *         .build();
      *
-     *     GenericRecord genericRecord = GenericRecordBuilder.portable(classDefinition)
-     *           .setString("name", "foo")
-     *           .setInt("id", 123).build();
-     * </pre>
+     * GenericRecord genericRecord = GenericRecordBuilder.portable(classDefinition)
+     *         .setString("name", "foo")
+     *         .setInt32("id", 123)
+     *         .build();
+     * }</pre>
      *
-     * @param classDefinition of the portable that we will create
+     * @param classDefinition of the Portable that will be created
      * @return GenericRecordBuilder for Portable format
      */
     @Nonnull
@@ -56,9 +58,19 @@ interface GenericRecordBuilder {
     }
 
     /**
-     * @return a new constructed GenericRecord which the resulting record will be serialized in Compact Format
-     * see {@link com.hazelcast.config.CompactSerializationConfig}
-     * @since Hazelcast 5.0 as BETA
+     * /** Creates a Builder that will build a {@link GenericRecord} in
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact} format
+     * with the given type name and schema:
+     * <pre>{@code
+     * GenericRecord genericRecord = GenericRecordBuilder.compact("typeName")
+     *         .setString("name", "foo")
+     *         .setInt32("id", 123)
+     *         .build();
+     * }</pre>
+     *
+     * @param typeName of the schema
+     * @return GenericRecordBuilder for Compact format
+     * @since 5.0
      */
     @Beta
     @Nonnull
@@ -68,775 +80,1025 @@ interface GenericRecordBuilder {
 
     /**
      * @return a new constructed GenericRecord
-     * @throws HazelcastSerializationException when the GenericRecord cannot be build.
+     * @throws HazelcastSerializationException when the GenericRecord cannot be
+     *                                         built.
      */
     @Nonnull
     GenericRecord build();
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  It should be composed of only alpha-numeric characters.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setBoolean(@Nonnull String fieldName, boolean value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  It should be composed of only alpha-numeric characters.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setInt8(@Nonnull String fieldName, byte value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link Portable}. Not applicable for {@link com.hazelcast.config.CompactSerializationConfig Compact}
+     * Supported only for {@link Portable}. Not applicable for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the class definition or the
+     *                                         type of the field does not match
+     *                                         the one in the class definition
+     *                                         or the same field is trying to be
+     *                                         set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setChar(@Nonnull String fieldName, char value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setInt16(@Nonnull String fieldName, short value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setInt32(@Nonnull String fieldName, int value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setInt64(@Nonnull String fieldName, long value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setFloat32(@Nonnull String fieldName, float value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setFloat64(@Nonnull String fieldName, double value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  It should be composed of only alpha-numeric characters.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableBoolean(@Nonnull String fieldName, @Nullable Boolean value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  It should be composed of only alpha-numeric characters.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableInt8(@Nonnull String fieldName, @Nullable Byte value);
 
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableInt16(@Nonnull String fieldName, @Nullable Short value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableInt32(@Nonnull String fieldName, @Nullable Integer value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableInt64(@Nonnull String fieldName, @Nullable Long value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableFloat32(@Nonnull String fieldName, @Nullable Float value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setNullableFloat64(@Nonnull String fieldName, @Nullable Double value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setString(@Nonnull String fieldName, @Nullable String value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * This method allows nested structures. Subclass should also created as `GenericRecord`.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. This method allows nested structures.
+     * Subclass should also be created as `GenericRecord`.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value);
 
     /**
-     * Sets a decimal which is arbitrary precision and scale floating-point number
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * Sets a decimal which is arbitrary precision and scale floating-point
+     * number It is legal to set the field again only when Builder is created
+     * with {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is
+     * illegal to set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setDecimal(@Nonnull String fieldName, @Nullable BigDecimal value);
 
     /**
-     * Sets a time field consisting of hour, minute, seconds and nanos parts
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * Sets a time field consisting of hour, minute, seconds and nanos parts It
+     * is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setTime(@Nonnull String fieldName, @Nullable LocalTime value);
 
     /**
-     * Sets a date field consisting of year , month of the year and day of the month
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * Sets a date field consisting of year , month of the year and day of the
+     * month It is legal to set the field again only when Builder is created
+     * with {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is
+     * illegal to set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setDate(@Nonnull String fieldName, @Nullable LocalDate value);
 
     /**
-     * Sets a timestamp field consisting of
-     * year , month of the year and day of the month, hour, minute, seconds, nanos parts
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * Sets a timestamp field consisting of year , month of the year and day of
+     * the month, hour, minute, seconds, nanos parts It is legal to set the
+     * field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value);
 
     /**
-     * Sets a timestamp with timezone field consisting of
-     * year , month of the year and day of the month, offset seconds , hour, minute, seconds, nanos parts
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * Sets a timestamp with timezone field consisting of year , month of the
+     * year and day of the month, offset seconds , hour, minute, seconds, nanos
+     * parts It is legal to set the field again only when Builder is created
+     * with {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is
+     * illegal to set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfBoolean(@Nonnull String fieldName, @Nullable boolean[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfInt8(@Nonnull String fieldName, @Nullable byte[] value);
 
     /**
-     * Supported only for {@link Portable}. Not applicable for {@link com.hazelcast.config.CompactSerializationConfig Compact}
+     * Supported only for {@link Portable}. Not applicable for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}
      * <p>
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the class definition or the
+     *                                         type of the field does not match
+     *                                         the one in the class definition
+     *                                         or the same field is trying to be
+     *                                         set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfChar(@Nonnull String fieldName, @Nullable char[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfInt16(@Nonnull String fieldName, @Nullable short[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfInt32(@Nonnull String fieldName, @Nullable int[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfInt64(@Nonnull String fieldName, @Nullable long[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfFloat32(@Nonnull String fieldName, @Nullable float[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfFloat64(@Nonnull String fieldName, @Nullable double[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableBoolean(@Nonnull String fieldName, @Nullable Boolean[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableInt8(@Nonnull String fieldName, @Nullable Byte[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableInt16(@Nonnull String fieldName, @Nullable Short[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableInt32(@Nonnull String fieldName, @Nullable Integer[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableInt64(@Nonnull String fieldName, @Nullable Long[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableFloat32(@Nonnull String fieldName, @Nullable Float[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      * <p>
-     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     * Supported only for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
+     * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema or the type of the
+     *                                         field does not match the one in
+     *                                         the schema or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfNullableFloat64(@Nonnull String fieldName, @Nullable Double[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * Array items can not be null.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. Array items can not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfString(@Nonnull String fieldName, @Nullable String[] value);
 
     /**
-     * Sets an array of Decimals
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * Array items can not be null.
+     * Sets an array of Decimals It is legal to set the field again only when
+     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
+     * Otherwise, it is illegal to set to the same field twice. Array items can
+     * not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      * @see #setDecimal(String, BigDecimal)
      */
     @Nonnull
     GenericRecordBuilder setArrayOfDecimal(@Nonnull String fieldName, @Nullable BigDecimal[] value);
 
     /**
-     * Sets an array of Time's
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * Array items can not be null.
+     * Sets an array of Time's It is legal to set the field again only when
+     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
+     * Otherwise, it is illegal to set to the same field twice. Array items can
+     * not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      * @see #setTime(String, LocalTime)
      */
     @Nonnull
     GenericRecordBuilder setArrayOfTime(@Nonnull String fieldName, @Nullable LocalTime[] value);
 
     /**
-     * Sets an array of Date's
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * Array items can not be null.
+     * Sets an array of Date's It is legal to set the field again only when
+     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
+     * Otherwise, it is illegal to set to the same field twice. Array items can
+     * not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      * @see #setDate(String, LocalDate)
      */
     @Nonnull
     GenericRecordBuilder setArrayOfDate(@Nonnull String fieldName, @Nullable LocalDate[] value);
 
     /**
-     * Sets an array of Timestamp's
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * Array items can not be null.
+     * Sets an array of Timestamp's It is legal to set the field again only when
+     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
+     * Otherwise, it is illegal to set to the same field twice. Array items can
+     * not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      * @see #setTimestamp(String, LocalDateTime)
      */
     @Nonnull
     GenericRecordBuilder setArrayOfTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime[] value);
 
     /**
-     * Sets an array of TimestampWithTimezone's
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * Array items can not be null.
+     * Sets an array of TimestampWithTimezone's It is legal to set the field
+     * again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. Array items can not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      * @see #setTimestampWithTimezone(String, OffsetDateTime)
      */
     @Nonnull
     GenericRecordBuilder setArrayOfTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime[] value);
 
     /**
-     * It is legal to set the field again only when Builder is created with {@link GenericRecord#cloneWithBuilder()}.
-     * Otherwise, it is illegal to set to the same field twice.
-     * This method allows nested structures. Subclasses should also created as `GenericRecord`.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. This method allows nested structures.
+     * Subclasses should also be created as `GenericRecord`.
      * <p>
      * Array items can not be null.
      *
-     * @param fieldName name of the field as it is defined in its class definition.
-     *                  See {@link ClassDefinition} for {@link Portable}
+     * @param fieldName name of the field as it is defined in its schema/class
+     *                  definition. It should be composed of only alphanumeric
+     *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist in the class definition or
-     *                                         the type of the field does not match the one in the class definition or
-     *                                         Same field is trying to be set without using
-     *                                         {@link GenericRecord#cloneWithBuilder()}.
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition or the same field is
+     *                                         trying to be set without using
+     *                                         {@link
+     *                                         GenericRecord#newBuilderWithClone()}.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value);

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/GenericRecordBuilder.java
@@ -274,8 +274,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -298,8 +297,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -323,8 +321,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -347,8 +344,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -371,8 +367,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -395,8 +390,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -419,8 +413,7 @@ public interface GenericRecordBuilder {
      * {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not
      * applicable to {@link Portable}.
      *
-     * @param fieldName name of the field as it is defined in its class
-     *                  definition.
+     * @param fieldName name of the field as it is defined in its schema.
      * @param value     to set to GenericRecord
      * @return itself for chaining
      * @throws HazelcastSerializationException if the field name does not exist
@@ -481,9 +474,11 @@ public interface GenericRecordBuilder {
 
     /**
      * Sets a decimal which is arbitrary precision and scale floating-point
-     * number It is legal to set the field again only when Builder is created
-     * with {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is
-     * illegal to set to the same field twice.
+     * number.
+     * <p>
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -503,8 +498,9 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setDecimal(@Nonnull String fieldName, @Nullable BigDecimal value);
 
     /**
-     * Sets a time field consisting of hour, minute, seconds and nanos parts It
-     * is legal to set the field again only when Builder is created with
+     * Sets a time field consisting of hour, minute, seconds, and nanos parts.
+     * <p>
+     * It is legal to set the field again only when Builder is created with
      * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
      * set to the same field twice.
      *
@@ -526,10 +522,12 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setTime(@Nonnull String fieldName, @Nullable LocalTime value);
 
     /**
-     * Sets a date field consisting of year , month of the year and day of the
-     * month It is legal to set the field again only when Builder is created
-     * with {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is
-     * illegal to set to the same field twice.
+     * Sets a date field consisting of year, month of the year, and day of the
+     * month.
+     * <p>
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -549,9 +547,10 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setDate(@Nonnull String fieldName, @Nullable LocalDate value);
 
     /**
-     * Sets a timestamp field consisting of year , month of the year and day of
-     * the month, hour, minute, seconds, nanos parts It is legal to set the
-     * field again only when Builder is created with
+     * Sets a timestamp field consisting of year, month of the year, and day of
+     * the month, hour, minute, seconds, nanos parts.
+     * <p>
+     * It is legal to set the field again only when Builder is created with
      * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
      * set to the same field twice.
      *
@@ -573,11 +572,13 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime value);
 
     /**
-     * Sets a timestamp with timezone field consisting of year , month of the
-     * year and day of the month, offset seconds , hour, minute, seconds, nanos
-     * parts It is legal to set the field again only when Builder is created
-     * with {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is
-     * illegal to set to the same field twice.
+     * Sets a timestamp with timezone field consisting of year, month of the
+     * year and day of the month, offset seconds, hour, minute, seconds, nanos
+     * parts.
+     * <p>
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -641,12 +642,12 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setArrayOfInt8(@Nonnull String fieldName, @Nullable byte[] value);
 
     /**
-     * Supported only for {@link Portable}. Not applicable for
-     * {@link com.hazelcast.config.CompactSerializationConfig Compact}
-     * <p>
      * It is legal to set the field again only when Builder is created with
      * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
      * set to the same field twice.
+     * <p>
+     * Supported only for {@link Portable}. Not applicable for
+     * {@link com.hazelcast.config.CompactSerializationConfig Compact}
      *
      * @param fieldName name of the field as it is defined in its class
      *                  definition. It should be composed of only alphanumeric
@@ -959,10 +960,9 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setArrayOfString(@Nonnull String fieldName, @Nullable String[] value);
 
     /**
-     * Sets an array of Decimals It is legal to set the field again only when
-     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
-     * Otherwise, it is illegal to set to the same field twice. Array items can
-     * not be null.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. Array items can not be null.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -983,10 +983,9 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setArrayOfDecimal(@Nonnull String fieldName, @Nullable BigDecimal[] value);
 
     /**
-     * Sets an array of Time's It is legal to set the field again only when
-     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
-     * Otherwise, it is illegal to set to the same field twice. Array items can
-     * not be null.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. Array items can not be null.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -1007,10 +1006,9 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setArrayOfTime(@Nonnull String fieldName, @Nullable LocalTime[] value);
 
     /**
-     * Sets an array of Date's It is legal to set the field again only when
-     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
-     * Otherwise, it is illegal to set to the same field twice. Array items can
-     * not be null.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. Array items can not be null.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -1031,10 +1029,9 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setArrayOfDate(@Nonnull String fieldName, @Nullable LocalDate[] value);
 
     /**
-     * Sets an array of Timestamp's It is legal to set the field again only when
-     * Builder is created with {@link GenericRecord#newBuilderWithClone()}.
-     * Otherwise, it is illegal to set to the same field twice. Array items can
-     * not be null.
+     * It is legal to set the field again only when Builder is created with
+     * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
+     * set to the same field twice. Array items can not be null.
      *
      * @param fieldName name of the field as it is defined in its schema/class
      *                  definition. It should be composed of only alphanumeric
@@ -1055,8 +1052,7 @@ public interface GenericRecordBuilder {
     GenericRecordBuilder setArrayOfTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime[] value);
 
     /**
-     * Sets an array of TimestampWithTimezone's It is legal to set the field
-     * again only when Builder is created with
+     * It is legal to set the field again only when Builder is created with
      * {@link GenericRecord#newBuilderWithClone()}. Otherwise, it is illegal to
      * set to the same field twice. Array items can not be null.
      *

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -103,7 +103,7 @@ public class GenericRecordTest {
         builder.setInt64("bar", 1231L);
         DeserializedGenericRecord genericRecord = (DeserializedGenericRecord) builder.build();
 
-        verifyCloneWithBuilder(genericRecord);
+        verifyNewBuilderWithClone(genericRecord);
     }
 
     @Test
@@ -120,10 +120,10 @@ public class GenericRecordTest {
         CompactInternalGenericRecord genericRecord = (CompactInternalGenericRecord)
                 serializationService.readAsInternalGenericRecord(data);
 
-        verifyCloneWithBuilder(genericRecord);
+        verifyNewBuilderWithClone(genericRecord);
     }
 
-    private void verifyCloneWithBuilder(GenericRecord genericRecord) {
+    private void verifyNewBuilderWithClone(GenericRecord genericRecord) {
         GenericRecordBuilder cloneBuilder = genericRecord.newBuilderWithClone();
         cloneBuilder.setInt32("foo", 2);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/CompactFormatIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/CompactFormatIntegrationTest.java
@@ -183,7 +183,7 @@ public abstract class CompactFormatIntegrationTest extends HazelcastTestSupport 
         @Override
         public Object process(Map.Entry<Integer, GenericRecord> entry) {
             GenericRecord value = entry.getValue();
-            GenericRecord newValue = value.cloneWithBuilder()
+            GenericRecord newValue = value.newBuilderWithClone()
                     .setInt32("age", value.getInt32("age") + 1000)
                     .build();
             entry.setValue(newValue);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordBuilderTest.java
@@ -68,7 +68,7 @@ public class GenericRecordBuilderTest {
                                                    .setString("name", "foo")
                                                    .setInt32("myint", 123).build();
 
-        GenericRecordBuilder builder = record.cloneWithBuilder().setString("name", "foo2");
+        GenericRecordBuilder builder = record.newBuilderWithClone().setString("name", "foo2");
         assertThrows(HazelcastSerializationException.class, () -> builder.setString("name", "foo3"));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/integration/AbstractGenericRecordIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/integration/AbstractGenericRecordIntegrationTest.java
@@ -201,7 +201,7 @@ public abstract class AbstractGenericRecordIntegrationTest extends HazelcastTest
             Object value = entry.getValue();
             GenericRecord genericRecord = (GenericRecord) value;
 
-            GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder()
+            GenericRecord modifiedGenericRecord = genericRecord.newBuilderWithClone()
                     .setInt32("myint", 4).build();
 
             entry.setValue(modifiedGenericRecord);


### PR DESCRIPTION
Also, the APIs of the `GenericRecord` and `GenericRecordBuilder`
interfaces are updated to reflect this change, along with formatting
fixes.

Also, lots of the documentation is corrected to have the proper
wording for Compact serialization and some code snippets are updated
with the new APIs.