### PR TITLE
Simplify WatermarkedFields, fix Union

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DropLateItemsLogicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/DropLateItemsLogicalRel.java
@@ -24,7 +24,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rex.RexNode;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
@@ -35,19 +34,19 @@ import java.util.List;
  * the last watermark.
  */
 public class DropLateItemsLogicalRel extends SingleRel implements LogicalRel {
-    private final RexNode wmField;
+    private final int wmField;
 
     protected DropLateItemsLogicalRel(
             RelOptCluster cluster,
             RelTraitSet traitSet,
             RelNode input,
-            RexNode wmField
+            int wmField
     ) {
         super(cluster, traitSet, input);
         this.wmField = wmField;
     }
 
-    public RexNode wmField() {
+    public int wmField() {
         return wmField;
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/WatermarkRules.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/WatermarkRules.java
@@ -39,8 +39,6 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 
-import java.util.Map;
-
 import static com.hazelcast.jet.sql.impl.opt.metadata.HazelcastRelMdWatermarkedFields.watermarkedFieldByIndex;
 import static com.hazelcast.sql.impl.plan.node.PlanNodeFieldTypeProvider.FAILING_FIELD_TYPE_PROVIDER;
 import static org.apache.calcite.plan.RelOptRule.none;
@@ -80,23 +78,19 @@ final class WatermarkRules {
                 call.transformTo(wmRel);
                 return;
             }
-            WatermarkedFields watermarkedFields = watermarkedFieldByIndex(wmRel, wmIndex);
+            WatermarkedFields watermarkedFields = watermarkedFieldByIndex(wmIndex);
             if (watermarkedFields == null || watermarkedFields.isEmpty()) {
                 call.transformTo(wmRel);
                 return;
             }
 
-            Map.Entry<Integer, RexNode> watermarkedField = watermarkedFields.findFirst();
-            if (watermarkedField == null) {
-                call.transformTo(wmRel);
-                return;
-            }
+            int watermarkedField = watermarkedFields.findFirst();
 
             DropLateItemsLogicalRel dropLateItemsRel = new DropLateItemsLogicalRel(
                     scan.getCluster(),
                     OptUtils.toLogicalConvention(scan.getTraitSet()),
                     wmRel,
-                    watermarkedField.getValue()
+                    watermarkedField
             );
             call.transformTo(dropLateItemsRel);
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/HazelcastRelMdWatermarkedFields.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/HazelcastRelMdWatermarkedFields.java
@@ -169,7 +169,7 @@ public final class HazelcastRelMdWatermarkedFields
     public WatermarkedFields extractWatermarkedFields(Union rel, RelMetadataQuery mq) {
         HazelcastRelMetadataQuery query = HazelcastRelMetadataQuery.reuseOrCreate(mq);
         assert !rel.getInputs().isEmpty();
-        Set<Integer> wmFields = query.extractWatermarkedFields(rel.getInput(0)).getFieldIndexes();
+        Set<Integer> wmFields = new HashSet<>(query.extractWatermarkedFields(rel.getInput(0)).getFieldIndexes());
         for (int i = 1; i < rel.getInputs().size(); i++) {
             WatermarkedFields wmFields2 = query.extractWatermarkedFields(rel.getInputs().get(i));
             if (wmFields2 == null) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/HazelcastRelMdWatermarkedFields.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/HazelcastRelMdWatermarkedFields.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.opt.metadata;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.hazelcast.jet.sql.impl.opt.FullScan;
 import com.hazelcast.jet.sql.impl.opt.SlidingWindow;
 import com.hazelcast.jet.sql.impl.opt.logical.DropLateItemsLogicalRel;
@@ -44,11 +44,10 @@ import org.apache.calcite.util.Util;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.jet.sql.impl.validate.ValidationUtil.unwrapAsOperatorOperand;
 
@@ -70,21 +69,20 @@ public final class HazelcastRelMdWatermarkedFields
 
     @SuppressWarnings("unused")
     public WatermarkedFields extractWatermarkedFields(FullScan rel, RelMetadataQuery mq) {
-        return watermarkedFieldByIndex(rel, rel.watermarkedColumnIndex());
+        return watermarkedFieldByIndex(rel.watermarkedColumnIndex());
     }
 
     @SuppressWarnings("unused")
     public WatermarkedFields extractWatermarkedFields(WatermarkLogicalRel rel) {
-        return watermarkedFieldByIndex(rel, rel.watermarkedColumnIndex());
+        return watermarkedFieldByIndex(rel.watermarkedColumnIndex());
     }
 
     @Nullable
-    public static WatermarkedFields watermarkedFieldByIndex(RelNode rel, int watermarkedFieldIndex) {
+    public static WatermarkedFields watermarkedFieldByIndex(int watermarkedFieldIndex) {
         if (watermarkedFieldIndex < 0) {
             return null;
         }
-        return new WatermarkedFields(ImmutableMap.of(watermarkedFieldIndex,
-                rel.getCluster().getRexBuilder().makeInputRef(rel, watermarkedFieldIndex)));
+        return new WatermarkedFields(ImmutableSet.of(watermarkedFieldIndex));
     }
 
     @SuppressWarnings("unused")
@@ -93,16 +91,15 @@ public final class HazelcastRelMdWatermarkedFields
         WatermarkedFields inputWatermarkedFields = query.extractWatermarkedFields(rel.getInput());
 
         if (inputWatermarkedFields == null
-                || !inputWatermarkedFields.getPropertiesByIndex().containsKey(rel.orderingFieldIndex())) {
+                || !inputWatermarkedFields.getFieldIndexes().contains(rel.orderingFieldIndex())) {
             // if there's no watermarked field in the input to a window function, or if the field used to
             // calculate window bounds isn't watermarked, the window bounds aren't watermarked either
             return inputWatermarkedFields;
         }
 
         RexBuilder rexBuilder = rel.getCluster().getRexBuilder();
-        return inputWatermarkedFields.merge(new WatermarkedFields(ImmutableMap.of(
-                rel.windowStartIndex(), rexBuilder.makeInputRef(rel, rel.windowStartIndex()),
-                rel.windowEndIndex(), rexBuilder.makeInputRef(rel, rel.windowEndIndex()))));
+        return inputWatermarkedFields.union(new WatermarkedFields(
+                ImmutableSet.of(rel.windowStartIndex(), rel.windowEndIndex())));
     }
 
     @SuppressWarnings("unused")
@@ -113,7 +110,7 @@ public final class HazelcastRelMdWatermarkedFields
             return null;
         }
 
-        Map<Integer, RexNode> outputWmFields = new HashMap<>();
+        Set<Integer> outputWmFields = new HashSet<>();
         List<RexNode> projectList = rel.getProgram().expandList(rel.getProgram().getProjectList());
         for (int i = 0; i < projectList.size(); i++) {
             RexNode project = projectList.get(i);
@@ -122,8 +119,8 @@ public final class HazelcastRelMdWatermarkedFields
             //  transformations of input references.
             if (project2 instanceof RexInputRef) {
                 int index = ((RexInputRef) project2).getIndex();
-                if (inputWmFields.getPropertiesByIndex().containsKey(index)) {
-                    outputWmFields.put(i, project);
+                if (inputWmFields.getFieldIndexes().contains(index)) {
+                    outputWmFields.add(i);
                 }
             }
         }
@@ -148,11 +145,11 @@ public final class HazelcastRelMdWatermarkedFields
         // The fields, by which the aggregation groups, and which are aggregated on input, are watermarked
         // also on the output.
         Iterator<Integer> groupedIndexes = rel.getGroupSets().get(0).iterator();
-        Map<Integer, RexNode> outputProperties = new HashMap<>();
+        Set<Integer> outputProperties = new HashSet<>();
         for (int outputIndex = 0; groupedIndexes.hasNext(); outputIndex++) {
             int groupedBy = groupedIndexes.next();
-            if (inputWmFields.getPropertiesByIndex().containsKey(groupedBy)) {
-                outputProperties.put(outputIndex, rel.getCluster().getRexBuilder().makeInputRef(rel, outputIndex));
+            if (inputWmFields.getFieldIndexes().contains(groupedBy)) {
+                outputProperties.add(outputIndex);
             }
         }
 
@@ -171,14 +168,16 @@ public final class HazelcastRelMdWatermarkedFields
     @SuppressWarnings("unused")
     public WatermarkedFields extractWatermarkedFields(Union rel, RelMetadataQuery mq) {
         HazelcastRelMetadataQuery query = HazelcastRelMetadataQuery.reuseOrCreate(mq);
-        WatermarkedFields wmFields = new WatermarkedFields(Collections.emptyMap());
-        for (RelNode input : rel.getInputs()) {
-            WatermarkedFields watermarkedFields = query.extractWatermarkedFields(input);
-            if (!wmFields.equals(watermarkedFields)) {
-                wmFields = wmFields.merge(watermarkedFields);
+        assert !rel.getInputs().isEmpty();
+        Set<Integer> wmFields = query.extractWatermarkedFields(rel.getInput(0)).getFieldIndexes();
+        for (int i = 1; i < rel.getInputs().size(); i++) {
+            WatermarkedFields wmFields2 = query.extractWatermarkedFields(rel.getInputs().get(i));
+            if (wmFields2 == null) {
+                return null;
             }
+            wmFields.retainAll(wmFields2.getFieldIndexes());
         }
-        return wmFields;
+        return new WatermarkedFields(wmFields);
     }
 
     @SuppressWarnings("unused")

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/WatermarkedFields.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/WatermarkedFields.java
@@ -16,45 +16,46 @@
 
 package com.hazelcast.jet.sql.impl.opt.metadata;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public final class WatermarkedFields implements Serializable {
 
-    private final Map<Integer, RexNode> propertiesByIndex;
+    private final Set<Integer> fieldIndexes;
 
-    public WatermarkedFields(Map<Integer, RexNode> propertiesByIndex) {
-        this.propertiesByIndex = Collections.unmodifiableMap(propertiesByIndex);
+    public WatermarkedFields(Set<Integer> fieldIndexes) {
+        this.fieldIndexes = Collections.unmodifiableSet(fieldIndexes);
     }
 
-    public WatermarkedFields merge(WatermarkedFields other) {
-        if (other == null || other.propertiesByIndex.isEmpty()) {
+    /**
+     * Returns an instance that will have all the fields of {@code this} and
+     * {@code other} instance watermarked.
+     */
+    public WatermarkedFields union(WatermarkedFields other) {
+        if (other == null || other.fieldIndexes.isEmpty()) {
             return this;
         }
 
-        Map<Integer, RexNode> newPropertiesByIndex = new HashMap<>(this.propertiesByIndex);
-        newPropertiesByIndex.putAll(other.propertiesByIndex);
-        assert this.propertiesByIndex.size() + other.propertiesByIndex.size() == newPropertiesByIndex.size();
-        return new WatermarkedFields(newPropertiesByIndex);
+        Set<Integer> newWatermarkedFields = new HashSet<>(this.fieldIndexes);
+        newWatermarkedFields.addAll(other.fieldIndexes);
+        assert this.fieldIndexes.size() + other.fieldIndexes.size() == newWatermarkedFields.size();
+        return new WatermarkedFields(newWatermarkedFields);
+    }
+
+    public int findFirst() {
+        return fieldIndexes.iterator().next();
     }
 
     @Nullable
-    public Map.Entry<Integer, RexNode> findFirst() {
-        return propertiesByIndex.entrySet().iterator().next();
-    }
-
-    @Nullable
-    public Map.Entry<Integer, RexNode> findFirst(ImmutableBitSet indices) {
-        for (Entry<Integer, RexNode> entry : propertiesByIndex.entrySet()) {
-            if (indices.get(entry.getKey())) {
+    public Integer findFirst(ImmutableBitSet indices) {
+        for (Integer entry : fieldIndexes) {
+            if (indices.get(entry)) {
                 return entry;
             }
         }
@@ -70,19 +71,19 @@ public final class WatermarkedFields implements Serializable {
             return false;
         }
         WatermarkedFields that = (WatermarkedFields) o;
-        return Objects.equals(propertiesByIndex, that.propertiesByIndex);
+        return Objects.equals(fieldIndexes, that.fieldIndexes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(propertiesByIndex);
+        return Objects.hash(fieldIndexes);
     }
 
     public boolean isEmpty() {
-        return propertiesByIndex.isEmpty();
+        return fieldIndexes.isEmpty();
     }
 
-    public Map<Integer, RexNode> getPropertiesByIndex() {
-        return propertiesByIndex;
+    public Set<Integer> getFieldIndexes() {
+        return fieldIndexes;
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/AggregateSlidingWindowPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/AggregateSlidingWindowPhysicalRule.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map.Entry;
 
 import static com.hazelcast.jet.sql.impl.opt.Conventions.LOGICAL;
 import static com.hazelcast.jet.sql.impl.opt.OptUtils.hasInputRef;
@@ -237,7 +236,6 @@ public final class AggregateSlidingWindowPhysicalRule extends AggregateAbstractP
         if (watermarkedFields == null) {
             return null;
         }
-        Entry<Integer, RexNode> watermarkedField = watermarkedFields.findFirst(logicalAggregate.getGroupSet());
-        return watermarkedField != null ? watermarkedField.getKey() : null;
+        return watermarkedFields.findFirst(logicalAggregate.getGroupSet());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/SlidingWindowAggregatePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/SlidingWindowAggregatePhysicalRel.java
@@ -38,15 +38,13 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
-import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexVisitor;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.hazelcast.jet.sql.impl.aggregate.WindowUtils.insertWindowBound;
@@ -144,13 +142,8 @@ public class SlidingWindowAggregatePhysicalRel extends Aggregate implements Phys
     }
 
     public WatermarkedFields watermarkedFields() {
-        Map<Integer, RexNode> propertiesByIndex = new HashMap<>();
-        RexBuilder rexBuilder = getCluster().getRexBuilder();
-        for (Integer index : windowEndIndexes) {
-            propertiesByIndex.put(index, rexBuilder.makeInputRef(getInput(), index));
-        }
-        // Backlog: also support windowStartIndexes by adding windowSize to windowStart
-        return new WatermarkedFields(propertiesByIndex);
+        // Backlog: also support windowStartIndexes
+        return new WatermarkedFields(new HashSet<>(windowEndIndexes));
     }
 
     @Override


### PR DESCRIPTION
The `WatermarkedFields` used a `Map<Integer, RexNode>`. The key was the field
index that was watermarked, and the value was the expression used to extract
that value from the rel's input. However, the value is never necessary. If
`rel1` is an input of `rel2`, then `rel2` never needs the expression used by
`rel1` to extract the watermarked value from `rel1`'s input, nor does it have
access to the `rel1`'s input. The `rel1` doesn't need that expression too, as it
must have it by other means, because it creates the output row.

This PR removes the value and replaces `Map<Integer, RexNode>` with just
`Set<Integer>`.

It also fixes the watermarked fields for `Union`: the output of union only
contains the watermark, if _all_ its input have that same field watermarked.
Before it contained it if _any_ input has a column watermarked.