### PR TITLE
Check nested fields of the Compact serializable objects are not serializable by other mechanisms in zero-config serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -125,7 +125,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         this.allowOverrideDefaultSerializers = builder.allowOverrideDefaultSerializers;
         CompactSerializationConfig compactSerializationCfg = builder.compactSerializationConfig == null
                 ? new CompactSerializationConfig() : builder.compactSerializationConfig;
-        compactStreamSerializer = new CompactStreamSerializer(compactSerializationCfg,
+        compactStreamSerializer = new CompactStreamSerializer(this, compactSerializationCfg,
                 managedContext, builder.schemaService, classLoader);
         this.compactWithSchemaSerializerAdapter = new CompactWithSchemaStreamSerializerAdapter(compactStreamSerializer);
         this.compactSerializerAdapter = new CompactStreamSerializerAdapter(compactStreamSerializer);
@@ -570,7 +570,10 @@ public abstract class AbstractSerializationService implements InternalSerializat
             return nullSerializerAdapter;
         }
         final Class type = object.getClass();
+        return serializerForClass(type, includeSchema);
+    }
 
+    public SerializerAdapter serializerForClass(Class type, boolean includeSchema) {
         //2-Default serializers, Dataserializable, Compact, Portable, primitives, arrays, String and
         // some helper Java types(BigInteger etc)
         SerializerAdapter serializer = lookupDefaultSerializer(type, includeSchema);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
 import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
 import com.hazelcast.internal.serialization.impl.compact.record.JavaRecordSerializer;
 import com.hazelcast.internal.util.TriTuple;
@@ -58,15 +59,18 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     private final Map<Class, CompactSerializableRegistration> classToRegistrationMap = new ConcurrentHashMap<>();
     private final Map<String, CompactSerializableRegistration> typeNameToRegistrationMap = new ConcurrentHashMap<>();
     private final Map<Class, Schema> classToSchemaMap = new ConcurrentHashMap<>();
-    private final ReflectiveCompactSerializer reflectiveSerializer = new ReflectiveCompactSerializer();
-    private final JavaRecordSerializer javaRecordSerializer = new JavaRecordSerializer();
+    private final ReflectiveCompactSerializer reflectiveSerializer = new ReflectiveCompactSerializer(this);
+    private final JavaRecordSerializer javaRecordSerializer = new JavaRecordSerializer(this);
     private final SchemaService schemaService;
     private final ManagedContext managedContext;
     private final ClassLoader classLoader;
+    private final AbstractSerializationService serializationService;
 
-    public CompactStreamSerializer(CompactSerializationConfig compactSerializationConfig,
+    public CompactStreamSerializer(AbstractSerializationService serializationService,
+                                   CompactSerializationConfig compactSerializationConfig,
                                    ManagedContext managedContext, SchemaService schemaService,
                                    ClassLoader classLoader) {
+        this.serializationService = serializationService;
         this.managedContext = managedContext;
         this.schemaService = schemaService;
         this.classLoader = classLoader;
@@ -85,6 +89,11 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
 
     public Collection<Class> getCompactSerializableClasses() {
         return classToRegistrationMap.keySet();
+    }
+
+    public boolean canBeSerializedAsCompact(Class<?> clazz) {
+        return serializationService.serializerForClass(clazz, false) instanceof CompactStreamSerializerAdapter
+                || serializationService.serializerForClass(clazz, false) instanceof CompactStreamSerializerAdapter;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -92,8 +92,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     }
 
     public boolean canBeSerializedAsCompact(Class<?> clazz) {
-        return serializationService.serializerForClass(clazz, false) instanceof CompactStreamSerializerAdapter
-                || serializationService.serializerForClass(clazz, false) instanceof CompactStreamSerializerAdapter;
+        return serializationService.serializerForClass(clazz, false) instanceof CompactStreamSerializerAdapter;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -198,6 +198,20 @@ public final class CompactUtil {
                 + "its fields, consider writing a CompactSerializer for it.");
     }
 
+    public static void verifyFieldClassShouldBeSerializedAsCompact(CompactStreamSerializer compactStreamSerializer,
+                                                                   Class<?> fieldClass, Class<?> clazz) {
+        if (compactStreamSerializer.canBeSerializedAsCompact(fieldClass)) {
+            return;
+        }
+
+        throw new HazelcastSerializationException("The '" + fieldClass + "' "
+                + "cannot be serialized with zero configuration Compact "
+                + "serialization because this type can be serialized with another "
+                + "serialization mechanism. If you want to serialize "
+                + "'" + clazz + "' which uses this class in its fields, consider"
+                + "overriding that serialization mechanism.");
+    }
+
     private static boolean canBeSerializedAsCompact(Class<?> clazz) {
         Package classPackage = clazz.getPackage();
         if (classPackage == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/ReflectiveCompactSerializer.java
@@ -67,6 +67,11 @@ import static java.util.stream.Collectors.toList;
 public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
 
     private final Map<Class, ReaderWriter[]> readerWritersCache = new ConcurrentHashMap<>();
+    private final CompactStreamSerializer compactStreamSerializer;
+
+    public ReflectiveCompactSerializer(CompactStreamSerializer compactStreamSerializer) {
+        this.compactStreamSerializer = compactStreamSerializer;
+    }
 
     @Override
     public void write(@Nonnull CompactWriter writer, @Nonnull T object) {
@@ -291,7 +296,8 @@ public class ReflectiveCompactSerializer<T> implements CompactSerializer<T> {
             } else {
                 // For anything else, rely on value reader writers to re-use the code we have
                 readerWriters[index] = new ReaderWriterAdapter(
-                        ValueReaderWriters.readerWriterFor(clazz, type, field.getGenericType(), name),
+                        ValueReaderWriters.readerWriterFor(compactStreamSerializer, clazz, type,
+                                field.getGenericType(), name),
                         field
                 );
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/record/JavaRecordSerializer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl.compact.record;
 
+import com.hazelcast.internal.serialization.impl.compact.CompactStreamSerializer;
 import com.hazelcast.internal.serialization.impl.compact.CompactUtil;
 import com.hazelcast.internal.serialization.impl.compact.DefaultCompactReader;
 import com.hazelcast.internal.serialization.impl.compact.Schema;
@@ -43,11 +44,12 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
     private final Method getTypeMethod;
     private final Method getNameMethod;
     private final Method getGenericTypeMethod;
-
+    private final CompactStreamSerializer compactStreamSerializer;
     private final Map<Class<?>, JavaRecordReader> readersCache = new ConcurrentHashMap<>();
     private final Map<Class<?>, ComponentReaderWriter[]> readerWritersCache = new ConcurrentHashMap<>();
 
-    public JavaRecordSerializer() {
+    public JavaRecordSerializer(CompactStreamSerializer compactStreamSerializer) {
+        this.compactStreamSerializer = compactStreamSerializer;
         Method isRecordMethod;
         Method getRecordComponentsMethod;
         Method getTypeMethod;
@@ -154,7 +156,7 @@ public class JavaRecordSerializer implements CompactSerializer<Object> {
                 Method componentGetter = clazz.getDeclaredMethod(name);
                 componentGetter.setAccessible(true);
                 componentReaderWriters[i] = new ComponentReaderWriterAdapter(
-                        ValueReaderWriters.readerWriterFor(clazz, type, genericType, name),
+                        ValueReaderWriters.readerWriterFor(compactStreamSerializer, clazz, type, genericType, name),
                         componentGetter
                 );
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -66,6 +66,9 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -469,7 +472,9 @@ public class CompactStreamSerializerTest {
 
         SchemaWriter writer = new SchemaWriter("typeName");
 
-        ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer();
+        CompactStreamSerializer compactStreamSerializer = mock(CompactStreamSerializer.class);
+        when(compactStreamSerializer.canBeSerializedAsCompact(any())).thenReturn(true);
+        ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer(compactStreamSerializer);
         EmployerDTO employerDTO = new EmployerDTO("nbss", 40, HIRING, ids, employeeDTO, employeeDTOS);
         reflectiveCompactSerializer.write(writer, employerDTO);
 
@@ -500,7 +505,9 @@ public class CompactStreamSerializerTest {
 
         SchemaWriter writer = new SchemaWriter("typeName");
 
-        ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer();
+        CompactStreamSerializer compactStreamSerializer = mock(CompactStreamSerializer.class);
+        when(compactStreamSerializer.canBeSerializedAsCompact(any())).thenReturn(true);
+        ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer(compactStreamSerializer);
         reflectiveCompactSerializer.write(writer, employeeDTO);
 
         Schema schema = writer.build();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -66,9 +66,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -459,26 +456,8 @@ public class CompactStreamSerializerTest {
     }
 
     @Test
-    public void testFieldOrder() throws IOException {
-        EmployeeDTO employeeDTO = new EmployeeDTO(30, 102310312);
-        long[] ids = new long[2];
-        ids[0] = 22;
-        ids[1] = 44;
-
-        EmployeeDTO[] employeeDTOS = new EmployeeDTO[5];
-        for (int j = 0; j < employeeDTOS.length; j++) {
-            employeeDTOS[j] = new EmployeeDTO(20 + j, j * 100);
-        }
-
-        SchemaWriter writer = new SchemaWriter("typeName");
-
-        CompactStreamSerializer compactStreamSerializer = mock(CompactStreamSerializer.class);
-        when(compactStreamSerializer.canBeSerializedAsCompact(any())).thenReturn(true);
-        ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer(compactStreamSerializer);
-        EmployerDTO employerDTO = new EmployerDTO("nbss", 40, HIRING, ids, employeeDTO, employeeDTOS);
-        reflectiveCompactSerializer.write(writer, employerDTO);
-
-        Schema schema = writer.build();
+    public void testFieldOrder() {
+        Schema schema = CompactTestUtil.getSchemasFor(EmployerDTO.class).iterator().next();
 
         assertEquals(0, schema.getField("zcode").getOffset());
         assertEquals(-1, schema.getField("zcode").getIndex());
@@ -500,17 +479,8 @@ public class CompactStreamSerializerTest {
     }
 
     @Test
-    public void testFieldOrderFixedSize() throws IOException {
-        EmployeeDTO employeeDTO = new EmployeeDTO(30, 102310312);
-
-        SchemaWriter writer = new SchemaWriter("typeName");
-
-        CompactStreamSerializer compactStreamSerializer = mock(CompactStreamSerializer.class);
-        when(compactStreamSerializer.canBeSerializedAsCompact(any())).thenReturn(true);
-        ReflectiveCompactSerializer reflectiveCompactSerializer = new ReflectiveCompactSerializer(compactStreamSerializer);
-        reflectiveCompactSerializer.write(writer, employeeDTO);
-
-        Schema schema = writer.build();
+    public void testFieldOrderFixedSize() {
+        Schema schema = CompactTestUtil.getSchemasFor(EmployeeDTO.class).iterator().next();
 
         assertEquals(schema.getField("id").getOffset(), 0);
         assertEquals(schema.getField("id").getIndex(), -1);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -46,6 +46,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class CompactTestUtil {
 
@@ -208,7 +211,9 @@ public final class CompactTestUtil {
      * reflective serializer.
      */
     public static Collection<Schema> getSchemasFor(Class<?>... classes) {
-        ReflectiveCompactSerializer serializer = new ReflectiveCompactSerializer();
+        CompactStreamSerializer compactStreamSerializer = mock(CompactStreamSerializer.class);
+        when(compactStreamSerializer.canBeSerializedAsCompact(any())).thenReturn(true);
+        ReflectiveCompactSerializer serializer = new ReflectiveCompactSerializer(compactStreamSerializer);
         ArrayList<Schema> schemas = new ArrayList<>(classes.length);
         for (Class<?> clazz : classes) {
             SchemaWriter writer = new SchemaWriter(clazz.getName());


### PR DESCRIPTION
It could be the case that the top level class is serializable by
Compact, but it might have nested fields, which can also be serialized
by other mechanisms like Java serialization.

The problem is, that we cache the serializers, even the reflective
serializers. And, if we cache that we can serialize Java serializable
objects with Compact, this can be problematic for such scenarios

```
map.put(javaSerializable, 1)
map.put(zeroConfigSerializableWithJavaSerializableField, 2)
map.get(javaSerializable) // this returns null now, as the
// key was serialized with identified, but now it is Compact
```

To solve this, we check if the nested field is only be
serializable with Compact (either there is no other serialization
mechanism or Compact serializer is explicitly serialized with
it with `addClass` or `addSerializer`).

Closes https://github.com/hazelcast/hazelcast/issues/22004