### PR TITLE
Fixed ClearBackupOperation [HZ-1210]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -33,7 +33,7 @@ public class ClearBackupOperation extends MapOperation implements BackupOperatio
     @Override
     protected void runInternal() {
         if (recordStore != null) {
-            recordStore.clear();
+            recordStore.clear(true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -49,7 +49,7 @@ public class ClearOperation extends MapOperation
             return;
         }
 
-        numberOfClearedEntries = recordStore.clear();
+        numberOfClearedEntries = recordStore.clear(false);
         shouldBackup = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ClearOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ClearOpSteps.java
@@ -90,7 +90,7 @@ public enum ClearOpSteps implements Step<State> {
         @Override
         public void runStep(State state) {
             DefaultRecordStore recordStore = ((DefaultRecordStore) state.getRecordStore());
-            int removedKeyCount = recordStore.removeBulk((ArrayList<Data>) state.getKeys(), state.getRecords());
+            int removedKeyCount = recordStore.removeBulk((ArrayList<Data>) state.getKeys(), state.getRecords(), false);
             if (removedKeyCount > 0) {
                 recordStore.updateStatsOnRemove(Clock.currentTimeMillis());
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/DeleteOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/DeleteOpSteps.java
@@ -79,7 +79,7 @@ public enum DeleteOpSteps implements Step<State> {
         public void runStep(State state) {
             DefaultRecordStore recordStore = (DefaultRecordStore) state.getRecordStore();
             Record record = recordStore.getRecord(state.getKey());
-            recordStore.removeRecord0(state.getKey(), record);
+            recordStore.removeRecord0(state.getKey(), record, false);
             recordStore.onStore(record);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveIfSameOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveIfSameOpSteps.java
@@ -116,7 +116,7 @@ public enum RemoveIfSameOpSteps implements Step<State> {
             if (state.isRecordExistsInMemory()) {
                 DefaultRecordStore recordStore = (DefaultRecordStore) state.getRecordStore();
                 Record record = recordStore.getRecord(state.getKey());
-                recordStore.removeRecord0(state.getKey(), record);
+                recordStore.removeRecord0(state.getKey(), record, false);
                 recordStore.onStore(record);
                 recordStore.updateStatsOnRemove(state.getNow());
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveOpSteps.java
@@ -106,7 +106,7 @@ public enum RemoveOpSteps implements Step<State> {
             if (record == null) {
                 return;
             }
-            recordStore.removeRecord0(state.getKey(), record);
+            recordStore.removeRecord0(state.getKey(), record, false);
             recordStore.onStore(record);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
@@ -118,11 +118,11 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
     }
 
     @Override
-    public void onRemoveRecord(Data key, R record) {
+    public void onRemoveRecord(Data key, R record, boolean backup) {
         Throwable throwable = null;
         for (int i = 0; i < mutationObservers.size(); i++) {
             try {
-                mutationObservers.get(i).onRemoveRecord(key, record);
+                mutationObservers.get(i).onRemoveRecord(key, record, backup);
             } catch (Throwable t) {
                 if (throwable == null) {
                     throwable = t;
@@ -136,11 +136,11 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
     }
 
     @Override
-    public void onEvictRecord(Data key, R record) {
+    public void onEvictRecord(Data key, R record, boolean backup) {
         Throwable throwable = null;
         for (int i = 0; i < mutationObservers.size(); i++) {
             try {
-                mutationObservers.get(i).onEvictRecord(key, record);
+                mutationObservers.get(i).onEvictRecord(key, record, backup);
             } catch (Throwable t) {
                 if (throwable == null) {
                     throwable = t;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -239,7 +239,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void removeReplicatedRecord(Data dataKey) {
         Record record = storage.get(dataKey);
         if (record != null) {
-            removeRecord0(dataKey, record);
+            removeRecord0(dataKey, record, true);
         }
     }
 
@@ -520,29 +520,30 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         return definedExpirationTime - System.currentTimeMillis();
     }
 
-    public int removeBulk(ArrayList<Data> dataKeys, ArrayList<Record> records) {
-        return removeOrEvictEntries(dataKeys, records, false);
+    public int removeBulk(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean backup) {
+        return removeOrEvictEntries(dataKeys, records, false, backup);
     }
 
-    protected int evictBulk(ArrayList<Data> dataKeys, ArrayList<Record> records) {
-        return removeOrEvictEntries(dataKeys, records, true);
+    protected int evictBulk(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean backup) {
+        return removeOrEvictEntries(dataKeys, records, true, backup);
     }
 
-    private int removeOrEvictEntries(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean eviction) {
+    private int removeOrEvictEntries(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean eviction,
+                                     boolean backup) {
         for (int i = 0; i < dataKeys.size(); i++) {
             Data dataKey = dataKeys.get(i);
             Record record = records.get(i);
-            removeOrEvictEntry(dataKey, record, eviction);
+            removeOrEvictEntry(dataKey, record, eviction, backup);
         }
 
         return dataKeys.size();
     }
 
-    private void removeOrEvictEntry(Data dataKey, Record record, boolean eviction) {
+    private void removeOrEvictEntry(Data dataKey, Record record, boolean eviction, boolean backup) {
         if (eviction) {
-            mutationObserver.onEvictRecord(dataKey, record);
+            mutationObserver.onEvictRecord(dataKey, record, backup);
         } else {
-            mutationObserver.onRemoveRecord(dataKey, record);
+            mutationObserver.onRemoveRecord(dataKey, record, backup);
         }
         removeKeyFromExpirySystem(dataKey);
         storage.removeRecord(dataKey, record);
@@ -555,7 +556,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record != null) {
             value = record.getValue();
             mapDataStore.flush(key, value, backup);
-            mutationObserver.onEvictRecord(key, record);
+            mutationObserver.onEvictRecord(key, record, backup);
             removeKeyFromExpirySystem(key);
             storage.removeRecord(key, record);
             if (!backup) {
@@ -586,7 +587,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             return;
         }
-        removeRecord0(key, record);
+        removeRecord0(key, record, true);
         if (persistenceEnabledFor(provenance)) {
             mapDataStore.removeBackup(key, now, transactionId);
         }
@@ -660,7 +661,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             mapDataStore.remove(key, now, null);
             if (record != null) {
                 onStore(record);
-                removeRecord0(key, record);
+                removeRecord0(key, record, false);
                 updateStatsOnRemove(now);
             }
             removed = true;
@@ -1079,7 +1080,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                     mapDataStore.remove(key, now, null);
                 }
                 onStore(record);
-                removeRecord0(key, record);
+                removeRecord0(key, record, false);
                 return true;
             }
 
@@ -1217,12 +1218,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             }
             onStore(record);
         }
-        removeRecord0(key, record);
+        removeRecord0(key, record, false);
         return oldValue;
     }
 
-    public void removeRecord0(Data key, @Nonnull Record record) {
-        mutationObserver.onRemoveRecord(key, record);
+    public void removeRecord0(Data key, @Nonnull Record record, boolean backup) {
+        mutationObserver.onRemoveRecord(key, record, backup);
         removeKeyFromExpirySystem(key);
         storage.removeRecord(key, record);
     }
@@ -1406,12 +1407,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }, true);
 
         flush(keys, records, backup);
-        return evictBulk(keys, records);
+        return evictBulk(keys, records, backup);
     }
 
     // TODO optimize when no mapdatastore
     @Override
-    public int clear() {
+    public int clear(boolean backup) {
         checkIfLoaded();
 
         ArrayList<Data> keys = new ArrayList<>();
@@ -1432,7 +1433,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         // This conversion is required by mapDataStore#removeAll call.
         mapDataStore.removeAll(keys);
         mapDataStore.reset();
-        int removedKeyCount = removeBulk(keys, records);
+        int removedKeyCount = removeBulk(keys, records, backup);
         if (removedKeyCount > 0) {
             updateStatsOnRemove(Clock.currentTimeMillis());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -236,10 +236,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public void removeReplicatedRecord(Data dataKey) {
+    public void removeReplicatedRecord(Data dataKey, boolean backup) {
         Record record = storage.get(dataKey);
         if (record != null) {
-            removeRecord0(dataKey, record, true);
+            removeRecord0(dataKey, record, backup);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
@@ -56,13 +56,13 @@ public class EventJournalWriterMutationObserver implements MutationObserver {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         eventJournal.writeRemoveEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
@@ -69,13 +69,17 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
     }
 
     @Override
-    public void onRemoveRecord(@Nonnull Data key, R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onRemoveRecord(@Nonnull Data key, R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override
-    public void onEvictRecord(@Nonnull Data key, @Nonnull R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
@@ -72,12 +72,12 @@ public class JsonMetadataMutationObserver implements MutationObserver<Record> {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         metadataStore.remove(key);
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         metadataStore.remove(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
@@ -70,16 +70,18 @@ public interface MutationObserver<R extends Record> {
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      */
-    void onRemoveRecord(@Nonnull Data key, R record);
+    void onRemoveRecord(@Nonnull Data key, R record, boolean backup);
 
     /**
      * Called when a record is evicted from the observed {@link RecordStore}
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.*
      */
-    void onEvictRecord(@Nonnull Data key, @Nonnull R record);
+    void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup);
 
     /**
      * Called when a record is loaded into the observed {@link RecordStore}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -632,9 +632,10 @@ public interface RecordStore<R extends Record> {
      * <p>
      * Clears data in this record store.
      *
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      * @return number of cleared entries.
      */
-    int clear();
+    int clear(boolean backup);
 
     /**
      * Resets the record store to it's initial state.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -312,8 +312,9 @@ public interface RecordStore<R extends Record> {
      * does not intercept.
      *
      * @param dataKey key to remove
+     * @param backup {@code true} if a backup partition, otherwise {@code false}.
      */
-    void removeReplicatedRecord(Data dataKey);
+    void removeReplicatedRecord(Data dataKey, boolean backup);
 
     void forEach(BiConsumer<Data, R> consumer, boolean backup);
 


### PR DESCRIPTION
Propagate backup flag into removeRecord method to disable
removeIndex calls on the replicas. 

The missing flag triggers calls to the global index on the replicas. For HD case the empty B+tree still may contain a few empty nodes that we have to traverse on _removeIndex_ and those calls might be noticeable performance-wise. 

EE https://github.com/hazelcast/hazelcast-enterprise/pull/5250