### PR TITLE
Bump gRPC version so that it's fully compatible with M1 (aarch64) and Python 3.10

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/JetToPythonServer.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/JetToPythonServer.java
@@ -74,7 +74,7 @@ class JetToPythonServer {
                     }
                 } catch (SocketTimeoutException e) {
                     if (!pythonProcess.isAlive()) {
-                        throw new IOException("Python process died before completing initialization");
+                        throw new IOException("Python process died before completing initialization", e);
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <aws.sdk.version>1.12.276</aws.sdk.version>
         <classgraph.version>4.8.149</classgraph.version>
         <debezium.version>1.9.3.Final</debezium.version>
-        <grpc.version>1.43.0</grpc.version>
+        <grpc.version>1.48.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
         <hadoop.version>3.3.3</hadoop.version>
         <jackson.version>2.13.3</jackson.version>


### PR DESCRIPTION
Without upgrade, Apple M1 is receiving such message when running `PythonServiceTest` with Python 3.10: mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e)).

Full stack trace:
```
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT] Traceback (most recent call last):
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]   File "/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_grpc_server.py", line 1, in <module>
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]     import grpc
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]   File "/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/__init__.py", line 22, in <module>
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]     from grpc import _compression
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]   File "/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/_compression.py", line 15, in <module>
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]     from grpc._cython import cygrpc
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@63f679a - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT] ImportError: dlopen(/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/_cython/cygrpc.cpython-310-darwin.so, 0x0002): tried: '/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/_cython/cygrpc.cpython-310-darwin.so' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e)))
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT] Traceback (most recent call last):
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]   File "/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_grpc_server.py", line 1, in <module>
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]     import grpc
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]   File "/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/__init__.py", line 22, in <module>
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]     from grpc import _compression
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]   File "/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/_compression.py", line 15, in <module>
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT]     from grpc._cython import cygrpc
17:18:01,172 DEBUG || - [python] python-main-logger_java.lang.UNIXProcess@9b0cba - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT] ImportError: dlopen(/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/_cython/cygrpc.cpython-310-darwin.so, 0x0002): tried: '/private/var/folders/st/j3j_44rn77d31r__9l8k04cw0000gp/T/jet-trusting_mccarthy-0873-c0cf-11d2-0001-_private_var_folders_st_j3j_44rn8357744841067043776/jet_to_python_env/lib/python3.10/site-packages/grpc/_cython/cygrpc.cpython-310-darwin.so' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e)))
```

**Note: it may happen, that pip will complain about grpc version installed. In such cases user is forced to do `pip uninstall grpcio`**. We may consider adding ` --ignore-installed`. option to `pip` command in init script, but it will re-install dependencies each time such service is launched.

See also: https://github.com/grpc/grpc/issues/28387 Conversation about such error and information, that it affects Python 3.10 (but not 3.9) and is fixed in gRPC 1.47

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
