### PR TITLE
CP Members shouldn't be auto removed if persistence is enabled [HZ-1300]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -619,8 +619,8 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
     }
 
     void updateMissingMembers() {
-        if (config.getMissingCPMemberAutoRemovalSeconds() == 0 || !metadataGroupManager.isDiscoveryCompleted()
-                || (!isStartCompleted() && getCPPersistenceService().getCPMetadataStore().containsLocalMemberFile())) {
+        if (config.getMissingCPMemberAutoRemovalSeconds() == 0 || config.isPersistenceEnabled()
+                || !metadataGroupManager.isDiscoveryCompleted() || (!isStartCompleted())) {
             return;
         }
 


### PR DESCRIPTION
Regarding Hazelcast documentation, automatically removing missing CP members from the CP Subsystem does not apply when CP Subsystem Persistence is enabled (https://docs.hazelcast.com/hazelcast/5.1/cp-subsystem/configuration#missing-cp-member-auto-removal-seconds).

To avoid automatic removing, we don't add missing CP members to the `missingMembers` list if persistence is enabled.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5101

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5104

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
