### PR TITLE
Jetty Util dependencies are upgraded to version fixing CVE-2022-2047 [5.1.z]

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -115,18 +115,6 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- explicit version upgrade to avoid CVE-2022-2047 -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util-ajax</artifactId>
-            <version>9.4.48.v20220622</version>
-        </dependency>
-        <!-- explicit version upgrade to avoid CVE-2022-2047 -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-            <version>9.4.48.v20220622</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -115,6 +115,18 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- explicit version upgrade to avoid CVE-2022-2047 -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util-ajax</artifactId>
+            <version>9.4.48.v20220622</version>
+        </dependency>
+        <!-- explicit version upgrade to avoid CVE-2022-2047 -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>9.4.48.v20220622</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1485,7 +1485,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>9.4.44.v20210927</version>
+                <version>9.4.48.v20220622</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Change is made in parent module of extensions, because multiple submodules are using Hadoop Client, which requires Jetty Utils

Backport of #21856 for 5.1.z

Fixes #21862 in 5.1.z

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
