### PR TITLE
[22034] Fixes `MetadataRaftGroupInitInProgressException` in test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -66,6 +66,7 @@ import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static com.hazelcast.test.TestHazelcastInstanceFactory.initOrCreateConfig;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.isIn;
 import static org.junit.Assert.assertArrayEquals;
@@ -74,7 +75,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -350,6 +350,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         instances[2] = factory.newHazelcastInstance(config);
 
         instance.getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
+        waitUntilCPDiscoveryCompleted(instances);
 
         List<CPMemberInfo> newEndpoints = getRaftInvocationManager(instance).<List<CPMemberInfo>>query(getMetadataGroupId(instance),
                 new GetActiveCPMembersOp(), LINEARIZABLE).get();
@@ -369,6 +370,7 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         instances[0] = factory.newHazelcastInstance(config);
 
         instances[1].getCPSubsystem().getCPSubsystemManagementService().reset().toCompletableFuture().get();
+        waitUntilCPDiscoveryCompleted(instances);
 
         List<CPMemberInfo> newEndpoints = invocationManager.<List<CPMemberInfo>>query(getMetadataGroupId(instances[2]),
                 new GetActiveCPMembersOp(), LINEARIZABLE).get();

--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -38,6 +38,9 @@
         <Logger name="com.hazelcast.client.impl.spi.ClientListenerService" level="trace"/>
         <Logger name="com.hazelcast.jet" level="debug"/>
         <Logger name="com.hazelcast.sql.impl.client" level="debug"/>
+        <Logger name="com.hazelcast.cp.internal.raft.impl.RaftNodeImpl" level="debug"/>
+        <Logger name="com.hazelcast.cp.internal.MetadataRaftGroupManager" level="debug"/>
+        <Logger name="com.hazelcast.cp.internal.RaftGroupMembershipManager" level="debug"/>
 <!--        <Logger name="com.hazelcast.internal.partition.operation.MigrationRequestOperation" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientInvocationService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.connection.ClientConnectionManager" level="trace"/>-->


### PR DESCRIPTION
The `MetadataRaftGroupOp` invocation performs before the Metadata group initialisation is completed after the `resetCPSubsystem` call.
Adding the `waitUntilCPDiscoveryCompleted` should fix this issue.

Fixes https://github.com/hazelcast/hazelcast/issues/22034

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
