### PR TITLE
Prevent unnecessary retries if the METADATA group is unaware of the requested CPGroup [HZ-1264]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/exception/CPGroupDestroyedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/exception/CPGroupDestroyedException.java
@@ -21,6 +21,8 @@ import com.hazelcast.cp.CPGroupId;
 /**
  * A {@code CPSubsystemException} which is thrown when a request is sent to
  * a destroyed CP group.
+ * This exception is used as an indicator for the caller's session invalidation
+ * for {@code FencedLock} and {@code Semaphore} data structures
  */
 public class CPGroupDestroyedException extends CPSubsystemException {
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -757,7 +757,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
         return node;
     }
 
-    boolean isStartCompleted() {
+    public boolean isStartCompleted() {
         return nodeEngine.getNode().getNodeExtension().isStartCompleted();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
@@ -60,19 +60,44 @@ public abstract class RaftReplicateOp extends Operation implements IdentifiedDat
         RaftService service = getService();
         RaftNode raftNode = service.getOrInitRaftNode(groupId);
         if (raftNode == null) {
-            if (service.isRaftGroupDestroyed(groupId)) {
-                sendResponse(new CPGroupDestroyedException(groupId));
-            } else {
-                sendResponse(new NotLeaderException(groupId, service.getLocalCPEndpoint(), null));
-            }
+            onNullRaftNode(service);
             return;
-        } else if (raftNode.getStatus() == RaftNodeStatus.STEPPED_DOWN) {
+        }
+        if (raftNode.getStatus() == RaftNodeStatus.STEPPED_DOWN) {
             sendResponse(new NotLeaderException(groupId, service.getLocalCPEndpoint(), null));
             getNodeEngine().getExecutionService().execute(CP_SUBSYSTEM_EXECUTOR, () -> service.stepDownRaftNode(groupId));
             return;
         }
 
         replicate(raftNode).whenCompleteAsync(this, CALLER_RUNS);
+    }
+
+    private void onNullRaftNode(RaftService service) {
+        if (service.isRaftGroupDestroyed(groupId)) {
+            sendResponse(new CPGroupDestroyedException(groupId));
+        } else if (!groupId.equals(service.getMetadataGroupId())
+                && service.isDiscoveryCompleted() && service.isStartCompleted()) {
+            sendResponseAfterMetadataCheck(service);
+        } else {
+            sendResponse(new NotLeaderException(groupId, service.getLocalCPEndpoint(), null));
+        }
+    }
+
+    private void sendResponseAfterMetadataCheck(RaftService service) {
+        getNodeEngine().getExecutionService().execute(CP_SUBSYSTEM_EXECUTOR, () ->
+            service.getCPGroup(groupId).whenCompleteAsync((group, throwable) -> {
+                        // Checking if groupId is known by the METADATA group.
+                        // If it is unaware, it means that the CP Subsystem has lost information about CPGroup after
+                        // the restart, and we can respond with a non-retriable exception.
+                        if (group == null && throwable == null) {
+                            getLogger().info("There is no info about " + groupId + " in the METADATA group");
+                            sendResponse(new CPGroupDestroyedException(groupId));
+                        } else {
+                            sendResponse(new NotLeaderException(groupId, service.getLocalCPEndpoint(), null));
+                        }
+                    },
+                    CALLER_RUNS)
+        );
     }
 
     protected abstract InternalCompletableFuture replicate(RaftNode raftNode);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cp.internal.session;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -41,6 +42,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -160,6 +162,31 @@ public abstract class AbstractProxySessionManagerTest extends HazelcastRaftTestS
 
         SessionAccessor sessionAccessor = getSessionAccessor();
         assertTrueEventually(() -> assertFalse(sessionAccessor.isActive(groupId, sessionId)));
+    }
+
+    @Test
+    public void sessionHeartbeatsStopSent_afterClusterRestart() {
+        AbstractProxySessionManager sessionManager = getSessionManager();
+        long sessionId = sessionManager.acquireSession(groupId);
+
+        assertTrueEventually(() -> verify(sessionManager, atLeastOnce()).heartbeat(groupId, sessionId));
+
+        Address address1 = members[0].getCPSubsystem().getLocalCPMember().getAddress();
+        Address address2 = members[1].getCPSubsystem().getLocalCPMember().getAddress();
+        Address address3 = members[2].getCPSubsystem().getLocalCPMember().getAddress();
+
+        members[0].getLifecycleService().terminate();
+        members[1].getLifecycleService().terminate();
+        members[2].getLifecycleService().terminate();
+
+        Config config = createConfig(3, 3);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(address1, config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(address2, config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(address3, config);
+
+        waitUntilCPDiscoveryCompleted(instance1, instance2, instance3);
+
+        assertTrueAllTheTime(() -> verify(sessionManager, atMost(10)).heartbeat(groupId, sessionId), 15);
     }
 
     @Test


### PR DESCRIPTION
Information about all CP groups should be present in the METADATA group. If there is no information, there is no point to retry Raft operations.

For example, this behaviour can happen in the case of `FencedLock` and `Semaphore` CP data structures. Those data structures require sessions to keep track of the liveliness of callers.
To keep its session alive, a caller commits a periodic heartbeat to the CP group. If the CP Subsystem lost information about this CP group after the restart, there is no way to tell the caller to invalidate the session.

To fix this, we check if CPGroup is known by the METADATA group.
If it is unaware, it means that the CP Subsystem has lost information about CPGroup after the restart, and we can respond with a non-retriable `CPGroupDestroyedException` exception.

Fixes https://hazelcast.atlassian.net/browse/HZ-1264

----

The correctness of these changes relies on the following assumptions:
- if we have a `groupId` it means that it has been returned by the https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java#L173 and the METADATA group should be aware of it
- we are querying the METADATA group with the `LINEARIZABLE` level, which, in theory, should give us the strongest consistency guarantees (_"Linearizability requires the results of a read to reflect a state of the system sometime after the read was initiated; each read must at least return the results of the latest committed write."_) https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java#L277
- since we extend cases when `CPGroupDestroyedException` could be thrown, we should analyse places where this exception is used. There are 3 places: two of them are used in a scope of `RaftQueryOp` and the last one is our case (an indicator to invalidate the client session) https://github.com/hazelcast/hazelcast/blob/14ef0dbefa4a6fa00a50a8873aeea02ec6c3f5e4/hazelcast/src/main/java/com/hazelcast/cp/internal/session/AbstractProxySessionManager.java#L321-L322 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
