### PR TITLE
Fixing failing DynamicConfigYamlGeneratorTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
@@ -86,10 +86,6 @@ import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.memory.Capacity;
-import org.snakeyaml.engine.v2.api.Dump;
-import org.snakeyaml.engine.v2.api.DumpSettings;
-import org.snakeyaml.engine.v2.common.FlowStyle;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -98,15 +94,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
-import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
-import static com.hazelcast.config.ConfigXmlGenerator.MASK_FOR_SENSITIVE_DATA;
-import static com.hazelcast.config.ConfigXmlGenerator.endpointConfigElementName;
-import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
-import static com.hazelcast.internal.config.ConfigSections.LICENSE_KEY;
-import static com.hazelcast.internal.dynamicconfig.DynamicConfigXmlGenerator.classNameOrImplClass;
-import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
-import static java.lang.Boolean.TRUE;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.common.FlowStyle;
 
 /**
  * YAML counterpart of {@link ConfigXmlGenerator}. Note that this class isn't
@@ -119,7 +109,7 @@ public class DynamicConfigYamlGenerator {
 
     private static final int INDENT = 2;
     private static final boolean DEFAULT_MASK_SENSITIVE_FIELDS = false;
-    private static boolean maskSensitiveFields = DEFAULT_MASK_SENSITIVE_FIELDS;
+    private static volatile boolean maskSensitiveFields = DEFAULT_MASK_SENSITIVE_FIELDS;
 
     String generate(Config config, boolean isMask) {
         maskSensitiveFields = isMask;

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
@@ -86,6 +86,10 @@ import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.memory.Capacity;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -94,9 +98,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import org.snakeyaml.engine.v2.api.Dump;
-import org.snakeyaml.engine.v2.api.DumpSettings;
-import org.snakeyaml.engine.v2.common.FlowStyle;
+
+import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
+import static com.hazelcast.config.ConfigXmlGenerator.MASK_FOR_SENSITIVE_DATA;
+import static com.hazelcast.config.ConfigXmlGenerator.endpointConfigElementName;
+import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
+import static com.hazelcast.internal.config.ConfigSections.LICENSE_KEY;
+import static com.hazelcast.internal.dynamicconfig.DynamicConfigXmlGenerator.classNameOrImplClass;
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+import static java.lang.Boolean.TRUE;
 
 /**
  * YAML counterpart of {@link ConfigXmlGenerator}. Note that this class isn't

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGeneratorTest.java
@@ -39,7 +39,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.spi.MemberAddressProvider;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DynamicConfigYamlGeneratorTest extends AbstractDynamicConfigGeneratorTest {
 


### PR DESCRIPTION
```java
    private static boolean maskSensitiveFields = DEFAULT_MASK_SENSITIVE_FIELDS;

    String generate(Config config, boolean isMask) {
        maskSensitiveFields = isMask;
    // ...
    }
```

We have a ```static``` field that determines if the mask should be applied, but that field is change in non-static method (without any thread synch). So 2 instances of the same object can mutate the ```maskSensitiveFields```

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
