### PR TITLE
[API-1250] Improve documentation for primitive-nullable primitive field interoperability

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -74,6 +74,10 @@ public interface CompactReader {
 
     /**
      * Reads a boolean.
+     * <p>
+     * This method can also read a nullable boolean, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -86,6 +90,10 @@ public interface CompactReader {
 
     /**
      * Reads an 8-bit two's complement signed integer.
+     * <p>
+     * This method can also read a nullable int8, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -99,6 +107,10 @@ public interface CompactReader {
 
     /**
      * Reads a 16-bit two's complement signed integer.
+     * <p>
+     * This method can also read a nullable int16, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -112,6 +124,10 @@ public interface CompactReader {
 
     /**
      * Reads a 32-bit two's complement signed integer.
+     * <p>
+     * This method can also read a nullable int32, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -125,6 +141,10 @@ public interface CompactReader {
 
     /**
      * Reads a 64-bit two's complement signed integer.
+     * <p>
+     * This method can also read a nullable int64, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -138,6 +158,10 @@ public interface CompactReader {
 
     /**
      * Reads a 32-bit IEEE 754 floating point number.
+     * <p>
+     * This method can also read a nullable float32, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -151,6 +175,10 @@ public interface CompactReader {
 
     /**
      * Reads a 64-bit IEEE 754 floating point number.
+     * <p>
+     * This method can also read a nullable float64, as long as it is not
+     * {@code null}. If a {@code null} value is read with this method,
+     * {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -266,6 +294,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of booleans.
+     * <p>
+     * This method can also read an array of nullable booleans, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -280,6 +312,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of 8-bit two's complement signed integers.
+     * <p>
+     * This method can also read an array of nullable int8s, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -294,6 +330,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of 16-bit two's complement signed integers.
+     * <p>
+     * This method can also read an array of nullable int16s, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -308,6 +348,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of 32-bit two's complement signed integers.
+     * <p>
+     * This method can also read an array of nullable int32s, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -322,6 +366,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of 64-bit two's complement signed integers.
+     * <p>
+     * This method can also read an array of nullable int64s, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -336,6 +384,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of 32-bit IEEE 754 floating point numbers.
+     * <p>
+     * This method can also read an array of nullable float32s, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -350,6 +402,10 @@ public interface CompactReader {
 
     /**
      * Reads an array of 64-bit IEEE 754 floating point numbers.
+     * <p>
+     * This method can also read an array of nullable float64s, as long as it
+     * does not contain {@code null} values. If a {@code null} array item is
+     * read with this method, {@link HazelcastSerializationException} is thrown.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -464,6 +520,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable boolean.
+     * <p>
+     * This method can also read a non-nullable boolean.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -478,6 +536,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable 8-bit two's complement signed integer.
+     * <p>
+     * This method can also read a non-nullable int8.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -492,6 +552,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable 16-bit two's complement signed integer.
+     * <p>
+     * This method can also read a non-nullable int16.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -506,6 +568,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable 32-bit two's complement signed integer.
+     * <p>
+     * This method can also read a non-nullable int32.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -520,6 +584,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable 64-bit two's complement signed integer.
+     * <p>
+     * This method can also read a non-nullable int64.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -534,6 +600,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable 32-bit IEEE 754 floating point number.
+     * <p>
+     * This method can also read a non-nullable float32.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -548,6 +616,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable 64-bit IEEE 754 floating point number.
+     * <p>
+     * This method can also read a non-nullable float64.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -562,6 +632,8 @@ public interface CompactReader {
 
     /**
      * Reads a nullable array of nullable booleans.
+     * <p>
+     * This method can also read array of non-nullable booleans.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -577,6 +649,8 @@ public interface CompactReader {
     /**
      * Reads a nullable array of nullable 8-bit two's complement signed
      * integers.
+     * <p>
+     * This method can also read array of non-nullable int8s.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -592,6 +666,8 @@ public interface CompactReader {
     /**
      * Reads a nullable array of nullable 16-bit two's complement signed
      * integers.
+     * <p>
+     * This method can also read array of non-nullable int16s.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -607,6 +683,8 @@ public interface CompactReader {
     /**
      * Reads a nullable array of nullable 32-bit two's complement signed
      * integers.
+     * <p>
+     * This method can also read array of non-nullable int32s.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -622,6 +700,8 @@ public interface CompactReader {
     /**
      * Reads a nullable array of nullable 64-bit two's complement signed
      * integers.
+     * <p>
+     * This method can also read array of non-nullable int64s.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -637,6 +717,8 @@ public interface CompactReader {
     /**
      * Reads a nullable array of nullable 32-bit IEEE 754 floating point
      * numbers.
+     * <p>
+     * This method can also read array of non-nullable float32s.
      *
      * @param fieldName name of the field.
      * @return the value of the field.
@@ -652,6 +734,8 @@ public interface CompactReader {
     /**
      * Reads a nullable array of nullable 64-bit IEEE 754 floating point
      * numbers.
+     * <p>
+     * This method can also read array of non-nullable float64s.
      *
      * @param fieldName name of the field.
      * @return the value of the field.


### PR DESCRIPTION
We allow reading nullable primitive fields as primitive fields
as long as they are not null. Also, it is possible to read
primitive fields as nullable primitives. The same holds true
for the arrays of such types.

This PR improves the Javadoc we have for these methods and mentions
about this possibility.
