### PR TITLE
[API-1250] Do not serialize JDK classes with zero-config Compact serialization

### DIFF
--- a/hazelcast-it/jdk17-tests/src/test/java/com/hazelcast/serialization/compact/record/RecordSerializationTest.java
+++ b/hazelcast-it/jdk17-tests/src/test/java/com/hazelcast/serialization/compact/record/RecordSerializationTest.java
@@ -211,7 +211,9 @@ public class RecordSerializationTest extends HazelcastTestSupport {
                 .hasStackTraceContaining("which uses this class in its fields");
     }
 
-    private record RecordWithUnsupportedField(ArrayList<String> list) {}
+    private record RecordWithUnsupportedField(ArrayList<String> list) {
+    }
 
-    private record RecordWithUnsupportedArrayField(ArrayList<String>[] lists) {}
+    private record RecordWithUnsupportedArrayField(ArrayList<String>[] lists) {
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordSerializer.java
@@ -173,6 +173,9 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
     }
 
     private void populateReadersWriters(Class<?> clazz) {
+        // The top level class might not be Compact serializable
+        CompactUtil.verifyClassIsCompactSerializable(clazz);
+
         try {
             Object[] recordComponents = (Object[]) getRecordComponentsMethod.invoke(clazz);
             Class<?>[] componentTypes = new Class<?>[recordComponents.length];
@@ -626,6 +629,9 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
                             compactWriter.writeArrayOfString(name, CompactUtil.enumArrayAsStringNameArray(values));
                         };
                     } else {
+                        // Elements of the array might not be Compact serializable
+                        CompactUtil.verifyFieldClassIsCompactSerializable(componentType, clazz);
+
                         componentReaders[i] = (compactReader, schema) -> {
                             if (!isFieldExist(schema, name, ARRAY_OF_COMPACT)) {
                                 return null;
@@ -636,6 +642,9 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
                                 -> compactWriter.writeArrayOfCompact(name, (Object[]) componentGetter.invoke(object));
                     }
                 } else {
+                    // The nested field might not be Compact serializable
+                    CompactUtil.verifyFieldClassIsCompactSerializable(type, clazz);
+
                     componentReaders[i] = (compactReader, schema) -> {
                         if (!isFieldExist(schema, name, COMPACT)) {
                             return null;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -36,13 +36,13 @@ import example.serialization.MainDTO;
 import example.serialization.MainDTOSerializer;
 import example.serialization.SameClassEmployeeDTOSerializer;
 import example.serialization.SameTypeNameEmployeeDTOSerializer;
+import example.serialization.SerializableEmployeeDTO;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.OptionalDouble;
 
@@ -205,7 +205,7 @@ public class CompactSerializationTest {
         SerializationConfig config = new SerializationConfig();
         config.getCompactSerializationConfig()
                 .setEnabled(true)
-                .setClasses(ExternalizableEmployeeDTO.class, SerializableFoo.class);
+                .setClasses(ExternalizableEmployeeDTO.class, SerializableEmployeeDTO.class);
 
         SerializationService service = createSerializationService(config);
 
@@ -214,7 +214,7 @@ public class CompactSerializationTest {
 
         assertFalse(externalizableEmployeeDTO.usedExternalizableSerialization());
 
-        Data data = service.toData(new SerializableFoo());
+        Data data = service.toData(new SerializableEmployeeDTO("John Doe", 42));
         assertTrue(data.isCompact());
     }
 
@@ -235,11 +235,11 @@ public class CompactSerializationTest {
         SerializationConfig config = new SerializationConfig();
         config.getCompactSerializationConfig()
                 .setEnabled(true)
-                .setClasses(SerializableFoo.class)
+                .setClasses(SerializableEmployeeDTO.class)
                 .setSerializers(new EmployeeDTOSerializer());
 
         SerializationService service = createSerializationService(config);
-        Data data = service.toData(new SerializableFoo());
+        Data data = service.toData(new SerializableEmployeeDTO("John Doe", 42));
         assertTrue(data.isCompact());
     }
 
@@ -250,7 +250,7 @@ public class CompactSerializationTest {
         config.getCompactSerializationConfig()
                 .setEnabled(true)
                 .setSerializers(serializer)
-                .setClasses(SerializableFoo.class);
+                .setClasses(SerializableEmployeeDTO.class);
 
         SerializationService service = createSerializationService(config);
         service.toObject(service.toData(new EmployeeDTO()));
@@ -352,11 +352,6 @@ public class CompactSerializationTest {
         private Foo(int bar) {
             this.bar = bar;
         }
-    }
-
-    // Not static by purpose to fail the test if Java Serialization is used
-    private class SerializableFoo implements Serializable {
-        private int i;
     }
 
     private static class DuplicateWritingSerializer implements CompactSerializer<Foo> {


### PR DESCRIPTION
It was decided to fail with meaningful exception messages in case
we are faced with a field type that is not supported by the
reflective serializer yet.

To do that, the team decided to exclude all JDK classes from the
zero-config serialization, meaning, they cannot be used as types,
field types, or array component types in the reflective serializers.