### PR TITLE
Add allowed lag to SourceBuilder_TopologyChangeTest.test_restartJob_nodeTerminated [HZ-1394]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourceBuilder_TopologyChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourceBuilder_TopologyChangeTest.java
@@ -105,7 +105,7 @@ public class SourceBuilder_TopologyChangeTest extends JetTestSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(source)
-                .withNativeTimestamps(0)
+                .withNativeTimestamps(100)
                 .window(tumbling(windowSize))
                 .aggregate(AggregateOperations.counting())
                 .peek()


### PR DESCRIPTION
Cause of the flakiness:
- source was generating number using SourceBuilder
- one node is crashing at some point
- just after recover from crash, the very last element of the sequence generated for current window was doubled

TBD Reasoning why exactly the lack of lag was causing item to be duplicated

Fixes #21908 HZ-1394

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
