### PR TITLE
Bump hadoop.version from 3.3.3 to 3.3.4 [5.1.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <classgraph.version>4.8.139</classgraph.version>
         <grpc.version>1.43.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
-        <hadoop.version>3.3.3</hadoop.version>
+        <hadoop.version>3.3.4</hadoop.version>
         <jackson.version>2.13.3</jackson.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jline.version>3.21.0</jline.version>


### PR DESCRIPTION
Fixes #21566 on 5.1.z branch.

Backport of #21923

Bumps `hadoop.version` from 3.3.3 to 3.3.4.

Updates `hadoop-client` from 3.3.3 to 3.3.4

Updates `hadoop-minicluster` from 3.3.3 to 3.3.4

Updates `hadoop-common` from 3.3.3 to 3.3.4

Updates `hadoop-azure` from 3.3.3 to 3.3.4

Updates `hadoop-azure-datalake` from 3.3.3 to 3.3.4

Updates `hadoop-aws` from 3.3.3 to 3.3.4

---
updated-dependencies:
- dependency-name: org.apache.hadoop:hadoop-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-minicluster
  dependency-type: direct:development
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-common
  dependency-type: direct:development
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-azure
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-azure-datalake
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.hadoop:hadoop-aws
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>



Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
