### PR TITLE
[API-1320] Introduce various updates to Compact serialization implementation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CustomTypeFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/CustomTypeFactory.java
@@ -239,11 +239,7 @@ public final class CustomTypeFactory {
     }
 
     public static Schema createSchema(String typeName, List<FieldDescriptor> fields) {
-        TreeMap<String, FieldDescriptor> map = new TreeMap<>(Comparator.naturalOrder());
-        for (FieldDescriptor field : fields) {
-            map.put(field.getFieldName(), field);
-        }
-        return new Schema(typeName, map);
+        return new Schema(typeName, fields);
     }
 
     public static HazelcastJsonValue createHazelcastJsonValue(String value) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -690,6 +690,39 @@ public abstract class AbstractSerializationService implements InternalSerializat
         return null;
     }
 
+    /**
+     * Makes sure that the classes registered as Compact serializable are not
+     * overriding the default serializers, if the
+     * {@link #allowOverrideDefaultSerializers} configuration option is set to
+     * {@code false}.
+     * <p>
+     * Must be called in the constructor of the child classes after they
+     * complete registering default serializers.
+     */
+    protected void verifyDefaultSerializersNotOverriddenWithCompact() {
+        // If the user explicitly set to override default serializers, we should
+        // respect that and allow it to register Compact serializers for such
+        // types. No need to perform further checks.
+        if (allowOverrideDefaultSerializers) {
+            return;
+        }
+
+
+        for (Class clazz : compactStreamSerializer.getCompactSerializableClasses()) {
+            if (!constantTypesMap.containsKey(clazz)) {
+                continue;
+            }
+
+            throw new IllegalArgumentException("Compact serializer for the "
+                    + clazz + " can not be registered as it overrides the "
+                    + "default serializer for that class provided by Hazelcast. "
+                    + "If you want to override the default serializer, set the "
+                    + "'allowOverrideDefaultSerializers' to 'true' in the "
+                    + "serialization configuration."
+            );
+        }
+    }
+
     public abstract static class Builder<T extends Builder<T>> {
         private InputOutputFactory inputOutputFactory;
         private byte version;
@@ -757,8 +790,9 @@ public abstract class AbstractSerializationService implements InternalSerializat
          * Sets whether the serialization service should (de)serialize in the
          * compatibility (3.x) format.
          *
-         * @param isCompatibility {@code true} if the serialized format should conform to the
-         *                        3.x serialization format, {@code false} otherwise
+         * @param isCompatibility {@code true} if the serialized format should
+         *                        conform to the 3.x serialization format,
+         *                        {@code false} otherwise
          * @return this builder
          */
         public final T withCompatibility(boolean isCompatibility) {
@@ -767,8 +801,9 @@ public abstract class AbstractSerializationService implements InternalSerializat
         }
 
         /**
-         * @return {@code true} if the serialized format of the serialization service should
-         * conform to the 3.x serialization format, {@code false} otherwise.
+         * @return {@code true} if the serialized format of the serialization
+         * service should conform to the 3.x serialization format, {@code false}
+         * otherwise.
          */
         public boolean isCompatibility() {
             return isCompatibility;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -166,6 +166,11 @@ public class SerializationServiceV1 extends AbstractSerializationService {
                 new JavaDefaultSerializers.ExternalizableSerializer(builder.enableCompression, builder.classNameFilter));
         registerConstantSerializers(builder.isCompatibility());
         registerJavaTypeSerializers(builder.isCompatibility());
+
+        // Called here so that we can make sure that we are not overriding
+        // any of the default serializers registered above with the Compact
+        // serialization, unless the user configured to so explicitly.
+        verifyDefaultSerializersNotOverriddenWithCompact();
     }
 
     @Override
@@ -365,8 +370,9 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     }
 
     /**
-     * Init the ObjectDataInput for the given Data skipping the serialization header-bytes and navigating to the position
-     * from where the readData() starts reading the object fields.
+     * Init the ObjectDataInput for the given Data skipping the serialization
+     * header-bytes and navigating to the position from where the readData()
+     * starts reading the object fields.
      *
      * @param data data to initialize the ObjectDataInput with.
      * @return the initialized ObjectDataInput without the header.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -192,7 +192,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public boolean getBoolean(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case BOOLEAN:
@@ -218,7 +218,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public byte getInt8(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT8:
@@ -236,7 +236,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public short getInt16(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT16:
@@ -254,7 +254,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public int getInt32(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT32:
@@ -272,7 +272,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public long getInt64(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT64:
@@ -290,7 +290,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public float getFloat32(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case FLOAT32:
@@ -308,7 +308,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     @Override
     public double getFloat64(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case FLOAT64:
@@ -362,7 +362,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     private <T> T getVariableSize(@Nonnull String fieldName, FieldKind fieldKind,
                                   Reader<T> reader) {
-        FieldDescriptor fd = getFieldDefinition(fieldName, fieldKind);
+        FieldDescriptor fd = getFieldDescriptor(fieldName, fieldKind);
         return getVariableSize(fd, reader);
     }
 
@@ -417,7 +417,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Override
     @Nullable
     public boolean[] getArrayOfBoolean(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case ARRAY_OF_BOOLEAN:
@@ -530,7 +530,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     private <T> T getArrayOfPrimitive(@Nonnull String fieldName, Reader<T> reader, FieldKind primitiveKind,
                                       FieldKind nullableKind, String methodSuffix) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         if (fieldKind == primitiveKind) {
             return getVariableSize(fd, reader);
@@ -572,7 +572,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Boolean getNullableBoolean(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case BOOLEAN:
@@ -587,7 +587,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Byte getNullableInt8(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT8:
@@ -606,7 +606,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Short getNullableInt16(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT16:
@@ -625,7 +625,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Integer getNullableInt32(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT32:
@@ -644,7 +644,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Long getNullableInt64(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case INT64:
@@ -663,7 +663,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Float getNullableFloat32(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case FLOAT32:
@@ -682,7 +682,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Double getNullableFloat64(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case FLOAT64:
@@ -701,7 +701,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Nullable
     @Override
     public Boolean[] getArrayOfNullableBoolean(@Nonnull String fieldName) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         switch (fieldKind) {
             case ARRAY_OF_BOOLEAN:
@@ -758,7 +758,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private <T> T[] getArrayOfNullable(@Nonnull String fieldName, Reader<T> reader,
                                        Function<Integer, T[]> constructor, FieldKind primitiveKind,
                                        FieldKind nullableKind) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();
         if (fieldKind == primitiveKind) {
             return getPrimitiveArrayAsNullableArray(fd, constructor, reader);
@@ -839,7 +839,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private <T> T[] getArrayOfVariableSize(@Nonnull String fieldName, FieldKind fieldKind,
                                            Function<Integer, T[]> constructor,
                                            Reader<T> reader) {
-        FieldDescriptor fieldDefinition = getFieldDefinition(fieldName, fieldKind);
+        FieldDescriptor fieldDefinition = getFieldDescriptor(fieldName, fieldKind);
         return getArrayOfVariableSize(fieldDefinition, constructor, reader);
     }
 
@@ -859,7 +859,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     @Nonnull
-    private FieldDescriptor getFieldDefinition(@Nonnull String fieldName) {
+    private FieldDescriptor getFieldDescriptor(@Nonnull String fieldName) {
         FieldDescriptor fd = schema.getField(fieldName);
         if (fd == null) {
             throw throwUnknownFieldException(fieldName);
@@ -868,8 +868,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     @Nonnull
-    private FieldDescriptor getFieldDefinition(@Nonnull String fieldName, FieldKind fieldKind) {
-        FieldDescriptor fd = getFieldDefinition(fieldName);
+    private FieldDescriptor getFieldDescriptor(@Nonnull String fieldName, FieldKind fieldKind) {
+        FieldDescriptor fd = getFieldDescriptor(fieldName);
         if (fd.getKind() != fieldKind) {
             throw unexpectedFieldKind(fd.getKind(), fieldName);
         }
@@ -906,7 +906,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     public Boolean getBooleanFromArray(@Nonnull String fieldName, int index) {
-        FieldDescriptor fd = getFieldDefinition(fieldName, ARRAY_OF_BOOLEAN);
+        FieldDescriptor fd = getFieldDescriptor(fieldName, ARRAY_OF_BOOLEAN);
         int position = readVariableSizeFieldPosition(fd);
         if (position == NULL_OFFSET) {
             return null;
@@ -954,7 +954,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     private <T> T getFixedSizeFieldFromArray(@Nonnull String fieldName, FieldKind fieldKind,
                                              Reader<T> reader, int index) {
         checkNotNegative(index, "Array indexes can not be negative");
-        FieldDescriptor fd = getFieldDefinition(fieldName, fieldKind);
+        FieldDescriptor fd = getFieldDescriptor(fieldName, fieldKind);
         int position = readVariableSizeFieldPosition(fd);
         if (position == NULL_OFFSET) {
             return null;
@@ -1075,7 +1075,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
                                            Reader<T> reader, int index) {
         int currentPos = in.position();
         try {
-            FieldDescriptor fd = getFieldDefinition(fieldName, fieldKind);
+            FieldDescriptor fd = getFieldDescriptor(fieldName, fieldKind);
             int pos = readVariableSizeFieldPosition(fd);
 
             if (pos == NULL_OFFSET) {
@@ -1114,15 +1114,12 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     private HazelcastSerializationException unexpectedFieldKind(FieldKind actualFieldKind,
                                                                 String fieldName) {
-        throw new HazelcastSerializationException("Unexpected fieldKind '" + actualFieldKind + "' for field: " + fieldName);
+        throw new HazelcastSerializationException("Unexpected field kind '" + actualFieldKind + "' for the field: " + fieldName);
     }
 
 
     private static boolean[] readBooleanBits(BufferObjectDataInput input) throws IOException {
         int len = input.readInt();
-        if (len == NULL_ARRAY_LENGTH) {
-            return null;
-        }
         if (len == 0) {
             return new boolean[0];
         }
@@ -1143,9 +1140,6 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
 
     private static Boolean[] readBooleanBitsAsNullables(BufferObjectDataInput input) throws IOException {
         int len = input.readInt();
-        if (len == NULL_ARRAY_LENGTH) {
-            return null;
-        }
         if (len == 0) {
             return new Boolean[0];
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -83,6 +83,10 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
         return classToRegistrationMap.containsKey(clazz);
     }
 
+    public Collection<Class> getCompactSerializableClasses() {
+        return classToRegistrationMap.keySet();
+    }
+
     @Override
     public int getTypeId() {
         return TYPE_COMPACT;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
@@ -35,7 +35,6 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
-import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.BYTE_OFFSET_READER_RANGE;
 import static com.hazelcast.internal.serialization.impl.compact.OffsetReader.SHORT_OFFSET_READER_RANGE;
 import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
@@ -82,8 +81,8 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIME;
 
 /**
- * Default implementation of the {@link CompactWriter} that writes
- * the serialized fields into a {@link BufferObjectDataOutput}.
+ * Default implementation of the {@link CompactWriter} that writes the
+ * serialized fields into a {@link BufferObjectDataOutput}.
  * <p>
  * The writer can also handle compact serializable classes that we want to
  * include schema in it.
@@ -125,9 +124,9 @@ public class DefaultCompactWriter implements CompactWriter {
     }
 
     /**
-     * Ends the serialization of the compact objects by writing
-     * the offsets of the variable-size fields as well as the
-     * data length, if there are some variable-size fields.
+     * Ends the serialization of the compact objects by writing the offsets of
+     * the variable-size fields as well as the data length, if there are some
+     * variable-size fields.
      */
     public void end() {
         try {
@@ -338,7 +337,7 @@ public class DefaultCompactWriter implements CompactWriter {
     }
 
     protected <T> void writeArrayOfVariableSize(@Nonnull String fieldName, @Nonnull FieldKind fieldKind,
-                                                 @Nullable T[] values, @Nonnull Writer<T> writer) {
+                                                @Nullable T[] values, @Nonnull Writer<T> writer) {
         if (values == null) {
             setPositionAsNull(fieldName, fieldKind);
             return;
@@ -504,22 +503,24 @@ public class DefaultCompactWriter implements CompactWriter {
         writeArrayOfVariableSize(fieldName, ARRAY_OF_NULLABLE_FLOAT64, value, DataOutput::writeDouble);
     }
 
-    static void writeBooleanBits(BufferObjectDataOutput out, @Nullable boolean[] booleans) throws IOException {
-        int len = (booleans != null) ? booleans.length : NULL_ARRAY_LENGTH;
+    static void writeBooleanBits(BufferObjectDataOutput out, @Nonnull boolean[] booleans) throws IOException {
+        int len = booleans.length;
         out.writeInt(len);
+        if (len == 0) {
+            return;
+        }
+
         int position = out.position();
-        if (len > 0) {
-            int index = 0;
-            out.writeZeroBytes(1);
-            for (boolean v : booleans) {
-                if (index == Byte.SIZE) {
-                    index = 0;
-                    out.writeZeroBytes(1);
-                    position++;
-                }
-                out.writeBooleanBit(position, index, v);
-                index++;
+        int index = 0;
+        out.writeZeroBytes(1);
+        for (boolean v : booleans) {
+            if (index == Byte.SIZE) {
+                index = 0;
+                out.writeZeroBytes(1);
+                position++;
             }
+            out.writeBooleanBit(position, index, v);
+            index++;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprint.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprint.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.internal.serialization.impl.compact;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
-
-import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
 
 /**
  * A very collision-resistant fingerprint method used to create automatic
@@ -69,10 +67,7 @@ public final class RabinFingerprint {
         return (fp >>> 8) ^ FP_TABLE[(int) (fp ^ b) & 0xff];
     }
 
-    private static long fingerprint64(long fp, @Nullable String value) {
-        if (value == null) {
-            return fingerprint64(fp, NULL_ARRAY_LENGTH);
-        }
+    private static long fingerprint64(long fp, @Nonnull String value) {
         byte[] utf8Bytes = value.getBytes(StandardCharsets.UTF_8);
         fp = fingerprint64(fp, utf8Bytes.length);
         for (byte utf8Byte : utf8Bytes) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/Schema.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/Schema.java
@@ -26,10 +26,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static com.hazelcast.internal.serialization.impl.FieldKindBasedOperations.VARIABLE_SIZE;
 import static com.hazelcast.internal.serialization.impl.FieldOperations.fieldOperations;
@@ -41,7 +42,8 @@ import static com.hazelcast.internal.serialization.impl.FieldOperations.fieldOpe
 public class Schema implements IdentifiedDataSerializable {
 
     private String typeName;
-    private TreeMap<String, FieldDescriptor> fieldDefinitionMap;
+    private Map<String, FieldDescriptor> fieldsMap;
+    private List<FieldDescriptor> fields;
     private int numberVarSizeFields;
     private int fixedSizeFieldsLength;
     private transient long schemaId;
@@ -49,18 +51,29 @@ public class Schema implements IdentifiedDataSerializable {
     public Schema() {
     }
 
-    public Schema(String typeName, TreeMap<String, FieldDescriptor> fieldDefinitionMap) {
+    public Schema(String typeName, List<FieldDescriptor> fields) {
         this.typeName = typeName;
-        this.fieldDefinitionMap = fieldDefinitionMap;
+        this.fields = fields;
         init();
     }
 
     private void init() {
+        // Construct the fields map for field lookups
+        Map<String, FieldDescriptor> fieldsMap = new HashMap<>(fields.size());
+        for (FieldDescriptor field : fields) {
+            fieldsMap.put(field.getFieldName(), field);
+        }
+        this.fieldsMap = fieldsMap;
+
+        // Sort the fields by the field name so that the field offsets/indexes
+        // can be set correctly.
+        fields.sort(Comparator.comparing(FieldDescriptor::getFieldName));
+
         List<FieldDescriptor> fixedSizeFields = new ArrayList<>();
         List<FieldDescriptor> booleanFields = new ArrayList<>();
         List<FieldDescriptor> variableSizeFields = new ArrayList<>();
 
-        for (FieldDescriptor descriptor : fieldDefinitionMap.values()) {
+        for (FieldDescriptor descriptor : fields) {
             FieldKind fieldKind = descriptor.getKind();
             if (fieldOperations(fieldKind).kindSizeInBytes() == VARIABLE_SIZE) {
                 variableSizeFields.add(descriptor);
@@ -73,8 +86,15 @@ public class Schema implements IdentifiedDataSerializable {
             }
         }
 
-        fixedSizeFields.sort(Comparator.comparingInt(
-                d -> fieldOperations(((FieldDescriptor) d).getKind()).kindSizeInBytes()).reversed()
+        // Fixed size fields should be in descending order of size in bytes.
+        // For ties, the alphabetical order(ascending) of the field name will
+        // be used. Since, `fields` is sorted at this point, and the `sort`
+        // method is stable, only sorting by the size in bytes is enough for
+        // this invariant to hold.
+        fixedSizeFields.sort(
+                Comparator.comparingInt(
+                        d -> fieldOperations(((FieldDescriptor) d).getKind()).kindSizeInBytes()
+                ).reversed()
         );
 
         int offset = 0;
@@ -98,6 +118,8 @@ public class Schema implements IdentifiedDataSerializable {
 
         fixedSizeFieldsLength = offset;
 
+        // Variable size fields should be in ascending alphabetical ordering
+        // of the field names
         int index = 0;
         for (FieldDescriptor descriptor : variableSizeFields) {
             descriptor.setIndex(index++);
@@ -119,11 +141,11 @@ public class Schema implements IdentifiedDataSerializable {
     }
 
     public Collection<FieldDescriptor> getFields() {
-        return fieldDefinitionMap.values();
+        return fields;
     }
 
     public Set<String> getFieldNames() {
-        return fieldDefinitionMap.keySet();
+        return fieldsMap.keySet();
     }
 
     public int getNumberOfVariableSizeFields() {
@@ -135,15 +157,15 @@ public class Schema implements IdentifiedDataSerializable {
     }
 
     public int getFieldCount() {
-        return fieldDefinitionMap.size();
+        return fieldsMap.size();
     }
 
     public FieldDescriptor getField(String fieldName) {
-        return fieldDefinitionMap.get(fieldName);
+        return fieldsMap.get(fieldName);
     }
 
     public boolean hasField(String fieldName) {
-        return fieldDefinitionMap.containsKey(fieldName);
+        return fieldsMap.containsKey(fieldName);
     }
 
     public long getSchemaId() {
@@ -154,17 +176,16 @@ public class Schema implements IdentifiedDataSerializable {
     public String toString() {
         return "Schema {"
                 + " className = " + typeName
-                + " numberOfComplexFields = " + numberVarSizeFields
-                + " primitivesLength = " + fixedSizeFieldsLength
-                + ", map = " + fieldDefinitionMap
+                + ", numberOfComplexFields = " + numberVarSizeFields
+                + ", primitivesLength = " + fixedSizeFieldsLength
+                + ", map = " + fieldsMap
                 + '}';
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeString(typeName);
-        out.writeInt(fieldDefinitionMap.size());
-        Collection<FieldDescriptor> fields = fieldDefinitionMap.values();
+        out.writeInt(fields.size());
         for (FieldDescriptor descriptor : fields) {
             out.writeString(descriptor.getFieldName());
             out.writeInt(descriptor.getKind().getId());
@@ -174,13 +195,13 @@ public class Schema implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         typeName = in.readString();
-        int fieldDefinitionsSize = in.readInt();
-        fieldDefinitionMap = new TreeMap<>(Comparator.naturalOrder());
-        for (int i = 0; i < fieldDefinitionsSize; i++) {
+        int fieldCount = in.readInt();
+        fields = new ArrayList<>(fieldCount);
+        for (int i = 0; i < fieldCount; i++) {
             String name = in.readString();
             FieldKind kind = FieldKind.get(in.readInt());
             FieldDescriptor descriptor = new FieldDescriptor(name, kind);
-            fieldDefinitionMap.put(name, descriptor);
+            fields.add(descriptor);
         }
         init();
     }
@@ -208,7 +229,8 @@ public class Schema implements IdentifiedDataSerializable {
                 && fixedSizeFieldsLength == schema.fixedSizeFieldsLength
                 && schemaId == schema.schemaId
                 && Objects.equals(typeName, schema.typeName)
-                && Objects.equals(fieldDefinitionMap, schema.fieldDefinitionMap);
+                && Objects.equals(fields, schema.fields)
+                && Objects.equals(fieldsMap, schema.fieldsMap);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.serialization.impl.compact;
 
 import com.hazelcast.nio.serialization.FieldKind;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.compact.CompactWriter;
 
 import javax.annotation.Nonnull;
@@ -26,8 +27,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.util.Comparator;
-import java.util.TreeMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A CompactWriter that constructs a schema from Compact
@@ -35,7 +37,8 @@ import java.util.TreeMap;
  */
 public final class SchemaWriter implements CompactWriter {
 
-    private final TreeMap<String, FieldDescriptor> fieldDefinitionMap = new TreeMap<>(Comparator.naturalOrder());
+    private final ArrayList<FieldDescriptor> fields = new ArrayList<>();
+    private final Set<String> fieldNames = new HashSet<>();
     private final String typeName;
 
     public SchemaWriter(String typeName) {
@@ -46,14 +49,19 @@ public final class SchemaWriter implements CompactWriter {
      * Builds the schema from the written fields and returns it.
      */
     public Schema build() {
-        return new Schema(typeName, fieldDefinitionMap);
+        return new Schema(typeName, fields);
     }
 
     /**
      * Adds a field to the schema.
      */
-    public void addField(FieldDescriptor fieldDefinition) {
-        fieldDefinitionMap.put(fieldDefinition.getFieldName(), fieldDefinition);
+    public void addField(FieldDescriptor field) {
+        String fieldName = field.getFieldName();
+        if (!fieldNames.add(fieldName)) {
+            throw new HazelcastSerializationException("Field with the name '" + fieldName + "' already exists");
+        }
+
+        fields.add(field);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -30,11 +30,11 @@ import java.time.OffsetDateTime;
 /**
  * Provides means of reading compact serialized fields from the binary data.
  * <p>
- * Read operations might throw {@link HazelcastSerializationException}
- * when a field with the given name is not found or there is a type mismatch. On such
- * occasions, one might provide default values to the read methods to return it in case
- * of the failure scenarios described above. Providing default values might be especially
- * useful, if the class might evolve in future, either by adding or removing fields.
+ * Read operations might throw {@link HazelcastSerializationException} when a
+ * field with the given name is not found or there is a type mismatch. On such
+ * occasions, one might provide default values to the read methods to return it.
+ * Providing default values might be especially useful if the class might
+ * evolve in the future, either by adding or removing fields.
  *
  * @since Hazelcast 5.0 as BETA
  */
@@ -46,9 +46,10 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     boolean readBoolean(@Nonnull String fieldName);
 
@@ -56,9 +57,10 @@ public interface CompactReader {
      * Reads a boolean or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     boolean readBoolean(@Nonnull String fieldName, boolean defaultValue);
@@ -68,19 +70,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     byte readInt8(@Nonnull String fieldName);
 
     /**
-     * Reads an 8-bit two's complement signed integer or returns the default value.
+     * Reads an 8-bit two's complement signed integer or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     byte readInt8(@Nonnull String fieldName, byte defaultValue);
@@ -90,19 +95,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     short readInt16(@Nonnull String fieldName);
 
     /**
-     * Reads a 16-bit two's complement signed integer or returns the default value.
+     * Reads a 16-bit two's complement signed integer or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     short readInt16(@Nonnull String fieldName, short defaultValue);
@@ -112,19 +120,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     int readInt32(@Nonnull String fieldName);
 
     /**
-     * Reads a 32-bit two's complement signed integer or returns the default value.
+     * Reads a 32-bit two's complement signed integer or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     int readInt32(@Nonnull String fieldName, int defaultValue);
@@ -134,19 +145,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     long readInt64(@Nonnull String fieldName);
 
     /**
-     * Reads a 64-bit two's complement signed integer or returns the default value.
+     * Reads a 64-bit two's complement signed integer or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     long readInt64(@Nonnull String fieldName, long defaultValue);
@@ -156,19 +170,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     float readFloat32(@Nonnull String fieldName);
 
     /**
-     * Reads a 32-bit IEEE 754 floating point number or returns the default value.
+     * Reads a 32-bit IEEE 754 floating point number or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     float readFloat32(@Nonnull String fieldName, float defaultValue);
@@ -178,19 +195,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     double readFloat64(@Nonnull String fieldName);
 
     /**
-     * Reads a 64-bit IEEE 754 floating point number or returns the default value.
+     * Reads a 64-bit IEEE 754 floating point number or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     double readFloat64(@Nonnull String fieldName, double defaultValue);
@@ -200,9 +220,10 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     String readString(@Nonnull String fieldName);
@@ -211,9 +232,10 @@ public interface CompactReader {
      * Reads an UTF-8 encoded string or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -224,21 +246,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     BigDecimal readDecimal(@Nonnull String fieldName);
 
     /**
-     * Reads an arbitrary precision and scale floating point number
-     * or returns the default value.
+     * Reads an arbitrary precision and scale floating point number or returns
+     * the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -249,21 +273,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     LocalTime readTime(@Nonnull String fieldName);
 
     /**
-     * Reads a time consisting of hour, minute, second, and nano seconds
-     * or returns the default value.
+     * Reads a time consisting of hour, minute, second, and nano seconds or
+     * returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -274,20 +300,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     LocalDate readDate(@Nonnull String fieldName);
 
     /**
-     * Reads a date consisting of year, month, and day or returns the default value.
+     * Reads a date consisting of year, month, and day or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -298,45 +327,51 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     LocalDateTime readTimestamp(@Nonnull String fieldName);
 
     /**
-     * Reads a timestamp consisting of date and time or returns the default value.
+     * Reads a timestamp consisting of date and time or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     LocalDateTime readTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime defaultValue);
 
     /**
-     * Reads a timestamp with timezone consisting of date, time and timezone offset.
+     * Reads a timestamp with timezone consisting of date, time and timezone
+     * offset.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName);
 
     /**
-     * Reads a timestamp with timezone consisting of date, time and timezone offset
-     * or returns the default value.
+     * Reads a timestamp with timezone consisting of date, time and timezone
+     * offset or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -347,22 +382,25 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException       if the field does not exist in the schema
-     *                                               or the type of the field does not match
-     *                                               with the one defined in the schema.
-     * @throws com.hazelcast.core.HazelcastException if the object cannot be created.
+     * @throws HazelcastSerializationException       if the field does not exist
+     *                                               in the schema or the type
+     *                                               of the field does not match
+     *                                               with the one defined in the
+     *                                               schema.
+     * @throws com.hazelcast.core.HazelcastException if the object cannot be
+     *                                               created.
      */
     @Nullable
     <T> T readCompact(@Nonnull String fieldName);
 
     /**
-     * Reads a compact object
-     * or returns the default value
+     * Reads a compact object or returns the default value
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -373,9 +411,10 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     boolean[] readArrayOfBoolean(@Nonnull String fieldName);
@@ -384,9 +423,10 @@ public interface CompactReader {
      * Reads an array of booleans or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -397,20 +437,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     byte[] readArrayOfInt8(@Nonnull String fieldName);
 
     /**
-     * Reads an array of 8-bit two's complement signed integers or returns the default value.
+     * Reads an array of 8-bit two's complement signed integers or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -421,20 +464,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     short[] readArrayOfInt16(@Nonnull String fieldName);
 
     /**
-     * Reads an array of 16-bit two's complement signed integers or returns the default value.
+     * Reads an array of 16-bit two's complement signed integers or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -445,20 +491,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     int[] readArrayOfInt32(@Nonnull String fieldName);
 
     /**
-     * Reads an array of 32-bit two's complement signed integers or returns the default value.
+     * Reads an array of 32-bit two's complement signed integers or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -469,20 +518,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     long[] readArrayOfInt64(@Nonnull String fieldName);
 
     /**
-     * Reads an array of 64-bit two's complement signed integers or returns the default value.
+     * Reads an array of 64-bit two's complement signed integers or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -493,20 +545,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     float[] readArrayOfFloat32(@Nonnull String fieldName);
 
     /**
-     * Reads an array of 32-bit IEEE 754 floating point numbers or returns the default value.
+     * Reads an array of 32-bit IEEE 754 floating point numbers or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -517,20 +572,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     double[] readArrayOfFloat64(@Nonnull String fieldName);
 
     /**
-     * Reads an array of 64-bit IEEE 754 floating point numbers or returns the default value.
+     * Reads an array of 64-bit IEEE 754 floating point numbers or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -541,9 +599,10 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     String[] readArrayOfString(@Nonnull String fieldName);
@@ -552,9 +611,10 @@ public interface CompactReader {
      * Reads an array of UTF-8 encoded strings or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -565,44 +625,51 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     BigDecimal[] readArrayOfDecimal(@Nonnull String fieldName);
 
     /**
-     * Reads an array of arbitrary precision and scale floating point numbers or returns the default value.
+     * Reads an array of arbitrary precision and scale floating point numbers or
+     * returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     BigDecimal[] readArrayOfDecimal(@Nonnull String fieldName, @Nullable BigDecimal[] defaultValue);
 
     /**
-     * Reads an array of times consisting of hour, minute, second, and nanoseconds
+     * Reads an array of times consisting of hour, minute, second, and
+     * nanoseconds
      *
      * @param fieldName name of the field.
      * @return the value of the field. The items in the array cannot be null.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     LocalTime[] readArrayOfTime(@Nonnull String fieldName);
 
     /**
-     * Reads an array of times consisting of hour, minute, second, and nanoseconds or returns the default value.
+     * Reads an array of times consisting of hour, minute, second, and
+     * nanoseconds or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -613,20 +680,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field. The items in the array cannot be null.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     LocalDate[] readArrayOfDate(@Nonnull String fieldName);
 
     /**
-     * Reads an array of dates consisting of year, month, and day or returns the default value.
+     * Reads an array of dates consisting of year, month, and day or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -637,44 +707,51 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field. The items in the array cannot be null.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     LocalDateTime[] readArrayOfTimestamp(@Nonnull String fieldName);
 
     /**
-     * Reads an array of timestamps consisting of date and time or returns the default value.
+     * Reads an array of timestamps consisting of date and time or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     LocalDateTime[] readArrayOfTimestamp(@Nonnull String fieldName, @Nullable LocalDateTime[] defaultValue);
 
     /**
-     * Reads an array of timestamps with timezone consisting of date, time and timezone offset.
+     * Reads an array of timestamps with timezone consisting of date, time and
+     * timezone offset.
      *
      * @param fieldName name of the field.
      * @return the value of the field. The items in the array cannot be null.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName);
 
     /**
-     * Reads an array of timestamps with timezone consisting of date, time and timezone offset or returns the default value.
+     * Reads an array of timestamps with timezone consisting of date, time and
+     * timezone offset or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -685,9 +762,10 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     <T> T[] readArrayOfCompact(@Nonnull String fieldName, @Nullable Class<T> componentType);
@@ -696,9 +774,10 @@ public interface CompactReader {
      * Reads an array of compact objects or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -709,9 +788,10 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Boolean readNullableBoolean(@Nonnull String fieldName);
@@ -720,9 +800,10 @@ public interface CompactReader {
      * Reads a nullable boolean or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -733,20 +814,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Byte readNullableInt8(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable 8-bit two's complement signed integer or returns the default value.
+     * Reads a nullable 8-bit two's complement signed integer or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -757,19 +841,22 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     Short readNullableInt16(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable 16-bit two's complement signed integer or returns the default value.
+     * Reads a nullable 16-bit two's complement signed integer or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     Short readNullableInt16(@Nonnull String fieldName, @Nullable Short defaultValue);
@@ -779,20 +866,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Integer readNullableInt32(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable 32-bit two's complement signed integer or returns the default value.
+     * Reads a nullable 32-bit two's complement signed integer or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -803,20 +893,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Long readNullableInt64(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable 64-bit two's complement signed integer or returns the default value.
+     * Reads a nullable 64-bit two's complement signed integer or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -827,20 +920,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Float readNullableFloat32(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable 32-bit IEEE 754 floating point number or returns the default value.
+     * Reads a nullable 32-bit IEEE 754 floating point number or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -851,20 +947,23 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Double readNullableFloat64(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable 64-bit IEEE 754 floating point number or returns the default value.
+     * Reads a nullable 64-bit IEEE 754 floating point number or returns the
+     * default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
@@ -875,164 +974,191 @@ public interface CompactReader {
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Boolean[] readArrayOfNullableBoolean(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable booleans or returns the default value.
+     * Reads a nullable array of nullable booleans or returns the default
+     * value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     Boolean[] readArrayOfNullableBoolean(@Nonnull String fieldName, @Nullable Boolean[] defaultValue);
 
     /**
-     * Reads a nullable array of nullable 8-bit two's complement signed integers.
+     * Reads a nullable array of nullable 8-bit two's complement signed
+     * integers.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Byte[] readArrayOfNullableInt8(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable 8-bit two's complement signed integers or returns the default value.
+     * Reads a nullable array of nullable 8-bit two's complement signed integers
+     * or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     Byte[] readArrayOfNullableInt8(@Nonnull String fieldName, @Nullable Byte[] defaultValue);
 
     /**
-     * Reads a nullable array of nullable 16-bit two's complement signed integers.
+     * Reads a nullable array of nullable 16-bit two's complement signed
+     * integers.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Short[] readArrayOfNullableInt16(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable 16-bit two's complement signed integers or returns the default value.
+     * Reads a nullable array of nullable 16-bit two's complement signed
+     * integers or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     Short[] readArrayOfNullableInt16(@Nonnull String fieldName, @Nullable Short[] defaultValue);
 
     /**
-     * Reads a nullable array of nullable 32-bit two's complement signed integers.
+     * Reads a nullable array of nullable 32-bit two's complement signed
+     * integers.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Integer[] readArrayOfNullableInt32(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable 32-bit two's complement signed integers or returns the default value.
+     * Reads a nullable array of nullable 32-bit two's complement signed
+     * integers or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     Integer[] readArrayOfNullableInt32(@Nonnull String fieldName, @Nullable Integer[] defaultValue);
 
     /**
-     * Reads a nullable array of nullable 64-bit two's complement signed integers.
+     * Reads a nullable array of nullable 64-bit two's complement signed
+     * integers.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Long[] readArrayOfNullableInt64(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable 64-bit two's complement signed integers or returns the default value.
+     * Reads a nullable array of nullable 64-bit two's complement signed
+     * integers or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     Long[] readArrayOfNullableInt64(@Nonnull String fieldName, @Nullable Long[] defaultValue);
 
     /**
-     * Reads a nullable array of nullable 32-bit IEEE 754 floating point numbers.
+     * Reads a nullable array of nullable 32-bit IEEE 754 floating point
+     * numbers.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Float[] readArrayOfNullableFloat32(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable 32-bit IEEE 754 floating point numbers or returns the default value.
+     * Reads a nullable array of nullable 32-bit IEEE 754 floating point numbers
+     * or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable
     Float[] readArrayOfNullableFloat32(@Nonnull String fieldName, @Nullable Float[] defaultValue);
 
     /**
-     * Reads a nullable array of nullable 64-bit IEEE 754 floating point numbers.
+     * Reads a nullable array of nullable 64-bit IEEE 754 floating point
+     * numbers.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
-     * @throws HazelcastSerializationException if the field does not exist in the schema
-     *                                         or the type of the field does not match
-     *                                         with the one defined in the schema.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
      */
     @Nullable
     Double[] readArrayOfNullableFloat64(@Nonnull String fieldName);
 
     /**
-     * Reads a nullable array of nullable 64-bit IEEE 754 floating point numbers or returns the default value.
+     * Reads a nullable array of nullable 64-bit IEEE 754 floating point numbers
+     * or returns the default value.
      *
      * @param fieldName    name of the field.
-     * @param defaultValue default value to return if the field with the given name
-     *                     does not exist in the schema or the type of the field does
-     *                     not match with the one defined in the schema.
+     * @param defaultValue default value to return if the field with the given
+     *                     name does not exist in the schema or the type of the
+     *                     field does not match with the one defined in the
+     *                     schema.
      * @return the value or the default value of the field.
      */
     @Nullable

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl.compact;
+
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactSerializer;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CompactSerializationTest {
+
+    private final SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
+
+    @Test
+    public void testOverridingDefaultSerializers() {
+        SerializationConfig config = new SerializationConfig();
+        config.getCompactSerializationConfig()
+                .register(Integer.class, "int", new IntegerSerializer());
+
+        assertThatThrownBy(() -> createSerializationService(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("allowOverrideDefaultSerializers");
+    }
+
+    @Test
+    public void testOverridingDefaultSerializers_withAllowOverrideDefaultSerializers() {
+        SerializationConfig config = new SerializationConfig();
+        config.setAllowOverrideDefaultSerializers(true);
+        config.getCompactSerializationConfig()
+                .register(Integer.class, "int", new IntegerSerializer());
+
+        SerializationService service = createSerializationService(config);
+        Data data = service.toData(42);
+
+        assertTrue(data.isCompact());
+
+        int i = service.toObject(data);
+
+        assertEquals(42, i);
+    }
+
+    @Test
+    public void testSerializer_withDuplicateFieldNames() {
+        SerializationConfig config = new SerializationConfig();
+        config.getCompactSerializationConfig()
+                .register(Foo.class, "foo", new DuplicateWritingSerializer());
+
+        SerializationService service = createSerializationService(config);
+
+        Foo foo = new Foo(42);
+
+        assertThatThrownBy(() -> service.toData(foo))
+                .isInstanceOf(HazelcastSerializationException.class)
+                .hasMessageContaining("Failed to serialize")
+                .hasRootCauseInstanceOf(HazelcastSerializationException.class)
+                .hasRootCauseMessage("Field with the name 'bar' already exists");
+    }
+
+    private SerializationService createSerializationService(SerializationConfig config) {
+        config.getCompactSerializationConfig().setEnabled(true);
+        return new DefaultSerializationServiceBuilder()
+                .setSchemaService(schemaService)
+                .setConfig(config)
+                .build();
+    }
+
+    private static class IntegerSerializer implements CompactSerializer<Integer> {
+        @Nonnull
+        @Override
+        public Integer read(@Nonnull CompactReader in) {
+            return in.readInt32("field");
+        }
+
+        @Override
+        public void write(@Nonnull CompactWriter out, @Nonnull Integer object) {
+            out.writeInt32("field", object);
+        }
+    }
+
+    private static class Foo {
+        private final int bar;
+
+        private Foo(int bar) {
+            this.bar = bar;
+        }
+    }
+
+    private static class DuplicateWritingSerializer implements CompactSerializer<Foo> {
+        @Nonnull
+        @Override
+        public Foo read(@Nonnull CompactReader in) {
+            return new Foo(in.readInt32("bar"));
+        }
+
+        @Override
+        public void write(@Nonnull CompactWriter out, @Nonnull Foo object) {
+            out.writeInt32("bar", object.bar);
+            out.writeInt32("bar", object.bar);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprintTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/RabinFingerprintTest.java
@@ -37,6 +37,17 @@ import static org.junit.Assert.assertEquals;
 public class RabinFingerprintTest {
 
     @Test
+    public void testRabinFingerprint() {
+        SchemaWriter writer = new SchemaWriter("SomeType");
+        writer.writeInt32("id", 0);
+        writer.writeString("name", null);
+        writer.writeInt8("age", (byte) 0);
+        writer.writeArrayOfTimestamp("times", null);
+        Schema schema = writer.build();
+        assertEquals(-5445839760245891300L, schema.getSchemaId());
+    }
+
+    @Test
     public void testRabinFingerprintIsConsistentWithWrittenData() throws IOException {
         SchemaWriter writer = new SchemaWriter("typeName");
         writer.addField(new FieldDescriptor("a", FieldKind.BOOLEAN));

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl.compact;
+
+import com.hazelcast.nio.serialization.FieldKind;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SchemaWriterTest {
+
+    @Test
+    public void testSchemaWriter() {
+        SchemaWriter writer = new SchemaWriter("foo");
+
+        writer.writeBoolean(FieldKind.BOOLEAN.name(), true);
+        writer.writeArrayOfBoolean(FieldKind.ARRAY_OF_BOOLEAN.name(), null);
+
+        writer.writeInt8(FieldKind.INT8.name(), (byte) 0);
+        writer.writeArrayOfInt8(FieldKind.ARRAY_OF_INT8.name(), null);
+
+        writer.writeInt16(FieldKind.INT16.name(), (short) 0);
+        writer.writeArrayOfInt16(FieldKind.ARRAY_OF_INT16.name(), null);
+
+        writer.writeInt32(FieldKind.INT32.name(), 0);
+        writer.writeArrayOfInt32(FieldKind.ARRAY_OF_INT32.name(), null);
+
+        writer.writeInt64(FieldKind.INT64.name(), 0);
+        writer.writeArrayOfInt64(FieldKind.ARRAY_OF_INT64.name(), null);
+
+        writer.writeFloat32(FieldKind.FLOAT32.name(), 0);
+        writer.writeArrayOfFloat32(FieldKind.ARRAY_OF_FLOAT32.name(), null);
+
+        writer.writeFloat64(FieldKind.FLOAT64.name(), 0);
+        writer.writeArrayOfFloat64(FieldKind.ARRAY_OF_FLOAT64.name(), null);
+
+        writer.writeString(FieldKind.STRING.name(), null);
+        writer.writeArrayOfString(FieldKind.ARRAY_OF_STRING.name(), null);
+
+        writer.writeDecimal(FieldKind.DECIMAL.name(), null);
+        writer.writeArrayOfDecimal(FieldKind.ARRAY_OF_DECIMAL.name(), null);
+
+        writer.writeTime(FieldKind.TIME.name(), null);
+        writer.writeArrayOfTime(FieldKind.ARRAY_OF_TIME.name(), null);
+
+        writer.writeDate(FieldKind.DATE.name(), null);
+        writer.writeArrayOfDate(FieldKind.ARRAY_OF_DATE.name(), null);
+
+        writer.writeTimestamp(FieldKind.TIMESTAMP.name(), null);
+        writer.writeArrayOfTimestamp(FieldKind.ARRAY_OF_TIMESTAMP.name(), null);
+
+        writer.writeTimestampWithTimezone(FieldKind.TIMESTAMP_WITH_TIMEZONE.name(), null);
+        writer.writeArrayOfTimestampWithTimezone(FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE.name(), null);
+
+        writer.writeCompact(FieldKind.COMPACT.name(), null);
+        writer.writeArrayOfCompact(FieldKind.ARRAY_OF_COMPACT.name(), null);
+
+        writer.writeNullableBoolean(FieldKind.NULLABLE_BOOLEAN.name(), null);
+        writer.writeArrayOfNullableBoolean(FieldKind.ARRAY_OF_NULLABLE_BOOLEAN.name(), null);
+
+        writer.writeNullableInt8(FieldKind.NULLABLE_INT8.name(), null);
+        writer.writeArrayOfNullableInt8(FieldKind.ARRAY_OF_NULLABLE_INT8.name(), null);
+
+        writer.writeNullableInt16(FieldKind.NULLABLE_INT16.name(), null);
+        writer.writeArrayOfNullableInt16(FieldKind.ARRAY_OF_NULLABLE_INT16.name(), null);
+
+        writer.writeNullableInt32(FieldKind.NULLABLE_INT32.name(), null);
+        writer.writeArrayOfNullableInt32(FieldKind.ARRAY_OF_NULLABLE_INT32.name(), null);
+
+        writer.writeNullableInt64(FieldKind.NULLABLE_INT64.name(), null);
+        writer.writeArrayOfNullableInt64(FieldKind.ARRAY_OF_NULLABLE_INT64.name(), null);
+
+        writer.writeNullableFloat32(FieldKind.NULLABLE_FLOAT32.name(), null);
+        writer.writeArrayOfNullableFloat32(FieldKind.ARRAY_OF_NULLABLE_FLOAT32.name(), null);
+
+        writer.writeNullableFloat64(FieldKind.NULLABLE_FLOAT64.name(), null);
+        writer.writeArrayOfNullableFloat64(FieldKind.ARRAY_OF_NULLABLE_FLOAT64.name(), null);
+
+        Schema schema = writer.build();
+
+        for (FieldKind kind : FieldKind.values()) {
+            if (!isSupportedByCompact(kind)) {
+                continue;
+            }
+
+            FieldDescriptor field = schema.getField(kind.name());
+            assertNotNull(field);
+
+            assertEquals(kind.name(), field.getFieldName());
+            assertEquals(kind, field.getKind());
+        }
+    }
+
+    @Test
+    public void testSchemaWriter_withDuplicateFields() {
+        SchemaWriter writer = new SchemaWriter("foo");
+        writer.writeInt32("bar", 0);
+        assertThatThrownBy(() -> writer.writeString("bar", null))
+                .isInstanceOf(HazelcastSerializationException.class)
+                .hasMessageContaining("already exists");
+    }
+
+    private boolean isSupportedByCompact(FieldKind kind) {
+        return !(FieldKind.CHAR == kind
+                || FieldKind.ARRAY_OF_CHAR == kind
+                || FieldKind.PORTABLE == kind
+                || FieldKind.ARRAY_OF_PORTABLE == kind
+        );
+    }
+}


### PR DESCRIPTION
This is the compound PR for the tasks listed in JIRA task API-1320.

It contains the following changes

- Schema class now holds the fields in a HashMap instead of TreeMap
for faster lookups
- Various JavaDoc fixes for some classes
- Removing non-reachable dead codes around RabinFingerprint,
DefaultCompactWriter, and CompactInternalGenericRecord
- Mechanism to prevent duplicate field names in the Compact serializers
- Check for making sure that the Compact serializers registered
would not override the default serializers, unless explicitly
set by the user to do so.
