### PR TITLE
[API-1503] Add support for List, Set, and Map fields to zero-config serializers

### DIFF
--- a/hazelcast-it/jdk17-tests/src/test/java/com/hazelcast/serialization/compact/record/AllTypesRecord.java
+++ b/hazelcast-it/jdk17-tests/src/test/java/com/hazelcast/serialization/compact/record/AllTypesRecord.java
@@ -21,8 +21,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public record AllTypesRecord(
         byte primitiveInt8,
@@ -72,7 +78,13 @@ public record AllTypesRecord(
         LocalDateTime[] timestampArray,
         OffsetDateTime[] timestampWithTimezoneArray,
         AnEnum[] anEnumArray,
-        NestedRecord[] nestedRecordArray
+        NestedRecord[] nestedRecordArray,
+        List<BigDecimal> list,
+        ArrayList<String> arrayList,
+        Set<Byte> set,
+        HashSet<Integer> hashSet,
+        Map<Short, Character> map,
+        HashMap<Long, Boolean> hashMap
 ) {
 
     enum AnEnum {
@@ -135,7 +147,31 @@ public record AllTypesRecord(
                 new LocalDateTime[]{null, LocalDateTime.now()},
                 new OffsetDateTime[]{null, OffsetDateTime.now()},
                 new AnEnum[]{AnEnum.VALUE0, null, AnEnum.VALUE1},
-                new NestedRecord[]{null, NestedRecord.create()}
+                new NestedRecord[]{null, NestedRecord.create()},
+                new ArrayList<>() {{
+                    add(BigDecimal.ONE);
+                    add(null);
+                    add(BigDecimal.TEN);
+                }},
+                new ArrayList<>() {{
+                    add("a");
+                    add("b");
+                    add("c");
+                }},
+                new HashSet<>() {{
+                    add((byte) 0);
+                }},
+                new HashSet<>() {{
+                    add(42);
+                    add(null);
+                }},
+                new HashMap<>() {{
+                    put((short) 42, 'x');
+                }},
+                new HashMap<>() {{
+                    put(0L, false);
+                    put(1L, true);
+                }}
         );
     }
 
@@ -156,6 +192,12 @@ public record AllTypesRecord(
                 0,
                 null,
                 false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -248,6 +290,12 @@ public record AllTypesRecord(
                 && Arrays.equals(timestampArray, that.timestampArray)
                 && Arrays.equals(timestampWithTimezoneArray, that.timestampWithTimezoneArray)
                 && Arrays.equals(anEnumArray, that.anEnumArray)
-                && Arrays.equals(nestedRecordArray, that.nestedRecordArray);
+                && Arrays.equals(nestedRecordArray, that.nestedRecordArray)
+                && Objects.equals(list, that.list)
+                && Objects.equals(arrayList, that.arrayList)
+                && Objects.equals(set, that.set)
+                && Objects.equals(hashSet, that.hashSet)
+                && Objects.equals(map, that.map)
+                && Objects.equals(hashMap, that.hashMap);
     }
 }

--- a/hazelcast-it/jdk17-tests/src/test/java/com/hazelcast/serialization/compact/record/RecordSerializationTest.java
+++ b/hazelcast-it/jdk17-tests/src/test/java/com/hazelcast/serialization/compact/record/RecordSerializationTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -193,7 +193,7 @@ public class RecordSerializationTest extends HazelcastTestSupport {
     @Test
     public void testSerializingRecordReflectively_withUnsupportedFieldType() {
         assertThatThrownBy(() -> {
-            service.toData(new RecordWithUnsupportedField(new ArrayList<>()));
+            service.toData(new RecordWithUnsupportedField(new LinkedList<>()));
         }).isInstanceOf(HazelcastSerializationException.class)
                 .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
                 .hasStackTraceContaining("which uses this class in its fields");
@@ -202,15 +202,15 @@ public class RecordSerializationTest extends HazelcastTestSupport {
     @Test
     public void testSerializingRecordReflectively_withUnsupportedArrayItemType() {
         assertThatThrownBy(() -> {
-            service.toData(new RecordWithUnsupportedArrayField(new ArrayList[0]));
+            service.toData(new RecordWithUnsupportedArrayField(new LinkedList[0]));
         }).isInstanceOf(HazelcastSerializationException.class)
                 .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
                 .hasStackTraceContaining("which uses this class in its fields");
     }
 
-    private record RecordWithUnsupportedField(ArrayList<String> list) {
+    private record RecordWithUnsupportedField(LinkedList<String> list) {
     }
 
-    private record RecordWithUnsupportedArrayField(ArrayList<String>[] lists) {
+    private record RecordWithUnsupportedArrayField(LinkedList<String>[] lists) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.serialization.impl.compact;
 
+import com.hazelcast.internal.serialization.impl.compact.zeroconfig.ValueReaderWriter;
+import com.hazelcast.internal.serialization.impl.compact.zeroconfig.ValueReaderWriters;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.compact.CompactReader;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;
@@ -24,11 +26,6 @@ import com.hazelcast.nio.serialization.compact.CompactWriter;
 import javax.annotation.Nonnull;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -37,31 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.internal.nio.InstanceCreationUtil.createNewInstance;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.isFieldExist;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_FLOAT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_FLOAT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT16;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT8;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_STRING;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIME;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE;
 import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
-import static com.hazelcast.nio.serialization.FieldKind.DATE;
-import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
 import static com.hazelcast.nio.serialization.FieldKind.FLOAT32;
 import static com.hazelcast.nio.serialization.FieldKind.FLOAT64;
 import static com.hazelcast.nio.serialization.FieldKind.INT16;
@@ -75,10 +48,6 @@ import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT16;
 import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT32;
 import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT64;
 import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT8;
-import static com.hazelcast.nio.serialization.FieldKind.STRING;
-import static com.hazelcast.nio.serialization.FieldKind.TIME;
-import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP;
-import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -97,8 +66,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
 
-    private final Map<Class, Writer[]> writersCache = new ConcurrentHashMap<>();
-    private final Map<Class, Reader[]> readersCache = new ConcurrentHashMap<>();
+    private final Map<Class, ReaderWriter[]> readerWritersCache = new ConcurrentHashMap<>();
 
     @Override
     public void write(@Nonnull CompactWriter writer, @Nonnull T object) {
@@ -123,13 +91,13 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
     }
 
     private boolean writeFast(Class clazz, CompactWriter compactWriter, Object object) {
-        Writer[] writers = writersCache.get(clazz);
-        if (writers == null) {
+        ReaderWriter[] readerWriters = readerWritersCache.get(clazz);
+        if (readerWriters == null) {
             return false;
         }
-        for (Writer writer : writers) {
+        for (ReaderWriter readerWriter : readerWriters) {
             try {
-                writer.write(compactWriter, object);
+                readerWriter.write(compactWriter, object);
             } catch (Exception e) {
                 throw new HazelcastSerializationException(e);
             }
@@ -138,14 +106,15 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
     }
 
     private boolean readFast(Class clazz, DefaultCompactReader compactReader, Object object) {
-        Reader[] readers = readersCache.get(clazz);
-        Schema schema = compactReader.getSchema();
-        if (readers == null) {
+        ReaderWriter[] readerWriters = readerWritersCache.get(clazz);
+        if (readerWriters == null) {
             return false;
         }
-        for (Reader reader : readers) {
+
+        Schema schema = compactReader.getSchema();
+        for (ReaderWriter readerWriter : readerWriters) {
             try {
-                reader.read(compactReader, schema, object);
+                readerWriter.read(compactReader, schema, object);
             } catch (Exception e) {
                 throw new HazelcastSerializationException(e);
             }
@@ -197,393 +166,167 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
 
         // get inherited fields as well
         List<Field> allFields = getAllFields(new LinkedList<>(), clazz);
-        Writer[] writers = new Writer[allFields.size()];
-        Reader[] readers = new Reader[allFields.size()];
+        ReaderWriter[] readerWriters = new ReaderWriter[allFields.size()];
 
         int index = 0;
         for (Field field : allFields) {
             field.setAccessible(true);
             Class<?> type = field.getType();
             String name = field.getName();
+
+
+            // Use normal reader-writers for the primitive types to avoid boxing-unboxing
             if (Byte.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT8, NULLABLE_INT8)) {
-                        field.setByte(o, reader.readInt8(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, INT8, NULLABLE_INT8)) {
+                            field.setByte(o, reader.readInt8(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeInt8(name, field.getByte(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeInt8(name, field.getByte(o));
             } else if (Character.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
-                        field.setChar(o, (char) reader.readInt16(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
+                            field.setChar(o, (char) reader.readInt16(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeInt16(name, (short) field.getChar(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeInt16(name, (short) field.getChar(o));
             } else if (Short.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
-                        field.setShort(o, reader.readInt16(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
+                            field.setShort(o, reader.readInt16(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeInt16(name, field.getShort(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeInt16(name, field.getShort(o));
             } else if (Integer.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT32, NULLABLE_INT32)) {
-                        field.setInt(o, reader.readInt32(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, INT32, NULLABLE_INT32)) {
+                            field.setInt(o, reader.readInt32(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeInt32(name, field.getInt(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeInt32(name, field.getInt(o));
             } else if (Long.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT64, NULLABLE_INT64)) {
-                        field.setLong(o, reader.readInt64(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, INT64, NULLABLE_INT64)) {
+                            field.setLong(o, reader.readInt64(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeInt64(name, field.getLong(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeInt64(name, field.getLong(o));
             } else if (Float.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, FLOAT32, NULLABLE_FLOAT32)) {
-                        field.setFloat(o, reader.readFloat32(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, FLOAT32, NULLABLE_FLOAT32)) {
+                            field.setFloat(o, reader.readFloat32(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeFloat32(name, field.getFloat(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeFloat32(name, field.getFloat(o));
             } else if (Double.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, FLOAT64, NULLABLE_FLOAT64)) {
-                        field.setDouble(o, reader.readFloat64(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, FLOAT64, NULLABLE_FLOAT64)) {
+                            field.setDouble(o, reader.readFloat64(name));
+                        }
+                    }
+
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeFloat64(name, field.getDouble(o));
                     }
                 };
-                writers[index] = (w, o) -> w.writeFloat64(name, field.getDouble(o));
             } else if (Boolean.TYPE.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, BOOLEAN, NULLABLE_BOOLEAN)) {
-                        field.setBoolean(o, reader.readBoolean(name));
+                readerWriters[index] = new ReaderWriter() {
+                    @Override
+                    public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+                        if (isFieldExist(schema, name, BOOLEAN, NULLABLE_BOOLEAN)) {
+                            field.setBoolean(o, reader.readBoolean(name));
+                        }
                     }
-                };
-                writers[index] = (w, o) -> w.writeBoolean(name, field.getBoolean(o));
-            } else if (String.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, STRING)) {
-                        field.set(o, reader.readString(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeString(name, (String) field.get(o));
-            } else if (BigDecimal.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, DECIMAL)) {
-                        field.set(o, reader.readDecimal(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeDecimal(name, (BigDecimal) field.get(o));
-            } else if (LocalTime.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, TIME)) {
-                        field.set(o, reader.readTime(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeTime(name, (LocalTime) field.get(o));
-            } else if (LocalDate.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, DATE)) {
-                        field.set(o, reader.readDate(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeDate(name, (LocalDate) field.get(o));
-            } else if (LocalDateTime.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, TIMESTAMP)) {
-                        field.set(o, reader.readTimestamp(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeTimestamp(name, (LocalDateTime) field.get(o));
-            } else if (OffsetDateTime.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, TIMESTAMP_WITH_TIMEZONE)) {
-                        field.set(o, reader.readTimestampWithTimezone(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeTimestampWithTimezone(name, (OffsetDateTime) field.get(o));
-            } else if (Byte.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT8, NULLABLE_INT8)) {
-                        field.set(o, reader.readNullableInt8(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableInt8(name, (Byte) field.get(o));
-            } else if (Character.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, NULLABLE_INT16, INT16)) {
-                        Short value = reader.readNullableInt16(name);
-                        field.set(o, CompactUtil.characterFromShort(value));
-                    }
-                };
-                writers[index] = (w, o) -> {
-                    Character value = (Character) field.get(o);
-                    w.writeNullableInt16(name, CompactUtil.characterAsShort(value));
-                };
-            } else if (Boolean.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, BOOLEAN, NULLABLE_BOOLEAN)) {
-                        field.set(o, reader.readNullableBoolean(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableBoolean(name, (Boolean) field.get(o));
-            } else if (Short.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
-                        field.set(o, reader.readNullableInt16(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableInt16(name, (Short) field.get(o));
-            } else if (Integer.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT32, NULLABLE_INT32)) {
-                        field.set(o, reader.readNullableInt32(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableInt32(name, (Integer) field.get(o));
-            } else if (Long.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, INT64, NULLABLE_INT64)) {
-                        field.set(o, reader.readNullableInt64(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableInt64(name, (Long) field.get(o));
-            } else if (Float.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, FLOAT32, NULLABLE_FLOAT32)) {
-                        field.set(o, reader.readNullableFloat32(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableFloat32(name, (Float) field.get(o));
-            } else if (Double.class.equals(type)) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, FLOAT64, NULLABLE_FLOAT64)) {
-                        field.set(o, reader.readNullableFloat64(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeNullableFloat64(name, (Double) field.get(o));
-            } else if (type.isEnum()) {
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, STRING)) {
-                        String value = reader.readString(name);
-                        field.set(o, CompactUtil.enumFromStringName((Class<? extends Enum>) type, value));
-                    }
-                };
-                writers[index] = (w, o) -> {
-                    Enum value = (Enum) field.get(o);
-                    w.writeString(name, CompactUtil.enumAsStringName(value));
-                };
-            } else if (type.isArray()) {
-                Class<?> componentType = type.getComponentType();
-                if (Boolean.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN)) {
-                            field.set(o, reader.readArrayOfBoolean(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfBoolean(name, (boolean[]) field.get(o));
-                } else if (Byte.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8)) {
-                            field.set(o, reader.readArrayOfInt8(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfInt8(name, (byte[]) field.get(o));
-                } else if (Character.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
-                            short[] values = reader.readArrayOfInt16(name);
-                            field.set(o, CompactUtil.charArrayFromShortArray(values));
-                        }
-                    };
-                    writers[index] = (w, o) -> {
-                        char[] values = (char[]) field.get(o);
-                        w.writeArrayOfInt16(name, CompactUtil.charArrayAsShortArray(values));
-                    };
-                } else if (Short.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
-                            field.set(o, reader.readArrayOfInt16(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfInt16(name, (short[]) field.get(o));
-                } else if (Integer.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32)) {
-                            field.set(o, reader.readArrayOfInt32(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfInt32(name, (int[]) field.get(o));
-                } else if (Long.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT64, ARRAY_OF_NULLABLE_INT64)) {
-                            field.set(o, reader.readArrayOfInt64(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfInt64(name, (long[]) field.get(o));
-                } else if (Float.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_FLOAT32, ARRAY_OF_NULLABLE_FLOAT32)) {
-                            field.set(o, reader.readArrayOfFloat32(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfFloat32(name, (float[]) field.get(o));
-                } else if (Double.TYPE.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_FLOAT64, ARRAY_OF_NULLABLE_FLOAT64)) {
-                            field.set(o, reader.readArrayOfFloat64(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfFloat64(name, (double[]) field.get(o));
-                } else if (Boolean.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN)) {
-                            field.set(o, reader.readArrayOfNullableBoolean(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableBoolean(name, (Boolean[]) field.get(o));
-                } else if (Byte.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8)) {
-                            field.set(o, reader.readArrayOfNullableInt8(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableInt8(name, (Byte[]) field.get(o));
-                } else if (Character.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_NULLABLE_INT16, ARRAY_OF_INT16)) {
-                            Short[] values = reader.readArrayOfNullableInt16(name);
-                            field.set(o, CompactUtil.characterArrayFromShortArray(values));
-                        }
-                    };
-                    writers[index] = (w, o) -> {
-                        Character[] values = (Character[]) field.get(o);
-                        w.writeArrayOfNullableInt16(name, CompactUtil.characterArrayAsShortArray(values));
-                    };
-                } else if (Short.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
-                            field.set(o, reader.readArrayOfNullableInt16(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableInt16(name, (Short[]) field.get(o));
-                } else if (Integer.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32)) {
-                            field.set(o, reader.readArrayOfNullableInt32(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableInt32(name, (Integer[]) field.get(o));
-                } else if (Long.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_INT64, ARRAY_OF_NULLABLE_INT64)) {
-                            field.set(o, reader.readArrayOfNullableInt64(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableInt64(name, (Long[]) field.get(o));
-                } else if (Float.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_FLOAT32, ARRAY_OF_NULLABLE_FLOAT32)) {
-                            field.set(o, reader.readArrayOfNullableFloat32(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableFloat32(name, (Float[]) field.get(o));
-                } else if (Double.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_FLOAT64, ARRAY_OF_NULLABLE_FLOAT64)) {
-                            field.set(o, reader.readArrayOfNullableFloat64(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfNullableFloat64(name, (Double[]) field.get(o));
-                } else if (String.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_STRING)) {
-                            field.set(o, reader.readArrayOfString(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfString(name, (String[]) field.get(o));
-                } else if (BigDecimal.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_DECIMAL)) {
-                            field.set(o, reader.readArrayOfDecimal(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfDecimal(name, (BigDecimal[]) field.get(o));
-                } else if (LocalTime.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_TIME)) {
-                            field.set(o, reader.readArrayOfTime(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfTime(name, (LocalTime[]) field.get(o));
-                } else if (LocalDate.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_DATE)) {
-                            field.set(o, reader.readArrayOfDate(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfDate(name, (LocalDate[]) field.get(o));
-                } else if (LocalDateTime.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_TIMESTAMP)) {
-                            field.set(o, reader.readArrayOfTimestamp(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfTimestamp(name, (LocalDateTime[]) field.get(o));
-                } else if (OffsetDateTime.class.equals(componentType)) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE)) {
-                            field.set(o, reader.readArrayOfTimestampWithTimezone(name));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfTimestampWithTimezone(name, (OffsetDateTime[]) field.get(o));
-                } else if (componentType.isEnum()) {
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_STRING)) {
-                            String[] values = reader.readArrayOfString(name);
-                            Class<? extends Enum> enumClass = (Class<? extends Enum>) componentType;
-                            field.set(o, CompactUtil.enumArrayFromStringNameArray(enumClass, values));
-                        }
-                    };
-                    writers[index] = (w, o) -> {
-                        Enum[] values = (Enum[]) field.get(o);
-                        w.writeArrayOfString(name, CompactUtil.enumArrayAsStringNameArray(values));
-                    };
-                } else {
-                    // Elements of the array might not be Compact serializable
-                    CompactUtil.verifyFieldClassIsCompactSerializable(componentType, clazz);
 
-                    readers[index] = (reader, schema, o) -> {
-                        if (isFieldExist(schema, name, ARRAY_OF_COMPACT)) {
-                            field.set(o, reader.readArrayOfCompact(name, componentType));
-                        }
-                    };
-                    writers[index] = (w, o) -> w.writeArrayOfCompact(name, (Object[]) field.get(o));
-                }
+                    @Override
+                    public void write(CompactWriter writer, Object o) throws Exception {
+                        writer.writeBoolean(name, field.getBoolean(o));
+                    }
+                };
             } else {
-                // The nested field might not be Compact serializable
-                CompactUtil.verifyFieldClassIsCompactSerializable(type, clazz);
-
-                readers[index] = (reader, schema, o) -> {
-                    if (isFieldExist(schema, name, COMPACT)) {
-                        field.set(o, reader.readCompact(name));
-                    }
-                };
-                writers[index] = (w, o) -> w.writeCompact(name, field.get(o));
+                // For anything else, rely on value reader writers to re-use the code we have
+                readerWriters[index] = new ReaderWriterAdapter(
+                        ValueReaderWriters.readerWriterFor(clazz, type, field.getGenericType(), name),
+                        field
+                );
             }
+
             index++;
         }
 
-        writersCache.put(clazz, writers);
-        readersCache.put(clazz, readers);
+        readerWritersCache.put(clazz, readerWriters);
     }
 
-    interface Reader {
+    private static final class ReaderWriterAdapter implements ReaderWriter {
+
+        private final ValueReaderWriter readerWriter;
+        private final Field field;
+
+
+        ReaderWriterAdapter(ValueReaderWriter readerWriter, Field field) {
+            this.readerWriter = readerWriter;
+            this.field = field;
+        }
+
+        @Override
+        public void read(CompactReader reader, Schema schema, Object o) throws Exception {
+            field.set(o, readerWriter.read(reader, schema));
+        }
+
+        @Override
+        public void write(CompactWriter writer, Object o) throws Exception {
+            readerWriter.write(writer, field.get(o));
+        }
+    }
+
+    private interface ReaderWriter {
         void read(CompactReader reader, Schema schema, Object o) throws Exception;
-    }
 
-    interface Writer {
         void write(CompactWriter writer, Object o) throws Exception;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/ComponentReaderWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/ComponentReaderWriter.java
@@ -16,13 +16,21 @@
 
 package com.hazelcast.internal.serialization.impl.compact.record;
 
+import com.hazelcast.internal.serialization.impl.compact.Schema;
+import com.hazelcast.nio.serialization.compact.CompactReader;
 import com.hazelcast.nio.serialization.compact.CompactWriter;
 
 /**
- * Writes a single component of the record object to writer.
+ * Reads or writes a single component of the record object to reader/writer.
  */
-@FunctionalInterface
-public interface ComponentWriter {
+public interface ComponentReaderWriter {
+
+    /**
+     * @param compactReader to read the component from.
+     * @param schema to validate expected and actual types.
+     * @return a single component of the record object.
+     */
+    Object readComponent(CompactReader compactReader, Schema schema);
 
     /**
      * @param compactWriter to write the component to.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordReader.java
@@ -29,19 +29,19 @@ import java.lang.reflect.Constructor;
 public final class JavaRecordReader {
 
     private final Constructor<?> recordConstructor;
-    private final ComponentReader[] componentReaders;
+    private final ComponentReaderWriter[] componentReaderWriters;
 
-    public JavaRecordReader(Constructor<?> recordConstructor, ComponentReader[] componentReaders) {
+    public JavaRecordReader(Constructor<?> recordConstructor, ComponentReaderWriter[] componentReaderWriters) {
         this.recordConstructor = recordConstructor;
-        this.componentReaders = componentReaders;
+        this.componentReaderWriters = componentReaderWriters;
     }
 
     public Object readRecord(CompactReader compactReader, Schema schema) {
-        Object[] components = new Object[componentReaders.length];
+        Object[] components = new Object[componentReaderWriters.length];
 
         try {
-            for (int i = 0; i < componentReaders.length; i++) {
-                components[i] = componentReaders[i].readComponent(compactReader, schema);
+            for (int i = 0; i < componentReaderWriters.length; i++) {
+                components[i] = componentReaderWriters[i].readComponent(compactReader, schema);
             }
             return recordConstructor.newInstance(components);
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordSerializer.java
@@ -18,6 +18,9 @@ package com.hazelcast.internal.serialization.impl.compact.record;
 
 import com.hazelcast.internal.serialization.impl.compact.CompactUtil;
 import com.hazelcast.internal.serialization.impl.compact.DefaultCompactReader;
+import com.hazelcast.internal.serialization.impl.compact.Schema;
+import com.hazelcast.internal.serialization.impl.compact.zeroconfig.ValueReaderWriter;
+import com.hazelcast.internal.serialization.impl.compact.zeroconfig.ValueReaderWriters;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.compact.CompactReader;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;
@@ -26,74 +29,30 @@ import com.hazelcast.nio.serialization.compact.CompactWriter;
 import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.isFieldExist;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_FLOAT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_FLOAT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT16;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT32;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT64;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT8;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_STRING;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIME;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE;
-import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
-import static com.hazelcast.nio.serialization.FieldKind.DATE;
-import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
-import static com.hazelcast.nio.serialization.FieldKind.FLOAT32;
-import static com.hazelcast.nio.serialization.FieldKind.FLOAT64;
-import static com.hazelcast.nio.serialization.FieldKind.INT16;
-import static com.hazelcast.nio.serialization.FieldKind.INT32;
-import static com.hazelcast.nio.serialization.FieldKind.INT64;
-import static com.hazelcast.nio.serialization.FieldKind.INT8;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_BOOLEAN;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_FLOAT32;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_FLOAT64;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT16;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT32;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT64;
-import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT8;
-import static com.hazelcast.nio.serialization.FieldKind.STRING;
-import static com.hazelcast.nio.serialization.FieldKind.TIME;
-import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP;
-import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
 import static java.util.Objects.requireNonNull;
 
+@SuppressWarnings("checkstyle:executablestatementcount")
 public class JavaRecordSerializer implements CompactSerializer<Object> {
 
     private final Method isRecordMethod;
     private final Method getRecordComponentsMethod;
     private final Method getTypeMethod;
     private final Method getNameMethod;
+    private final Method getGenericTypeMethod;
 
     private final Map<Class<?>, JavaRecordReader> readersCache = new ConcurrentHashMap<>();
-    private final Map<Class<?>, ComponentWriter[]> writersCache = new ConcurrentHashMap<>();
+    private final Map<Class<?>, ComponentReaderWriter[]> readerWritersCache = new ConcurrentHashMap<>();
 
     public JavaRecordSerializer() {
         Method isRecordMethod;
         Method getRecordComponentsMethod;
         Method getTypeMethod;
         Method getNameMethod;
+        Method getGenericTypeMethod;
 
         try {
             isRecordMethod = Class.class.getMethod("isRecord");
@@ -101,17 +60,20 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
             Class<?> recordComponentClass = Class.forName("java.lang.reflect.RecordComponent");
             getTypeMethod = recordComponentClass.getMethod("getType");
             getNameMethod = recordComponentClass.getMethod("getName");
+            getGenericTypeMethod = recordComponentClass.getMethod("getGenericType");
         } catch (Throwable t) {
             isRecordMethod = null;
             getRecordComponentsMethod = null;
             getTypeMethod = null;
             getNameMethod = null;
+            getGenericTypeMethod = null;
         }
 
         this.isRecordMethod = isRecordMethod;
         this.getRecordComponentsMethod = getRecordComponentsMethod;
         this.getTypeMethod = getTypeMethod;
         this.getNameMethod = getNameMethod;
+        this.getGenericTypeMethod = getGenericTypeMethod;
     }
 
     public boolean isRecord(Class<?> clazz) {
@@ -145,15 +107,15 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
     @Override
     public void write(@Nonnull CompactWriter writer, @Nonnull Object object) {
         Class<?> clazz = object.getClass();
-        ComponentWriter[] componentWriters = writersCache.get(clazz);
-        if (componentWriters == null) {
+        ComponentReaderWriter[] readerWriters = readerWritersCache.get(clazz);
+        if (readerWriters == null) {
             populateReadersWriters(clazz);
-            componentWriters = writersCache.get(clazz);
+            readerWriters = readerWritersCache.get(clazz);
         }
 
         try {
-            for (ComponentWriter componentWriter : componentWriters) {
-                componentWriter.writeComponent(writer, object);
+            for (ComponentReaderWriter readerWriter : readerWriters) {
+                readerWriter.writeComponent(writer, object);
             }
         } catch (Exception e) {
             throw new HazelcastSerializationException("Failed to write the Java record", e);
@@ -180,490 +142,52 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
             Object[] recordComponents = (Object[]) getRecordComponentsMethod.invoke(clazz);
             Class<?>[] componentTypes = new Class<?>[recordComponents.length];
 
-            ComponentReader[] componentReaders = new ComponentReader[recordComponents.length];
-            ComponentWriter[] componentWriters = new ComponentWriter[recordComponents.length];
+            ComponentReaderWriter[] componentReaderWriters = new ComponentReaderWriter[recordComponents.length];
 
             for (int i = 0; i < recordComponents.length; i++) {
                 Object recordComponent = recordComponents[i];
                 Class<?> type = (Class<?>) getTypeMethod.invoke(recordComponent);
+                Type genericType = (Type) getGenericTypeMethod.invoke(recordComponent);
                 String name = (String) getNameMethod.invoke(recordComponent);
 
                 componentTypes[i] = type;
                 Method componentGetter = clazz.getDeclaredMethod(name);
                 componentGetter.setAccessible(true);
-
-                // In case the component we want to read does not exist, we use
-                // a default value for it, so that the schema evolution works
-                // frictionless for reflectively serialized record objects.
-                if (Byte.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, INT8, NULLABLE_INT8)) {
-                            return (byte) 0;
-                        }
-                        return compactReader.readInt8(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeInt8(name, (byte) componentGetter.invoke(object));
-                } else if (Byte.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_INT8, INT8)) {
-                            return null;
-                        }
-                        return compactReader.readNullableInt8(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableInt8(name, (Byte) componentGetter.invoke(object));
-                } else if (Character.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
-                            return '\u0000';
-                        }
-                        return (char) compactReader.readInt16(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeInt16(name, (short) ((char) componentGetter.invoke(object)));
-                } else if (Character.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_INT16, INT16)) {
-                            return null;
-                        }
-                        Short value = compactReader.readNullableInt16(name);
-                        return CompactUtil.characterFromShort(value);
-                    };
-                    componentWriters[i] = (compactWriter, object) -> {
-                        Character value = (Character) componentGetter.invoke(object);
-                        compactWriter.writeNullableInt16(name, CompactUtil.characterAsShort(value));
-                    };
-                } else if (Short.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, INT16, NULLABLE_INT16)) {
-                            return (short) 0;
-                        }
-                        return compactReader.readInt16(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeInt16(name, (short) componentGetter.invoke(object));
-                } else if (Short.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_INT16, INT16)) {
-                            return null;
-                        }
-                        return compactReader.readNullableInt16(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableInt16(name, (Short) componentGetter.invoke(object));
-                } else if (Integer.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, INT32, NULLABLE_INT32)) {
-                            return 0;
-                        }
-                        return compactReader.readInt32(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeInt32(name, (int) componentGetter.invoke(object));
-                } else if (Integer.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_INT32, INT32)) {
-                            return null;
-                        }
-                        return compactReader.readNullableInt32(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableInt32(name, (Integer) componentGetter.invoke(object));
-                } else if (Long.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, INT64, NULLABLE_INT64)) {
-                            return 0L;
-                        }
-                        return compactReader.readInt64(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeInt64(name, (long) componentGetter.invoke(object));
-                } else if (Long.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_INT64, INT64)) {
-                            return null;
-                        }
-                        return compactReader.readNullableInt64(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableInt64(name, (Long) componentGetter.invoke(object));
-                } else if (Float.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, FLOAT32, NULLABLE_FLOAT32)) {
-                            return 0F;
-                        }
-                        return compactReader.readFloat32(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeFloat32(name, (float) componentGetter.invoke(object));
-                } else if (Float.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_FLOAT32, FLOAT32)) {
-                            return null;
-                        }
-                        return compactReader.readNullableFloat32(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableFloat32(name, (Float) componentGetter.invoke(object));
-                } else if (Double.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, FLOAT64, NULLABLE_FLOAT64)) {
-                            return 0D;
-                        }
-                        return compactReader.readFloat64(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeFloat64(name, (double) componentGetter.invoke(object));
-                } else if (Double.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_FLOAT64, FLOAT64)) {
-                            return null;
-                        }
-                        return compactReader.readNullableFloat64(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableFloat64(name, (Double) componentGetter.invoke(object));
-                } else if (Boolean.TYPE.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, BOOLEAN, NULLABLE_BOOLEAN)) {
-                            return false;
-                        }
-                        return compactReader.readBoolean(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeBoolean(name, (boolean) componentGetter.invoke(object));
-                } else if (Boolean.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, NULLABLE_BOOLEAN, BOOLEAN)) {
-                            return null;
-                        }
-                        return compactReader.readNullableBoolean(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeNullableBoolean(name, (Boolean) componentGetter.invoke(object));
-                } else if (String.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, STRING)) {
-                            return null;
-                        }
-                        return compactReader.readString(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeString(name, (String) componentGetter.invoke(object));
-                } else if (BigDecimal.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, DECIMAL)) {
-                            return null;
-                        }
-                        return compactReader.readDecimal(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeDecimal(name, (BigDecimal) componentGetter.invoke(object));
-                } else if (LocalTime.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, TIME)) {
-                            return null;
-                        }
-                        return compactReader.readTime(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeTime(name, (LocalTime) componentGetter.invoke(object));
-                } else if (LocalDate.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, DATE)) {
-                            return null;
-                        }
-                        return compactReader.readDate(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeDate(name, (LocalDate) componentGetter.invoke(object));
-                } else if (LocalDateTime.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, TIMESTAMP)) {
-                            return null;
-                        }
-                        return compactReader.readTimestamp(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeTimestamp(name, (LocalDateTime) componentGetter.invoke(object));
-                } else if (OffsetDateTime.class.equals(type)) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, TIMESTAMP_WITH_TIMEZONE)) {
-                            return null;
-                        }
-                        return compactReader.readTimestampWithTimezone(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeTimestampWithTimezone(name, (OffsetDateTime) componentGetter.invoke(object));
-                } else if (type.isEnum()) {
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, STRING)) {
-                            return null;
-                        }
-                        String value = compactReader.readString(name);
-                        return CompactUtil.enumFromStringName((Class<? extends Enum>) type, value);
-                    };
-                    componentWriters[i] = (compactWriter, object) -> {
-                        Enum value = (Enum) componentGetter.invoke(object);
-                        compactWriter.writeString(name, CompactUtil.enumAsStringName(value));
-                    };
-                } else if (type.isArray()) {
-                    Class<?> componentType = type.getComponentType();
-                    if (Byte.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfInt8(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfInt8(name, (byte[]) componentGetter.invoke(object));
-                    } else if (Byte.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_INT8, ARRAY_OF_INT8)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableInt8(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableInt8(name, (Byte[]) componentGetter.invoke(object));
-                    } else if (Character.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
-                                return null;
-                            }
-                            short[] values = compactReader.readArrayOfInt16(name);
-                            return CompactUtil.charArrayFromShortArray(values);
-                        };
-                        componentWriters[i] = (compactWriter, object) -> {
-                            char[] values = (char[]) componentGetter.invoke(object);
-                            compactWriter.writeArrayOfInt16(name, CompactUtil.charArrayAsShortArray(values));
-                        };
-                    } else if (Character.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_INT16, ARRAY_OF_INT16)) {
-                                return null;
-                            }
-                            Short[] values = compactReader.readArrayOfNullableInt16(name);
-                            return CompactUtil.characterArrayFromShortArray(values);
-                        };
-                        componentWriters[i] = (compactWriter, object) -> {
-                            Character[] values = (Character[]) componentGetter.invoke(object);
-                            compactWriter.writeArrayOfNullableInt16(name, CompactUtil.characterArrayAsShortArray(values));
-                        };
-                    } else if (Short.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfInt16(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfInt16(name, (short[]) componentGetter.invoke(object));
-                    } else if (Short.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_INT16, ARRAY_OF_INT16)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableInt16(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableInt16(name, (Short[]) componentGetter.invoke(object));
-                    } else if (Integer.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfInt32(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfInt32(name, (int[]) componentGetter.invoke(object));
-                    } else if (Integer.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_INT32, ARRAY_OF_INT32)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableInt32(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableInt32(name, (Integer[]) componentGetter.invoke(object));
-                    } else if (Long.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_INT64, ARRAY_OF_NULLABLE_INT64)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfInt64(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfInt64(name, (long[]) componentGetter.invoke(object));
-                    } else if (Long.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_INT64, ARRAY_OF_INT64)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableInt64(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableInt64(name, (Long[]) componentGetter.invoke(object));
-                    } else if (Float.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_FLOAT32, ARRAY_OF_NULLABLE_FLOAT32)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfFloat32(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfFloat32(name, (float[]) componentGetter.invoke(object));
-                    } else if (Float.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_FLOAT32, ARRAY_OF_FLOAT32)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableFloat32(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableFloat32(name, (Float[]) componentGetter.invoke(object));
-                    } else if (Double.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_FLOAT64, ARRAY_OF_NULLABLE_FLOAT64)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfFloat64(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfFloat64(name, (double[]) componentGetter.invoke(object));
-                    } else if (Double.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_FLOAT64, ARRAY_OF_FLOAT64)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableFloat64(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableFloat64(name, (Double[]) componentGetter.invoke(object));
-                    } else if (Boolean.TYPE.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfBoolean(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfBoolean(name, (boolean[]) componentGetter.invoke(object));
-                    } else if (Boolean.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_NULLABLE_BOOLEAN, ARRAY_OF_BOOLEAN)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfNullableBoolean(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfNullableBoolean(name, (Boolean[]) componentGetter.invoke(object));
-                    } else if (String.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_STRING)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfString(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfString(name, (String[]) componentGetter.invoke(object));
-                    } else if (BigDecimal.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_DECIMAL)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfDecimal(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfDecimal(name, (BigDecimal[]) componentGetter.invoke(object));
-                    } else if (LocalTime.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_TIME)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfTime(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfTime(name, (LocalTime[]) componentGetter.invoke(object));
-                    } else if (LocalDate.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_DATE)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfDate(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfDate(name, (LocalDate[]) componentGetter.invoke(object));
-                    } else if (LocalDateTime.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_TIMESTAMP)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfTimestamp(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfTimestamp(name, (LocalDateTime[]) componentGetter.invoke(object));
-                    } else if (OffsetDateTime.class.equals(componentType)) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfTimestampWithTimezone(name);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfTimestampWithTimezone(
-                                name, (OffsetDateTime[]) componentGetter.invoke(object));
-                    } else if (componentType.isEnum()) {
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_STRING)) {
-                                return null;
-                            }
-                            String[] values = compactReader.readArrayOfString(name);
-                            Class<? extends Enum> enumClass = (Class<? extends Enum>) componentType;
-                            return CompactUtil.enumArrayFromStringNameArray(enumClass, values);
-                        };
-                        componentWriters[i] = (compactWriter, object) -> {
-                            Enum[] values = (Enum[]) componentGetter.invoke(object);
-                            compactWriter.writeArrayOfString(name, CompactUtil.enumArrayAsStringNameArray(values));
-                        };
-                    } else {
-                        // Elements of the array might not be Compact serializable
-                        CompactUtil.verifyFieldClassIsCompactSerializable(componentType, clazz);
-
-                        componentReaders[i] = (compactReader, schema) -> {
-                            if (!isFieldExist(schema, name, ARRAY_OF_COMPACT)) {
-                                return null;
-                            }
-                            return compactReader.readArrayOfCompact(name, componentType);
-                        };
-                        componentWriters[i] = (compactWriter, object)
-                                -> compactWriter.writeArrayOfCompact(name, (Object[]) componentGetter.invoke(object));
-                    }
-                } else {
-                    // The nested field might not be Compact serializable
-                    CompactUtil.verifyFieldClassIsCompactSerializable(type, clazz);
-
-                    componentReaders[i] = (compactReader, schema) -> {
-                        if (!isFieldExist(schema, name, COMPACT)) {
-                            return null;
-                        }
-                        return compactReader.readCompact(name);
-                    };
-                    componentWriters[i] = (compactWriter, object)
-                            -> compactWriter.writeCompact(name, componentGetter.invoke(object));
-                }
+                componentReaderWriters[i] = new ComponentReaderWriterAdapter(
+                        ValueReaderWriters.readerWriterFor(clazz, type, genericType, name),
+                        componentGetter
+                );
             }
 
             Constructor<?> constructor = clazz.getDeclaredConstructor(componentTypes);
             constructor.setAccessible(true);
 
-            JavaRecordReader recordReader = new JavaRecordReader(constructor, componentReaders);
+            JavaRecordReader recordReader = new JavaRecordReader(constructor, componentReaderWriters);
             readersCache.put(clazz, recordReader);
-            writersCache.put(clazz, componentWriters);
+            readerWritersCache.put(clazz, componentReaderWriters);
         } catch (Exception e) {
             throw new HazelcastSerializationException("Failed to construct the readers/writers for the Java record", e);
+        }
+    }
+
+    private static final class ComponentReaderWriterAdapter implements ComponentReaderWriter {
+
+        private final ValueReaderWriter readerWriter;
+        private final Method componentGetter;
+
+        private ComponentReaderWriterAdapter(ValueReaderWriter readerWriter, Method componentGetter) {
+            this.readerWriter = readerWriter;
+            this.componentGetter = componentGetter;
+        }
+
+        @Override
+        public Object readComponent(CompactReader compactReader, Schema schema) {
+            return readerWriter.read(compactReader, schema);
+        }
+
+        @Override
+        public void writeComponent(CompactWriter compactWriter, Object recordObject) throws Exception {
+            readerWriter.write(compactWriter, componentGetter.invoke(recordObject));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriter.java
@@ -14,21 +14,30 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.serialization.impl.compact.record;
+package com.hazelcast.internal.serialization.impl.compact.zeroconfig;
 
 import com.hazelcast.internal.serialization.impl.compact.Schema;
 import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
 
 /**
- * Reads a single component of the record object and returns it.
+ * Subclasses of this class are expected to read or write values directly from
+ * the Compact reader and writers, using the provided field name.
+ * <p>
+ * It is expected that the Reflective and Record serializers will re-use those
+ * subclasses to avoid code duplication.
+ *
+ * @param <T> Type of the value to read/write
  */
-@FunctionalInterface
-public interface ComponentReader {
+public abstract class ValueReaderWriter<T> {
 
-    /**
-     * @param compactReader to read the component from.
-     * @param schema to validate expected and actual types.
-     * @return a single component of the record object.
-     */
-    Object readComponent(CompactReader compactReader, Schema schema);
+    protected final String fieldName;
+
+    protected ValueReaderWriter(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public abstract T read(CompactReader reader, Schema schema);
+
+    public abstract void write(CompactWriter writer, T value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
@@ -1,0 +1,1384 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl.compact.zeroconfig;
+
+import com.hazelcast.internal.serialization.impl.compact.Schema;
+import com.hazelcast.internal.util.BiTuple;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.charArrayAsShortArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.charArrayFromShortArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.characterArrayAsShortArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.characterArrayFromShortArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.characterAsShort;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.characterFromShort;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumArrayAsStringNameArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumArrayFromStringNameArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumAsStringName;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumFromStringName;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.isFieldExist;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.verifyFieldClassIsCompactSerializable;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_BOOLEAN;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_COMPACT;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT32;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT32;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT8;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_BOOLEAN;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_FLOAT32;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT16;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT32;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_NULLABLE_INT8;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_STRING;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIME;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE;
+import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
+import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
+import static com.hazelcast.nio.serialization.FieldKind.DATE;
+import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
+import static com.hazelcast.nio.serialization.FieldKind.FLOAT32;
+import static com.hazelcast.nio.serialization.FieldKind.FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.INT16;
+import static com.hazelcast.nio.serialization.FieldKind.INT32;
+import static com.hazelcast.nio.serialization.FieldKind.INT64;
+import static com.hazelcast.nio.serialization.FieldKind.INT8;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_BOOLEAN;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_FLOAT32;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT16;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT32;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT64;
+import static com.hazelcast.nio.serialization.FieldKind.NULLABLE_INT8;
+import static com.hazelcast.nio.serialization.FieldKind.STRING;
+import static com.hazelcast.nio.serialization.FieldKind.TIME;
+import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP;
+import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
+
+/**
+ * Class that stores all the value reader writers and returns the appropriate
+ * one for the class that requested it.
+ */
+@SuppressWarnings("checkstyle:executablestatementcount")
+public final class ValueReaderWriters {
+    private static final Map<Class<?>, Function<String, ValueReaderWriter<?>>> CONSTRUCTORS = new HashMap<>();
+    private static final Map<Class<?>, Function<String, ValueReaderWriter<?>>> ARRAY_CONSTRUCTORS = new HashMap<>();
+
+    static {
+        CONSTRUCTORS.put(String.class, StringReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(String.class, StringArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(BigDecimal.class, BigDecimalReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(BigDecimal.class, BigDecimalArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(LocalTime.class, LocalTimeReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(LocalTime.class, LocalTimeArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(LocalDate.class, LocalDateReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(LocalDate.class, LocalDateArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(LocalDateTime.class, LocalDateTimeReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(LocalDateTime.class, LocalDateTimeArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(OffsetDateTime.class, OffsetDateTimeReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(OffsetDateTime.class, OffsetDateTimeArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Boolean.class, NullableBooleanReaderWriter::new);
+        CONSTRUCTORS.put(Boolean.TYPE, BooleanReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Boolean.class, NullableBooleanArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Boolean.TYPE, BooleanArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Byte.class, NullableByteReaderWriter::new);
+        CONSTRUCTORS.put(Byte.TYPE, ByteReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Byte.class, NullableByteArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Byte.TYPE, ByteArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Character.class, NullableCharacterReaderWriter::new);
+        CONSTRUCTORS.put(Character.TYPE, CharacterReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Character.class, NullableCharacterArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Character.TYPE, CharArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Short.class, NullableShortReaderWriter::new);
+        CONSTRUCTORS.put(Short.TYPE, ShortReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Short.class, NullableShortArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Short.TYPE, ShortArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Integer.class, NullableIntegerReaderWriter::new);
+        CONSTRUCTORS.put(Integer.TYPE, IntegerReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Integer.class, NullableIntegerArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Integer.TYPE, IntArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Long.class, NullableLongReaderWriter::new);
+        CONSTRUCTORS.put(Long.TYPE, LongReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Long.class, NullableLongArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Long.TYPE, LongArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Float.class, NullableFloatReaderWriter::new);
+        CONSTRUCTORS.put(Float.TYPE, FloatReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Float.class, NullableFloatArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Float.TYPE, FloatArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Double.class, NullableDoubleReaderWriter::new);
+        CONSTRUCTORS.put(Double.TYPE, DoubleReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Double.class, NullableDoubleArrayReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Double.TYPE, DoubleArrayReaderWriter::new);
+    }
+
+    private ValueReaderWriters() {
+    }
+
+    /**
+     * Returns the reader writer for the given {@code type}.
+     *
+     * @param clazz       Top level class
+     * @param type        Class to return the reader writer for
+     * @param genericType Generic type of the {@code type}
+     * @param fieldName   Name of the field
+     * @return Appropriate reader for the given {@code type}
+     */
+    public static ValueReaderWriter<?> readerWriterFor(Class<?> clazz, Class<?> type, Type genericType, String fieldName) {
+        if (type.isArray()) {
+            Class<?> componentType = type.getComponentType();
+            return createReaderWriterForArray(clazz, componentType, fieldName);
+        } else if (isList(type)) {
+            Class<?> componentType = getSingleComponentType(genericType);
+            ValueReaderWriter readerWriter = createReaderWriterForArray(clazz, componentType, fieldName);
+            return new ArrayListReaderWriter(fieldName, componentType, readerWriter);
+        } else if (isSet(type)) {
+            Class<?> componentType = getSingleComponentType(genericType);
+            ValueReaderWriter readerWriter = createReaderWriterForArray(clazz, componentType, fieldName);
+            return new HashSetReaderWriter(fieldName, componentType, readerWriter);
+        } else if (isMap(type)) {
+            BiTuple<Class<?>, Class<?>> componentTypes = getTupleComponentTypes(genericType);
+            ValueReaderWriter keyReaderWriter
+                    = createReaderWriterForArray(clazz, componentTypes.element1, fieldName + "!keys");
+            ValueReaderWriter valueReaderWriter
+                    = createReaderWriterForArray(clazz, componentTypes.element2, fieldName + "!values");
+            return new HashMapReaderWriter(fieldName, componentTypes.element1,
+                    componentTypes.element2, keyReaderWriter, valueReaderWriter);
+        } else if (type.isEnum()) {
+            return new EnumReaderWriter(fieldName, (Class<? extends Enum>) type);
+        }
+
+        Function<String, ValueReaderWriter<?>> constructor = CONSTRUCTORS.get(type);
+        if (constructor != null) {
+            return constructor.apply(fieldName);
+        }
+
+        // The nested field might not be Compact serializable
+        verifyFieldClassIsCompactSerializable(type, clazz);
+        return new CompactReaderWriter(fieldName);
+    }
+
+    private static ValueReaderWriter createReaderWriterForArray(Class<?> clazz, Class<?> componentType, String fieldName) {
+        if (componentType.isEnum()) {
+            return new EnumArrayReaderWriter(fieldName, (Class<? extends Enum>) componentType);
+        }
+
+        Function<String, ValueReaderWriter<?>> constructor = ARRAY_CONSTRUCTORS.get(componentType);
+        if (constructor != null) {
+            return constructor.apply(fieldName);
+        }
+
+        // Elements of the array might not be Compact serializable
+        verifyFieldClassIsCompactSerializable(componentType, clazz);
+        return new CompactArrayReaderWriter(fieldName, componentType);
+    }
+
+    private static boolean isList(Class<?> clazz) {
+        return List.class.equals(clazz) || ArrayList.class.equals(clazz);
+    }
+
+    private static boolean isSet(Class<?> clazz) {
+        return Set.class.equals(clazz) || HashSet.class.equals(clazz);
+    }
+
+    private static boolean isMap(Class<?> clazz) {
+        return Map.class.equals(clazz) || HashMap.class.equals(clazz);
+    }
+
+    private static Class<?> getSingleComponentType(Type genericType) {
+        if (!(genericType instanceof ParameterizedType)) {
+            throw new HazelcastSerializationException(
+                    "It is required that the type " + genericType + " must be parameterized."
+            );
+        }
+
+        ParameterizedType parameterizedType = (ParameterizedType) genericType;
+        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+        if (typeArguments.length != 1) {
+            throw new HazelcastSerializationException(
+                    "Expected type " + genericType + " to have a single type argument."
+            );
+        }
+
+        Type typeArgument = typeArguments[0];
+        if (!(typeArgument instanceof Class)) {
+            throw new HazelcastSerializationException(
+                    "Expected type argument of type " + genericType + " to be a class"
+            );
+        }
+
+        return (Class<?>) typeArgument;
+    }
+
+    private static BiTuple<Class<?>, Class<?>> getTupleComponentTypes(Type genericType) {
+        if (!(genericType instanceof ParameterizedType)) {
+            throw new HazelcastSerializationException(
+                    "Expected the type " + genericType + " to be parameterized."
+            );
+        }
+
+        ParameterizedType parameterizedType = (ParameterizedType) genericType;
+        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+        if (typeArguments.length != 2) {
+            throw new HazelcastSerializationException(
+                    "Expected type " + genericType + " to have two type arguments."
+            );
+        }
+
+        Type keyTypeArgument = typeArguments[0];
+        Type valueTypeArgument = typeArguments[1];
+        if (!(keyTypeArgument instanceof Class) || !(valueTypeArgument instanceof Class)) {
+            throw new HazelcastSerializationException(
+                    "Expected type arguments of type " + genericType + " to be classes"
+            );
+        }
+
+        return BiTuple.of((Class<?>) keyTypeArgument, (Class<?>) valueTypeArgument);
+    }
+
+    private static final class StringReaderWriter extends ValueReaderWriter<String> {
+
+        private StringReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public String read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, STRING)) {
+                return null;
+            }
+            return reader.readString(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, String value) {
+            writer.writeString(fieldName, value);
+        }
+    }
+
+    private static final class StringArrayReaderWriter extends ValueReaderWriter<String[]> {
+
+        private StringArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public String[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_STRING)) {
+                return null;
+            }
+            return reader.readArrayOfString(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, String[] value) {
+            writer.writeArrayOfString(fieldName, value);
+        }
+    }
+
+    private static final class BigDecimalReaderWriter extends ValueReaderWriter<BigDecimal> {
+
+        private BigDecimalReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public BigDecimal read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, DECIMAL)) {
+                return null;
+            }
+            return reader.readDecimal(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, BigDecimal value) {
+            writer.writeDecimal(fieldName, value);
+        }
+    }
+
+    private static final class BigDecimalArrayReaderWriter extends ValueReaderWriter<BigDecimal[]> {
+
+        private BigDecimalArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public BigDecimal[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_DECIMAL)) {
+                return null;
+            }
+            return reader.readArrayOfDecimal(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, BigDecimal[] value) {
+            writer.writeArrayOfDecimal(fieldName, value);
+        }
+    }
+
+    private static final class LocalTimeReaderWriter extends ValueReaderWriter<LocalTime> {
+
+        private LocalTimeReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public LocalTime read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, TIME)) {
+                return null;
+            }
+            return reader.readTime(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, LocalTime value) {
+            writer.writeTime(fieldName, value);
+        }
+    }
+
+    private static final class LocalTimeArrayReaderWriter extends ValueReaderWriter<LocalTime[]> {
+
+        private LocalTimeArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public LocalTime[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_TIME)) {
+                return null;
+            }
+            return reader.readArrayOfTime(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, LocalTime[] value) {
+            writer.writeArrayOfTime(fieldName, value);
+        }
+    }
+
+    private static final class LocalDateReaderWriter extends ValueReaderWriter<LocalDate> {
+
+        private LocalDateReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public LocalDate read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, DATE)) {
+                return null;
+            }
+            return reader.readDate(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, LocalDate value) {
+            writer.writeDate(fieldName, value);
+        }
+    }
+
+    private static final class LocalDateArrayReaderWriter extends ValueReaderWriter<LocalDate[]> {
+
+        private LocalDateArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public LocalDate[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_DATE)) {
+                return null;
+            }
+            return reader.readArrayOfDate(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, LocalDate[] value) {
+            writer.writeArrayOfDate(fieldName, value);
+        }
+    }
+
+    private static final class LocalDateTimeReaderWriter extends ValueReaderWriter<LocalDateTime> {
+
+        private LocalDateTimeReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public LocalDateTime read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, TIMESTAMP)) {
+                return null;
+            }
+            return reader.readTimestamp(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, LocalDateTime value) {
+            writer.writeTimestamp(fieldName, value);
+        }
+    }
+
+    private static final class LocalDateTimeArrayReaderWriter extends ValueReaderWriter<LocalDateTime[]> {
+
+        private LocalDateTimeArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public LocalDateTime[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_TIMESTAMP)) {
+                return null;
+            }
+            return reader.readArrayOfTimestamp(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, LocalDateTime[] value) {
+            writer.writeArrayOfTimestamp(fieldName, value);
+        }
+    }
+
+    private static final class OffsetDateTimeReaderWriter extends ValueReaderWriter<OffsetDateTime> {
+
+        private OffsetDateTimeReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public OffsetDateTime read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, TIMESTAMP_WITH_TIMEZONE)) {
+                return null;
+            }
+            return reader.readTimestampWithTimezone(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, OffsetDateTime value) {
+            writer.writeTimestampWithTimezone(fieldName, value);
+        }
+    }
+
+    private static final class OffsetDateTimeArrayReaderWriter extends ValueReaderWriter<OffsetDateTime[]> {
+
+        private OffsetDateTimeArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public OffsetDateTime[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE)) {
+                return null;
+            }
+            return reader.readArrayOfTimestampWithTimezone(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, OffsetDateTime[] value) {
+            writer.writeArrayOfTimestampWithTimezone(fieldName, value);
+        }
+    }
+
+    private static final class NullableBooleanReaderWriter extends ValueReaderWriter<Boolean> {
+
+        private NullableBooleanReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Boolean read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_BOOLEAN, BOOLEAN)) {
+                return null;
+            }
+            return reader.readNullableBoolean(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Boolean value) {
+            writer.writeNullableBoolean(fieldName, value);
+        }
+    }
+
+    private static final class BooleanReaderWriter extends ValueReaderWriter<Boolean> {
+
+        private BooleanReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Boolean read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, BOOLEAN, NULLABLE_BOOLEAN)) {
+                return false;
+            }
+            return reader.readBoolean(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Boolean value) {
+            writer.writeBoolean(fieldName, value);
+        }
+    }
+
+    private static final class NullableBooleanArrayReaderWriter extends ValueReaderWriter<Boolean[]> {
+
+        private NullableBooleanArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Boolean[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_BOOLEAN, ARRAY_OF_BOOLEAN)) {
+                return null;
+            }
+            return reader.readArrayOfNullableBoolean(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Boolean[] value) {
+            writer.writeArrayOfNullableBoolean(fieldName, value);
+        }
+    }
+
+    private static final class BooleanArrayReaderWriter extends ValueReaderWriter<boolean[]> {
+
+        private BooleanArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public boolean[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN)) {
+                return null;
+            }
+            return reader.readArrayOfBoolean(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, boolean[] value) {
+            writer.writeArrayOfBoolean(fieldName, value);
+        }
+    }
+
+    private static final class NullableByteReaderWriter extends ValueReaderWriter<Byte> {
+
+        private NullableByteReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Byte read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_INT8, INT8)) {
+                return null;
+            }
+            return reader.readNullableInt8(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Byte value) {
+            writer.writeNullableInt8(fieldName, value);
+        }
+    }
+
+    private static final class ByteReaderWriter extends ValueReaderWriter<Byte> {
+
+        private ByteReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Byte read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, INT8, NULLABLE_INT8)) {
+                return 0;
+            }
+            return reader.readInt8(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Byte value) {
+            writer.writeInt8(fieldName, value);
+        }
+    }
+
+    private static final class NullableByteArrayReaderWriter extends ValueReaderWriter<Byte[]> {
+
+        private NullableByteArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Byte[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_INT8, ARRAY_OF_INT8)) {
+                return null;
+            }
+            return reader.readArrayOfNullableInt8(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Byte[] value) {
+            writer.writeArrayOfNullableInt8(fieldName, value);
+        }
+    }
+
+    private static final class ByteArrayReaderWriter extends ValueReaderWriter<byte[]> {
+
+        private ByteArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public byte[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8)) {
+                return null;
+            }
+            return reader.readArrayOfInt8(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, byte[] value) {
+            writer.writeArrayOfInt8(fieldName, value);
+        }
+    }
+
+    private static final class NullableCharacterReaderWriter extends ValueReaderWriter<Character> {
+
+        private NullableCharacterReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Character read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_INT16, INT16)) {
+                return null;
+            }
+            return characterFromShort(reader.readNullableInt16(fieldName));
+        }
+
+        @Override
+        public void write(CompactWriter writer, Character value) {
+            writer.writeNullableInt16(fieldName, characterAsShort(value));
+        }
+    }
+
+    private static final class CharacterReaderWriter extends ValueReaderWriter<Character> {
+
+        private CharacterReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Character read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, INT16, NULLABLE_INT16)) {
+                return 0;
+            }
+            return (char) reader.readInt16(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Character value) {
+            writer.writeInt16(fieldName, (short) ((char) value));
+        }
+    }
+
+    private static final class NullableCharacterArrayReaderWriter extends ValueReaderWriter<Character[]> {
+
+        private NullableCharacterArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Character[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_INT16, ARRAY_OF_INT16)) {
+                return null;
+            }
+            return characterArrayFromShortArray(reader.readArrayOfNullableInt16(fieldName));
+        }
+
+        @Override
+        public void write(CompactWriter writer, Character[] value) {
+            writer.writeArrayOfNullableInt16(fieldName, characterArrayAsShortArray(value));
+        }
+    }
+
+    private static final class CharArrayReaderWriter extends ValueReaderWriter<char[]> {
+
+        private CharArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public char[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
+                return null;
+            }
+            return charArrayFromShortArray(reader.readArrayOfInt16(fieldName));
+        }
+
+        @Override
+        public void write(CompactWriter writer, char[] value) {
+            writer.writeArrayOfInt16(fieldName, charArrayAsShortArray(value));
+        }
+    }
+
+    private static final class NullableShortReaderWriter extends ValueReaderWriter<Short> {
+
+        private NullableShortReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Short read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_INT16, INT16)) {
+                return null;
+            }
+            return reader.readNullableInt16(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Short value) {
+            writer.writeNullableInt16(fieldName, value);
+        }
+    }
+
+    private static final class ShortReaderWriter extends ValueReaderWriter<Short> {
+
+        private ShortReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Short read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, INT16, NULLABLE_INT16)) {
+                return 0;
+            }
+            return reader.readInt16(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Short value) {
+            writer.writeInt16(fieldName, value);
+        }
+    }
+
+    private static final class NullableShortArrayReaderWriter extends ValueReaderWriter<Short[]> {
+
+        private NullableShortArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Short[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_INT16, ARRAY_OF_INT16)) {
+                return null;
+            }
+            return reader.readArrayOfNullableInt16(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Short[] value) {
+            writer.writeArrayOfNullableInt16(fieldName, value);
+        }
+    }
+
+    private static final class ShortArrayReaderWriter extends ValueReaderWriter<short[]> {
+
+        private ShortArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public short[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16)) {
+                return null;
+            }
+            return reader.readArrayOfInt16(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, short[] value) {
+            writer.writeArrayOfInt16(fieldName, value);
+        }
+    }
+
+    private static final class NullableIntegerReaderWriter extends ValueReaderWriter<Integer> {
+
+        private NullableIntegerReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Integer read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_INT32, INT32)) {
+                return null;
+            }
+            return reader.readNullableInt32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Integer value) {
+            writer.writeNullableInt32(fieldName, value);
+        }
+    }
+
+    private static final class IntegerReaderWriter extends ValueReaderWriter<Integer> {
+
+        private IntegerReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Integer read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, INT32, NULLABLE_INT32)) {
+                return 0;
+            }
+            return reader.readInt32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Integer value) {
+            writer.writeInt32(fieldName, value);
+        }
+    }
+
+    private static final class NullableIntegerArrayReaderWriter extends ValueReaderWriter<Integer[]> {
+
+        private NullableIntegerArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Integer[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_INT32, ARRAY_OF_INT32)) {
+                return null;
+            }
+            return reader.readArrayOfNullableInt32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Integer[] value) {
+            writer.writeArrayOfNullableInt32(fieldName, value);
+        }
+    }
+
+    private static final class IntArrayReaderWriter extends ValueReaderWriter<int[]> {
+
+        private IntArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public int[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32)) {
+                return null;
+            }
+            return reader.readArrayOfInt32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, int[] value) {
+            writer.writeArrayOfInt32(fieldName, value);
+        }
+    }
+
+    private static final class NullableLongReaderWriter extends ValueReaderWriter<Long> {
+
+        private NullableLongReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Long read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_INT64, INT64)) {
+                return null;
+            }
+            return reader.readNullableInt64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Long value) {
+            writer.writeNullableInt64(fieldName, value);
+        }
+    }
+
+    private static final class LongReaderWriter extends ValueReaderWriter<Long> {
+
+        private LongReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Long read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, INT64, NULLABLE_INT64)) {
+                return 0L;
+            }
+            return reader.readInt64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Long value) {
+            writer.writeInt64(fieldName, value);
+        }
+    }
+
+    private static final class NullableLongArrayReaderWriter extends ValueReaderWriter<Long[]> {
+
+        private NullableLongArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Long[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_INT64, ARRAY_OF_INT64)) {
+                return null;
+            }
+            return reader.readArrayOfNullableInt64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Long[] value) {
+            writer.writeArrayOfNullableInt64(fieldName, value);
+        }
+    }
+
+    private static final class LongArrayReaderWriter extends ValueReaderWriter<long[]> {
+
+        private LongArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public long[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_INT64, ARRAY_OF_NULLABLE_INT64)) {
+                return null;
+            }
+            return reader.readArrayOfInt64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, long[] value) {
+            writer.writeArrayOfInt64(fieldName, value);
+        }
+    }
+
+    private static final class NullableFloatReaderWriter extends ValueReaderWriter<Float> {
+
+        private NullableFloatReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Float read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_FLOAT32, FLOAT32)) {
+                return null;
+            }
+            return reader.readNullableFloat32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Float value) {
+            writer.writeNullableFloat32(fieldName, value);
+        }
+    }
+
+    private static final class FloatReaderWriter extends ValueReaderWriter<Float> {
+
+        private FloatReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Float read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, FLOAT32, NULLABLE_FLOAT32)) {
+                return 0F;
+            }
+            return reader.readFloat32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Float value) {
+            writer.writeFloat32(fieldName, value);
+        }
+    }
+
+    private static final class NullableFloatArrayReaderWriter extends ValueReaderWriter<Float[]> {
+
+        private NullableFloatArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Float[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_FLOAT32, ARRAY_OF_FLOAT32)) {
+                return null;
+            }
+            return reader.readArrayOfNullableFloat32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Float[] value) {
+            writer.writeArrayOfNullableFloat32(fieldName, value);
+        }
+    }
+
+    private static final class FloatArrayReaderWriter extends ValueReaderWriter<float[]> {
+
+        private FloatArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public float[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_FLOAT32, ARRAY_OF_NULLABLE_FLOAT32)) {
+                return null;
+            }
+            return reader.readArrayOfFloat32(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, float[] value) {
+            writer.writeArrayOfFloat32(fieldName, value);
+        }
+    }
+
+    private static final class NullableDoubleReaderWriter extends ValueReaderWriter<Double> {
+
+        private NullableDoubleReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Double read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, NULLABLE_FLOAT64, FLOAT64)) {
+                return null;
+            }
+            return reader.readNullableFloat64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Double value) {
+            writer.writeNullableFloat64(fieldName, value);
+        }
+    }
+
+    private static final class DoubleReaderWriter extends ValueReaderWriter<Double> {
+
+        private DoubleReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Double read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, FLOAT64, NULLABLE_FLOAT64)) {
+                return 0D;
+            }
+            return reader.readFloat64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Double value) {
+            writer.writeFloat64(fieldName, value);
+        }
+    }
+
+    private static final class NullableDoubleArrayReaderWriter extends ValueReaderWriter<Double[]> {
+
+        private NullableDoubleArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Double[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_NULLABLE_FLOAT64, ARRAY_OF_FLOAT64)) {
+                return null;
+            }
+            return reader.readArrayOfNullableFloat64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Double[] value) {
+            writer.writeArrayOfNullableFloat64(fieldName, value);
+        }
+    }
+
+    private static final class DoubleArrayReaderWriter extends ValueReaderWriter<double[]> {
+
+        private DoubleArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public double[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_FLOAT64, ARRAY_OF_NULLABLE_FLOAT64)) {
+                return null;
+            }
+            return reader.readArrayOfFloat64(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, double[] value) {
+            writer.writeArrayOfFloat64(fieldName, value);
+        }
+    }
+
+    private static final class EnumReaderWriter extends ValueReaderWriter<Enum> {
+
+        private final Class<? extends Enum> clazz;
+
+        private EnumReaderWriter(String fieldName, Class<? extends Enum> clazz) {
+            super(fieldName);
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Enum read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, STRING)) {
+                return null;
+            }
+
+            String value = reader.readString(fieldName);
+            return enumFromStringName(clazz, value);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Enum value) {
+            writer.writeString(fieldName, enumAsStringName(value));
+        }
+    }
+
+    private static final class EnumArrayReaderWriter extends ValueReaderWriter<Enum[]> {
+
+        private final Class<? extends Enum> clazz;
+
+        private EnumArrayReaderWriter(String fieldName, Class<? extends Enum> clazz) {
+            super(fieldName);
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Enum[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_STRING)) {
+                return null;
+            }
+
+            String[] values = reader.readArrayOfString(fieldName);
+            return enumArrayFromStringNameArray(clazz, values);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Enum[] value) {
+            writer.writeArrayOfString(fieldName, enumArrayAsStringNameArray(value));
+        }
+    }
+
+    private static final class CompactReaderWriter extends ValueReaderWriter<Object> {
+
+        private CompactReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Object read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, COMPACT)) {
+                return null;
+            }
+
+            return reader.readCompact(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Object value) {
+            writer.writeCompact(fieldName, value);
+        }
+    }
+
+    private static final class CompactArrayReaderWriter extends ValueReaderWriter<Object[]> {
+
+        private final Class<?> clazz;
+
+        private CompactArrayReaderWriter(String fieldName, Class<?> clazz) {
+            super(fieldName);
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Object[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_COMPACT)) {
+                return null;
+            }
+
+            return reader.readArrayOfCompact(fieldName, clazz);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Object[] value) {
+            writer.writeArrayOfCompact(fieldName, value);
+        }
+    }
+
+    private static final class ArrayListReaderWriter extends ValueReaderWriter<List> {
+
+        private final Class<?> componentType;
+        private final ValueReaderWriter valueReaderWriter;
+
+        private ArrayListReaderWriter(String fieldName, Class<?> componentType, ValueReaderWriter valueReaderWriter) {
+            super(fieldName);
+            this.componentType = componentType;
+            this.valueReaderWriter = valueReaderWriter;
+        }
+
+        @Override
+        public List read(CompactReader reader, Schema schema) {
+            Object[] value = (Object[]) valueReaderWriter.read(reader, schema);
+            if (value == null) {
+                return null;
+            }
+
+            return new ArrayList(Arrays.asList(value));
+        }
+
+        @Override
+        public void write(CompactWriter writer, List value) {
+            if (value == null) {
+                valueReaderWriter.write(writer, null);
+                return;
+            }
+
+            Object o = Array.newInstance(componentType, value.size());
+            Object array = value.toArray((Object[]) o);
+            valueReaderWriter.write(writer, array);
+        }
+    }
+
+    private static final class HashSetReaderWriter extends ValueReaderWriter<Set> {
+
+        private final Class<?> componentType;
+        private final ValueReaderWriter valueReaderWriter;
+
+        private HashSetReaderWriter(String fieldName, Class<?> componentType, ValueReaderWriter valueReaderWriter) {
+            super(fieldName);
+            this.componentType = componentType;
+            this.valueReaderWriter = valueReaderWriter;
+        }
+
+        @Override
+        public Set read(CompactReader reader, Schema schema) {
+            Object[] value = (Object[]) valueReaderWriter.read(reader, schema);
+            if (value == null) {
+                return null;
+            }
+
+            return new HashSet(Arrays.asList(value));
+        }
+
+        @Override
+        public void write(CompactWriter writer, Set value) {
+            if (value == null) {
+                valueReaderWriter.write(writer, null);
+                return;
+            }
+
+            Object o = Array.newInstance(componentType, value.size());
+            Object array = value.toArray((Object[]) o);
+            valueReaderWriter.write(writer, array);
+        }
+    }
+
+    private static final class HashMapReaderWriter extends ValueReaderWriter<Map> {
+
+        private final Class<?> keyComponentType;
+        private final Class<?> valueComponentType;
+        private final ValueReaderWriter keyReaderWriter;
+        private final ValueReaderWriter valueReaderWriter;
+
+        private HashMapReaderWriter(String fieldName,
+                                    Class<?> keyComponentType,
+                                    Class<?> valueComponentType,
+                                    ValueReaderWriter keyReaderWriter,
+                                    ValueReaderWriter valueReaderWriter) {
+            super(fieldName);
+            this.keyComponentType = keyComponentType;
+            this.valueComponentType = valueComponentType;
+            this.keyReaderWriter = keyReaderWriter;
+            this.valueReaderWriter = valueReaderWriter;
+        }
+
+        @Override
+        public Map read(CompactReader reader, Schema schema) {
+            Object[] keys = (Object[]) keyReaderWriter.read(reader, schema);
+            Object[] values = (Object[]) valueReaderWriter.read(reader, schema);
+            if (keys == null || values == null) {
+                return null;
+            }
+
+            HashMap map = new HashMap(keys.length);
+            for (int i = 0; i < keys.length; i++) {
+                map.put(keys[i], values[i]);
+            }
+            return map;
+        }
+
+        @Override
+        public void write(CompactWriter writer, Map value) {
+            if (value == null) {
+                keyReaderWriter.write(writer, null);
+                valueReaderWriter.write(writer, null);
+            }
+
+            Object keys = Array.newInstance(keyComponentType, value.size());
+            Object values = Array.newInstance(valueComponentType, value.size());
+
+            keys = value.keySet().toArray((Object[]) keys);
+            values = value.values().toArray((Object[]) values);
+
+            keyReaderWriter.write(writer, keys);
+            valueReaderWriter.write(writer, values);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for List (and ArrayList), Set (and HashSet),
and Map (and HashMap) fields to the zero config serializers.

List and Set are written as the arrays of the component types they have
(like List<String> -> ARRAY_OF_STRING).

Maps are written as two lists back to back, with the key and value
type of the Map. The field names of these two lists are fieldName + !keys
and fieldName + !values respectively.

Also, this PR changes the reflective and record serializer so
that they re-use the same code.
