### PR TITLE
Fix incompatible AddMapConfigMessageTask[HZ-1303]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -108,8 +108,12 @@ public class AddMapConfigMessageTask
         }
         config.setWanReplicationRef(parameters.wanReplicationRef);
         config.setMetadataPolicy(MetadataPolicy.getById(parameters.metadataPolicy));
-        config.setDataPersistenceConfig(parameters.dataPersistenceConfig);
-        config.setTieredStoreConfig(parameters.tieredStoreConfig);
+        if (parameters.isDataPersistenceConfigExists) {
+            config.setDataPersistenceConfig(parameters.dataPersistenceConfig);
+        }
+        if (parameters.isTieredStoreConfigExists) {
+            config.setTieredStoreConfig(parameters.tieredStoreConfig);
+        }
         return config;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -53,7 +53,7 @@ public class AddMapConfigMessageTask
     }
 
     @Override
-    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity", "checkstyle:MethodLength"})
     protected IdentifiedDataSerializable getConfig() {
         MapConfig config = new MapConfig(parameters.name);
         config.setAsyncBackupCount(parameters.asyncBackupCount);


### PR DESCRIPTION
Because of the lack of field existence check, we were getting the NPE
while materializing the transmitted config object. Added the existence check
for these newly added config elements to fix this issue.

Note that: The regular client compatibility test suite doesn’t catch this type
of issue. Maybe we can automatically generate message task tests to detect
this kind of issues beforehand. 

Fixes https://github.com/hazelcast/hazelcast/issues/21732

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

