### PR TITLE
Update the GenericRecord package in JdbcIMapTest

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcIMapTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcIMapTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
-import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.Test;


### PR DESCRIPTION
The class was added after we have created the other PR to update
the generic record package.

Therefore, we have missed to update this class in this PR, and
we are updating the import path in this PR.