### PR TITLE
Improve handling of SQLNonTransientException in WriteJdbcP

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
@@ -285,10 +285,10 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
     }
 
     private boolean isNonTransientException(SQLException e) {
+        SQLException next = e.getNextException();
         return e instanceof SQLNonTransientException
                 || e.getCause() instanceof SQLNonTransientException
-                || e.getNextException() instanceof SQLNonTransientException
-                || (e.getNextException() != null && isNonTransientException(e.getNextException()));
+                || (next != null && e != next && isNonTransientException(next));
     }
 
 }


### PR DESCRIPTION
In `WriteJdbcP#process` we check for `SQLNonTransientException`, but there
can be a chain of exceptions via `getNextException()`, where a
SQLNonTransientException can be present.

Also in `WriteJdbcP#connectAndPrepareStatement` we call
`javax.sql.DataSource#getConnection` which can throw
`SQLNonTransientException`, in such case we just keep retrying.

This PR fixes and unifies the check for `SQLNonTransientException`.
It improves the state, but it really depends on JDBC driver implementing
the `SQLNonTransientException` correctly. E.g. PostgreSQL throws only
`PSQLException` and doesn't carry any information if the failure is
transient (apart from the server error).

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
