### PR TITLE
[HZ-1007] Introduce force offload for all map operations for testing purposes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MutableInteger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MutableInteger.java
@@ -39,4 +39,9 @@ public class MutableInteger {
     public int getAndInc() {
         return value++;
     }
+
+    public int addAndGet(int value) {
+        this.value += value;
+        return this.value;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MutableLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MutableLong.java
@@ -35,6 +35,15 @@ public class MutableLong {
         return instance;
     }
 
+    public long addAndGet(long value) {
+        this.value += value;
+        return this.value;
+    }
+
+    public long getAndInc() {
+        return value++;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -365,10 +365,12 @@ public class MapService implements ManagedService, ChunkedMigrationAwareService,
         for (PartitionContainer partitionContainer : partitionContainers) {
             Collection<RecordStore> allRecordStores = partitionContainer.getAllRecordStores();
             for (RecordStore recordStore : allRecordStores) {
-                if (recordStore.getMapContainer().getMapConfig().getMapStoreConfig().isEnabled()) {
-                    MutableLong count = offloaded.computeIfAbsent(recordStore.getName(), s -> new MutableLong());
-                    count.value += recordStore.getMapStoreOffloadedOperationsCount();
+                if (!recordStore.getMapContainer().getMapConfig().isStatisticsEnabled()) {
+                    continue;
                 }
+
+                MutableLong count = offloaded.computeIfAbsent(recordStore.getName(), s -> new MutableLong());
+                count.value += recordStore.getMapStoreOffloadedOperationsCount();
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -370,7 +370,7 @@ public class MapService implements ManagedService, ChunkedMigrationAwareService,
                 }
 
                 MutableLong count = offloaded.computeIfAbsent(recordStore.getName(), s -> new MutableLong());
-                count.value += recordStore.getMapStoreOffloadedOperationsCount();
+                count.addAndGet(recordStore.getMapStoreOffloadedOperationsCount());
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.internal.eviction.ExpirationManager;
 import com.hazelcast.internal.serialization.Data;
@@ -42,6 +43,7 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
+import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.Map;
 import java.util.UUID;
@@ -68,6 +70,20 @@ import java.util.function.Predicate;
 @SuppressWarnings("checkstyle:classfanoutcomplexity")
 public interface MapServiceContext extends MapServiceContextInterceptorSupport,
         MapServiceContextEventListenerSupport {
+
+    /**
+     * Following fields for FORCE_OFFLOAD_ALL_OPERATIONS
+     * are introduced only for testing purposes.
+     *
+     * @see {@link MapServiceContext#isForceOffloadEnabled}
+     */
+    boolean DEFAULT_FORCE_OFFLOAD_ALL_OPERATIONS = false;
+    String PROP_FORCE_OFFLOAD_ALL_OPERATIONS
+            = "hazelcast.internal.map.force.offload.all.map.operations";
+    HazelcastProperty FORCE_OFFLOAD_ALL_OPERATIONS
+            = new HazelcastProperty(PROP_FORCE_OFFLOAD_ALL_OPERATIONS,
+            DEFAULT_FORCE_OFFLOAD_ALL_OPERATIONS);
+
 
     Object toObject(Object data);
 
@@ -200,6 +216,20 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
     NodeWideUsedCapacityCounter getNodeWideUsedCapacityCounter();
 
     ExecutorStats getOffloadedEntryProcessorExecutorStats();
+
+    /**
+     * Only used for testing purposes.
+     * <p>
+     * Default value is {@code false}
+     * <p>
+     * Forces offload of all operations of all maps regardless of a
+     * map-store is being configured. This has identical behavior
+     * with enabling {@link MapStoreConfig#isOffload()} for all maps.
+     *
+     * @return {@code true} if force offload for all
+     * operations are enabled, otherwise {@code false}.
+     */
+    boolean isForceOffloadEnabled();
 
     Semaphore getNodeWideLoadedKeyLimiter();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -148,6 +148,7 @@ class MapServiceContextImpl implements MapServiceContext {
      * @see {@link MapKeyLoader#DEFAULT_LOADED_KEY_LIMIT_PER_NODE}
      */
     private final Semaphore nodeWideLoadedKeyLimiter;
+    private final boolean forceOffloadEnabled;
 
     private MapService mapService;
 
@@ -179,8 +180,21 @@ class MapServiceContextImpl implements MapServiceContext {
         this.nodeWideLoadedKeyLimiter = new Semaphore(checkPositive(PROP_LOADED_KEY_LIMITER_PER_NODE,
                 nodeEngine.getProperties().getInteger(LOADED_KEY_LIMITER_PER_NODE)));
         this.logger = nodeEngine.getLogger(getClass());
+        this.forceOffloadEnabled = nodeEngine.getProperties()
+                .getBoolean(FORCE_OFFLOAD_ALL_OPERATIONS);
+        if (this.forceOffloadEnabled) {
+            logger.info("Force offload is enabled for all maps. This "
+                    + "means all map operations will run as if they have map-store configured. "
+                    + "The intended usage for this flag is testing purposes.");
+        }
     }
 
+    @Override
+    public boolean isForceOffloadEnabled() {
+        return forceOffloadEnabled;
+    }
+
+    @Override
     public ExecutorStats getOffloadedEntryProcessorExecutorStats() {
         return offloadedExecutorStats;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -81,7 +81,6 @@ public abstract class MapOperation extends AbstractNamedOperation
     protected transient MapServiceContext mapServiceContext;
     protected transient MapEventPublisher mapEventPublisher;
 
-    protected transient boolean hasMapStore;
     protected transient boolean createRecordStoreOnDemand = true;
     protected transient boolean disposeDeferredBlocks = true;
 
@@ -117,13 +116,17 @@ public abstract class MapOperation extends AbstractNamedOperation
         }
 
         canPublishWanEvent = canPublishWanEvent(mapContainer);
-        hasMapStore = recordStore != null
-                && recordStore.getMapDataStore() != MapDataStores.EMPTY_MAP_DATA_STORE;
+
         MapConfig mapConfig = mapContainer.getMapConfig();
         MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
-        mapStoreOffloadEnabled = hasMapStore
-                && mapStoreConfig.isEnabled()
-                && mapStoreConfig.isOffload()
+
+        boolean hasUserConfiguredOffload = mapServiceContext.isForceOffloadEnabled()
+                || (mapStoreConfig.isOffload()
+                && recordStore != null
+                && recordStore.getMapDataStore() != MapDataStores.EMPTY_MAP_DATA_STORE);
+
+        // check mapStoreOffloadEnabled is true for current operation
+        mapStoreOffloadEnabled = recordStore != null && hasUserConfiguredOffload
                 && getStartingStep() != null
                 && !mapConfig.getTieredStoreConfig().isEnabled();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/MutableIntegerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/MutableIntegerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MutableIntegerTest extends TestCase {
+
+    @Test
+    public void testGetAndInc() {
+        MutableInteger mutableInteger = new MutableInteger(13);
+
+        assertEquals(13, mutableInteger.getAndInc());
+        assertEquals(14, mutableInteger.value);
+    }
+
+    @Test
+    public void testAddAndGet() {
+        MutableInteger mutableInteger = new MutableInteger(13);
+
+        assertEquals(24, mutableInteger.addAndGet(11));
+        assertEquals(24, mutableInteger.value);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/MutableLongTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/MutableLongTest.java
@@ -32,6 +32,22 @@ import static org.junit.Assert.assertNotEquals;
 public class MutableLongTest {
 
     @Test
+    public void testAddAndGet() {
+        MutableLong mutableLong = MutableLong.valueOf(13);
+
+        assertEquals(24L, mutableLong.addAndGet(11));
+        assertEquals(24L, mutableLong.value);
+    }
+
+    @Test
+    public void testGetAndInc() {
+        MutableLong mutableLong = MutableLong.valueOf(13);
+
+        assertEquals(13L, mutableLong.getAndInc());
+        assertEquals(14L, mutableLong.value);
+    }
+
+    @Test
     public void testToString() {
         MutableLong mutableLong = new MutableLong();
         String s = mutableLong.toString();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreForceOffloadAllOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreForceOffloadAllOperationTest.java
@@ -17,13 +17,12 @@
 package com.hazelcast.map.impl.mapstore;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.map.IMap;
-import com.hazelcast.map.MapStoreAdapter;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -41,19 +40,16 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_METRIC_MAP_STORE_WAITING_TO_BE_PROCESSED_COUNT;
 import static com.hazelcast.test.Accessors.getNode;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class MapStoreOffloadedOperationMetricsTest extends HazelcastTestSupport {
+public class MapStoreForceOffloadAllOperationTest extends HazelcastTestSupport {
 
-    private static final String MAP_WITH_MAP_STORE_NAME = "map-with-map-store";
-    private static final String MAP_WITHOUT_MAP_STORE_NAME = "no-map-store-map";
+    private static final String MAP_NAME = "default-map";
     private static final int INSTANCE_COUNT = 1;
 
-    private IMap<String, String> mapWithMapStore;
-    private IMap<String, String> mapWithoutMapStore;
+    private IMap<String, String> map;
     private MetricsRegistry registry;
 
     @Before
@@ -62,66 +58,23 @@ public class MapStoreOffloadedOperationMetricsTest extends HazelcastTestSupport 
         Config config = getConfig();
         HazelcastInstance instance = factory.newHazelcastInstance(config);
         registry = getNode(instance).nodeEngine.getMetricsRegistry();
-        mapWithMapStore = instance.getMap(MAP_WITH_MAP_STORE_NAME);
-        mapWithoutMapStore = instance.getMap(MAP_WITHOUT_MAP_STORE_NAME);
+        map = instance.getMap(MAP_NAME);
     }
 
     protected Config getConfig() {
-        Config config = super.smallInstanceConfig();
-        MapStoreConfig mapStoreConfig = new MapStoreConfig();
-        mapStoreConfig.setEnabled(true);
-        mapStoreConfig.setOffload(true);
-        mapStoreConfig.setImplementation(new MapStoreAdapter<String, String>() {
-
-            @Override
-            public String load(String key) {
-                // mimic a slow map loader
-                sleepMillis(100);
-                return randomString();
-            }
-        });
-        config.getMapConfig(MAP_WITH_MAP_STORE_NAME)
-                .setMapStoreConfig(mapStoreConfig);
-        return config;
+        return super.smallInstanceConfig()
+                .setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(), "true");
     }
 
     @Test
-    public void metrics_show_zero_offloaded_operation_count_after_methods_return() {
-        int opCount = 1_000;
-
-        List<Future> futures = new ArrayList<>(opCount * 2);
-        for (int i = 0; i < opCount; i++) {
-            futures.add(mapWithMapStore.setAsync(Integer.toString(i),
-                    Integer.toString(i)).toCompletableFuture());
-            futures.add(mapWithoutMapStore.setAsync(Integer.toString(i),
-                    Integer.toString(i)).toCompletableFuture());
-        }
-
-        sleepSeconds(2);
-
-        assertTrueEventually(() -> {
-            ProbeCatcher mapWithMapStore = new ProbeCatcher();
-            ProbeCatcher mapWithoutMapStore = new ProbeCatcher();
-
-            registry.collect(mapWithMapStore);
-            registry.collect(mapWithoutMapStore);
-
-            assertEquals(0L, mapWithMapStore.length);
-            assertEquals(0L, mapWithoutMapStore.length);
-        });
-    }
-
-    @Test
-    public void metrics_show_offloaded_operation_count_when_offload_is_configured() {
-        int opCount = 1_000;
+    public void metrics_show_offloaded_operation_count_when_forced_offload_enabled() {
+        int opCount = 10_000;
 
         List<Future> futures = new ArrayList<>(opCount);
         for (int i = 0; i < opCount; i++) {
-            futures.add(mapWithMapStore.setAsync(Integer.toString(i),
+            futures.add(map.setAsync(Integer.toString(i),
                     Integer.toString(i)).toCompletableFuture());
         }
-
-        sleepSeconds(2);
 
         MutableInt observedOffloadedOpCount = new MutableInt();
 
@@ -132,29 +85,6 @@ public class MapStoreOffloadedOperationMetricsTest extends HazelcastTestSupport 
 
             assertTrue(observedOffloadedOpCount.addAndGet(mapWithMapStore.length) > 0);
         });
-    }
-
-    @Test
-    public void metrics_show_zero_offloaded_operation_count_when_no_map_store_configured() {
-        int opCount = 1_000;
-
-        List<Future> futures = new ArrayList<>(opCount);
-        for (int i = 0; i < opCount; i++) {
-            futures.add(mapWithoutMapStore.setAsync(Integer.toString(i),
-                    Integer.toString(i)).toCompletableFuture());
-        }
-
-        sleepSeconds(2);
-
-        MutableInt observedOffloadedOpCount = new MutableInt();
-
-        assertTrueAllTheTime(() -> {
-            ProbeCatcher mapWithoutMapStore = new ProbeCatcher();
-
-            registry.collect(mapWithoutMapStore);
-
-            assertEquals(0, observedOffloadedOpCount.addAndGet(mapWithoutMapStore.length));
-        }, 5);
     }
 
     static class ProbeCatcher implements MetricsCollector {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreForceOffloadAllOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreForceOffloadAllOperationTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.internal.util.MutableLong;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -32,7 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.testcontainers.shaded.org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,7 +76,7 @@ public class MapStoreForceOffloadAllOperationTest extends HazelcastTestSupport {
                     Integer.toString(i)).toCompletableFuture());
         }
 
-        MutableInt observedOffloadedOpCount = new MutableInt();
+        MutableLong observedOffloadedOpCount = new MutableLong();
 
         assertTrueEventually(() -> {
             ProbeCatcher mapWithMapStore = new ProbeCatcher();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreOffloadedOperationMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreOffloadedOperationMetricsTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.internal.util.MutableLong;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapStoreAdapter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -33,7 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.testcontainers.shaded.org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -123,7 +123,7 @@ public class MapStoreOffloadedOperationMetricsTest extends HazelcastTestSupport 
 
         sleepSeconds(2);
 
-        MutableInt observedOffloadedOpCount = new MutableInt();
+        MutableLong observedOffloadedOpCount = new MutableLong();
 
         assertTrueEventually(() -> {
             ProbeCatcher mapWithMapStore = new ProbeCatcher();
@@ -146,7 +146,7 @@ public class MapStoreOffloadedOperationMetricsTest extends HazelcastTestSupport 
 
         sleepSeconds(2);
 
-        MutableInt observedOffloadedOpCount = new MutableInt();
+        MutableLong observedOffloadedOpCount = new MutableLong();
 
         assertTrueAllTheTime(() -> {
             ProbeCatcher mapWithoutMapStore = new ProbeCatcher();


### PR DESCRIPTION
**Goal:**
To make map-store offloading feature robust and bug-free by having a jenkins job which runs all map tests by forcing operation offloading.

**Modification:**
Introduced flag forces all map-operations to be offloaded regardless of a
map-store is being configured for them. This has identical behavior
with enabling {@link MapStoreConfig#isOffload()} for all maps.

```
boolean DEFAULT_FORCE_OFFLOAD_ALL_OPERATIONS = false;
String PROP_FORCE_OFFLOAD_ALL_OPERATIONS= "hazelcast.internal.map.force.offload.all.map.operations";
HazelcastProperty FORCE_OFFLOAD_ALL_OPERATIONS
            = new HazelcastProperty(PROP_FORCE_OFFLOAD_ALL_OPERATIONS,         DEFAULT_FORCE_OFFLOAD_ALL_OPERATIONS);
```