### PR TITLE
Bump AWS Java SDK version to fix CVE-2022-31159 [5.0.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <!--<affinity.version>3.2.3</affinity.version>-->
         <antlr4.version>4.9.3</antlr4.version>
         <avro.version>1.11.0</avro.version>
-        <aws.sdk.version>1.12.183</aws.sdk.version>
+        <aws.sdk.version>1.12.267</aws.sdk.version>
         <classgraph.version>4.8.139</classgraph.version>
         <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
Bump AWS Java SDK version to fix CVE 2022 31159 [5.0.z]

Note: this is reported as MEDIUM by OWASP, but HIGH by Docker scans.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
