### PR TITLE
[API-1503] Add missing return to the zero-config map reader writer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
@@ -1379,6 +1379,7 @@ public final class ValueReaderWriters {
             if (value == null) {
                 keyReaderWriter.write(writer, null);
                 valueReaderWriter.write(writer, null);
+                return;
             }
 
             Object keys = Array.newInstance(keyComponentType, value.size());

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -383,6 +383,24 @@ public class CompactSerializationTest {
     }
 
     @Test
+    public void testSerializingClassReflectively_withCollectionTypes_whenTheyAreNull() {
+        SerializationConfig config = new SerializationConfig();
+        SerializationService service = createSerializationService(config);
+        ClassWithCollectionFields object = new ClassWithCollectionFields(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        Data data = service.toData(object);
+        ClassWithCollectionFields deserialized = service.toObject(data);
+        assertEquals(object, deserialized);
+    }
+
+    @Test
     public void testReflectiveSerializer_withFieldsWithOtherSerializationMechanisms() {
         SerializationConfig config = new SerializationConfig();
         SerializationService service = createSerializationService(config);


### PR DESCRIPTION
We missed to return early if the value was null in the map
reader writer.

This PR adds this, and adds a test to verify it.