### PR TITLE
Invalidate client session if CP Subsystem is unaware of it [HZ-1264]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftOp.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.logging.Level;
 
@@ -98,6 +99,13 @@ public abstract class RaftOp implements DataSerializable {
                 logger.log(level, e.getMessage(), e);
             }
         }
+    }
+
+    public boolean hasOnNullRaftNodeAction() {
+        return false;
+    }
+
+    public void onNullRaftNodeAction(CPGroupId groupId, Operation operation) {
     }
 
     protected void toString(StringBuilder sb) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/DefaultRaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/DefaultRaftReplicateOp.java
@@ -47,6 +47,16 @@ public class DefaultRaftReplicateOp extends RaftReplicateOp implements Indetermi
         this.op = op;
     }
 
+    protected boolean hasOnNullRaftNodeAction() {
+        return op.hasOnNullRaftNodeAction();
+    }
+
+    @Override
+    protected void onNullRaftNodeAction(CPGroupId groupId) {
+        op.setNodeEngine(getNodeEngine());
+        op.onNullRaftNodeAction(groupId, this);
+    }
+
     @Override
     protected InternalCompletableFuture replicate(RaftNode raftNode) {
         if (op instanceof CallerAware) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cp.internal.session;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -41,6 +42,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -160,6 +162,31 @@ public abstract class AbstractProxySessionManagerTest extends HazelcastRaftTestS
 
         SessionAccessor sessionAccessor = getSessionAccessor();
         assertTrueEventually(() -> assertFalse(sessionAccessor.isActive(groupId, sessionId)));
+    }
+
+    @Test
+    public void sessionHeartbeatsStopSent_afterClusterRestart() {
+        AbstractProxySessionManager sessionManager = getSessionManager();
+        long sessionId = sessionManager.acquireSession(groupId);
+
+        assertTrueEventually(() -> verify(sessionManager, atLeastOnce()).heartbeat(groupId, sessionId));
+
+        Address address1 = members[0].getCPSubsystem().getLocalCPMember().getAddress();
+        Address address2 = members[1].getCPSubsystem().getLocalCPMember().getAddress();
+        Address address3 = members[2].getCPSubsystem().getLocalCPMember().getAddress();
+
+        members[0].getLifecycleService().terminate();
+        members[1].getLifecycleService().terminate();
+        members[2].getLifecycleService().terminate();
+
+        Config config = createConfig(3, 3);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(address1, config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(address2, config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(address3, config);
+
+        waitUntilCPDiscoveryCompleted(instance1, instance2, instance3);
+
+        assertTrueAllTheTime(() -> verify(sessionManager, atMost(10)).heartbeat(groupId, sessionId), 15);
     }
 
     @Test


### PR DESCRIPTION
For `FencedLock` and `Semaphore` CP data structures, sessions are required to keep track of the liveliness of callers (https://docs.hazelcast.com/hazelcast/5.1/cp-subsystem/cp-subsystem#sessions)
To keep its session alive, a caller commits a periodic heartbeat to the CP group. If the CP Subsystem lost information about this CP group after the restart/failure, there is no way to tell the caller to invalidate the session.

To fix this, we check if a `groupId`, that session belongs to, is known by the CP Subsystem. If it doesn't, it means the CPGroup and session have been destroyed, and we can respond to the caller with `CPGroupDestroyedException`, which invalidates the caller's session.

Fixes https://hazelcast.atlassian.net/browse/HZ-1264

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

