### PR TITLE
Handle null return [HZ-1404]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1814,14 +1814,22 @@ public class EntryProcessorTest extends HazelcastTestSupport {
 
         @Override
         public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
-            Index index = queryContext.getIndex(attributeName);
+            Index index = getIndex(queryContext);
+            if (index == null) {
+                return null;
+            }
+
             Set records = index.getRecords(key);
             return records;
         }
 
+        private Index getIndex(QueryContext queryContext) {
+            return queryContext.getIndex(attributeName);
+        }
+
         @Override
         public boolean isIndexed(QueryContext queryContext) {
-            return true;
+            return getIndex(queryContext) != null;
         }
 
         @Override


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/4337

**Modification:**
EP code is fixed. Index can be null during migration.

**Issue:**
```
java.lang.NullPointerException
	at com.hazelcast.map.EntryProcessorTest$ApplyCountAwareIndexedTestPredicate.filter(EntryProcessorTest.java:1818)
	at com.hazelcast.query.impl.Indexes.query(Indexes.java:455)
	at com.hazelcast.map.impl.operation.PartitionWideEntryOperation.runWithIndex(PartitionWideEntryOperation.java:139)
	at com.hazelcast.map.impl.operation.PartitionWideEntryOperation.runForNative(PartitionWideEntryOperation.java:120)
	at com.hazelcast.map.impl.operation.PartitionWideEntryOperation.runInternal(PartitionWideEntryOperation.java:113)
	at com.hazelcast.map.impl.operation.MapOperation.run(MapOperation.java:150)
	at com.hazelcast.map.impl.operation.MapOperation.call(MapOperation.java:170)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:281)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:256)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(Opera
```