### PR TITLE
Fix possible spinning in MapIndexScanP

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -200,7 +200,9 @@ final class MapIndexScanP extends AbstractProcessor {
     }
 
     private boolean runHashIndex() {
-        for (; ; ) {
+        boolean allIdle;
+        do {
+            allIdle = true;
             for (int i = 0; i < splits.size(); ++i) {
                 Split split = splits.get(i);
                 try {
@@ -219,6 +221,7 @@ final class MapIndexScanP extends AbstractProcessor {
                         }
                     }
                 } else {
+                    allIdle = false;
                     if (tryEmit(split.currentRow)) {
                         split.remove();
                     } else {
@@ -226,7 +229,9 @@ final class MapIndexScanP extends AbstractProcessor {
                     }
                 }
             }
-        }
+        } while (!allIdle);
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
When all splits were waiting for more data, the processor was spinning without
any sleep, wasting CPU time and breaking the cooperative contract.