### PR TITLE
Improve "fixing" async stack traces for classes without expected constructor signature[HZ-1243]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -332,7 +332,8 @@ public final class ExceptionUtil {
      * stack-trace the cloned exception has the same
      * cause and the message as the original exception
      */
-    public static <T extends Throwable> T cloneExceptionWithFixedAsyncStackTrace(T original) {
+    @Nonnull
+    public static <T extends Throwable> T cloneExceptionWithFixedAsyncStackTrace(@Nonnull T original) {
         StackTraceElement[] fixedStackTrace = getFixedStackTrace(original, Thread.currentThread().getStackTrace());
 
         Class<? extends Throwable> exceptionClass = original.getClass();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -911,7 +911,7 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         try {
             executor.execute(() -> {
                 try {
-                    biConsumer.accept((V) value, throwable);
+                    biConsumer.accept(value, throwable);
                 } catch (Throwable t) {
                     completeDependentExceptionally(future, throwable, t);
                     return;
@@ -1966,12 +1966,10 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         if (cause instanceof WrappableException) {
             return ((WrappableException) cause).wrap();
         }
-        RuntimeException wrapped = cloneExceptionWithFixedAsyncStackTrace(cause);
-        return wrapped == null ? new HazelcastException(cause) : wrapped;
+        return cloneExceptionWithFixedAsyncStackTrace(cause);
     }
 
     private static Error wrapError(Error cause) {
-        Error result = cloneExceptionWithFixedAsyncStackTrace(cause);
-        return result == null ? cause : result;
+        return cloneExceptionWithFixedAsyncStackTrace(cause);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -86,7 +85,7 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testCloneExceptionWithFixedAsyncStackTrace() {
+    public void testCloneExceptionWithFixedAsyncStackTrace_whenStandardConstructorSignature_thenAppendAsyncTrace() {
         IOException expectedException = new IOException();
         ExecutionException result = ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(new ExecutionException(expectedException));
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
@@ -94,13 +94,28 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testCloneExceptionWithFixedAsyncStackTrace_whenCannotConstructSource_then_returnWithoutCloning() {
+    public void testCloneExceptionWithFixedAsyncStackTrace_whenNonStandardConstructor_then_cloneReflectively() {
         IOException expectedException = new IOException();
         Throwable result = ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(
                 new NonStandardException(1337, expectedException));
 
         assertEquals(NonStandardException.class, result.getClass());
         assertEquals(expectedException, result.getCause());
+        assertNoAsyncTrace(result);
+    }
+
+    @Test
+    public void testCloneExceptionWithFixedAsyncStackTrace_whenCannotConstructSource_then_returnWithoutCloning() {
+        IOException expectedException = new IOException();
+        NoPublicConstructorException result = ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(
+                new NoPublicConstructorException(expectedException));
+
+        assertEquals(NoPublicConstructorException.class, result.getClass());
+        assertEquals(expectedException, result.getCause());
+        assertNoAsyncTrace(result);
+    }
+
+    private void assertNoAsyncTrace(Throwable result) {
         for (StackTraceElement stackTraceElement : result.getStackTrace()) {
             if (stackTraceElement.getClassName().equals(ExceptionUtil.EXCEPTION_SEPARATOR)) {
                 fail("if exception cannot be cloned to append async stack trace, then nothing should be modified");
@@ -108,17 +123,7 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
         }
     }
 
-    @Test
-    public void testCloneExceptionWithFixedAsyncStackTrace_whenNonStandardConstructor_then_cloneReflectively() {
-        IOException expectedException = new IOException();
-        NoPublicConstructorException result = ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(
-                new NoPublicConstructorException(expectedException));
-
-        assertEquals(NoPublicConstructorException.class, result.getClass());
-        assertEquals(expectedException, result.getCause());
-    }
-
-    public static class NoPublicConstructorException extends RuntimeException {
+    private static class NoPublicConstructorException extends RuntimeException {
         private NoPublicConstructorException(Throwable cause) {
             super(cause);
         }


### PR DESCRIPTION
Unreflect even private constructor + make it accessible to clone exceptions with non-public constructor.

Return original, non-modified exception if nothing can be appended as a fallback (better exception without async stack trace, than nothing).

Fixes #20357

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
