### PR TITLE
[3.12.z] Remember previously joined member addresses in TcpIpJoiner

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -41,6 +41,7 @@ import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -482,8 +483,13 @@ public class TcpIpJoiner extends AbstractJoiner {
 
     private void cleanupKnownMemberAddresses() {
         long currentTime = Clock.currentTimeMillis();
-        knownMemberAddresses.values().removeIf(memberLeftTime ->
-                (currentTime - memberLeftTime) >= previouslyJoinedMemberAddressRetentionDuration);
+        Iterator<Long> iterator = knownMemberAddresses.values().iterator();
+        while (iterator.hasNext()) {
+            Long memberLeftTime = iterator.next();
+            if (currentTime - memberLeftTime >= previouslyJoinedMemberAddressRetentionDuration) {
+                iterator.remove();
+            }
+        }
     }
 
     // only used in tests

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -59,14 +59,6 @@ import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 
 public class TcpIpJoiner extends AbstractJoiner {
 
-    /**
-     * Specifies how long the address of a member that has previously joined the cluster
-     * will be retained in the knownMemberAddresses after the member leaves the cluster.
-     */
-    public static final String PREVIOUSLY_JOINED_MEMBER_ADDRESS_RETENTION_DURATION_PROP =
-            "hazelcast.previously.joined.member.address.retention.duration.seconds";
-    // Selected this default value same as default value of missing-cp-member-auto-removal-seconds
-    private static final int DEFAULT_PREVIOUSLY_JOINED_MEMBER_ADDRESS_RETENTION_DURATION_IN_SECS = 14400;
     private static final long JOIN_RETRY_WAIT_TIME = 1000L;
     private static final int MASTERSHIP_CLAIM_TIMEOUT = 10;
 
@@ -90,9 +82,8 @@ public class TcpIpJoiner extends AbstractJoiner {
         }
         maxPortTryCount = tryCount;
         joinConfig = getActiveMemberNetworkConfig(config).getJoin();
-        previouslyJoinedMemberAddressRetentionDuration = TimeUnit.SECONDS.toMillis(
-                Integer.getInteger(PREVIOUSLY_JOINED_MEMBER_ADDRESS_RETENTION_DURATION_PROP,
-                        DEFAULT_PREVIOUSLY_JOINED_MEMBER_ADDRESS_RETENTION_DURATION_IN_SECS));
+        previouslyJoinedMemberAddressRetentionDuration = node.getProperties().getMillis(
+                GroupProperty.TCP_PREVIOUSLY_JOINED_MEMBER_ADDRESS_RETENTION_DURATION);
     }
 
     public boolean isClaimingMastership() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -758,7 +758,7 @@ public class MembershipManager {
         nodeEngine.onMemberLeft(deadMember);
         node.getNodeExtension().onMemberListChange();
         Joiner joiner = node.getJoiner();
-        if (joiner instanceof TcpIpJoiner) {
+        if (joiner != null && joiner.getClass() == TcpIpJoiner.class) {
             ((TcpIpJoiner) joiner).onMemberRemoved(deadMember);
         }
     }
@@ -771,7 +771,7 @@ public class MembershipManager {
                 node.getPartitionService().memberAdded(newMember);
                 node.getNodeExtension().onMemberListChange();
                 Joiner joiner = node.getJoiner();
-                if (joiner instanceof TcpIpJoiner) {
+                if (joiner != null && joiner.getClass() == TcpIpJoiner.class) {
                     ((TcpIpJoiner) joiner).onMemberAdded(newMember);
                 }
                 // async events

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -758,7 +758,7 @@ public class MembershipManager {
         nodeEngine.onMemberLeft(deadMember);
         node.getNodeExtension().onMemberListChange();
         Joiner joiner = node.getJoiner();
-        if (joiner != null && joiner.getClass() == TcpIpJoiner.class) {
+        if (joiner instanceof TcpIpJoiner) {
             ((TcpIpJoiner) joiner).onMemberRemoved(deadMember);
         }
     }
@@ -771,7 +771,7 @@ public class MembershipManager {
                 node.getPartitionService().memberAdded(newMember);
                 node.getNodeExtension().onMemberListChange();
                 Joiner joiner = node.getJoiner();
-                if (joiner != null && joiner.getClass() == TcpIpJoiner.class) {
+                if (joiner instanceof TcpIpJoiner) {
                     ((TcpIpJoiner) joiner).onMemberAdded(newMember);
                 }
                 // async events

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -17,6 +17,8 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.cluster.Joiner;
+import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.hotrestart.InternalHotRestartService;
@@ -755,6 +757,10 @@ public class MembershipManager {
         node.getPartitionService().memberRemoved(deadMember);
         nodeEngine.onMemberLeft(deadMember);
         node.getNodeExtension().onMemberListChange();
+        Joiner joiner = node.getJoiner();
+        if (joiner != null && joiner.getClass() == TcpIpJoiner.class) {
+            ((TcpIpJoiner) joiner).onMemberRemoved(deadMember);
+        }
     }
 
     void sendMembershipEvents(Collection<MemberImpl> currentMembers, Collection<MemberImpl> newMembers, boolean sortMembers) {
@@ -764,7 +770,10 @@ public class MembershipManager {
                 // sync calls
                 node.getPartitionService().memberAdded(newMember);
                 node.getNodeExtension().onMemberListChange();
-
+                Joiner joiner = node.getJoiner();
+                if (joiner != null && joiner.getClass() == TcpIpJoiner.class) {
+                    ((TcpIpJoiner) joiner).onMemberAdded(newMember);
+                }
                 // async events
                 eventMembers.add(newMember);
                 if (sortMembers) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -559,6 +559,16 @@ public final class GroupProperty {
     public static final HazelcastProperty TCP_JOIN_PORT_TRY_COUNT
             = new HazelcastProperty("hazelcast.tcp.join.port.try.count", 3);
 
+    /**
+     * Specifies how long the address of a member that has previously joined the
+     * cluster will be retained/remembered in the TcpIpJoiner after it leaves the
+     * cluster. The remembered member addresses is used to discover other cluster
+     * by split-brain handler.
+     */
+    public static final HazelcastProperty TCP_PREVIOUSLY_JOINED_MEMBER_ADDRESS_RETENTION_DURATION
+            = new HazelcastProperty("hazelcast.tcp.join.previously.joined.member.address.retention.seconds",
+            14400, SECONDS);
+
     public static final HazelcastProperty MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.map.replica.scheduled.task.delay.seconds", 10, SECONDS);
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -295,7 +295,7 @@ public class TcpIpJoinTest extends AbstractJoinTest {
         TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
         tcpIpConfig.setEnabled(true);
         for (int otherMemberPort : otherKnownMemberPorts) {
-            tcpIpConfig.setEnabled(true).addMember("127.0.0.1:" + otherMemberPort);
+            tcpIpConfig.addMember("127.0.0.1:" + otherMemberPort);
         }
         return config;
     }


### PR DESCRIPTION
This PR is the partial backport of https://github.com/hazelcast/hazelcast/pull/21552.
It only includes address remembering mechanism, not include the config update part.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
