### PR TITLE
[21785] Fix negative map hits [HZ-1313]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -231,7 +231,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         Records.copyMetadataFrom(replicatedRecord, newRecord);
         expirySystem.add(dataKey, expiryMetadata, now);
         mutationObserver.onReplicationPutRecord(dataKey, newRecord, indexesMustBePopulated);
-        updateStatsOnPut(replicatedRecord.getHits(), now);
 
         return newRecord;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsMultipleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsMultipleNodeTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.map.listener.EntryEvictedListener;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -52,8 +51,27 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LocalMapStatsMultipleNodeTest extends HazelcastTestSupport {
 
+    //https://github.com/hazelcast/hazelcast/issues/21785
     @Test
-    public void testHits_whenMultipleNodes() throws InterruptedException {
+    public void testHits_isZero_afterPutAndReplicated() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(getConfig());
+        IMap<Integer, Integer> iMap = instance1.getMap("test-hits");
+
+        for (int i = 0; i < 100; i++) {
+            iMap.put(i, i);
+        }
+
+        HazelcastInstance instance2 = factory.newHazelcastInstance(getConfig());
+        HazelcastInstance instance3 = factory.newHazelcastInstance(getConfig());
+        waitAllForSafeState(instance1, instance2, instance3);
+        assertEquals(0, instance1.getMap("test-hits").getLocalMapStats().getHits());
+        assertEquals(0, instance2.getMap("test-hits").getLocalMapStats().getHits());
+        assertEquals(0, instance3.getMap("test-hits").getLocalMapStats().getHits());
+    }
+
+    @Test
+    public void testHits_whenMultipleNodes() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance[] instances = factory.newInstances(getConfig());
         MultiMap<Object, Object> multiMap0 = instances[0].getMultiMap("testHits_whenMultipleNodes");
@@ -81,7 +99,7 @@ public class LocalMapStatsMultipleNodeTest extends HazelcastTestSupport {
     public void testPutStats_afterPutAll() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance[] instances = factory.newInstances(getConfig());
-        Map<Integer, Integer> map = new HashMap<Integer, Integer>();
+        Map<Integer, Integer> map = new HashMap<>();
         for (int i = 1; i <= 5000; i++) {
             map.put(i, i);
         }
@@ -89,16 +107,11 @@ public class LocalMapStatsMultipleNodeTest extends HazelcastTestSupport {
         IMap<Integer, Integer> iMap = instances[0].getMap("example");
         iMap.putAll(map);
         final LocalMapStats localMapStats = iMap.getLocalMapStats();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEquals(5000, localMapStats.getPutOperationCount());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(5000, localMapStats.getPutOperationCount()));
     }
 
     @Test
-    public void testLocalMapStats_withMemberGroups() throws Exception {
+    public void testLocalMapStats_withMemberGroups() {
         final String mapName = randomMapName();
         final String[] firstMemberGroup = {"127.0.0.1", "127.0.0.2"};
         final String[] secondMemberGroup = {"127.0.0.3"};
@@ -167,16 +180,13 @@ public class LocalMapStatsMultipleNodeTest extends HazelcastTestSupport {
 
     private void assertBackupEntryCount(final long expectedBackupEntryCount, final String mapName,
                                         final Collection<HazelcastInstance> nodes) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                long backup = 0;
-                for (HazelcastInstance node : nodes) {
-                    final IMap<Object, Object> map = node.getMap(mapName);
-                    backup += getBackupEntryCount(map);
-                }
-                assertEquals(expectedBackupEntryCount, backup);
+        assertTrueEventually(() -> {
+            long backup = 0;
+            for (HazelcastInstance node : nodes) {
+                final IMap<Object, Object> map = node.getMap(mapName);
+                backup += getBackupEntryCount(map);
             }
+            assertEquals(expectedBackupEntryCount, backup);
         });
     }
 


### PR DESCRIPTION
Negative `map.hits` metric values are reported by members started after the map is populated.
The cause of the issue is that the default `Record#getHits()` method returns -1.

Fixes #21785 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
