### PR TITLE
Move checkstyle to validate phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
                 <version>${maven.checkstyle.plugin.version}</version>
                 <executions>
                     <execution>
-                        <phase>process-sources</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>checkstyle</goal>
                         </goals>


### PR DESCRIPTION
In sql module we generate sources during the build, updating their
timestamps each build in the generate-sources phase.

Checkstyle then checks those files in process-sources phase. The
violations are actually suppressed.

Moving to validate phase (earlier phase) means checkstyle will not run
on generated sources at all.

Reduces time for 2nd consecutive run of `mvn compile` from 20 s to 6 s
on my machine.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
