### PR TITLE
Add support for Spring property placeholders in aliased discovery strategies [HZ-1226]

### DIFF
--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -89,9 +89,9 @@
                               tag="TAG-NAME=HZLCAST001"/>
                     <hz:kubernetes enabled="false"
                                    namespace="MY-KUBERNETES-NAMESPACE"
-                                   service-name="MY-SERVICE-NAME"
+                                   service-name="${kubernetes.service.name}"
                                    service-label-name="MY-SERVICE-LABEL-NAME"
-                                   service-label-value="MY-SERVICE-LABEL-VALUE"/>
+                                   service-label-value="${kubernetes.service.label}"/>
                     <hz:eureka enabled="false"
                                self-registration="true"
                                namespace="hazelcast"/>
@@ -165,9 +165,9 @@
                               tag="TAG-NAME=HZLCAST001"/>
                     <hz:kubernetes enabled="false"
                                    namespace="MY-KUBERNETES-NAMESPACE"
-                                   service-name="MY-SERVICE-NAME"
+                                   service-name="${kubernetes.service.name}"
                                    service-label-name="MY-SERVICE-LABEL-NAME"
-                                   service-label-value="MY-SERVICE-LABEL-VALUE"/>
+                                   service-label-value="${kubernetes.service.label}"/>
                     <hz:eureka enabled="false"
                                self-registration="true"
                                namespace="hazelcast"/>

--- a/hazelcast-spring-tests/src/test/resources/hazelcast-default.properties
+++ b/hazelcast-spring-tests/src/test/resources/hazelcast-default.properties
@@ -46,3 +46,5 @@ network.auto-detection=false
 test.factory.id=1
 external.datastore.name=my-data-store
 external.datastore.url=jdbc:mysql://dummy:3306
+kubernetes.service.name=MY-SERVICE-NAME
+kubernetes.service.label=MY-SERVICE-LABEL-VALUE

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static com.hazelcast.internal.config.DomConfigHelper.childElements;
 import static com.hazelcast.internal.config.DomConfigHelper.cleanNodeName;
@@ -202,17 +203,24 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             }
         }
 
-        protected void fillAttributesForAliasedDiscoveryStrategy(AliasedDiscoveryConfig config, Node node,
-                                                                 BeanDefinitionBuilder builder, String name) {
+        protected void handleAliasedDiscoveryStrategy(Node node, BeanDefinitionBuilder builder, String name) {
             NamedNodeMap attributes = node.getAttributes();
+            Map<String, String> properties = new ManagedMap<>();
             if (attributes != null) {
                 for (int i = 0; i < attributes.getLength(); i++) {
                     Node attribute = attributes.item(i);
-                    config.setProperty(attribute.getNodeName(), attribute.getNodeValue());
+                    properties.put(attribute.getNodeName(), attribute.getNodeValue());
                 }
             }
+            BeanDefinitionBuilder discoveryConfigBuilder = createBeanBuilder(AliasedDiscoveryConfig.class);
+            discoveryConfigBuilder.getBeanDefinition().setBeanClass(ConfigFactory.class);
+            discoveryConfigBuilder.setFactoryMethod("newAliasedDiscoveryConfig");
+
+            discoveryConfigBuilder.addConstructorArgValue(name);
+            discoveryConfigBuilder.addConstructorArgValue(properties);
+
             String propertyName = String.format("%sConfig", name);
-            builder.addPropertyValue(propertyName, config);
+            builder.addPropertyValue(propertyName, discoveryConfigBuilder.getBeanDefinition());
         }
 
         protected ManagedList parseListeners(Node node, Class listenerConfigClass) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -32,7 +32,6 @@ import com.hazelcast.client.config.ProxyFactoryConfig;
 import com.hazelcast.client.config.SocketOptions;
 import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
-import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.InMemoryFormat;
@@ -335,11 +334,6 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             clientNetworkConfig.addPropertyValue("addresses", members);
 
             configBuilder.addPropertyValue("networkConfig", clientNetworkConfig.getBeanDefinition());
-        }
-
-        private void handleAliasedDiscoveryStrategy(Node node, BeanDefinitionBuilder builder, String name) {
-            AliasedDiscoveryConfig config = AliasedDiscoveryConfigUtils.newConfigFor(name);
-            fillAttributesForAliasedDiscoveryStrategy(config, node, builder, name);
         }
 
         private void handleSSLConfig(Node node, BeanDefinitionBuilder networkConfigBuilder) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spring;
 
 import com.hazelcast.config.AdvancedNetworkConfig;
-import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.AuditlogConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
@@ -1128,11 +1127,6 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 }
             }
             builder.addPropertyValue("members", members);
-        }
-
-        private void handleAliasedDiscoveryStrategy(Node node, BeanDefinitionBuilder builder, String name) {
-            AliasedDiscoveryConfig config = AliasedDiscoveryConfigUtils.newConfigFor(name);
-            fillAttributesForAliasedDiscoveryStrategy(config, node, builder, name);
         }
 
         public void handleReliableTopic(Node node) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/config/ConfigFactory.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/config/ConfigFactory.java
@@ -18,6 +18,7 @@ package com.hazelcast.spring.config;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.config.AliasedDiscoveryConfig;
 import com.hazelcast.config.CompactSerializationConfig;
 import com.hazelcast.config.CompactSerializationConfigAccessor;
 import com.hazelcast.config.Config;
@@ -26,12 +27,14 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.spi.eviction.EvictionPolicyComparator;
 import com.hazelcast.spring.HazelcastClientBeanDefinitionParser;
 import com.hazelcast.spring.HazelcastConfigBeanDefinitionParser;
 import com.hazelcast.spring.HazelcastFailoverClientBeanDefinitionParser;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.hazelcast.internal.config.ConfigValidator.COMMONLY_SUPPORTED_EVICTION_POLICIES;
@@ -107,6 +110,13 @@ public final class ConfigFactory {
             evictionConfig.setComparator(comparator);
         }
         return evictionConfig;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static AliasedDiscoveryConfig newAliasedDiscoveryConfig(String tag, Map<String, String> properties) {
+        AliasedDiscoveryConfig config = AliasedDiscoveryConfigUtils.newConfigFor(tag);
+        properties.forEach(config::setProperty);
+        return config;
     }
 
     public static CompactSerializationConfig newCompactSerializationConfig(


### PR DESCRIPTION
Member discovery configs (AWS, GCP, Azure, Kubernetes, Eureka) in Spring XML can be configured now using property placeholders.

Fixes https://github.com/hazelcast/hazelcast/issues/21585

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
