### PR TITLE
Assert all method calls to CompletableFuture#xyzAsync() are using explicit Executor argument[HZ-658]

### DIFF
--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -16,18 +16,26 @@
 
 package com.hazelcast.test.archunit;
 
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
-import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
+import static com.hazelcast.test.archunit.ArchUnitRules.CompletableFutureAsyncActionsWithExecutorOnlyCondition
+        .useExplicitExecutorServiceInCFAsyncMethods;
 import static com.hazelcast.test.archunit.ArchUnitRules.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.beStatic;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.haveRawType;
@@ -47,6 +55,14 @@ public final class ArchUnitRules {
             .and().areNotAnonymousClasses()
             .should(haveValidSerialVersionUid());
 
+    /**
+     * ArchUnit rule checking that {@link CompletableFuture} {@code async} methods are not used without
+     * explicit executor service.
+     */
+    public static final ArchRule COMPLETABLE_FUTURE_ASYNC_USED_ONLY_WITH_EXPLICIT_EXECUTOR = classes()
+            .that().areNotAssignableTo(CompletableFuture.class)
+            .should(useExplicitExecutorServiceInCFAsyncMethods());
+
     private ArchUnitRules() {
     }
 
@@ -63,12 +79,47 @@ public final class ArchUnitRules {
             if (field.isPresent()) {
                 haveRawType("long").and(beFinal()).and(beStatic()).check(field.get(), events);
             } else {
-                events.add(SimpleConditionEvent.violated(clazz, FIELD_NAME + " field is missing in class " + clazz.getName()));
+                events.add(violated(clazz, FIELD_NAME + " field is missing in class " + clazz.getName()));
             }
         }
 
         static SerialVersionUidFieldCondition haveValidSerialVersionUid() {
             return new SerialVersionUidFieldCondition();
+        }
+    }
+
+    static class CompletableFutureAsyncActionsWithExecutorOnlyCondition extends ArchCondition<JavaClass> {
+
+        public CompletableFutureAsyncActionsWithExecutorOnlyCondition() {
+            super("use CompletableFuture async actions only with explicit executor service");
+        }
+
+        @Override
+        public void check(JavaClass item, ConditionEvents events) {
+            for (JavaMethodCall methodCalled : item.getMethodCallsFromSelf()) {
+                String calledMethodName = methodCalled.getTarget().getName();
+                if (isFromCompletableFuture(methodCalled) && calledMethodName.endsWith("Async")) {
+                    List<JavaType> parameterTypes = methodCalled.getTarget().getParameterTypes();
+                    if (withoutExecutorArgument(parameterTypes)) {
+                        String violatingMethodName = methodCalled.getOwner().getFullName();
+                        events.add(violated(item, violatingMethodName + ":" + methodCalled.getLineNumber()
+                                + " calls CompletableFuture." + calledMethodName));
+                    }
+                }
+            }
+        }
+
+        private boolean isFromCompletableFuture(JavaMethodCall methodCalled) {
+            return methodCalled.getTarget().getOwner().isEquivalentTo(CompletableFuture.class);
+        }
+
+        private boolean withoutExecutorArgument(List<JavaType> parameterTypes) {
+            return parameterTypes.isEmpty()
+                    || !parameterTypes.get(parameterTypes.size() - 1).toErasure().isEquivalentTo(Executor.class);
+        }
+
+        static ArchCondition<? super JavaClass> useExplicitExecutorServiceInCFAsyncMethods() {
+            return new CompletableFutureAsyncActionsWithExecutorOnlyCondition();
         }
     }
 }

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.test.archunit;
 
-import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaField;
@@ -90,7 +89,7 @@ public final class ArchUnitRules {
 
     static class CompletableFutureAsyncActionsWithExecutorOnlyCondition extends ArchCondition<JavaClass> {
 
-        public CompletableFutureAsyncActionsWithExecutorOnlyCondition() {
+        CompletableFutureAsyncActionsWithExecutorOnlyCondition() {
             super("use CompletableFuture async actions only with explicit executor service");
         }
 
@@ -110,7 +109,9 @@ public final class ArchUnitRules {
         }
 
         private boolean isFromCompletableFuture(JavaMethodCall methodCalled) {
-            return methodCalled.getTarget().getOwner().isEquivalentTo(CompletableFuture.class);
+            JavaClass calledClass = methodCalled.getTarget().getOwner();
+            return calledClass.isAssignableFrom(CompletableFuture.class)
+                    && !calledClass.isAssignableFrom("com.hazelcast.spi.impl.InternalCompletableFuture");
         }
 
         private boolean withoutExecutorArgument(List<JavaType> parameterTypes) {

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/nearcache/NearCachedClientCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/nearcache/NearCachedClientCacheProxy.java
@@ -65,6 +65,7 @@ import static com.hazelcast.internal.nearcache.NearCache.NOT_CACHED;
 import static com.hazelcast.internal.nearcache.NearCache.UpdateSemantic.READ_UPDATE;
 import static com.hazelcast.internal.nearcache.NearCache.UpdateSemantic.WRITE_UPDATE;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.NOT_RESERVED;
+import static com.hazelcast.internal.util.ConcurrencyUtil.getDefaultAsyncExecutor;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
@@ -324,7 +325,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
             } finally {
                 invalidateNearCache(toNearCacheKey(key, keyData));
             }
-        });
+        }, getDefaultAsyncExecutor());
     }
 
     @Nonnull
@@ -347,7 +348,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
                 statsCallback.accept(t, throwable);
             }
             invalidateNearCache(toNearCacheKey(key, keyData));
-        });
+        }, getDefaultAsyncExecutor());
     }
 
     @Override
@@ -907,7 +908,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
                     // Remove reservation, we haven't managed to put value.
                     invalidateNearCache(nearCacheKey);
                 }
-            });
+            }, getDefaultAsyncExecutor());
         } else {
             return future.whenCompleteAsync((response, throwable) -> {
                 if (statsCallback != null) {
@@ -915,7 +916,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
                 }
 
                 invalidateNearCache(nearCacheKey);
-            });
+            }, getDefaultAsyncExecutor());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -62,6 +62,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cp.internal.RaftService.CP_SUBSYSTEM_MANAGEMENT_EXECUTOR;
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LEADER_LOCAL;
+import static com.hazelcast.internal.util.ConcurrencyUtil.getDefaultAsyncExecutor;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -150,7 +151,7 @@ class RaftGroupMembershipManager {
                     } else {
                         logger.warning("Could not get CP group info of " + groupId, t);
                     }
-                });
+                }, getDefaultAsyncExecutor());
             }
         }
 
@@ -303,7 +304,7 @@ class RaftGroupMembershipManager {
                         latch.countDown();
                     }
                 }
-            });
+            }, getDefaultAsyncExecutor());
         }
 
         private void addMember(CountDownLatch latch, Map<CPGroupId, BiTuple<Long, Long>> changedGroups,
@@ -318,7 +319,7 @@ class RaftGroupMembershipManager {
                     checkMemberAddCommitIndex(changedGroups, change, t);
                     latch.countDown();
                 }
-            });
+            }, getDefaultAsyncExecutor());
         }
 
         private void checkMemberAddCommitIndex(Map<CPGroupId, BiTuple<Long, Long>> changedGroups, CPGroupMembershipChange change,

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
@@ -46,8 +46,8 @@ public final class ConcurrencyUtil {
         }
     };
 
-    // Default executor for async callbacks: ForkJoinPool.commonPool() or a thread-per-task executor when
-    // the common pool does not support parallelism
+    // Default executor for async callbacks: Executors.newFixedThreadPool of ForkJoinPool.commonPool()
+    // size or a thread-per-task executor when the common pool does not support parallelism
     private static Executor defaultAsyncExecutor;
 
     static {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.util;
 
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -51,8 +52,9 @@ public final class ConcurrencyUtil {
 
     static {
         Executor asyncExecutor;
-        if (ForkJoinPool.getCommonPoolParallelism() > 1) {
-            asyncExecutor = ForkJoinPool.commonPool();
+        int commonPoolParallelism = ForkJoinPool.getCommonPoolParallelism();
+        if (commonPoolParallelism > 1) {
+            asyncExecutor = Executors.newFixedThreadPool(commonPoolParallelism);
         } else {
             asyncExecutor = command -> new Thread(command).start();
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/Observable.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/Observable.java
@@ -33,6 +33,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.getDefaultAsyncExecutor;
+
 /**
  * Represents a flowing sequence of events produced by {@linkplain
  * Sinks#observable(String) observable sinks}. To observe the events, call
@@ -207,7 +209,7 @@ public interface Observable<T> extends Iterable<T> {
         return CompletableFuture.supplyAsync(() -> {
             Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(iterator, 0);
             return fn.apply(StreamSupport.stream(spliterator, false));
-        });
+        }, getDefaultAsyncExecutor());
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -73,6 +73,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.getDefaultAsyncExecutor;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.JobClassLoaderService.JobPhase.EXECUTION;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
@@ -576,7 +577,7 @@ public class JobExecutionService implements DynamicMetricsProvider {
                     } else {
                         logger.fine("Execution of " + execCtx.jobNameAndExecutionId() + " completed");
                     }
-                }));
+                }), getDefaultAsyncExecutor());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -77,6 +77,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.function.Functions.entryKey;
+import static com.hazelcast.internal.util.ConcurrencyUtil.getDefaultAsyncExecutor;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
@@ -595,7 +596,7 @@ public class MasterJobContext {
             // StartExecutionOp, so wait for that too.
             mc.snapshotContext().terminalSnapshotFuture()
                     // have to use Async version, the future is completed inside a synchronized block
-                    .whenCompleteAsync(withTryCatch(logger, (r, e) -> finalizeJob(finalError)));
+                    .whenCompleteAsync(withTryCatch(logger, (r, e) -> finalizeJob(finalError)), getDefaultAsyncExecutor());
         } else {
             if (error instanceof ExecutionNotFoundException) {
                 // If the StartExecutionOperation didn't find the execution, it means that it was cancelled.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -118,6 +118,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.core.EntryEventType.CLEAR_ALL;
 import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.internal.util.ConcurrencyUtil.getDefaultAsyncExecutor;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
 import static com.hazelcast.internal.util.IterableUtil.nullToEmpty;
@@ -1276,7 +1277,7 @@ abstract class MapProxySupport<K, V>
                     } else {
                         resultFuture.completeExceptionally(throwable);
                     }
-                });
+                }, getDefaultAsyncExecutor());
         return resultFuture;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalCompletableFuture.java
@@ -44,8 +44,8 @@ import static com.hazelcast.spi.impl.AbstractInvocationFuture.wrapOrPeel;
  * using methods with the {@code Async} suffix) or custom executor (when using
  * methods with the {@code Async} suffix and an {@link Executor} argument).
  * Both default and async execution use the default async executor, which is
- * either the {@link ForkJoinPool#commonPool()} or, in case it does not support
- * parallelism of at least 2, a thread-per-task executor.
+ * either the {@link java.util.concurrent.Executors#newFixedThreadPool(int)} of {@link ForkJoinPool#commonPool()}'s size
+ * or, in case FJP does not support parallelism of at least 2, a thread-per-task executor.
  *
  * <p>This class provides static factory methods for more specific implementations
  * supporting custom default async executor or deserialization of completion value.

--- a/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
@@ -1,0 +1,21 @@
+package com.hazelcast;
+
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
+
+public class HazelcastCompletableFutureAsyncUsageTest {
+
+    @Test
+    public void noClassUsesCompletableFuture() {
+        String basePackage = "com.hazelcast";
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(onlyCurrentModule())
+                .importPackages(basePackage);
+
+        ArchUnitRules.COMPLETABLE_FUTURE_ASYNC_USED_ONLY_WITH_EXPLICIT_EXECUTOR.check(classes);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast;
 
 import com.hazelcast.test.archunit.ArchUnitRules;


### PR DESCRIPTION
Assert all method calls to CompletableFuture#xyzAsync() are using explicit Executor argument.

We do not enforce this rule if the CompletableFuture is a subclass of InternalCompletableFuture - then we know we are not using ForkJoinPool.

For now the test is only for main module, there is probably only Hz3 compatibility module which is using Async actions too - however, not backporting as for now.

Fixes #18190

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
