### PR TITLE
[HZ-1064] Hazelcast configs to specify the CP member priority

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1547,6 +1547,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertTrue(cpSubsystemConfig.isFailOnIndeterminateOperationState());
         assertFalse(cpSubsystemConfig.isPersistenceEnabled());
         assertEquals(new File("/custom-dir").getAbsolutePath(), cpSubsystemConfig.getBaseDir().getAbsolutePath());
+        assertEquals(-1, cpSubsystemConfig.getCPMemberPriority());
         RaftAlgorithmConfig raftAlgorithmConfig = cpSubsystemConfig.getRaftAlgorithmConfig();
         assertEquals(500, raftAlgorithmConfig.getLeaderElectionTimeoutInMillis());
         assertEquals(100, raftAlgorithmConfig.getLeaderHeartbeatPeriodInMillis());

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -1029,6 +1029,7 @@
                 <hz:persistence-enabled>false</hz:persistence-enabled>
                 <hz:base-dir>/custom-dir</hz:base-dir>
                 <hz:data-load-timeout-seconds>30</hz:data-load-timeout-seconds>
+                <hz:cp-member-priority>-1</hz:cp-member-priority>
                 <hz:raft-algorithm>
                     <hz:leader-election-timeout-in-millis>500</hz:leader-election-timeout-in-millis>
                     <hz:leader-heartbeat-period-in-millis>100</hz:leader-heartbeat-period-in-millis>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -539,7 +539,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder cpSubsystemConfigBuilder = createBeanBuilder(CPSubsystemConfig.class);
 
             fillValues(node, cpSubsystemConfigBuilder, "raftAlgorithm", "semaphores", "locks", "cpMemberCount",
-                    "missingCpMemberAutoRemovalSeconds");
+                    "missingCpMemberAutoRemovalSeconds", "cpMemberPriority");
 
             for (Node child : childElements(node)) {
                 String nodeName = cleanNodeName(child);
@@ -564,6 +564,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     } else if ("missing-cp-member-auto-removal-seconds".equals(nodeName)) {
                         cpSubsystemConfigBuilder.addPropertyValue("missingCPMemberAutoRemovalSeconds",
                                 getIntegerValue("missing-cp-member-auto-removal-seconds", value));
+                    } else if ("cp-member-priority".equals(nodeName)) {
+                        cpSubsystemConfigBuilder.addPropertyValue("CPMemberPriority",
+                                getIntegerValue("cp-member-priority", value));
                     }
                 }
             }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.2.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.2.xsd
@@ -5361,6 +5361,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="cp-member-priority" type="xs:integer" minOccurs="0" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The CP member priority. The CP groups' leadership will be eventually
+                        transferred to members with higher priorities within the CP group.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="raft-algorithm" type="raft-algorithm" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -993,7 +993,8 @@ public class ConfigXmlGenerator {
                 .node("fail-on-indeterminate-operation-state", cpSubsystemConfig.isFailOnIndeterminateOperationState())
                 .node("persistence-enabled", cpSubsystemConfig.isPersistenceEnabled())
                 .node("base-dir", cpSubsystemConfig.getBaseDir().getAbsolutePath())
-                .node("data-load-timeout-seconds", cpSubsystemConfig.getDataLoadTimeoutSeconds());
+                .node("data-load-timeout-seconds", cpSubsystemConfig.getDataLoadTimeoutSeconds())
+                .node("cp-member-priority", cpSubsystemConfig.getCPMemberPriority());
 
         RaftAlgorithmConfig raftAlgorithmConfig = cpSubsystemConfig.getRaftAlgorithmConfig();
         gen.open("raft-algorithm")

--- a/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
@@ -280,6 +280,12 @@ public class CPSubsystemConfig {
     private int dataLoadTimeoutSeconds = DEFAULT_DATA_LOAD_TIMEOUT_SECONDS;
 
     /**
+     * The CP member priority. The Raft leader's role eventually will be transferred to members with
+     * higher priorities within the CP group.
+     */
+    private int cpMemberPriority;
+
+    /**
      * Contains configuration options for Hazelcast's Raft consensus algorithm
      * implementation.
      */
@@ -311,6 +317,7 @@ public class CPSubsystemConfig {
         this.persistenceEnabled = config.persistenceEnabled;
         this.baseDir = config.baseDir;
         this.dataLoadTimeoutSeconds = config.dataLoadTimeoutSeconds;
+        this.cpMemberPriority = config.cpMemberPriority;
         for (SemaphoreConfig semaphoreConfig : config.semaphoreConfigs.values()) {
             this.semaphoreConfigs.put(semaphoreConfig.getName(), new SemaphoreConfig(semaphoreConfig));
         }
@@ -540,6 +547,27 @@ public class CPSubsystemConfig {
     }
 
     /**
+     * Sets the CP member priority. CP groups' leadership will be transferred to members with
+     * higher priorities within the CP group.
+     *
+     * @param cpMemberPriority can be any integer number
+     * @return this config instance
+     */
+    public CPSubsystemConfig setCPMemberPriority(int cpMemberPriority) {
+        this.cpMemberPriority = cpMemberPriority;
+        return this;
+    }
+
+    /**
+     * Returns the CP member priority.
+     *
+     * @return the CP member priority
+     */
+    public int getCPMemberPriority() {
+        return cpMemberPriority;
+    }
+
+    /**
      * Returns configuration options for Hazelcast's Raft consensus algorithm
      * implementation
      *
@@ -673,8 +701,9 @@ public class CPSubsystemConfig {
         return "CPSubsystemConfig{" + "cpMemberCount=" + cpMemberCount + ", groupSize=" + groupSize
                 + ", sessionTimeToLiveSeconds=" + sessionTimeToLiveSeconds + ", sessionHeartbeatIntervalSeconds="
                 + sessionHeartbeatIntervalSeconds + ", missingCPMemberAutoRemovalSeconds=" + missingCPMemberAutoRemovalSeconds
-                + ", failOnIndeterminateOperationState=" + failOnIndeterminateOperationState + ", raftAlgorithmConfig="
-                + raftAlgorithmConfig + ", semaphoreConfigs=" + semaphoreConfigs + ", lockConfigs=" + lockConfigs + '}';
+                + ", failOnIndeterminateOperationState=" + failOnIndeterminateOperationState
+                + ", cpMemberPriority=" + cpMemberPriority + ", raftAlgorithmConfig=" + raftAlgorithmConfig
+                + ", semaphoreConfigs=" + semaphoreConfigs + ", lockConfigs=" + lockConfigs + '}';
     }
 
     @Override
@@ -693,6 +722,7 @@ public class CPSubsystemConfig {
                 && missingCPMemberAutoRemovalSeconds == that.missingCPMemberAutoRemovalSeconds
                 && failOnIndeterminateOperationState == that.failOnIndeterminateOperationState
                 && persistenceEnabled == that.persistenceEnabled && dataLoadTimeoutSeconds == that.dataLoadTimeoutSeconds
+                && cpMemberPriority == that.cpMemberPriority
                 && Objects.equals(baseDir, that.baseDir)
                 && Objects.equals(raftAlgorithmConfig, that.raftAlgorithmConfig)
                 && Objects.equals(semaphoreConfigs, that.semaphoreConfigs)
@@ -703,7 +733,7 @@ public class CPSubsystemConfig {
     @Override
     public int hashCode() {
         return Objects.hash(cpMemberCount, groupSize, sessionTimeToLiveSeconds, sessionHeartbeatIntervalSeconds,
-                missingCPMemberAutoRemovalSeconds, failOnIndeterminateOperationState, persistenceEnabled, baseDir,
-                dataLoadTimeoutSeconds, raftAlgorithmConfig, semaphoreConfigs, lockConfigs, configPatternMatcher);
+                missingCPMemberAutoRemovalSeconds, failOnIndeterminateOperationState, persistenceEnabled, cpMemberPriority,
+                baseDir, dataLoadTimeoutSeconds, raftAlgorithmConfig, semaphoreConfigs, lockConfigs, configPatternMatcher);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2983,6 +2983,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                     cpSubsystemConfig.setBaseDir(new File(getTextContent(child)).getAbsoluteFile());
                 } else if (matches("data-load-timeout-seconds", nodeName)) {
                     cpSubsystemConfig.setDataLoadTimeoutSeconds(Integer.parseInt(getTextContent(child)));
+                } else if (matches("cp-member-priority", nodeName)) {
+                    cpSubsystemConfig.setCPMemberPriority(Integer.parseInt(getTextContent(child)));
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicCPSubsystemConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicCPSubsystemConfig.java
@@ -64,6 +64,11 @@ class DynamicCPSubsystemConfig extends CPSubsystemConfig {
     }
 
     @Override
+    public CPSubsystemConfig setCPMemberPriority(int cpMemberPriority) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public RaftAlgorithmConfig getRaftAlgorithmConfig() {
         return new DynamicRaftAlgorithmConfig(super.getRaftAlgorithmConfig());
     }

--- a/hazelcast/src/main/resources/hazelcast-config-5.2.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.2.json
@@ -2457,6 +2457,11 @@
           "default": 120,
           "description": "Timeout duration for CP members to restore their data from disk. CP member fails its startup if it cannot complete its CP data restore rocess in the configured duration."
         },
+        "cp-member-priority": {
+          "type": "integer",
+          "default": 0,
+          "description": "The CP member priority. The CP groups' leadership will be eventually transferred to members with higher priorities within the CP group."
+        },
         "raft-algorithm": {
           "type": "object",
           "additionalProperties": false,

--- a/hazelcast/src/main/resources/hazelcast-config-5.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.2.xsd
@@ -5203,6 +5203,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="cp-member-priority" type="xs:int" minOccurs="0" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The CP member priority. The CP groups' leadership will be eventually transferred to members
+                        with higher priorities within the CP group.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="raft-algorithm" type="raft-algorithm" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -489,6 +489,7 @@
         <session-heartbeat-interval-seconds>5</session-heartbeat-interval-seconds>
         <missing-cp-member-auto-removal-seconds>14400</missing-cp-member-auto-removal-seconds>
         <fail-on-indeterminate-operation-state>false</fail-on-indeterminate-operation-state>
+        <cp-member-priority>0</cp-member-priority>
         <raft-algorithm>
             <leader-election-timeout-in-millis>2000</leader-election-timeout-in-millis>
             <leader-heartbeat-period-in-millis>5000</leader-heartbeat-period-in-millis>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -711,6 +711,9 @@ hazelcast:
     # committed multiple times. If it is enabled, the public API call fails
     # with com.hazelcast.core.IndeterminateOperationStateException.
     fail-on-indeterminate-operation-state: false
+    # The CP member priority. The CP groups' leadership will be eventually
+    # transferred to members with higher priorities within the CP group.
+    cp-member-priority: 0
     raft-algorithm:
       # Leader election timeout in milliseconds. If a candidate cannot win
       # majority of the votes in time, a new leader election round is initiated.

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -3481,6 +3481,9 @@
             Timeout duration for CP members to restore their data from disk.
             A CP member fails its startup if it cannot complete its CP data restore
             process in the configured duration.
+        * <cp-member-priority>:
+            The CP member priority. The CP groups' leadership will be eventually
+            transferred to members with higher priorities within the CP group.
 
         * <raft-algorithm>:
             These parameters tune specific parameters of Hazelcast’s Raft consensus
@@ -3558,6 +3561,7 @@
         <persistence-enabled>true</persistence-enabled>
         <base-dir>custom-cp-dir</base-dir>
         <data-load-timeout-seconds>30</data-load-timeout-seconds>
+        <cp-member-priority>1</cp-member-priority>
         <raft-algorithm>
             <leader-election-timeout-in-millis>2000</leader-election-timeout-in-millis>
             <leader-heartbeat-period-in-millis>5000</leader-heartbeat-period-in-millis>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -3402,6 +3402,9 @@ hazelcast:
   #   Timeout duration for CP members to restore their data from disk.
   #   A CP member fails its startup if it cannot complete its CP data restore
   #   process in the configured duration.
+  #  * <cp-member-priority>:
+  #    The CP member priority. The CP groups' leadership will be eventually
+  #    transferred to members with higher priorities within the CP group.
   #
   # * "raft-algorithm":
   #     These parameters tune specific parameters of Hazelcast’s Raft consensus
@@ -3476,6 +3479,7 @@ hazelcast:
     persistence-enabled: true
     base-dir: custom-cp-dir
     data-load-timeout-seconds: 30
+    cp-member-priority: 1
     raft-algorithm:
       leader-election-timeout-in-millis: 2000
       leader-heartbeat-period-in-millis: 5000

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -706,7 +706,8 @@ public class ConfigCompatibilityChecker {
                             && c1.isFailOnIndeterminateOperationState() == c2.isFailOnIndeterminateOperationState())
                             && c1.isPersistenceEnabled() == c2.isPersistenceEnabled()
                             && c1.getBaseDir().getAbsoluteFile().equals(c2.getBaseDir().getAbsoluteFile())
-                            && c1.getDataLoadTimeoutSeconds() == c2.getDataLoadTimeoutSeconds();
+                            && c1.getDataLoadTimeoutSeconds() == c2.getDataLoadTimeoutSeconds()
+                            && c1.getCPMemberPriority() == c2.getCPMemberPriority();
 
             if (!cpSubsystemConfigValuesEqual) {
                 return false;

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1090,7 +1090,8 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                 .setMissingCPMemberAutoRemovalSeconds(120)
                 .setFailOnIndeterminateOperationState(true)
                 .setPersistenceEnabled(true)
-                .setBaseDir(new File("/custom-dir"));
+                .setBaseDir(new File("/custom-dir"))
+                .setCPMemberPriority(-1);
 
         config.getCPSubsystemConfig()
                 .getRaftAlgorithmConfig()

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3760,6 +3760,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "  <persistence-enabled>true</persistence-enabled>\n"
                 + "  <base-dir>/mnt/cp-data</base-dir>\n"
                 + "  <data-load-timeout-seconds>30</data-load-timeout-seconds>\n"
+                + "  <cp-member-priority>-1</cp-member-priority>\n"
                 + "  <raft-algorithm>\n"
                 + "    <leader-election-timeout-in-millis>500</leader-election-timeout-in-millis>\n"
                 + "    <leader-heartbeat-period-in-millis>100</leader-heartbeat-period-in-millis>\n"
@@ -3804,6 +3805,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertTrue(cpSubsystemConfig.isPersistenceEnabled());
         assertEquals(new File("/mnt/cp-data").getAbsoluteFile(), cpSubsystemConfig.getBaseDir().getAbsoluteFile());
         assertEquals(30, cpSubsystemConfig.getDataLoadTimeoutSeconds());
+        assertEquals(-1, cpSubsystemConfig.getCPMemberPriority());
         RaftAlgorithmConfig raftAlgorithmConfig = cpSubsystemConfig.getRaftAlgorithmConfig();
         assertEquals(500, raftAlgorithmConfig.getLeaderElectionTimeoutInMillis());
         assertEquals(100, raftAlgorithmConfig.getLeaderHeartbeatPeriodInMillis());

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -4026,6 +4026,7 @@ public class YamlConfigBuilderTest
                 + "    persistence-enabled: true\n"
                 + "    base-dir: /mnt/cp-data\n"
                 + "    data-load-timeout-seconds: 30\n"
+                + "    cp-member-priority: -1\n"
                 + "    raft-algorithm:\n"
                 + "      leader-election-timeout-in-millis: 500\n"
                 + "      leader-heartbeat-period-in-millis: 100\n"
@@ -4057,6 +4058,7 @@ public class YamlConfigBuilderTest
         assertTrue(cpSubsystemConfig.isPersistenceEnabled());
         assertEquals(new File("/mnt/cp-data").getAbsoluteFile(), cpSubsystemConfig.getBaseDir().getAbsoluteFile());
         assertEquals(30, cpSubsystemConfig.getDataLoadTimeoutSeconds());
+        assertEquals(-1, cpSubsystemConfig.getCPMemberPriority());
         RaftAlgorithmConfig raftAlgorithmConfig = cpSubsystemConfig.getRaftAlgorithmConfig();
         assertEquals(500, raftAlgorithmConfig.getLeaderElectionTimeoutInMillis());
         assertEquals(100, raftAlgorithmConfig.getLeaderHeartbeatPeriodInMillis());

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/cpsubsystem/range-failures.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/cpsubsystem/range-failures.json
@@ -8,6 +8,7 @@
         "session-heartbeat-interval-seconds": 0,
         "missing-cp-member-auto-removal-seconds": -1,
         "data-load-timeout-seconds": 0,
+        "cp-member-priority": 0,
         "raft-algorithm": {
           "leader-election-timeout-in-millis": 0,
           "leader-heartbeat-period-in-millis": 0,

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/cpsubsystem/success.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/cpsubsystem/success.json
@@ -11,6 +11,7 @@
         "persistence-enabled": true,
         "base-dir": "custom-cp-dir",
         "data-load-timeout-seconds": 30,
+        "cp-member-priority": -1,
         "raft-algorithm": {
           "leader-election-timeout-in-millis": 2000,
           "leader-heartbeat-period-in-millis": 5000,

--- a/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/cpsubsystem/type-failures.json
+++ b/hazelcast/src/test/resources/com/hazelcast/config/yaml/testcases/member/cpsubsystem/type-failures.json
@@ -11,6 +11,7 @@
         "persistence-enabled": "true",
         "base-dir": null,
         "data-load-timeout-seconds": "30",
+        "cp-member-priority": "0",
         "raft-algorithm": {
           "leader-election-timeout-in-millis": "2000",
           "leader-heartbeat-period-in-millis": "5000",
@@ -227,8 +228,15 @@
         "causingExceptions": [],
         "keyword": "type",
         "message": "expected type: Integer, found: String"
+      },
+      {
+        "schemaLocation": "#/definitions/CPSubsystem/properties/cp-member-priority",
+        "pointerToViolation": "#/hazelcast/cp-subsystem/cp-member-priority",
+        "causingExceptions": [],
+        "keyword": "type",
+        "message": "expected type: Integer, found: String"
       }
     ],
-    "message": "22 schema violations found"
+    "message": "23 schema violations found"
   }
 }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -1032,6 +1032,7 @@
         <persistence-enabled>false</persistence-enabled>
         <base-dir>data</base-dir>
         <data-load-timeout-seconds>30</data-load-timeout-seconds>
+        <cp-member-priority>-1</cp-member-priority>
         <raft-algorithm>
             <leader-election-timeout-in-millis>2000</leader-election-timeout-in-millis>
             <leader-heartbeat-period-in-millis>5000</leader-heartbeat-period-in-millis>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -973,6 +973,7 @@ hazelcast:
     persistence-enabled: false
     base-dir: data
     data-load-timeout-seconds: 30
+    cp-member-priority: -1
     raft-algorithm:
       leader-election-timeout-in-millis: 2000
       leader-heartbeat-period-in-millis: 5000


### PR DESCRIPTION
Configs update for the new CP member property `cpMemberPriority`

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

