### PR TITLE
Moving queue statistic updates to run method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -21,15 +21,15 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.operationservice.BlockingOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
@@ -53,23 +53,20 @@ public final class OfferOperation extends QueueBackupAwareOperation
     @Override
     public void run() {
         QueueContainer queueContainer = getContainer();
+        LocalQueueStatsImpl stats = getQueueService().getLocalQueueStatsImpl(name);
         if (queueContainer.hasEnoughCapacity()) {
             itemId = queueContainer.offer(data);
+            stats.incrementOffers();
             response = true;
         } else {
+            stats.incrementRejectedOffers();
             response = false;
         }
     }
 
     @Override
     public void afterRun() throws Exception {
-        LocalQueueStatsImpl stats = getQueueService().getLocalQueueStatsImpl(name);
-        if (Boolean.TRUE.equals(response)) {
-            stats.incrementOffers();
-            publishEvent(ItemEventType.ADDED, data);
-        } else {
-            stats.incrementRejectedOffers();
-        }
+        publishEvent(ItemEventType.ADDED, data);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -66,7 +66,9 @@ public final class OfferOperation extends QueueBackupAwareOperation
 
     @Override
     public void afterRun() throws Exception {
-        publishEvent(ItemEventType.ADDED, data);
+        if (Boolean.TRUE.equals(response)) {
+            publishEvent(ItemEventType.ADDED, data);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/21696

This is a code of: ```OperationRunnerImpl#call```:
```java
                try {
                    op.sendResponse(response);
                } catch (ResponseAlreadySentException e) {
                    logOperationError(op, e);
                }
                afterRun(op);
```
So we send a response to a caller and after sending it we do ```afterRun```. The ```OfferOperation#afterRun```:
```java
    @Override
    public void afterRun() throws Exception {
        LocalQueueStatsImpl stats = getQueueService().getLocalQueueStatsImpl(name);
        if (Boolean.TRUE.equals(response)) {
            stats.incrementOffers();
            publishEvent(ItemEventType.ADDED, data);
        } else {
            stats.incrementRejectedOffers();
        }
    }
```
The problem here is that ```getQueueService().getLocalQueueStatsImpl``` will recreate ```LocalQueueStatsImpl``` if it doesn't exists. The problematic flow:
- (op 1 part 1) offer new value to the queue
  - we execute the operation
  - we send the response
- (op 2) destroy of a quere
  - we execute the operation, the ```LocalQueueStatsImpl``` for the queue is destroyed
- (op 1 part 2)
  - we execute ```afterRun``` which recreates the ```LocalQueueStatsImpl```


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
