### PR TITLE
Improve exception cause investigation in CDC

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
@@ -61,6 +61,7 @@ import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
 import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
 import static com.hazelcast.jet.core.EventTimeMapper.NO_NATIVE_TIME;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 
 public abstract class CdcSourceP<T> extends AbstractProcessor {
@@ -210,7 +211,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
                 state = new State();
             }
         } else {
-            throw shutDownAndThrow(new JetException("Failed to connect to database" + getCause(re)));
+            throw shutDownAndThrow(new JetException("Failed to connect to database", peel(re)));
         }
     }
 
@@ -247,6 +248,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
     }
 
     private SourceTask startNewTask() {
+        logger.info("starting new task with config: " + taskConfig);
         SourceTask task = newInstance(connector.taskClass().getName(), "task");
         task.initialize(new JetSourceTaskContext());
 
@@ -266,7 +268,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
             long waitTimeMs = reconnectTracker.getNextWaitTimeMs();
             logger.warning("Failed to initialize the connector task, retrying in " + waitTimeMs + "ms" + getCause(ce));
         } else {
-            throw shutDownAndThrow(new JetException("Failed to connect to database" + getCause(ce)));
+            throw shutDownAndThrow(new JetException("Failed to connect to database", peel(ce)));
         }
     }
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.9.3.Final")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.9.5.Final")
             .asCompatibleSubstituteFor("mysql");
 
     @Rule
@@ -68,7 +68,7 @@ public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegra
     }
 
     protected void createDb(String database) throws SQLException {
-        String jdbcUrl = "jdbc:mysql://" + mysql.getContainerIpAddress() + ":" + mysql.getMappedPort(MYSQL_PORT) + "/";
+        String jdbcUrl = "jdbc:mysql://" + mysql.getHost() + ":" + mysql.getMappedPort(MYSQL_PORT) + "/";
         try (Connection connection = getMySqlConnection(jdbcUrl, "root", "mysqlpw")) {
             Statement statement = connection.createStatement();
             statement.addBatch("CREATE DATABASE " + database);

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcAuthIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcAuthIntegrationTest.java
@@ -36,7 +36,7 @@ public class MySqlCdcAuthIntegrationTest extends AbstractMySqlCdcIntegrationTest
     @Test
     public void wrongPassword() {
         StreamSource<ChangeRecord> source = MySqlCdcSources.mysql("name")
-                .setDatabaseAddress(mysql.getContainerIpAddress())
+                .setDatabaseAddress(mysql.getHost())
                 .setDatabasePort(mysql.getMappedPort(MYSQL_PORT))
                 .setDatabaseUser("debezium")
                 .setDatabasePassword("wrongPassword")
@@ -51,7 +51,7 @@ public class MySqlCdcAuthIntegrationTest extends AbstractMySqlCdcIntegrationTest
 
         // then
         assertThatThrownBy(job::join)
-                .hasRootCauseInstanceOf(JetException.class)
+                .hasCauseInstanceOf(JetException.class)
                 .hasStackTraceContaining("Access denied for user");
     }
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -390,7 +390,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         } catch (ExecutionException ee) {
             //job completed exceptionally, as expected, we check the details of it
             assertThat(ee)
-                    .hasRootCauseInstanceOf(JetException.class)
+                    .hasCauseInstanceOf(JetException.class)
                     .hasStackTraceContaining("Failed to connect to database");
         }
     }


### PR DESCRIPTION
Up to now the exception was trimmed in CDC source processor, so in case of any problems the root cause was cut. This PR makes investigation easier

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
