### PR TITLE
Add spring support for external data stores [HZ-1259]

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -48,6 +48,7 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.ExternalDataStoreConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GcpConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
@@ -1630,5 +1631,15 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     public void testIntegrityCheckerConfig() {
         final IntegrityCheckerConfig integrityCheckerConfig = config.getIntegrityCheckerConfig();
         assertFalse(integrityCheckerConfig.isEnabled());
+    }
+
+    @Test
+    public void testExternalDataStoreConfig() {
+        ExternalDataStoreConfig externalDataStoreConfig = config.getExternalDataStoreConfig("my-data-store");
+        assertNotNull(externalDataStoreConfig);
+        assertEquals("my-data-store", externalDataStoreConfig.getName());
+        assertEquals("com.hazelcast.datastore.JdbcDataStoreFactory", externalDataStoreConfig.getClassName());
+        assertFalse(externalDataStoreConfig.isShared());
+        assertEquals("jdbc:mysql://dummy:3306", externalDataStoreConfig.getProperty("jdbcUrl"));
     }
 }

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -1118,6 +1118,13 @@
                 </hz:properties>
             </hz:auditlog>
             <hz:integrity-checker enabled="false"/>
+            <hz:external-data-store name="${external.datastore.name}">
+                <hz:class-name>com.hazelcast.datastore.JdbcDataStoreFactory</hz:class-name>
+                <hz:properties>
+                    <hz:property name="jdbcUrl">${external.datastore.url}</hz:property>
+                </hz:properties>
+                <hz:shared>false</hz:shared>
+            </hz:external-data-store>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast-spring-tests/src/test/resources/hazelcast-default.properties
+++ b/hazelcast-spring-tests/src/test/resources/hazelcast-default.properties
@@ -44,3 +44,5 @@ numa.node.first=0
 native.memory.unit=GIGABYTES
 network.auto-detection=false
 test.factory.id=1
+external.datastore.name=my-data-store
+external.datastore.url=jdbc:mysql://dummy:3306

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -39,6 +39,7 @@ import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.ExternalDataStoreConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
@@ -247,6 +248,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> pnCounterManagedMap;
         private ManagedMap<EndpointQualifier, AbstractBeanDefinition> endpointConfigsMap;
         private ManagedMap<String, AbstractBeanDefinition> deviceConfigManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> externalDataStoreConfigMap;
 
         private boolean hasNetwork;
         private boolean hasAdvancedNetworkEnabled;
@@ -274,6 +276,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.pnCounterManagedMap = createManagedMap("PNCounterConfigs");
             this.endpointConfigsMap = new ManagedMap<>();
             this.deviceConfigManagedMap = createManagedMap("deviceConfigs");
+            this.externalDataStoreConfigMap = createManagedMap("externalDataStoreConfigs");
         }
 
         private ManagedMap<String, AbstractBeanDefinition> createManagedMap(String configName) {
@@ -381,6 +384,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleDynamicConfiguration(node);
                     } else if ("integrity-checker".equals(nodeName)) {
                         handleIntegrityChecker(node);
+                    } else if ("external-data-store".equals(nodeName)) {
+                        handleExternalDataStore(node);
                     }
                 }
             }
@@ -2316,6 +2321,20 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder builder = createBeanBuilder(IntegrityCheckerConfig.class);
             fillValues(node, builder);
             configBuilder.addPropertyValue("integrityCheckerConfig", builder.getBeanDefinition());
+        }
+
+        private void handleExternalDataStore(Node node) {
+            BeanDefinitionBuilder builder = createBeanBuilder(ExternalDataStoreConfig.class);
+            builder.addPropertyValue("name", getAttribute(node, "name"));
+            fillValues(node, builder, "properties");
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("properties".equals(nodeName)) {
+                    handleProperties(child, builder);
+                    break;
+                }
+            }
+            externalDataStoreConfigMap.put(getAttribute(node, "name"), builder.getBeanDefinition());
         }
     }
 }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.2.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.2.xsd
@@ -1396,6 +1396,7 @@
                         <xs:element name="jet" type="jet" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="local-device" type="local-device" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="integrity-checker" type="integrity-checker" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="external-data-store" type="external-data-store" minOccurs="0" maxOccurs="unbounded"/>
                     </xs:choice>
                 </xs:extension>
             </xs:complexContent>
@@ -6211,6 +6212,34 @@
             <xs:annotation>
                 <xs:documentation>
                     Specifies whether the Integrity Checker is enabled or not. Values can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="external-data-store">
+        <xs:all>
+            <xs:element name="class-name" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the class implementing ExternalDataStoreFactory.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="shared" type="xs:boolean" minOccurs="0" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        If true reuse an instance of JDBC pool or any other storage driver (e.g. kafka client) between jobs or
+                        instances of MapStore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the external data store configuration
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-config-5.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.2.xsd
@@ -6031,10 +6031,11 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="shared" type="xs:boolean" minOccurs="0" default="false">
+            <xs:element name="shared" type="xs:boolean" minOccurs="0" default="true">
                 <xs:annotation>
                     <xs:documentation>
-                        If true reuse an instance of JDBC pool or any other storage driver (e.g. kafka client) between jobs or instances of MapStore.
+                        If true reuse an instance of JDBC pool or any other storage driver (e.g. kafka client) between jobs or
+                        instances of MapStore.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>


### PR DESCRIPTION
Adds support for external data store in the spring XML files.

Fixes https://hazelcast.atlassian.net/browse/HZ-1259

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
