### PR TITLE
Use assertOpenEventually in failing ClientExecutorServiceTest API-1397

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceTest.java
@@ -227,7 +227,7 @@ public class ClientExecutorServiceTest {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertOpenEventually(latch);
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
This test was failing because there was 10 seconds of timeout. I used assertOpenEventually instead which has 120 seconds of timeout by default.

Fixes #19784

Breaking changes (list specific methods/types/messages):
- None


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
