### PR TITLE
Wrapping cause of cancellation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
@@ -1,0 +1,16 @@
+package com.hazelcast.jet.impl.execution;
+
+import java.util.concurrent.CancellationException;
+
+public class ExecutionCancellationException extends CancellationException {
+    private final Throwable cause;
+
+    public ExecutionCancellationException(Throwable cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public synchronized Throwable getCause() {
+        return cause;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.impl.execution;
 
 import java.util.concurrent.CancellationException;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
@@ -19,6 +19,8 @@ package com.hazelcast.jet.impl.execution;
 import java.util.concurrent.CancellationException;
 
 public class ExecutionCancellationException extends CancellationException {
+    private static final long serialVersionUID = 1L;
+
     private final Throwable cause;
 
     public ExecutionCancellationException(Throwable cause) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionCancellationException.java
@@ -24,6 +24,7 @@ public class ExecutionCancellationException extends CancellationException {
     private final Throwable cause;
 
     public ExecutionCancellationException(Throwable cause) {
+        super(cause.getMessage());
         this.cause = cause;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -291,7 +291,7 @@ public class ExecutionContext implements DynamicMetricsProvider {
 
         synchronized (executionLock) {
             if (mode == null) {
-                cancellationFuture.completeExceptionally(cause);
+                cancellationFuture.completeExceptionally(new ExecutionCancellationException(cause));
             } else {
                 cancellationFuture.completeExceptionally(new JobTerminateRequestedException(mode));
             }


### PR DESCRIPTION
Some tests expect ```CancellationException``` to be thrown in that case. The behavior was changed in SQL resubmission and causes some tests failing.

Fixes:
- https://github.com/hazelcast/hazelcast/issues/21966
- https://github.com/hazelcast/hazelcast/issues/21969
- https://github.com/hazelcast/hazelcast/issues/21967

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
