### PR TITLE
[HZ-1323] Tiered Store usage metrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -606,8 +606,8 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_AVG = "tstore.hlog.paging.frequency.avg";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MIN = "tstore.hlog.paging.frequency.min";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MAX = "tstore.hlog.paging.frequency.max";
-    public static final String TSTORE_HLOG_DISK_USAGE = "tstore.hlog.disk.usage";
-    public static final String TSTORE_HLOG_LOG_LENGTH = "tstore.hlog.log.length";
+    public static final String TSTORE_DISK_USAGE = "tstore.disk.usage";
+    public static final String TSTORE_LOG_LENGTH = "tstore.log.length";
     // ===[/TSTORE]=====================================================
 
     // ===[WAN]=========================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -574,6 +574,10 @@ public final class MetricDescriptorConstants {
     // ===[/THREAD]=====================================================
 
     // ===[TSTORE]======================================================
+    public static final String DEVICE_DISCRIMINATOR_NAME = "name";
+    public static final String TSTORE_DEVICE_USED_SPACE = "tstore.device.usedSpace";
+    public static final String TSTORE_DEVICE_FREE_SPACE = "tstore.device.freeSpace";
+    public static final String TSTORE_DEVICE_MAX_SPACE = "tstore.device.maxSpace";
     public static final String TSTORE_HLOG_PAGE_WRITE_DURATION_AVG = "tstore.hlog.pageWriteDuration.avg";
     public static final String TSTORE_HLOG_PAGE_WRITE_DURATION_MIN = "tstore.hlog.pageWriteDuration.min";
     public static final String TSTORE_HLOG_PAGE_WRITE_DURATION_MAX = "tstore.hlog.pageWriteDuration.max";

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -578,6 +578,8 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_DEVICE_USED_SPACE = "tstore.device.usedSpace";
     public static final String TSTORE_DEVICE_FREE_SPACE = "tstore.device.freeSpace";
     public static final String TSTORE_DEVICE_MAX_SPACE = "tstore.device.maxSpace";
+    public static final String TSTORE_DEVICE_USAGE = "tstore.device.usage";
+    public static final String TSTORE_HLOG_LENGTH = "tstore.hlog.length";
     public static final String TSTORE_HLOG_PAGE_WRITE_DURATION_AVG = "tstore.hlog.pageWriteDuration.avg";
     public static final String TSTORE_HLOG_PAGE_WRITE_DURATION_MIN = "tstore.hlog.pageWriteDuration.min";
     public static final String TSTORE_HLOG_PAGE_WRITE_DURATION_MAX = "tstore.hlog.pageWriteDuration.max";
@@ -610,8 +612,6 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_AVG = "tstore.hlog.paging.frequency.avg";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MIN = "tstore.hlog.paging.frequency.min";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MAX = "tstore.hlog.paging.frequency.max";
-    public static final String TSTORE_DISK_USAGE = "tstore.disk.usage";
-    public static final String TSTORE_LOG_LENGTH = "tstore.log.length";
     // ===[/TSTORE]=====================================================
 
     // ===[WAN]=========================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -574,7 +574,7 @@ public final class MetricDescriptorConstants {
     // ===[/THREAD]=====================================================
 
     // ===[TSTORE]======================================================
-    public static final String DEVICE_DISCRIMINATOR_NAME = "name";
+    public static final String TSTORE_DEVICE_DISCRIMINATOR_NAME = "name";
     public static final String TSTORE_DEVICE_USED_SPACE = "tstore.device.usedSpace";
     public static final String TSTORE_DEVICE_FREE_SPACE = "tstore.device.freeSpace";
     public static final String TSTORE_DEVICE_MAX_SPACE = "tstore.device.maxSpace";

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -606,6 +606,8 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_AVG = "tstore.hlog.paging.frequency.avg";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MIN = "tstore.hlog.paging.frequency.min";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MAX = "tstore.hlog.paging.frequency.max";
+    public static final String TSTORE_HLOG_DISK_USAGE = "tstore.hlog.disk.usage";
+    public static final String TSTORE_HLOG_LOG_LENGTH = "tstore.hlog.log.length";
     // ===[/TSTORE]=====================================================
 
     // ===[WAN]=========================================================


### PR DESCRIPTION
This PR introduces 5 metrics and fixes 3 minor bugs.

---

Regarding metrics:

 - hlog.length
 - device.usage

 - device.usedSpace
 - device.freeSpace
 - device.maxSpace

Hlog length and device usage are available as aggregated per map and per
member. Device usage is also available per device.

Device usage increased and decreased when the files actually written to
and deleted from the device. So this will be accurate indicator of 
device consumption of hazelcast member via tstore.

Hlog length is introduced for licensing purposes. This metric is
basically size of valid logic address space. It's increased when a new
allocation occurs and decreased when hlog is deleted.

Partition based metrics or primary/backup separation is easily doable 
for the above 2 mentioned metrics. I didn't include them yet because it 
wasn't a requirement.

Space metrics are calculated using File.getUsableSpace() and
File.getTotalSpace() and they are device-wide.

---

Regarding bugs:

In hybridLogForGlobalIndexFactories, keys are TStoreUserId and their
usernames are a string which includes index config name. This causes a 
problem if index config is not normalized because not normalized index 
config has a null name and later on hybridLogForGlobalIndexFactories 
will have duplicated entry. TBH, I don't see the need for saving these 
factories but that is outside this PR's scope.

Index metric collection wasn't working. Collection was using 
TStoreUserId usernames as mapName, which isn't correct for 
hybridLogForGlobalIndexFactories.

TieredStoreMetricsTest was only looking at the first expected descriptor
to see if that exist in the hazelcast instance. Now it looks all.

---

Regarding licensing, one improvement could be removing garbage records
from hlog length. I would advise against that because hybrid log is
unaware of what index does and what records are garbage. This means
that you would need to introduce record garbage mechanisms in
index/storage. One huge disadvantage of this beside its messy
structure is since hybrid log isn't aware of which records are garbage,
so it must assume all of a file is garbage when truncated. This is
normally not an issue however, if you miss garbage, with time garbage
may even become negative. The places I found in storage that produces
garbage of which hybrid log isn't aware are as follows:

 - TieredStorageImpl.removeRecord()
 - TieredStorageImpl.updateRecordValue()
 - TieredStorageImpl.clear()

It's easy to miss one of the places garbage produced, and it's possible
that future changes can be overlooked. This is why I didn't calculate
garbage.

If calculating garbage is a must, although I didn't go into deeper,
I would suggest calculating usage from operations/storage/index in the
future and ditching hybrid log.

---

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5178
