### PR TITLE
MC-1505 - return null member UUID for offline member

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetCPMembersMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/GetCPMembersMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.management;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MCGetCPMembersCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractAsyncMessageTask;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.cp.CPMember;
 import com.hazelcast.cp.CPSubsystemManagementService;
 import com.hazelcast.instance.impl.Node;
@@ -52,7 +53,8 @@ public class GetCPMembersMessageTask extends AbstractAsyncMessageTask<Void, List
                 .thenApply(cpMembers -> {
                     List<SimpleEntry<UUID, UUID>> result = new ArrayList<>(cpMembers.size());
                     for (CPMember cpMember : cpMembers) {
-                        UUID apUuid = clusterService.getMember(cpMember.getAddress()).getUuid();
+                        Member member = clusterService.getMember(cpMember.getAddress());
+                        UUID apUuid = member != null ? member.getUuid() : null;
                         result.add(new SimpleEntry<>(cpMember.getUuid(), apUuid));
                     }
                     return result;


### PR DESCRIPTION
When CP Subsystem Persistence is enabled and a participating member is shut down, the member data remains a part of CP group. It led to NPE previously because member UUID can't be found by the address from CP member info. The fix returns `null` member UUID along with CP UUID for such cases. `null` UUID is properly handled on MC.

Fixes https://hazelcast.atlassian.net/browse/MC-1505
MC PR: https://github.com/hazelcast/management-center/pull/6081

Breaking changes (list specific methods/types/messages):
* `MCGetCPMembersCodec` call will cause NPE in MC 5.1- in the described situation. MC before 5.2 didn't expect that the member UUID could be `null`. Previously it was NPE on the member, so no new failing scenario is added.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
