### PR TITLE
Export jdk.management/com.ibm.. only for OpenJ9 VM [5.1.z]

### DIFF
--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -39,12 +39,16 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
     JDK_OPTS="\
         --add-modules java.se \
         --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
-        --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED \
         --add-opens java.base/java.lang=ALL-UNNAMED \
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
         --add-opens java.management/sun.management=ALL-UNNAMED \
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
     "
+
+    VM_NAME=$(${JAVA} -XshowSettings:properties -version 2>&1 | grep java.vm.name | cut -d "=" -f2)
+    if [[ "$VM_NAME" =~ "OpenJ9" ]]; then
+        JDK_OPTS="$JDK_OPTS --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED"
+    fi
 fi
 
 if [ -n "${CLASSPATH}" ]; then

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -11,7 +11,7 @@ if "x%JAVA_HOME%" == "x" (
 
 "%RUN_JAVA%" -version 1>nul 2>nul || (
     echo JAVA could not be found in your system.
-    echo Please install Java 1.8 or higher!!!
+    echo Please install Java 1.8 or higher
     exit /b 2
 )
 set HAZELCAST_HOME=%~dp0..
@@ -36,7 +36,17 @@ if NOT "%MAX_HEAP_SIZE%" == "" (
 FOR /F "tokens=* USEBACKQ" %%F IN (`CALL "%RUN_JAVA%" -cp "%HAZELCAST_HOME%\lib\*" com.hazelcast.internal.util.JavaVersion`) DO SET JAVA_VERSION=%%F
 
 IF NOT "%JAVA_VERSION%" == "8" (
-	set JAVA_OPTS=%JAVA_OPTS% --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
+	set JAVA_OPTS=%JAVA_OPTS% --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+
+    for /f "tokens=2 delims== usebackq" %%a in (`java -XshowSettings:properties -version 2^>^&1 ^| findstr /c:"java.vm.name"`) do (
+    		set VM_NAME=%%a
+    )
+
+    echo "!VM_NAME!" | find /I "OpenJ9" && (
+    	REM OpenJ9 detected, adding additional exports
+    	set JAVA_OPTS=%JAVA_OPTS% --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
+    )
+
 )
 
 REM HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).


### PR DESCRIPTION
Using `java.vm.name` seems stable between different distributions with
OpenJ9 (Semeru, AdoptOpenJDK).

Fixes #20908 on 5.1.z
Backport of #21586

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
