### PR TITLE
[HZ-1007] Follow-up Offload map-store api calls for offloaded-entry-processor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -24,9 +24,6 @@ import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.operation.steps.EntryOpSteps;
-import com.hazelcast.map.impl.operation.steps.engine.State;
-import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
@@ -88,23 +85,6 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         } finally {
             recordStore.afterOperation();
         }
-    }
-
-    @Override
-    public State createState() {
-        return super.createState()
-                .setKey(dataKey)
-                .setOldValue(oldValue)
-                .setNewValue(newValue)
-                .setModificationTypeForEP(modificationType)
-                .setTtl(newTtl)
-                .setEntryOperator(null)
-                .setUnlockNeededForEP(true);
-    }
-
-    @Override
-    public Step getStartingStep() {
-        return EntryOpSteps.EP_START;
     }
 
     private void verifyLock() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.operation.steps.MultipleEntryOpSteps;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
+import com.hazelcast.map.impl.recordstore.StaticParams;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
@@ -73,7 +74,8 @@ public class MultipleEntryOperation extends MapOperation
                 .setKeys(keys)
                 .setPredicate(getPredicate())
                 .setCallerProvenance(CallerProvenance.NOT_WAN)
-                .setEntryProcessor(entryProcessor);
+                .setEntryProcessor(entryProcessor)
+                .setStaticPutParams(StaticParams.SET_WITH_NO_ACCESS_PARAMS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.operation.steps.PartitionWideOpSteps;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
+import com.hazelcast.map.impl.recordstore.StaticParams;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
@@ -88,7 +89,8 @@ public class PartitionWideEntryOperation extends MapOperation
         return super.createState()
                 .setPredicate(getPredicate())
                 .setCallerProvenance(CallerProvenance.NOT_WAN)
-                .setEntryProcessor(entryProcessor);
+                .setEntryProcessor(entryProcessor)
+                .setStaticPutParams(StaticParams.SET_WITH_NO_ACCESS_PARAMS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
@@ -19,13 +19,11 @@ package com.hazelcast.map.impl.operation.steps;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.operation.EntryOffloadableSetUnlockOperation;
 import com.hazelcast.map.impl.operation.EntryOperation;
 import com.hazelcast.map.impl.operation.EntryOperator;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.map.impl.recordstore.StaticParams;
 
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 
@@ -36,7 +34,7 @@ public enum EntryOpSteps implements Step<State> {
         public void runStep(State state) {
             EntryOperator operator = operator(state.getOperation(), state.getEntryProcessor());
             operator.init(state.getKey(), state.getOldValue(), state.getNewValue(),
-                    null, state.getModificationTypeForEP(), null, state.getTtl());
+                    null, null, null, state.getTtl());
             state.setEntryOperator(operator);
 
             if (operator.belongsAnotherPartition(state.getKey())) {
@@ -52,8 +50,15 @@ public enum EntryOpSteps implements Step<State> {
             if (state.isStopExecution()) {
                 return EntryOpSteps.AFTER_RUN;
             }
-            return state.getOldValue() == null
-                    ? EntryOpSteps.LOAD : EntryOpSteps.PROCESS;
+
+            if (state.getOldValue() == null) {
+                return EntryOpSteps.LOAD;
+            }
+
+            if (state.isEntryProcessorOffload()) {
+                return EntryOpSteps.RUN_OFFLOADED_ENTRY_PROCESSOR;
+            }
+            return EntryOpSteps.PROCESS;
         }
     },
 
@@ -70,8 +75,42 @@ public enum EntryOpSteps implements Step<State> {
 
         @Override
         public Step nextStep(State state) {
-            return state.getOldValue() == null
-                    ? EntryOpSteps.PROCESS : EntryOpSteps.ON_LOAD;
+            if (state.getOldValue() != null) {
+                return EntryOpSteps.ON_LOAD;
+            }
+
+            if (state.isEntryProcessorOffload()) {
+                return EntryOpSteps.RUN_OFFLOADED_ENTRY_PROCESSOR;
+            }
+            return EntryOpSteps.PROCESS;
+        }
+    },
+
+    RUN_OFFLOADED_ENTRY_PROCESSOR() {
+        @Override
+        public boolean isOffloadStep() {
+            return true;
+        }
+
+        @Override
+        public void runStep(State state) {
+            EntryOperation operation = (EntryOperation) state.getOperation();
+            Object oldValueByInMemoryFormat = operation.getOldValueByInMemoryFormat(state.getOldValue());
+
+            EntryOperator entryOperator = operator(operation, state.getEntryProcessor())
+                    .operateOnKeyValue(state.getKey(), oldValueByInMemoryFormat);
+            state.setEntryOperator(entryOperator);
+        }
+
+        @Override
+        public Step nextStep(State state) {
+            EntryOperator entryOperator = state.getOperator();
+            EntryEventType modificationType = entryOperator.getEventType();
+            if (modificationType != null) {
+                return DO_POST_OPERATE_OPS;
+            }
+
+            return UtilSteps.SEND_RESPONSE;
         }
     },
 
@@ -83,6 +122,9 @@ public enum EntryOpSteps implements Step<State> {
 
         @Override
         public Step nextStep(State state) {
+            if (state.isEntryProcessorOffload()) {
+                return EntryOpSteps.RUN_OFFLOADED_ENTRY_PROCESSOR;
+            }
             return EntryOpSteps.PROCESS;
         }
     },
@@ -90,37 +132,43 @@ public enum EntryOpSteps implements Step<State> {
     PROCESS() {
         @Override
         public void runStep(State state) {
-            if (state.isEntryProcessorOffload()) {
-                return;
-            }
-
             RecordStore recordStore = state.getRecordStore();
-            MapContainer mapContainer = recordStore.getMapContainer();
-            MapServiceContext mapServiceContext = mapContainer.getMapServiceContext();
 
             EntryOperator entryOperator = state.getOperator();
-            // If result is ready, EP can be null as
-            // in EntryOffloadableSetUnlockOperation
-            if (entryOperator.getEntryProcessor() != null) {
-                entryOperator.init(state.getKey(), state.getOldValue(),
-                        null, null, null, recordStore.isLocked(state.getKey()), state.getTtl());
+            entryOperator.init(state.getKey(), state.getOldValue(),
+                    null, null, null, recordStore.isLocked(state.getKey()), state.getTtl());
 
-                Object clonedOldValue = entryOperator.clonedOrRawOldValue();
+            Object clonedOldValue = entryOperator.clonedOrRawOldValue();
 
-                entryOperator.init(state.getKey(), clonedOldValue,
-                        null, null, null, recordStore.isLocked(state.getKey()), state.getTtl());
+            entryOperator.init(state.getKey(), clonedOldValue,
+                    null, null, null, recordStore.isLocked(state.getKey()), state.getTtl());
 
-                if (!entryOperator.checkCanProceed()) {
-                    entryOperator.onTouched();
-                    state.setStopExecution(true);
-                    return;
-                }
-                entryOperator.operateOnKeyValueInternal();
-
-                if (!entryOperator.isDidMatchPredicate()) {
-                    return;
-                }
+            if (!entryOperator.checkCanProceed()) {
+                entryOperator.onTouched();
+                state.setStopExecution(true);
+                return;
             }
+            entryOperator.operateOnKeyValueInternal();
+
+            state.setEntryOperator(entryOperator);
+        }
+
+        @Override
+        public Step nextStep(State state) {
+            EntryOperator entryOperator = state.getOperator();
+            if (!entryOperator.isDidMatchPredicate()) {
+                return AFTER_RUN;
+            }
+            return DO_POST_OPERATE_OPS;
+        }
+    },
+
+    DO_POST_OPERATE_OPS() {
+        @Override
+        public void runStep(State state) {
+            EntryOperator entryOperator = state.getOperator();
+            MapContainer mapContainer = state.getRecordStore().getMapContainer();
+            MapServiceContext mapServiceContext = mapContainer.getMapServiceContext();
 
             EntryEventType eventType = entryOperator.getEventType();
             if (eventType == null) {
@@ -130,7 +178,6 @@ public enum EntryOpSteps implements Step<State> {
                 switch (eventType) {
                     case ADDED:
                     case UPDATED:
-                        state.setStaticPutParams(StaticParams.SET_WITH_NO_ACCESS_PARAMS);
                         if (eventType == EntryEventType.UPDATED) {
                             entryOperator.onTouched();
                         }
@@ -147,20 +194,10 @@ public enum EntryOpSteps implements Step<State> {
                         throw new IllegalArgumentException("Unexpected event found:" + eventType);
                 }
             }
-
-            if (state.isUnlockNeededForEP()) {
-                ((EntryOffloadableSetUnlockOperation) state.getOperation()).unlockKey();
-            }
         }
 
         @Override
         public Step nextStep(State state) {
-            if (state.isEntryProcessorOffload()) {
-                EntryOperation operation = (EntryOperation) state.getOperation();
-                operation.new EntryOperationOffload(state.getOldValue()).start();
-                return UtilSteps.SEND_RESPONSE;
-            }
-
             EntryEventType eventType = state.getOperator().getEventType();
             if (eventType == null) {
                 return AFTER_RUN;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MultipleEntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MultipleEntryOpSteps.java
@@ -142,6 +142,7 @@ public enum MultipleEntryOpSteps implements Step<State> {
                                 state.getEntryProcessor(), state.getPredicate()));
 
                 EntryOpSteps.PROCESS.runStep(singleKeyState);
+                EntryOpSteps.DO_POST_OPERATE_OPS.runStep(singleKeyState);
 
                 EntryEventType eventType = singleKeyState.getOperator().getEventType();
                 if (eventType == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
@@ -100,8 +100,6 @@ public class State {
     private volatile Queue<InternalIndex> notMarkedIndexes;
     private volatile Set keysFromIndex;
     private volatile Throwable throwable;
-    private volatile EntryEventType modificationTypeForEP;
-    private volatile boolean unlockNeededForEP;
 
     public State(RecordStore recordStore, MapOperation operation) {
         this.recordStore = recordStore;
@@ -506,23 +504,5 @@ public class State {
 
     public List getBackupPairs() {
         return backupPairs;
-    }
-
-    public State setModificationTypeForEP(EntryEventType modificationTypeForEP) {
-        this.modificationTypeForEP = modificationTypeForEP;
-        return null;
-    }
-
-    public EntryEventType getModificationTypeForEP() {
-        return modificationTypeForEP;
-    }
-
-    public State setUnlockNeededForEP(boolean unlockNeededForEP) {
-        this.unlockNeededForEP = unlockNeededForEP;
-        return this;
-    }
-
-    public boolean isUnlockNeededForEP() {
-        return unlockNeededForEP;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
@@ -23,7 +23,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
@@ -32,15 +34,30 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category(SlowTest.class)
 public class EntryProcessorOffloadableBouncingNodesTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean runWithForceOffload;
+
+    @Parameterized.Parameters(name = "runWithForceOffload: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {false},
+                {true},
+        });
+    }
 
     public static final String MAP_NAME = "EntryProcessorOffloadableTest";
     public static final int COUNT_ENTRIES = 1000;
@@ -58,6 +75,8 @@ public class EntryProcessorOffloadableBouncingNodesTest extends HazelcastTestSup
 
     public Config getBouncingTestConfig() {
         Config config = getConfig();
+        config.setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(),
+                String.valueOf(runWithForceOffload));
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
         mapConfig.setAsyncBackupCount(1);

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.core.ReadOnly;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.internal.util.FutureUtil;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationMonitor;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -93,15 +94,22 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
     @Parameter(2)
     public int asyncBackupCount;
 
+    @Parameter(3)
+    public boolean runWithForceOffload;
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Parameters(name = "{index}: {0} sync={1} async={2}")
+    @Parameters(name = "{index}: {0} sync={1} async={2} runWithForceOffload={3}")
     public static Collection<Object[]> data() {
         return asList(new Object[][]{
-                {BINARY, 0, 0}, {OBJECT, 0, 0},
-                {BINARY, 1, 0}, {OBJECT, 1, 0},
-                {BINARY, 0, 1}, {OBJECT, 0, 1},
+                {BINARY, 0, 0, false},
+                {OBJECT, 0, 0, false},
+                {BINARY, 1, 0, false},
+                {OBJECT, 1, 0, false},
+                {BINARY, 0, 1, false},
+                {OBJECT, 0, 1, false},
+                {OBJECT, 1, 1, true},
         });
     }
 
@@ -112,6 +120,9 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
     @Override
     public Config getConfig() {
         Config config = smallInstanceConfig();
+        config.setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(),
+                String.valueOf(runWithForceOffload));
+        config.getMetricsConfig().setEnabled(false);
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(inMemoryFormat);
         mapConfig.setAsyncBackupCount(asyncBackupCount);
@@ -730,7 +741,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
 
         // not locked -> will offload
         String thread = map.executeOnKey(key, new ThreadSneakingOffloadableEntryProcessor<>());
-        assertTrue(thread.contains("cached.thread"));
+        assertTrue(thread, thread.contains("cached.thread"));
 
         // locked -> won't offload
         map.lock(key);
@@ -745,12 +756,12 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
 
         // not locked -> will offload
         String thread = map.executeOnKey(key, new ThreadSneakingOffloadableReadOnlyEntryProcessor<>());
-        assertTrue(thread.contains("cached.thread"));
+        assertTrue(thread, thread.contains("cached.thread"));
 
         // locked -> will offload
         map.lock(key);
         thread = map.executeOnKey(key, new ThreadSneakingOffloadableReadOnlyEntryProcessor<>());
-        assertTrue(thread.contains("cached.thread"));
+        assertTrue(thread, thread.contains("cached.thread"));
     }
 
     private static class ThreadSneakingOffloadableEntryProcessor<K, V>
@@ -787,7 +798,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testEntryProcessorWithKey_localNotReentrant() throws ExecutionException, InterruptedException {
+    public void testEntryProcessorWithKey_localNotReentrant() {
         String key = init();
         IMap<String, SimpleValue> map = instances[1].getMap(MAP_NAME);
         int count = 100;


### PR DESCRIPTION
ee: https://github.com/hazelcast/hazelcast-enterprise/pull/5266

**Issue:**
Fixing failures in this nightly test: https://jenkins.hazelcast.com/view/force-offload-map/job/force-offload-Hazelcast-EE-master-OracleJDK8-nightly-clone/lastCompletedBuild/testReport/

**Modifications:**
- Reverted changes in `EntryOffloadableSetUnlockOperation` which is done in #22038. No need lock and unlock when map-store-offload in use, since only one operation for a partition can run at the same time for a map-store-offload-enabled map. Only one operation execution per map is guaranteed by design of map-store-offload mechanism. In current behavior, when we lock a key, other operations have to wait for unlock. It is same behavior from this perspective.
- Used Steps engine for EP-offload. Stepped approach already provides offload logic per se. See `EntryOpSteps` to check how it works.

**Note:** 
Read-only EP execution will be running as-is if entry is available in memory, this is same with current behavior. So even map-store-offload in use, there can be multiple read-only EP running in parallel for a key.



Follow-up of https://github.com/hazelcast/hazelcast/pull/22038