### PR TITLE
Make ClientRegressionWithRealNetworkTest use TestAwareClientFactory

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -93,7 +93,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
     public void testClientConnectionBeforeServerReady() {
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         executorService.submit(() -> {
-            factory.newHazelcastInstance(null);
+            factory.newHazelcastInstance(new Config());
         });
 
         CountDownLatch clientLatch = new CountDownLatch(1);
@@ -220,7 +220,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
     }
 
     private void testOperationsContinueWhenClientDisconnected(ClientConnectionStrategyConfig.ReconnectMode reconnectMode) {
-        HazelcastInstance instance1 = factory.newHazelcastInstance(null);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(new Config());
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().setReconnectMode(reconnectMode);
         AtomicBoolean waitFlag = new AtomicBoolean();
@@ -252,7 +252,8 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
         HazelcastInstance client = factory.newHazelcastClient(clientConfig, addressProvider);
 
-        HazelcastInstance instance2 = factory.newHazelcastInstance(null);
+
+        HazelcastInstance instance2 = factory.newHazelcastInstance(new Config());
 
         warmUpPartitions(instance1, instance2);
         String keyOwnedBy2 = generateKeyOwnedBy(instance2);


### PR DESCRIPTION
The two issues https://github.com/hazelcast/hazelcast/issues/21094 and https://github.com/hazelcast/hazelcast/issues/19757 has the same underlying fail reason.  The tests are using real network.

I have found out that in the fail scenario the following happens:

1. We create two members which runs at 127.0.0.1:5701(member1) and 127.0.0.1:5702(member2). We create a client as well, but there is nothing wrong regarding the client in the fail scenario.
2. Members find each other, join, and form a cluster
3. After several ms later, member2 receives a new join request from 127.0.0.1:5701 with a completely new UUID than member1's (or client's). It suspects member1 to be dead and therefore closes connection to member1. see this code here.
4. Then, member1 receives the suspicion request and it closes its connection to member2 as well.
5. test fails due to this "suspicious" request

I have searched all test stdouts that ran in the same build with the failing test, and could not find a member or client with that UUID. 

The fail seems like due to a somehow leaked member. I get suggested to use `TestAwareClientFactory` [here](https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1660734907885269?thread_ts=1660732614.861759&cid=C01JU7ZJYGP). 

We may need to update other tests in order to fix the fail completely. But for now, I will update the failing test. 

May Fix issues https://github.com/hazelcast/hazelcast/issues/21094 and https://github.com/hazelcast/hazelcast/issues/19757

Breaking changes (list specific methods/types/messages):
 
 - none
 
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
