### PR TITLE
Fix #21746 - flaky MultiTableCacheIntegrationTest test [HZ-1310]

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/RecordPartImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/RecordPartImpl.java
@@ -86,7 +86,7 @@ class RecordPartImpl implements RecordPart {
 
     @Override
     public int hashCode() {
-        return json.hashCode();
+        return toJson().hashCode();
     }
 
     @Override
@@ -98,7 +98,7 @@ class RecordPartImpl implements RecordPart {
             return false;
         }
         RecordPartImpl other = (RecordPartImpl) obj;
-        return Objects.equals(json, other.json);
+        return Objects.equals(toJson(), other.toJson());
     }
 
     @Override

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -17,12 +17,8 @@
 package com.hazelcast.jet.cdc.postgres;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.jet.Job;
 import com.hazelcast.jet.cdc.ChangeRecord;
-import com.hazelcast.jet.cdc.Operation;
 import com.hazelcast.jet.cdc.ParsingException;
-import com.hazelcast.jet.cdc.RecordPart;
-import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
@@ -42,18 +38,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.jet.cdc.Operation.DELETE;
+import static com.hazelcast.jet.cdc.Operation.INSERT;
+import static com.hazelcast.jet.cdc.Operation.SYNC;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+import static java.util.Objects.requireNonNull;
 
 @Category(NightlyTest.class)
 public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
-    private static final int MAX_CONCURRENT_OPERATIONS = 1;
     private static final String CACHE = "cache";
-    private static final int REPEATS = 1000;
+    private static final int REPEATS = 1;
 
     @Test
     public void ordersOfCustomers() throws Exception {
@@ -63,25 +61,23 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
 
         Pipeline pipeline = Pipeline.create();
         StreamStage<ChangeRecord> allRecords = pipeline.readFrom(source)
-                .withNativeTimestamps(0);
+                .withNativeTimestamps(0).setLocalParallelism(1);
 
         allRecords.filter(r -> r.table().equals("customers"))
-                .apply(this::fixOrdering)
-                .writeTo(Sinks.mapWithEntryProcessor(MAX_CONCURRENT_OPERATIONS, CACHE,
+                .writeTo(Sinks.mapWithEntryProcessor(CACHE,
                         record -> (Integer) record.key().toMap().get("id"),
                         CustomerEntryProcessor::new
                 ));
 
         allRecords.filter(r -> r.table().equals("orders"))
-                .apply(this::fixOrdering)
-                .writeTo(Sinks.mapWithEntryProcessor(MAX_CONCURRENT_OPERATIONS, CACHE,
+                .writeTo(Sinks.mapWithEntryProcessor(CACHE,
                         record -> (Integer) record.value().toMap().get("purchaser"),
                         OrderEntryProcessor::new
                 ));
 
         // when
         HazelcastInstance hz = createHazelcastInstances(1)[0];
-        Job job = hz.getJet().newJob(pipeline);
+        hz.getJet().newJob(pipeline);
         //then
         Map<Integer, OrdersOfCustomer> expected = toMap(
         new OrdersOfCustomer(
@@ -96,22 +92,20 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
                 new Order(10004, new Date(1456012800000L), 1003, 1, 107)),
         new OrdersOfCustomer(
                 new Customer(1004, "Anne", "Kretchmar", "annek@noanswer.org")));
-        assertEqualsEventually(() -> getIMapContent(hz, CACHE), expected);
+        assertEqualsEventually(() -> getIMapContent(hz), expected);
 
         //when
         List<String> batch = new ArrayList<>();
+        batch.add("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
         for (int i = 1; i <= REPEATS; i++) {
             batch.add("UPDATE customers SET first_name='Anne" + i + "' WHERE id=1004");
-
-            batch.add("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
-            batch.add("DELETE FROM customers WHERE id=1005");
-
             batch.add("UPDATE orders SET quantity='" + i + "' WHERE id=10004");
 
             batch.add("DELETE FROM orders WHERE id=10003");
-            batch.add("INSERT INTO orders VALUES (10003, '2016-02-19', 1002, 2, 106)");
+            batch.add("INSERT INTO orders VALUES (10007, '2016-02-19', 1002, 2, 106)");
         }
         executeBatch(batch.toArray(new String[0]));
+        executeBatch("DELETE FROM customers WHERE id=1005");
 
         //then
         expected = toMap(
@@ -121,73 +115,25 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
                 new OrdersOfCustomer(
                         new Customer(1002, "George", "Bailey", "gbailey@foobar.com"),
                         new Order(10002, new Date(1452988800000L) , 1002, 2, 105),
-                        new Order(10003, new Date(1455840000000L), 1002, 2, 106)),
+                        new Order(10007, new Date(1455840000000L), 1002, 2, 106)),
                 new OrdersOfCustomer(
                         new Customer(1003, "Edward", "Walker", "ed@walker.com"),
                         new Order(10004, new Date(1456012800000L), 1003, REPEATS, 107)),
                 new OrdersOfCustomer(
                         new Customer(1004, "Anne" + REPEATS, "Kretchmar", "annek@noanswer.org")));
         expected.put(1005, new OrdersOfCustomer());
-        assertEqualsEventually(() -> getIMapContent(hz, CACHE), expected);
-    }
-
-    private StreamStage<ChangeRecord> fixOrdering(StreamStage<ChangeRecord> input) {
-        return input
-                .groupingKey(ChangeRecord::key)
-                .mapStateful(
-                        TimeUnit.SECONDS.toMillis(10),
-                        () -> new Sequence(0, 0),
-                        (lastSequence, key, record) -> {
-                            long source = record.sequenceSource();
-                            long sequence = record.sequenceValue();
-                            if (lastSequence.update(source, sequence)) {
-                                return record;
-                            }
-                            return null;
-                        },
-                        (TriFunction<Sequence, RecordPart, Long, ChangeRecord>) (sequence, recordPart, aLong) -> null);
+        assertEqualsEventually(() -> getIMapContent(hz), expected);
     }
 
     @Nonnull
-    private static Map<Integer, OrdersOfCustomer> getIMapContent(HazelcastInstance hz, String name) {
-        return new HashMap<>(hz.getMap(name));
+    private static Map<Integer, OrdersOfCustomer> getIMapContent(HazelcastInstance hz) {
+        return new HashMap<>(hz.getMap(MultiTableCacheIntegrationTest.CACHE));
     }
 
     @Nonnull
     private static Map<Integer, OrdersOfCustomer> toMap(OrdersOfCustomer... ordersOfCustomers) {
         return Arrays.stream(ordersOfCustomers).collect(Collectors.toMap(
                 orders -> orders.getCustomer().getId(), Function.identity()));
-    }
-
-    private static class Sequence {
-
-        private long source;
-        private long sequence;
-
-        Sequence(long source, long sequence) {
-            this.source = source;
-            this.sequence = sequence;
-        }
-
-        boolean update(long source, long sequence) {
-            if (this.source != source) { //sequence source changed for key
-                this.source = source;
-                this.sequence = sequence;
-                return true;
-            }
-
-            if (this.sequence < sequence) { //sequence is newer than previous for key
-                this.sequence = sequence;
-                return true;
-            }
-
-            return false;
-        }
-
-        @Override
-        public String toString() {
-            return "source=" + source + ", sequence=" + sequence;
-        }
     }
 
     private static class OrdersOfCustomer implements Serializable {
@@ -241,7 +187,7 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
 
         @Override
         public String toString() {
-            return String.format("Customer: %s, Orders: %s", customer, orders);
+            return String.format("%s, Orders: %s", customer, orders);
         }
     }
 
@@ -256,16 +202,14 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
         @Override
         public Object process(Entry<Integer, OrdersOfCustomer> entry) {
             try {
-                boolean deletion = Operation.DELETE.equals(record.operation());
                 OrdersOfCustomer value = entry.getValue();
-                if (deletion) {
-                    if (value != null) {
-                        value.setCustomer(null);
-                    }
+                if (value == null && (record.operation() == SYNC || record.operation() == INSERT)) {
+                    value = new OrdersOfCustomer();
+                }
+                requireNonNull(value, "value is null");
+                if (DELETE == record.operation()) {
+                    value.setCustomer(null);
                 } else {
-                    if (value == null) {
-                        value = new OrdersOfCustomer();
-                    }
                     value.setCustomer(record.value().toObject(Customer.class));
                 }
                 entry.setValue(value);
@@ -287,7 +231,7 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
         @Override
         public Object process(Entry<Integer, OrdersOfCustomer> entry) {
             try {
-                boolean deletion = Operation.DELETE.equals(record.operation());
+                boolean deletion = DELETE.equals(record.operation());
                 OrdersOfCustomer value = entry.getValue();
                 if (deletion) {
                     if (value != null) {

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -45,13 +45,14 @@ import static com.hazelcast.jet.cdc.Operation.DELETE;
 import static com.hazelcast.jet.cdc.Operation.INSERT;
 import static com.hazelcast.jet.cdc.Operation.SYNC;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 @Category(NightlyTest.class)
 public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
     private static final String CACHE = "cache";
-    private static final int REPEATS = 1;
+    private static final int REPEATS = 1000;
 
     @Test
     public void ordersOfCustomers() throws Exception {
@@ -102,10 +103,10 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
             batch.add("UPDATE orders SET quantity='" + i + "' WHERE id=10004");
 
             batch.add("DELETE FROM orders WHERE id=10003");
-            batch.add("INSERT INTO orders VALUES (10007, '2016-02-19', 1002, 2, 106)");
         }
         executeBatch(batch.toArray(new String[0]));
         executeBatch("DELETE FROM customers WHERE id=1005");
+        executeBatch("INSERT INTO orders VALUES (10007, '2016-02-19', 1002, 2, 106)");
 
         //then
         expected = toMap(
@@ -187,7 +188,7 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
 
         @Override
         public String toString() {
-            return String.format("%s, Orders: %s", customer, orders);
+            return format("%s, Orders: %s", customer, orders);
         }
     }
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -232,7 +232,7 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
         @Override
         public Object process(Entry<Integer, OrdersOfCustomer> entry) {
             try {
-                boolean deletion = DELETE.equals(record.operation());
+                boolean deletion = DELETE == record.operation();
                 OrdersOfCustomer value = entry.getValue();
                 if (deletion) {
                     if (value != null) {

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcAuthAndConnectionIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcAuthAndConnectionIntegrationTest.java
@@ -36,7 +36,7 @@ public class PostgresCdcAuthAndConnectionIntegrationTest extends AbstractPostgre
     @Test
     public void wrongPassword() {
         StreamSource<ChangeRecord> source = PostgresCdcSources.postgres("name")
-                .setDatabaseAddress(postgres.getContainerIpAddress())
+                .setDatabaseAddress(postgres.getHost())
                 .setDatabasePort(postgres.getMappedPort(POSTGRESQL_PORT))
                 .setDatabaseUser("postgres")
                 .setDatabasePassword("wrongPassword")
@@ -51,14 +51,14 @@ public class PostgresCdcAuthAndConnectionIntegrationTest extends AbstractPostgre
         Job job = hz.getJet().newJob(pipeline);
         // then
         assertThatThrownBy(job::join)
-                .hasRootCauseInstanceOf(JetException.class)
+                .hasCauseInstanceOf(JetException.class)
                 .hasStackTraceContaining("password authentication failed for user \"postgres\"");
     }
 
     @Test
     public void incorrectDatabaseName() {
         StreamSource<ChangeRecord> source = PostgresCdcSources.postgres("name")
-                .setDatabaseAddress(postgres.getContainerIpAddress())
+                .setDatabaseAddress(postgres.getHost())
                 .setDatabasePort(postgres.getMappedPort(POSTGRESQL_PORT))
                 .setDatabaseUser("postgres")
                 .setDatabasePassword("postgres")
@@ -73,7 +73,7 @@ public class PostgresCdcAuthAndConnectionIntegrationTest extends AbstractPostgre
         Job job = hz.getJet().newJob(pipeline);
         // then
         assertThatThrownBy(job::join)
-                .hasRootCauseInstanceOf(JetException.class)
+                .hasCauseInstanceOf(JetException.class)
                 .hasStackTraceContaining("database \"wrongDatabaseName\" does not exist");
     }
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -43,6 +43,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import javax.annotation.Nonnull;
 import java.sql.Connection;
@@ -55,6 +56,7 @@ import java.util.function.Consumer;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.cdc.postgres.AbstractPostgresCdcIntegrationTest.getConnection;
+import static com.hazelcast.jet.cdc.postgres.PostgresCdcSources.PostgresSnapshotMode.INITIAL;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -64,12 +66,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
+@SuppressWarnings("resource")
 @RunWith(HazelcastParametrizedRunner.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({NightlyTest.class})
 public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);
+    private static final DockerImageName TOXI_PROXY_IMAGE = DockerImageName
+            .parse("ghcr.io/shopify/toxiproxy:2.4.0")
+            .asCompatibleSubstituteFor("shopify/toxiproxy");
 
     @Parameter(value = 0)
     public RetryStrategy reconnectBehavior;
@@ -99,10 +105,10 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
     }
 
     @Test
-    public void when_noDatabaseToConnectTo() throws Exception {
+    public void when_noDatabaseToConnectTo() {
         postgres = initPostgres(null, null);
         int port = fixPortBinding(postgres, POSTGRESQL_PORT);
-        String containerIpAddress = postgres.getContainerIpAddress();
+        String containerIpAddress = postgres.getHost();
         stopContainer(postgres);
 
         Pipeline pipeline = initPipeline(containerIpAddress, port);
@@ -115,7 +121,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         if (neverReconnect) {
             // then job fails
             assertThatThrownBy(job::join)
-                    .hasRootCauseInstanceOf(JetException.class)
+                    .hasCauseInstanceOf(JetException.class)
                     .hasStackTraceContaining("Failed to connect to database");
             assertTrue(hz.getMap("results").isEmpty());
         } else {
@@ -139,7 +145,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
     public void when_shortNetworkDisconnectDuringSnapshotting_then_connectorDoesNotNoticeAnything() throws Exception {
         try (
                 Network network = initNetwork();
-                ToxiproxyContainer toxiproxy = initToxiproxy(network);
+                ToxiproxyContainer toxiproxy = initToxiproxy(network)
         ) {
             postgres = initPostgres(network, null);
             ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
@@ -177,7 +183,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         postgres = initPostgres(null, null);
         int port = fixPortBinding(postgres, POSTGRESQL_PORT);
 
-        Pipeline pipeline = initPipeline(postgres.getContainerIpAddress(), port);
+        Pipeline pipeline = initPipeline(postgres.getHost(), port);
         // when job starts
         HazelcastInstance hz = createHazelcastInstances(2)[0];
         Job job = hz.getJet().newJob(pipeline);
@@ -195,7 +201,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         if (neverReconnect) {
             // then job fails
             assertThatThrownBy(job::join)
-                    .hasRootCauseInstanceOf(JetException.class)
+                    .hasCauseInstanceOf(JetException.class)
                     .hasStackTraceContaining("Failed to connect to database");
         } else {
             // and DB is started anew
@@ -215,7 +221,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
     public void when_shortConnectionLossDuringBinlogReading_then_connectorDoesNotNoticeAnything() throws Exception {
         try (
                 Network network = initNetwork();
-                ToxiproxyContainer toxiproxy = initToxiproxy(network);
+                ToxiproxyContainer toxiproxy = initToxiproxy(network)
         ) {
             postgres = initPostgres(network, null);
             ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
@@ -258,7 +264,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         postgres = initPostgres(null, null);
         int port = fixPortBinding(postgres, POSTGRESQL_PORT);
 
-        Pipeline pipeline = initPipeline(postgres.getContainerIpAddress(), port);
+        Pipeline pipeline = initPipeline(postgres.getHost(), port);
         // when connector is up and transitions to binlog reading
         HazelcastInstance hz = createHazelcastInstances(2)[0];
         Job job = hz.getJet().newJob(pipeline);
@@ -274,7 +280,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         if (neverReconnect) {
             // then job fails
             assertThatThrownBy(job::join)
-                    .hasRootCauseInstanceOf(JetException.class)
+                    .hasCauseInstanceOf(JetException.class)
                     .hasStackTraceContaining("Failed to connect to database");
         } else {
             // and results are cleared
@@ -310,6 +316,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 .setTableWhitelist("inventory.customers")
                 .setReconnectBehavior(reconnectBehavior)
                 .setShouldStateBeResetOnReconnect(resetStateOnReconnect)
+                .setSnapshotMode(INITIAL)
                 .build();
     }
 
@@ -331,6 +338,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         }
     }
 
+    @SuppressWarnings("ConstantConditions")
     private PostgreSQLContainer<?> initPostgres(Network network, Integer fixedExposedPort) {
         PostgreSQLContainer<?> postgres = namedTestContainer(
                 new PostgreSQLContainer<>(AbstractPostgresCdcIntegrationTest.DOCKER_IMAGE)
@@ -339,7 +347,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                         .withPassword("postgres")
         );
         if (fixedExposedPort != null) {
-            Consumer<CreateContainerCmd> cmd = e -> e.withPortBindings(
+            Consumer<CreateContainerCmd> cmd = e -> e.getHostConfig().withPortBindings(
                     new PortBinding(Ports.Binding.bindPort(fixedExposedPort), new ExposedPort(POSTGRESQL_PORT)));
             postgres = postgres.withCreateContainerCmdModifier(cmd);
         }
@@ -350,8 +358,9 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         return postgres;
     }
 
+    @SuppressWarnings("resource")
     private ToxiproxyContainer initToxiproxy(Network network) {
-        ToxiproxyContainer toxiproxy = namedTestContainer(new ToxiproxyContainer().withNetwork(network));
+        ToxiproxyContainer toxiproxy = namedTestContainer(new ToxiproxyContainer(TOXI_PROXY_IMAGE).withNetwork(network));
         toxiproxy.start();
         return toxiproxy;
     }


### PR DESCRIPTION
Fix #21746 - flaky MultiTableCacheIntegrationTest test by making it much simpler and not be prone to concurrency problems in entry processor.

As a side effect, this PR will also make ToxiProxy work on Mac M1

Fixes #21746

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
