### PR TITLE
[API-1531] Send client state to cluster in re-connections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -961,7 +961,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                 // The first connection that opens a connection to the new cluster should set `clusterId`.
                 // This one will initiate `initializeClientOnCluster` if necessary.
                 clusterId = newClusterId;
-                if (clusterIdChanged || establishedInitialClusterConnection) {
+                if (establishedInitialClusterConnection) {
                     // In split brain, the client might connect to the one half
                     // of the cluster, and then later might reconnect to the
                     // other half, after the half it was connected to is

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -968,12 +968,12 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                     // completely dead. Since the cluster id is preserved in
                     // split brain scenarios, it is impossible to distinguish
                     // reconnection to the same cluster vs reconnection to the
-                    // other half of the split brain. However, in latter,
+                    // other half of the split brain. However, in the latter,
                     // we might need to send some state to the other half of
                     // the split brain (like Compact schemas or user code
-                    // deployment classes). That forces us to send client state
-                    // to the cluster after first cluster connection, regardless
-                    // the cluster id is changed or not.
+                    // deployment classes). That forces us to send the client
+                    // state to the cluster after the first cluster connection,
+                    // regardless the cluster id is changed or not.
                     clientState = ClientState.CONNECTED_TO_CLUSTER;
                     executor.execute(() -> initializeClientOnCluster(newClusterId));
                 } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
@@ -161,9 +161,10 @@ public class ClientUserCodeDeploymentService {
     }
 
     public void deploy(HazelcastClientInstanceImpl client) throws ExecutionException, InterruptedException {
-        if (!clientUserCodeDeploymentConfig.isEnabled()) {
+        if (!clientUserCodeDeploymentConfig.isEnabled() || classDefinitionList.isEmpty()) {
             return;
         }
+
         ClientMessage request = ClientDeployClassesCodec.encodeRequest(classDefinitionList);
         ClientInvocation invocation = new ClientInvocation(client, request, null);
         ClientInvocationFuture future = invocation.invokeUrgent();

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -21,10 +21,10 @@ import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
@@ -38,9 +38,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.instance.impl.TestUtil.getNode;
 import static com.hazelcast.test.Accessors.getClientEngineImpl;
 import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
 import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
@@ -51,10 +53,11 @@ import static org.junit.Assert.assertTrue;
 @Category(NightlyTest.class)
 public class ClientSplitBrainTest extends ClientTestSupport {
 
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
     @After
-    public void cleanup() {
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+    public void tearDown() throws Exception {
+        factory.terminateAll();
     }
 
     @Test
@@ -62,11 +65,11 @@ public class ClientSplitBrainTest extends ClientTestSupport {
         Config config = new Config()
                 .setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
                 .setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
-        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
 
         final ClientConfig clientConfig = new ClientConfig();
-        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
 
         final String mapName = randomMapName();
         final IMap mapNode1 = h1.getMap(mapName);
@@ -166,13 +169,12 @@ public class ClientSplitBrainTest extends ClientTestSupport {
         config.setProperty(ClusterProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "5");
         config.setProperty(ClusterProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
 
-        TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
 
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        HazelcastInstance client = factory.newHazelcastClient();
 
-        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
-        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+        HazelcastInstance h3 = factory.newHazelcastInstance(config);
 
         HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
 
@@ -214,7 +216,77 @@ public class ClientSplitBrainTest extends ClientTestSupport {
         assertEquals(1, clientEngineImpl1.getClientEndpointCount());
         assertEquals(1, clientEngineImpl2.getClientEndpointCount());
         assertEquals(1, clientEngineImpl3.getClientEndpointCount());
+    }
 
-        hazelcastFactory.shutdownAll();
+    @Test
+    public void testMemberList_afterConnectingToOtherHalf() {
+        Config config = smallInstanceConfig();
+        config.getJetConfig().setEnabled(false);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+
+        // Client now has the cluster view listener registered to instance1
+        HazelcastInstance client = factory.newHazelcastClient();
+
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(4, instance1, instance2, instance3, instance4);
+
+        // split the cluster [1, 3, 4], [2]
+        blockCommunicationBetween(instance2, instance1);
+        blockCommunicationBetween(instance2, instance3);
+        blockCommunicationBetween(instance2, instance4);
+
+        // make sure that each member quickly drops the other from their member list
+        suspectMember(instance1, instance2);
+        suspectMember(instance2, instance1);
+        suspectMember(instance3, instance2);
+        suspectMember(instance2, instance3);
+        suspectMember(instance4, instance2);
+        suspectMember(instance2, instance4);
+
+        assertClusterSizeEventually(3, instance1, instance3, instance4);
+        assertClusterSizeEventually(1, instance2);
+
+        // make sure that the client is connected to [1, 3, 4]
+        assertTrueEventually(() -> {
+            assertEquals(3, client.getCluster().getMembers().size());
+        });
+
+        // Shutdown 3 and 4 to make sure that the member list version in
+        // instance1 is greater than the instance2
+        instance3.shutdown();
+        instance4.shutdown();
+
+        assertTrueEventually(() -> {
+            int memberListVersion1 = getNode(instance1).getClusterService().getMemberListVersion();
+            int memberListVersion2 = getNode(instance2).getClusterService().getMemberListVersion();
+            assertTrue(memberListVersion1 > memberListVersion2);
+        });
+
+        // make sure the client has received the member list updates for 3 and 4
+        assertTrueEventually(() -> {
+            assertEquals(1, client.getCluster().getMembers().size());
+        });
+
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
+
+        instance1.shutdown();
+
+        // wait until the client reconnects to instance2
+        assertOpenEventually(reconnectListener.reconnectedLatch);
+
+        // make sure that the member list is updated with the instance 2, despite
+        // the fact that it has a member list version less than the previously
+        // set value
+        assertTrueEventually(() -> {
+            Set<Member> members = client.getCluster().getMembers();
+            assertEquals(1, members.size());
+
+            Member member = members.iterator().next();
+            assertEquals(instance2.getLocalEndpoint().getUuid(), member.getUuid());
+        });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -162,7 +162,7 @@ public class ClientUserCodeDeploymentTest extends ClientTestSupport {
     }
 
     @Test
-    public void testWithSplitBrain_clientReconnectsToOtherHalf() {
+    public void testClassesAreDeployed_whenClientReconnectsToOtherHalf() {
         ClientConfig clientConfig = createClientConfig();
         Config config = createNodeConfig();
 

--- a/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientUserCodeDeploymentConfig;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.AttributeConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.UserCodeDeploymentConfig;
@@ -50,8 +51,10 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
@@ -60,7 +63,7 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientUserCodeDeploymentTest extends ClientTestSupport {
 
-    private TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
 
     @After
     public void tearDown() throws Exception {
@@ -140,7 +143,7 @@ public class ClientUserCodeDeploymentTest extends ClientTestSupport {
     }
 
     @Test
-    public void testWithMultipleNodes_clientReconnectsToNewNode() throws InterruptedException {
+    public void testWithMultipleNodes_clientReconnectsToNewNode() {
         ClientConfig clientConfig = createClientConfig();
         Config config = createNodeConfig();
 
@@ -155,6 +158,46 @@ public class ClientUserCodeDeploymentTest extends ClientTestSupport {
         factory.newHazelcastInstance(config);
 
         assertOpenEventually(reconnectListener.reconnectedLatch);
+        assertCodeDeploymentWorking(client, new IncrementingEntryProcessor());
+    }
+
+    @Test
+    public void testWithSplitBrain_clientReconnectsToOtherHalf() {
+        ClientConfig clientConfig = createClientConfig();
+        Config config = createNodeConfig();
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(2, instance1, instance2);
+
+        // split the cluster
+        blockCommunicationBetween(instance1, instance2);
+
+        // make sure that each member quickly drops the other from their member list
+        suspectMember(instance1, instance2);
+        suspectMember(instance2, instance1);
+
+        assertClusterSizeEventually(1, instance1);
+        assertClusterSizeEventually(1, instance2);
+
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        Set<Member> members = client.getCluster().getMembers();
+        assertEquals(1, members.size());
+
+        UUID connectedMemberUUID = members.iterator().next().getUuid();
+
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
+
+        if (connectedMemberUUID.equals(instance1.getLocalEndpoint().getUuid())) {
+            instance1.shutdown();
+        } else {
+            instance2.shutdown();
+        }
+
+        assertOpenEventually(reconnectListener.reconnectedLatch);
+
         assertCodeDeploymentWorking(client, new IncrementingEntryProcessor());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -53,7 +53,6 @@ import static org.mockito.Mockito.when;
 public final class CompactTestUtil {
 
     private CompactTestUtil() {
-
     }
 
     @Nonnull

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/ClientCompactSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/ClientCompactSplitBrainTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl.compact.integration;
+
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.impl.compact.CompactTestUtil;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import example.serialization.EmployeeDTO;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientCompactSplitBrainTest extends ClientTestSupport {
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() throws Exception {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testWithSplitBrain_clientReconnectsToOtherHalf() {
+        Config config = smallInstanceConfig();
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(2, instance1, instance2);
+
+        // split the cluster
+        blockCommunicationBetween(instance1, instance2);
+
+        // make sure that each member quickly drops the other from their member list
+        suspectMember(instance1, instance2);
+        suspectMember(instance2, instance1);
+
+        assertClusterSizeEventually(1, instance1);
+        assertClusterSizeEventually(1, instance2);
+
+        HazelcastInstance client = factory.newHazelcastClient();
+        Set<Member> members = client.getCluster().getMembers();
+        assertEquals(1, members.size());
+
+        HazelcastInstance connectedMember;
+        if (members.iterator().next().getUuid().equals(instance1.getLocalEndpoint().getUuid())) {
+            connectedMember = instance1;
+        } else {
+            connectedMember = instance2;
+        }
+
+        // Put a compact serializable object
+        IMap<Integer, EmployeeDTO> map = client.getMap("test");
+        map.put(1, new EmployeeDTO(1, 1));
+
+        CompactTestUtil.assertSchemasAvailable(Collections.singletonList(connectedMember), EmployeeDTO.class);
+
+        ReconnectListener reconnectListener = new ReconnectListener();
+        client.getLifecycleService().addLifecycleListener(reconnectListener);
+
+        connectedMember.shutdown();
+
+        assertOpenEventually(reconnectListener.reconnectedLatch);
+
+        HazelcastInstance reconnectedMember = connectedMember == instance1
+                ? instance2
+                : instance1;
+
+        // It might take a while until the state is sent from the client to the
+        // reconnected member
+        assertTrueEventually(() -> {
+            CompactTestUtil.assertSchemasAvailable(Collections.singletonList(reconnectedMember), EmployeeDTO.class);
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/ClientCompactSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/integration/ClientCompactSplitBrainTest.java
@@ -50,7 +50,7 @@ public class ClientCompactSplitBrainTest extends ClientTestSupport {
     }
 
     @Test
-    public void testWithSplitBrain_clientReconnectsToOtherHalf() {
+    public void testLocalSchemasAreSent_whenClientReconnectsToOtherHalf() {
         Config config = smallInstanceConfig();
 
         HazelcastInstance instance1 = factory.newHazelcastInstance(config);


### PR DESCRIPTION
In split-brain scenarios, the cluster id stays the same for different halves of the split.

When the client disconnects from the first half it was connected to and reconnects to the other half, from the point of view of the client, it connects to the same cluster.

However, it might very well be the case that, the client has sent some state to the first half of the cluster, and that state must be replicated to the other half when the client reconnects to it.

This is especially needed for Compact schemas and user code deployment classes.

In this PR, we are sending the client state to the cluster after reconnections, regardless it is connected back to possibly the same cluster with the same id or not.