### PR TITLE
Simplify handling init of GenericMapStore [HZ-1430]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -537,7 +537,10 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
     private void awaitInitFinished() {
         try {
             boolean finished = initFinished.await(initTimeoutMillis, MILLISECONDS);
-            if (!finished || initFailure != null) {
+            if (!finished) {
+                throw new HazelcastException("MapStore init for map: " + mapName + " timed out after " + initTimeoutMillis + " ms", initFailure);
+            }
+            if (initFailure != null) {
                 throw new HazelcastException("MapStore init failed for map: " + mapName, initFailure);
             }
         } catch (InterruptedException e) {

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -538,7 +538,8 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
         try {
             boolean finished = initFinished.await(initTimeoutMillis, MILLISECONDS);
             if (!finished) {
-                throw new HazelcastException("MapStore init for map: " + mapName + " timed out after " + initTimeoutMillis + " ms", initFailure);
+                throw new HazelcastException("MapStore init for map: " + mapName + " timed out after " + initTimeoutMillis
+                        + " ms", initFailure);
             }
             if (initFailure != null) {
                 throw new HazelcastException("MapStore init failed for map: " + mapName, initFailure);


### PR DESCRIPTION
I haven't found any specific issue, only refactored an async initialization and added more details to the exception thrown when it init fails.

Hopefully fixes https://github.com/hazelcast/hazelcast/issues/22079

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
