### PR TITLE
[HZ-1007] Offload map-store api calls for offloaded-entry-processor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -120,6 +120,10 @@ public final class EntryOperator {
         this.entry = new LockAwareLazyMapEntry();
     }
 
+    public EntryProcessor getEntryProcessor() {
+        return entryProcessor;
+    }
+
     private void setProcessor(Object processor) {
         if (backup) {
             backupProcessor = ((EntryProcessor) processor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
@@ -85,6 +85,7 @@ public class State {
     private volatile Collection<Data> keys;
     private volatile ArrayList<Record> records;
     private volatile EntryProcessor entryProcessor;
+    private volatile boolean entryProcessorOffload;
     private volatile EntryOperator operator;
     private volatile List<State> toStore;
     private volatile List<State> toRemove;
@@ -208,6 +209,15 @@ public class State {
 
     public State setEntryProcessor(EntryProcessor entryProcessor) {
         this.entryProcessor = entryProcessor;
+        return this;
+    }
+
+    public boolean isEntryProcessorOffload() {
+        return entryProcessorOffload;
+    }
+
+    public State setEntryProcessorOffload(boolean entryProcessorOffload) {
+        this.entryProcessorOffload = entryProcessorOffload;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
@@ -100,6 +100,8 @@ public class State {
     private volatile Queue<InternalIndex> notMarkedIndexes;
     private volatile Set keysFromIndex;
     private volatile Throwable throwable;
+    private volatile EntryEventType modificationTypeForEP;
+    private volatile boolean unlockNeededForEP;
 
     public State(RecordStore recordStore, MapOperation operation) {
         this.recordStore = recordStore;
@@ -504,5 +506,23 @@ public class State {
 
     public List getBackupPairs() {
         return backupPairs;
+    }
+
+    public State setModificationTypeForEP(EntryEventType modificationTypeForEP) {
+        this.modificationTypeForEP = modificationTypeForEP;
+        return null;
+    }
+
+    public EntryEventType getModificationTypeForEP() {
+        return modificationTypeForEP;
+    }
+
+    public State setUnlockNeededForEP(boolean unlockNeededForEP) {
+        this.unlockNeededForEP = unlockNeededForEP;
+        return this;
+    }
+
+    public boolean isUnlockNeededForEP() {
+        return unlockNeededForEP;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/Step.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/Step.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.operation.steps.engine;
 import javax.annotation.Nullable;
 
 /**
- * Represent an isolated step of an operation. e.g.
+ * Represents an isolated step of an operation. e.g.
  * {@link  com.hazelcast.map.impl.operation.PutOperation}
  * <p>
  * By using this interface, an operation can be modeled as

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1195,7 +1195,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public boolean setWithUncountedAccess(Data dataKey, Object value, long ttl, long maxIdle) {
         long now = getNow();
         Object oldValue = putInternal(dataKey, value, ttl, maxIdle, UNSET, now,
-                null, null, null, StaticParams.SET_WTH_NO_ACCESS_PARAMS);
+                null, null, null, StaticParams.SET_WITH_NO_ACCESS_PARAMS);
         return oldValue == null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StaticParams.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StaticParams.java
@@ -58,7 +58,7 @@ public final class StaticParams {
             .importFrom(SET_PARAMS)
             .setTryPut(true);
 
-    public static final StaticParams SET_WTH_NO_ACCESS_PARAMS = new StaticParams()
+    public static final StaticParams SET_WITH_NO_ACCESS_PARAMS = new StaticParams()
             .importFrom(SET_PARAMS)
             .setCountAsAccess(false);
 


### PR DESCRIPTION
**Reasoning:**
This was the missing piece of offloading map-store operations PR, now this PR is addressing `FIXME` at here: https://github.com/hazelcast/hazelcast/blob/021e2af77ad6ba6d32d56a623fbe43f30fd76864/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java#L183

**Modifications:**
- `EntryOffloadableSetUnlockOperation` now supports stepped approach
-  Added missing step support for the offload case in `EntryOperation`
-  Added related tests