### PR TITLE
Send stats after cluster id change MC-1584 API-1448

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -890,6 +890,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
         dispose(onClusterChangeDisposables);
         clusterService.onClusterConnect();
+        clientStatisticsService.onClusterConnect();
     }
 
     public void waitForInitialMembershipEvents() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -892,7 +892,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         clusterService.onClusterConnect();
         // Send statistics to the new cluster immediately to make clientVersion, isEnterprise and other fields
         // available in Management Center as soon as possible. They are currently sent as part of client statistics.
-        clientStatisticsService.onConnectionToNewCluster();
+        clientStatisticsService.collectAndSendStatsNow();
     }
 
     public void waitForInitialMembershipEvents() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -890,10 +890,14 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
         dispose(onClusterChangeDisposables);
         clusterService.onClusterConnect();
+    }
+
+    public void collectAndSendStatsNow() {
         // Send statistics to the new cluster immediately to make clientVersion, isEnterprise and other fields
         // available in Management Center as soon as possible. They are currently sent as part of client statistics.
         clientStatisticsService.collectAndSendStatsNow();
     }
+
 
     public void waitForInitialMembershipEvents() {
         clusterService.waitInitialMemberListFetched();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -893,8 +893,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     public void collectAndSendStatsNow() {
-        // Send statistics to the new cluster immediately to make clientVersion, isEnterprise and other fields
-        // available in Management Center as soon as possible. They are currently sent as part of client statistics.
         clientStatisticsService.collectAndSendStatsNow();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -869,7 +869,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return clientExtension.getJet();
     }
 
-    public void onClusterChange() {
+    public void onTryNextCluster() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Resetting local state of the client, because of a cluster change.");
 
@@ -884,7 +884,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager.reset();
     }
 
-    public void onClusterConnect() {
+    public void onClusterIdChange() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Clearing local state of the client, because of a cluster restart.");
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -869,13 +869,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return clientExtension.getJet();
     }
 
-    public void onNextCluster() {
+    public void onTryToConnectNextCluster() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Resetting local state of the client, because of a cluster change.");
 
         dispose(onClusterChangeDisposables);
         //reset the member list version
-        clusterService.onNextCluster();
+        clusterService.onTryToConnectNextCluster();
         //clear partition service
         partitionService.reset();
         //close all the connections, consequently waiting invocations get TargetDisconnectedException

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -957,15 +957,16 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
+                client.onConnectionToNewCluster();
             }
             checkClientState(connection, switchingToNextCluster);
 
             boolean connectionsEmpty = activeConnections.isEmpty();
             activeConnections.put(response.memberUuid, connection);
-            // This is called here instead of above on purpose because onConnectionToNewCluster sends statistics
-            // which require a random connection to exist in activeConnections map.
+            // This is called here instead of above on purpose because sending statistics
+            // require a random connection to exist in activeConnections map.
             if (clusterIdChanged) {
-                client.onConnectionToNewCluster();
+                client.collectAndSendStatsNow();
             }
             if (connectionsEmpty) {
                 // The first connection that opens a connection to the new cluster should set `clusterId`.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -963,9 +963,11 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
 
             boolean connectionsEmpty = activeConnections.isEmpty();
             activeConnections.put(response.memberUuid, connection);
-            // This is called here instead of above on purpose because sending statistics
-            // require a random connection to exist in activeConnections map.
+            // We send statistics to the new cluster immediately to make clientVersion, isEnterprise and other fields
+            // available in Management Center as soon as possible. They are currently sent as part of client statistics.
             if (clusterIdChanged) {
+                // This is called here instead of above on purpose because sending statistics
+                // require a random connection to exist in activeConnections map.
                 client.collectAndSendStatsNow();
             }
             if (connectionsEmpty) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -441,7 +441,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                                                                      CandidateClusterContext nextContext) {
         currentContext.destroy();
 
-        client.onNextCluster();
+        client.onTryToConnectNextCluster();
 
         nextContext.start();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -441,7 +441,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                                                                      CandidateClusterContext nextContext) {
         currentContext.destroy();
 
-        client.onTryNextCluster();
+        client.onNextCluster();
 
         nextContext.start();
 
@@ -957,7 +957,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onClusterIdChange();
+                client.onConnectionToNewCluster();
             }
             checkClientState(connection, switchingToNextCluster);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -973,12 +973,13 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                     executor.execute(() -> {
                         initializeClientOnCluster(newClusterId);
                         /*
-                          We send statistics to the new cluster immediately to make clientVersion, isEnterprise and some other fields
-                          available in Management Center as soon as possible. They are currently sent as part of client statistics.
+                          We send statistics to the new cluster immediately to make clientVersion, isEnterprise and some other
+                          fields available in Management Center as soon as possible. They are currently sent as part of client
+                          statistics.
 
                           This method is called here instead of above on purpose because sending statistics require an active
-                          connection to exist. Also, the client needs to be initialized on the new cluster in order for invocations
-                          to be allowed.
+                          connection to exist. Also, the client needs to be initialized on the new cluster in order for
+                          invocations to be allowed.
                          */
                         client.collectAndSendStatsNow();
                     });

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -441,7 +441,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                                                                      CandidateClusterContext nextContext) {
         currentContext.destroy();
 
-        client.onClusterChange();
+        client.onTryNextCluster();
 
         nextContext.start();
 
@@ -957,7 +957,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onClusterConnect();
+                client.onClusterIdChange();
             }
             checkClientState(connection, switchingToNextCluster);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -957,12 +957,16 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onConnectionToNewCluster();
             }
             checkClientState(connection, switchingToNextCluster);
 
             boolean connectionsEmpty = activeConnections.isEmpty();
             activeConnections.put(response.memberUuid, connection);
+            // This is called here instead of above on purpose because onConnectionToNewCluster sends statistics
+            // which require a random connection to exist in activeConnections map.
+            if (clusterIdChanged) {
+                client.onConnectionToNewCluster();
+            }
             if (connectionsEmpty) {
                 // The first connection that opens a connection to the new cluster should set `clusterId`.
                 // This one will initiate `initializeClientOnCluster` if necessary.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -191,7 +191,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         }
     }
 
-    public void onClusterChange() {
+    public void onNextCluster() {
         synchronized (clusterViewLock) {
             if (logger.isFineEnabled()) {
                 logger.fine("Resetting the cluster snapshot");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -191,7 +191,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         }
     }
 
-    public void onNextCluster() {
+    public void onTryToConnectNextCluster() {
         synchronized (clusterViewLock) {
             if (logger.isFineEnabled()) {
                 logger.fine("Resetting the cluster snapshot");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
@@ -108,7 +108,7 @@ public class ClientStatisticsService {
         logger.info("Client statistics is enabled with period " + periodSeconds + " seconds.");
     }
 
-    public void onClusterConnect() {
+    public void onConnectionToNewCluster() {
         client.getTaskScheduler().schedule(this::collectAndSendStats, 0, SECONDS);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
@@ -106,7 +106,7 @@ public class ClientStatisticsService {
         logger.info("Client statistics is enabled with period " + periodSeconds + " seconds.");
     }
 
-    public void onConnectionToNewCluster() {
+    public void collectAndSendStatsNow() {
         client.getTaskScheduler().schedule(this::collectAndSendStats, 0, SECONDS);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
@@ -58,8 +58,6 @@ public class ClientStatisticsService {
     private static final char ESCAPE_CHAR = '\\';
 
     private final MetricsRegistry metricsRegistry;
-    private ClientMetricCollector clientMetricCollector;
-    private CompositeMetricsCollector compositeMetricsCollector;
     private final boolean enabled;
     private final ILogger logger = Logger.getLogger(this.getClass());
 
@@ -134,14 +132,14 @@ public class ClientStatisticsService {
      * @param periodSeconds the interval at which the statistics collection and send is being run
      */
     private void schedulePeriodicStatisticsSendTask(long periodSeconds) {
-        clientMetricCollector = new ClientMetricCollector();
-        compositeMetricsCollector = new CompositeMetricsCollector(clientMetricCollector,
-                publisherMetricsCollector);
-
         client.getTaskScheduler().scheduleWithRepetition(this::collectAndSendStats, 0, periodSeconds, SECONDS);
     }
 
     private void collectAndSendStats() {
+        ClientMetricCollector clientMetricCollector = new ClientMetricCollector();
+        CompositeMetricsCollector compositeMetricsCollector = new CompositeMetricsCollector(clientMetricCollector,
+                publisherMetricsCollector);
+
         long collectionTimestamp = System.currentTimeMillis();
         metricsRegistry.collect(compositeMetricsCollector);
         publisherMetricsCollector.publishCollectedMetrics();

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
@@ -212,7 +212,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         });
 
         //called on cluster change
-        clusterService.onNextCluster();
+        clusterService.onTryToConnectNextCluster();
 
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.1")), UUID.randomUUID());
         assertEquals(1, clusterService.getMemberList().size());
@@ -369,7 +369,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.1")), UUID.randomUUID());
         assertEquals(1, clusterService.getMemberList().size());
         //called on cluster change
-        clusterService.onNextCluster();
+        clusterService.onTryToConnectNextCluster();
         assertEquals(1, clusterService.getMemberList().size());
         assertEquals(ClientClusterServiceImpl.INITIAL_MEMBER_LIST_VERSION, clusterService.getMemberListVersion());
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.2")), UUID.randomUUID());

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
@@ -212,7 +212,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         });
 
         //called on cluster change
-        clusterService.onClusterChange();
+        clusterService.onNextCluster();
 
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.1")), UUID.randomUUID());
         assertEquals(1, clusterService.getMemberList().size());
@@ -369,7 +369,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.1")), UUID.randomUUID());
         assertEquals(1, clusterService.getMemberList().size());
         //called on cluster change
-        clusterService.onClusterChange();
+        clusterService.onNextCluster();
         assertEquals(1, clusterService.getMemberList().size());
         assertEquals(ClientClusterServiceImpl.INITIAL_MEMBER_LIST_VERSION, clusterService.getMemberListVersion());
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.2")), UUID.randomUUID());

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.impl.statistics.ClientStatisticsService;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -196,7 +197,10 @@ public class ClientStatisticsTest extends ClientTestSupport {
 
     @Test
     public void testStatisticsSentImmediatelyOnClusterChange() {
-        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+        String clusterName = randomString();
+        Config config = new Config();
+        config.setClusterName(clusterName);
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
 
@@ -204,6 +208,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
         // set the collection frequency to something really high to test that statistics are sent on cluster change
         clientConfig.getMetricsConfig()
                 .setCollectionFrequencySeconds(Integer.MAX_VALUE);
+        clientConfig.setClusterName(clusterName);
 
         HazelcastInstance clientInstance = hazelcastFactory.newHazelcastClient(clientConfig);
         HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(clientInstance);
@@ -212,7 +217,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
         client.getLifecycleService().addLifecycleListener(reconnectListener);
 
         hazelcastInstance.getLifecycleService().terminate();
-        Node hazelcastNode = getNode(hazelcastFactory.newHazelcastInstance());
+        Node hazelcastNode = getNode(hazelcastFactory.newHazelcastInstance(config));
 
         assertOpenEventually(reconnectListener.reconnectedLatch);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -197,10 +197,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
 
     @Test
     public void testStatisticsSentImmediatelyOnClusterChange() {
-        String clusterName = randomString();
-        Config config = new Config();
-        config.setClusterName(clusterName);
-        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
 
@@ -208,7 +205,6 @@ public class ClientStatisticsTest extends ClientTestSupport {
         // set the collection frequency to something really high to test that statistics are sent on cluster change
         clientConfig.getMetricsConfig()
                 .setCollectionFrequencySeconds(Integer.MAX_VALUE);
-        clientConfig.setClusterName(clusterName);
 
         HazelcastInstance clientInstance = hazelcastFactory.newHazelcastClient(clientConfig);
         HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(clientInstance);
@@ -217,7 +213,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
         client.getLifecycleService().addLifecycleListener(reconnectListener);
 
         hazelcastInstance.getLifecycleService().terminate();
-        Node hazelcastNode = getNode(hazelcastFactory.newHazelcastInstance(config));
+        Node hazelcastNode = getNode(hazelcastFactory.newHazelcastInstance());
 
         assertOpenEventually(reconnectListener.reconnectedLatch);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.client.impl.statistics.ClientStatisticsService;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;

--- a/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -198,15 +198,12 @@ public class ClientStatisticsTest extends ClientTestSupport {
     public void testStatisticsSentImmediatelyOnClusterChange() {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
-        ClientConfig clientConfig = new ClientConfig()
-                // add IMap and ICache with Near Cache config
-                .addNearCacheConfig(new NearCacheConfig(MAP_NAME))
-                .addNearCacheConfig(new NearCacheConfig(CACHE_NAME));
+        ClientConfig clientConfig = new ClientConfig();
 
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
         // set the collection frequency to something really high to test that statistics are sent on cluster change
         clientConfig.getMetricsConfig()
-                .setCollectionFrequencySeconds(1000);
+                .setCollectionFrequencySeconds(Integer.MAX_VALUE);
 
         HazelcastInstance clientInstance = hazelcastFactory.newHazelcastClient(clientConfig);
         HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(clientInstance);
@@ -224,7 +221,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
             Collection<ClientEndpoint> endpoints = hazelcastNode.getClientEngine().getEndpointManager().getEndpoints();
             ClientEndpoint[] endpointArray = endpoints.toArray(new ClientEndpoint[0]);
             assertNotNull("Statistics are not sent on cluster change", endpointArray[0].getClientStatistics());
-        }, 120);
+        });
     }
 
     @Test


### PR DESCRIPTION
This pr also does some naming changes around hook methods (`onSomething()`)

We start client statistics service after the client connects to the cluster. In `ClientStatisticsService.start()` we schedule a statistics send task with `scheduleWithRepetition` which sends the stats right away. Then, stats are only send every "metrics send interval" seconds. If the client connects to a new cluster after disconnecting, like when a failover cluster is configured, the stats won't be sent for some time. This may lead to some confusion in the management center as the client version, isEnterprise and all other stats fields will be shown as N/A.

I think this is not a bug because we promise users to send stats every "x" seconds and not sending stats to a newly connected cluster seems not to be a bug. However, I think it is a good to have "feature".

MC team verified that the fact that cluster id does not change when hot restart is enabled is not a problem because statistics are cached in MC based on cluster id.

Fixes https://hazelcast.atlassian.net/browse/MC-1584 and https://hazelcast.atlassian.net/browse/API-1448



Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
