### PR TITLE
Drop mapping idempotently within all members when destroying GenericMapStore

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -292,9 +292,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
 
     @Override
     public void destroy() {
-        if (isMaster()) {
-            dropMapping(mapping);
-        }
+        dropMapping(mapping);
     }
 
     @Override
@@ -530,15 +528,8 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
         sql.execute(queries.deleteAll(keys.size()), keys.toArray()).close();
     }
 
-    /**
-     * Returns true if the instance where the MapStore is instantiated is master
-     */
-    private boolean isMaster() {
-        return nodeEngine().getClusterService().isMaster();
-    }
-
     private void dropMapping(String mappingName) {
-        sql.execute("DROP MAPPING \"" + mappingName + "\"").close();
+        sql.execute("DROP MAPPING IF EXISTS \"" + mappingName + "\"").close();
     }
 
     /**

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -292,6 +292,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
 
     @Override
     public void destroy() {
+        awaitInitFinished();
         dropMapping(mapping);
     }
 

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -106,7 +106,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     }
 
     @Test
-    public void whenMapStoreDestroy_thenDropMapping() throws Exception {
+    public void whenMapStoreDestroyOnMaster_thenDropMapping() throws Exception {
         createTable(mapName);
 
         GenericMapStore<Object> mapStore = createMapStore();
@@ -119,7 +119,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     }
 
     @Test
-    public void whenMapStoreDestroyNotMaster_thenDoNotDropMapping() throws Exception {
+    public void whenMapStoreDestroyOnNonMaster_thenDropMapping() throws Exception {
         createTable(mapName);
 
         createMapStore();
@@ -128,7 +128,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         GenericMapStore<Object> mapStoreNotMaster = createMapStore(instances()[1]);
         mapStoreNotMaster.destroy();
         assertTrueEventually(() -> {
-            assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList(new Row(MAPPING_PREFIX + mapName)));
+            assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList());
         }, 5);
     }
 


### PR DESCRIPTION
Drops SQL mappings on all members (not only master) using `DROP MAPPING IF EXISTS`
 
Fixes https://github.com/hazelcast/hazelcast/issues/21993


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
