### PR TITLE
Handle default package in the zero-config Compact serializers better for Java 8

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -215,7 +215,24 @@ public final class CompactUtil {
     private static boolean canBeSerializedAsCompact(Class<?> clazz) {
         Package classPackage = clazz.getPackage();
         if (classPackage == null) {
-            return false;
+            // If the Java version is 8, we can hit this branch if the user
+            // class does not have a package defined for it (the default
+            // package). In Java 9 and above, in that case, we won't hit this,
+            // but it will return a package whose name is an empty string.
+
+            // In Java 9 and above, the method returns null if the class is
+            // primitive, array or Void.
+
+            // We won't hit this line for primitive types, as they are already
+            // supported by the reflective serializers. For arrays, we can only
+            // hit this line for arrays of arrays which is not supported by
+            // Compact. And, Void is not a type we support in the Compact
+            // serialization.
+
+            // So, we can return false here, if the clazz is one of the types
+            // mentioned above, and return true if not, to be able to serialize
+            // user classes without a package in Java 8.
+            return !clazz.isPrimitive() && !clazz.isArray() && !Void.class.equals(clazz);
         }
 
         String name = classPackage.getName();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -301,6 +301,26 @@ public class CompactSerializationTest {
     }
 
     @Test
+    public void testSerializingClassReflectively_withArrayOfArrayField() {
+        SerializationService service = createSerializationService(new SerializationConfig());
+        assertThatThrownBy(() -> {
+                service.toData(new ClassWithArrayOfArrayField());
+        }).isInstanceOf(HazelcastSerializationException.class)
+                .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
+                .hasStackTraceContaining("which uses this class in its fields");
+    }
+
+    @Test
+    public void testSerializingClassReflectively_withVoidField() {
+        SerializationService service = createSerializationService(new SerializationConfig());
+        assertThatThrownBy(() -> {
+            service.toData(new ClassWithVoidField());
+        }).isInstanceOf(HazelcastSerializationException.class)
+                .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
+                .hasStackTraceContaining("which uses this class in its fields");
+    }
+
+    @Test
     public void testWritingArrayOfCompactGenericRecordField_withDifferentSchemas() {
         SerializationService service = createSerializationService(new SerializationConfig());
 
@@ -460,6 +480,14 @@ public class CompactSerializationTest {
 
     private static class ClassWithUnsupportedArrayField {
         private LinkedList<String>[] lists;
+    }
+
+    private static class ClassWithArrayOfArrayField {
+        private int[][] arrays;
+    }
+
+    private static class ClassWithVoidField {
+        private Void aVoid;
     }
 
     private static class ClassWithCollectionFields {


### PR DESCRIPTION
In Java 9 and above, for the classes in the default package, the
`clazz.getPackage()` method returns a non-null package with an
empty class name.

However, it returns a null package in Java 8, for the same classes.

We were saying that a class is not-zero-config-serializable if the
package was null (because it is null if it is a primitive type, array
or void in Java 9+, which are not supported in the paths that we do
the checks in this method). That was not correct in Java 8.

Now, if the package is null, we are performing the checks done in
Java 9+ and above again to distinguish classes in the default package.