### PR TITLE
Use serial runner for tests using TestProcessors

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.TestProcessors;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  * Tests for JobMetrics that don't use shared cluster. The cluster in each test
  * has a specific configuration.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
@@ -37,7 +37,7 @@ import com.hazelcast.jet.impl.processor.TransformP;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MetricsTest extends JetTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -33,7 +33,7 @@ import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JobRepositoryTest extends JetTestSupport {
 


### PR DESCRIPTION
TestProcessors class has some static fields, using HazelcastParallelClassRunner can lead to test isolation issues. 
However there is no issue reported for any of these 3 classes.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

Backports to 5.1.z and 5.0.z to follow.