### PR TITLE
Add throwable to assertion message

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.ProbeUnit;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
@@ -93,7 +94,8 @@ class MetricsCollectionCycle {
                 metricsSource.provideDynamicMetrics(descriptorSupplier.get(), metricsContext);
             } catch (Throwable t) {
                 logger.warning("Collecting metrics from source " + metricsSource.getClass().getName() + " failed", t);
-                assert false : "Collecting metrics from source " + metricsSource.getClass().getName() + " failed\n" + t;
+                assert false : "Collecting metrics from source " + metricsSource.getClass().getName() + " failed\n"
+                        + ExceptionUtil.toString(t);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -93,7 +93,7 @@ class MetricsCollectionCycle {
                 metricsSource.provideDynamicMetrics(descriptorSupplier.get(), metricsContext);
             } catch (Throwable t) {
                 logger.warning("Collecting metrics from source " + metricsSource.getClass().getName() + " failed", t);
-                assert false : "Collecting metrics from source " + metricsSource.getClass().getName() + " failed";
+                assert false : "Collecting metrics from source " + metricsSource.getClass().getName() + " failed\n" + t;
             }
         }
     }


### PR DESCRIPTION
I added throwable as assertion message in case we have an issue like [this one](https://github.com/hazelcast/hazelcast-enterprise/issues/4626) in the future where we lose logging.

Related: https://github.com/hazelcast/hazelcast-enterprise/pull/5254

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
