### PR TITLE
Use IDS for wrapping processor supplier

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
@@ -56,6 +56,8 @@ import com.hazelcast.jet.impl.processor.ProcessorSupplierFromSimpleSupplier;
 import com.hazelcast.jet.impl.processor.SessionWindowP;
 import com.hazelcast.jet.impl.processor.SlidingWindowP.SnapshotKey;
 import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl;
+import com.hazelcast.jet.impl.util.WrappingProcessorMetaSupplier;
+import com.hazelcast.jet.impl.util.WrappingProcessorSupplier;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -108,6 +110,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
     public static final int NOOP_PROCESSOR_SUPPLIER = 46;
     public static final int CHECK_LIGHT_JOBS_OP = 47;
     public static final int SQL_SUMMARY = 48;
+    public static final int WRAPPING_PROCESSOR_META_SUPPLIER = 49;
+    public static final int WRAPPING_PROCESSOR_SUPPLIER = 50;
 
     public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(JET_IMPL_DS_FACTORY, JET_IMPL_DS_FACTORY_ID);
 
@@ -210,6 +214,10 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
                     return new CheckLightJobsOperation();
                 case SQL_SUMMARY:
                     return new SqlSummary();
+                case WRAPPING_PROCESSOR_META_SUPPLIER:
+                    return new WrappingProcessorMetaSupplier();
+                case WRAPPING_PROCESSOR_SUPPLIER:
+                    return new WrappingProcessorSupplier();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
@@ -21,8 +21,13 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.security.Permission;
 import java.util.List;
 import java.util.Map;
@@ -33,15 +38,17 @@ import java.util.function.Function;
  * ProcessorMetaSupplier} with one that will wrap its processors using
  * {@code wrapperSupplier}.
  */
-public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplier {
-
-    private static final long serialVersionUID = 1L;
+public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplier, IdentifiedDataSerializable {
 
     private ProcessorMetaSupplier wrapped;
     private FunctionEx<Processor, Processor> wrapperSupplier;
 
-    public WrappingProcessorMetaSupplier(ProcessorMetaSupplier wrapped,
-                                         FunctionEx<Processor, Processor> wrapperSupplier) {
+    public WrappingProcessorMetaSupplier() { }
+
+    public WrappingProcessorMetaSupplier(
+            ProcessorMetaSupplier wrapped,
+            FunctionEx<Processor, Processor> wrapperSupplier
+    ) {
         this.wrapped = wrapped;
         this.wrapperSupplier = wrapperSupplier;
     }
@@ -76,5 +83,27 @@ public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplie
     @Override
     public Permission getRequiredPermission() {
         return wrapped.getRequiredPermission();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(wrapped);
+        out.writeObject(wrapperSupplier);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        wrapped = in.readObject();
+        wrapperSupplier = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return JetInitDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return JetInitDataSerializerHook.WRAPPING_PROCESSOR_META_SUPPLIER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
@@ -35,9 +35,6 @@ import static com.hazelcast.jet.impl.util.Util.toList;
  * with one that will wrap its processors using {@code wrapperSupplier}.
  */
 public final class WrappingProcessorSupplier implements ProcessorSupplier, IdentifiedDataSerializable {
-
-    private static final long serialVersionUID = 1L;
-
     private ProcessorSupplier wrapped;
     private FunctionEx<Processor, Processor> wrapperSupplier;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
@@ -19,8 +19,13 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.util.Collection;
 
 import static com.hazelcast.jet.impl.util.Util.toList;
@@ -29,15 +34,18 @@ import static com.hazelcast.jet.impl.util.Util.toList;
  * A {@link ProcessorSupplier} which wraps another {@code ProcessorSupplier}
  * with one that will wrap its processors using {@code wrapperSupplier}.
  */
-public final class WrappingProcessorSupplier implements ProcessorSupplier {
+public final class WrappingProcessorSupplier implements ProcessorSupplier, IdentifiedDataSerializable {
 
     private static final long serialVersionUID = 1L;
 
     private ProcessorSupplier wrapped;
     private FunctionEx<Processor, Processor> wrapperSupplier;
 
-    public WrappingProcessorSupplier(ProcessorSupplier wrapped,
-                                     FunctionEx<Processor, Processor> wrapperSupplier
+    public WrappingProcessorSupplier() { }
+
+    public WrappingProcessorSupplier(
+            ProcessorSupplier wrapped,
+            FunctionEx<Processor, Processor> wrapperSupplier
     ) {
         this.wrapped = wrapped;
         this.wrapperSupplier = wrapperSupplier;
@@ -58,5 +66,27 @@ public final class WrappingProcessorSupplier implements ProcessorSupplier {
     @Override
     public void close(Throwable error) throws Exception {
         wrapped.close(error);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(wrapped);
+        out.writeObject(wrapperSupplier);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        wrapped = in.readObject();
+        wrapperSupplier = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return JetInitDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return JetInitDataSerializerHook.WRAPPING_PROCESSOR_SUPPLIER;
     }
 }


### PR DESCRIPTION
It allows of wrapping of IDS-serialized processors. Before those failed as
non-serializable, because java-serialized instances don't know to serialize
ids-serialized fields.
