### PR TITLE
Patch client authentication information leak API-1534

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpoint.java
@@ -123,4 +123,10 @@ public interface ClientEndpoint extends Client, DynamicMetricsProvider {
      * @return the time this endpoint is created
      */
     long getCreationTime();
+
+    /**
+     * Similar to {@link ClientEndpointImpl#toString()} but lacks some information due to security reasons.
+     * Used when handling unauthenticated requests.
+     */
+    String toSecureString();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -287,9 +287,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
         return "ClientEndpoint{"
                 + "clientUuid=" + clientUuid
                 + ", clientName=" + clientName
-                + ", authenticated=" + authenticated
                 + ", clientVersion=" + clientVersion
-                + ", creationTime=" + creationTime
                 + ", labels=" + labels
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -283,6 +283,18 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     }
 
     @Override
+    public String toSecureString() {
+        return "ClientEndpoint{"
+                + "clientUuid=" + clientUuid
+                + ", clientName=" + clientName
+                + ", authenticated=" + authenticated
+                + ", clientVersion=" + clientVersion
+                + ", creationTime=" + creationTime
+                + ", labels=" + labels
+                + '}';
+    }
+
+    @Override
     public void provideDynamicMetrics(MetricDescriptor descriptor, MetricsCollectionContext context) {
         ClientStatistics clientStatistics = statsRef.get();
         if (clientStatistics != null && clientStatistics.metricsBlob() != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -170,8 +170,9 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         Exception exception;
         if (nodeEngine.isRunning()) {
             String message = "Client " + endpoint + " must authenticate before any operation.";
+            String secureMessage = "Client " + endpoint.toSecureString() + " must authenticate before any operation.";
             logger.severe(message);
-            exception = new RetryableHazelcastException(new AuthenticationException(message));
+            exception = new RetryableHazelcastException(new AuthenticationException(secureMessage));
         } else {
             exception = new HazelcastInstanceNotActiveException();
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -168,16 +168,21 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
 
     private void handleAuthenticationFailure() {
         Exception exception;
+        String closeReason;
         if (nodeEngine.isRunning()) {
             String message = "Client " + endpoint + " must authenticate before any operation.";
             String secureMessage = "Client " + endpoint.toSecureString() + " must authenticate before any operation.";
+
             logger.severe(message);
+
+            closeReason = new AuthenticationException(message).getMessage();
             exception = new RetryableHazelcastException(new AuthenticationException(secureMessage));
         } else {
             exception = new HazelcastInstanceNotActiveException();
+            closeReason = exception.getMessage();
         }
         sendClientMessage(exception);
-        connection.close("Authentication failed. " + exception.getMessage(), null);
+        connection.close("Authentication failed. " + closeReason, null);
     }
 
     private void logProcessingFailure(Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -175,7 +175,7 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
 
             logger.severe(message);
 
-            closeReason = new AuthenticationException(message).getMessage();
+            closeReason = message;
             exception = new RetryableHazelcastException(new AuthenticationException(secureMessage));
         } else {
             exception = new HazelcastInstanceNotActiveException();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -172,19 +172,19 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
         logger.warning("Received auth from " + connection + " with clientUuid " + clientUuid
                 + " and clientName " + clientName + ", authentication failed");
         byte status = CREDENTIALS_FAILED.getId();
-        return encodeAuth(status, null, null, serializationService.getVersion(), -1, null, clientFailoverSupported, false);
+        return encodeAuth(status, null, null, (byte) -1, -1, null, clientFailoverSupported, false);
     }
 
     private ClientMessage prepareNotAllowedInCluster() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
         byte status = NOT_ALLOWED_IN_CLUSTER.getId();
-        return encodeAuth(status, null, null, serializationService.getVersion(), -1, null, clientFailoverSupported, false);
+        return encodeAuth(status, null, null, (byte) -1, -1, null, clientFailoverSupported, false);
     }
 
     private ClientMessage prepareSerializationVersionMismatchClientMessage() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
-        return encodeAuth(SERIALIZATION_VERSION_MISMATCH.getId(), null, null, serializationService.getVersion(), -1,
-                null, clientFailoverSupported, false);
+        return encodeAuth(SERIALIZATION_VERSION_MISMATCH.getId(), null, null, (byte) -1, -1, null, clientFailoverSupported,
+                false);
     }
 
     private ClientMessage prepareAuthenticatedClientMessage() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -172,25 +172,21 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
         logger.warning("Received auth from " + connection + " with clientUuid " + clientUuid
                 + " and clientName " + clientName + ", authentication failed");
         byte status = CREDENTIALS_FAILED.getId();
-        return encodeAuth(status, null, null, serializationService.getVersion(),
-                clientEngine.getPartitionService().getPartitionCount(), clientEngine.getClusterService().getClusterId(),
-                clientFailoverSupported);
+        return encodeAuth(status, null, null, serializationService.getVersion(), -1,
+                clientEngine.getClusterService().getClusterId(), clientFailoverSupported, false);
     }
 
     private ClientMessage prepareNotAllowedInCluster() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
         byte status = NOT_ALLOWED_IN_CLUSTER.getId();
-        return encodeAuth(status, null, null, serializationService.getVersion(),
-                clientEngine.getPartitionService().getPartitionCount(), clientEngine.getClusterService().getClusterId(),
-                clientFailoverSupported);
+        return encodeAuth(status, null, null, serializationService.getVersion(), -1,
+                clientEngine.getClusterService().getClusterId(), clientFailoverSupported, false);
     }
 
     private ClientMessage prepareSerializationVersionMismatchClientMessage() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
-        return encodeAuth(SERIALIZATION_VERSION_MISMATCH.getId(), null, null,
-                serializationService.getVersion(),
-                clientEngine.getPartitionService().getPartitionCount(),
-                clientEngine.getClusterService().getClusterId(), clientFailoverSupported);
+        return encodeAuth(SERIALIZATION_VERSION_MISMATCH.getId(), null, null, serializationService.getVersion(), -1,
+                clientEngine.getClusterService().getClusterId(), clientFailoverSupported, false);
     }
 
     private ClientMessage prepareAuthenticatedClientMessage() {
@@ -216,7 +212,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
         byte status = AUTHENTICATED.getId();
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
         return encodeAuth(status, thisAddress, uuid, serializationService.getVersion(),
-                clientEngine.getPartitionService().getPartitionCount(), clusterId, clientFailoverSupported);
+                clientEngine.getPartitionService().getPartitionCount(), clusterId, clientFailoverSupported, true);
     }
 
     private void setConnectionType() {
@@ -225,7 +221,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
 
     protected abstract ClientMessage encodeAuth(byte status, Address thisAddress, UUID uuid,
                                                 byte serializationVersion,
-                                                int partitionCount, UUID clusterId, boolean failoverSupported);
+                                                int partitionCount, UUID clusterId, boolean failoverSupported,
+                                                boolean isAuthenticated);
 
     protected abstract String getClientType();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -172,21 +172,19 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMessageTa
         logger.warning("Received auth from " + connection + " with clientUuid " + clientUuid
                 + " and clientName " + clientName + ", authentication failed");
         byte status = CREDENTIALS_FAILED.getId();
-        return encodeAuth(status, null, null, serializationService.getVersion(), -1,
-                clientEngine.getClusterService().getClusterId(), clientFailoverSupported, false);
+        return encodeAuth(status, null, null, serializationService.getVersion(), -1, null, clientFailoverSupported, false);
     }
 
     private ClientMessage prepareNotAllowedInCluster() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
         byte status = NOT_ALLOWED_IN_CLUSTER.getId();
-        return encodeAuth(status, null, null, serializationService.getVersion(), -1,
-                clientEngine.getClusterService().getClusterId(), clientFailoverSupported, false);
+        return encodeAuth(status, null, null, serializationService.getVersion(), -1, null, clientFailoverSupported, false);
     }
 
     private ClientMessage prepareSerializationVersionMismatchClientMessage() {
         boolean clientFailoverSupported = nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
         return encodeAuth(SERIALIZATION_VERSION_MISMATCH.getId(), null, null, serializationService.getVersion(), -1,
-                clientEngine.getClusterService().getClusterId(), clientFailoverSupported, false);
+                null, clientFailoverSupported, false);
     }
 
     private ClientMessage prepareAuthenticatedClientMessage() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
@@ -66,10 +66,14 @@ public class AuthenticationCustomCredentialsMessageTask
 
     @Override
     protected ClientMessage encodeAuth(byte status, Address thisAddress, UUID uuid, byte version,
-                                       int partitionCount, UUID clusterId, boolean clientFailoverSupported) {
-        return ClientAuthenticationCustomCodec
-                .encodeResponse(status, thisAddress, uuid, version,
-                        getMemberBuildInfo().getVersion(), partitionCount, clusterId, clientFailoverSupported);
+                                       int partitionCount, UUID clusterId, boolean clientFailoverSupported,
+                                       boolean isAuthenticated) {
+        String serverHazelcastVersion = "";
+        if (isAuthenticated) {
+            serverHazelcastVersion = getMemberBuildInfo().getVersion();
+        }
+        return ClientAuthenticationCustomCodec.encodeResponse(status, thisAddress, uuid, version,
+                        serverHazelcastVersion, partitionCount, clusterId, clientFailoverSupported);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
@@ -59,9 +59,14 @@ public class AuthenticationMessageTask extends AuthenticationBaseMessageTask<Cli
 
     @Override
     protected ClientMessage encodeAuth(byte status, Address thisAddress, UUID uuid, byte version,
-                                       int partitionCount, UUID clusterId, boolean clientFailoverSupported) {
-        return ClientAuthenticationCodec.encodeResponse(status, thisAddress, uuid, version,
-                getMemberBuildInfo().getVersion(), partitionCount, clusterId, clientFailoverSupported);
+                                       int partitionCount, UUID clusterId, boolean clientFailoverSupported,
+                                       boolean isAuthenticated) {
+        String serverHazelcastVersion = "";
+        if (isAuthenticated) {
+            serverHazelcastVersion = getMemberBuildInfo().getVersion();
+        }
+        return ClientAuthenticationCodec.encodeResponse(status, thisAddress, uuid, version, serverHazelcastVersion,
+                partitionCount, clusterId, clientFailoverSupported);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
@@ -87,7 +87,7 @@ public class AuthenticationInformationLeakTest {
     }
 
     @Test
-    public void testAuthenticationExceptionDoesNotLeakInfo() {
+    public void testAuthenticationExceptionDoesNotLeakInfo() throws IOException {
         SerializationService ss = new DefaultSerializationServiceBuilder().build();
         InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
         try (Socket socket = new Socket()) {
@@ -100,8 +100,7 @@ public class AuthenticationInformationLeakTest {
             }
             assertEquals(res.getMessageType(), ErrorsCodec.EXCEPTION_MESSAGE_TYPE);
             ClientExceptionFactory factory = new ClientExceptionFactory(false, Thread.currentThread().getContextClassLoader());
-            throw factory.createException(res);
-        } catch (Throwable err) {
+            Throwable err = factory.createException(res);
             String message = err.getMessage();
             assertInstanceOf(AuthenticationException.class, err.getCause());
             assertContains(message, "must authenticate before any operation");

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
@@ -104,7 +104,11 @@ public class AuthenticationInformationLeakTest {
             String message = err.getMessage();
             assertInstanceOf(AuthenticationException.class, err.getCause());
             assertContains(message, "must authenticate before any operation");
-            assertNotContains(message.toLowerCase(), "connection");
+            String messageLowerCase = message.toLowerCase();
+            assertNotContains(messageLowerCase, "connection");
+            assertNotContains(messageLowerCase, "authenticated");
+            assertNotContains(messageLowerCase, "creationTime");
+            assertNotContains(messageLowerCase, "clientAttributes");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
@@ -87,7 +87,7 @@ public class AuthenticationInformationLeakTest {
     }
 
     @Test
-    public void testAuthenticationExceptionDoesNotLeakInfo() throws Exception {
+    public void testAuthenticationExceptionDoesNotLeakInfo() {
         SerializationService ss = new DefaultSerializationServiceBuilder().build();
         InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
         try (Socket socket = new Socket()) {
@@ -101,9 +101,9 @@ public class AuthenticationInformationLeakTest {
             assertEquals(res.getMessageType(), ErrorsCodec.EXCEPTION_MESSAGE_TYPE);
             ClientExceptionFactory factory = new ClientExceptionFactory(false, Thread.currentThread().getContextClassLoader());
             throw factory.createException(res);
-        } catch (Throwable runtimeException) {
-            String message = runtimeException.getMessage();
-            assertInstanceOf(AuthenticationException.class, runtimeException.getCause());
+        } catch (Throwable err) {
+            String message = err.getMessage();
+            assertInstanceOf(AuthenticationException.class, err.getCause());
             assertContains(message, "must authenticate before any operation");
             assertNotContains(message.toLowerCase(), "connection");
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationLeakTest.java
@@ -107,8 +107,7 @@ public class AuthenticationLeakTest {
             String message = runtimeException.getMessage();
             assertContains(message, "AuthenticationException");
             assertContains(message, "must authenticate before any operation");
-            assertNotContains(message, "connection");
-            assertNotContains(message, "Connection");
+            assertNotContains(message.toLowerCase(), "connection");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationLeakTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.impl.ClientSelectors;
+import com.hazelcast.client.impl.protocol.AuthenticationStatus;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCodec;
+import com.hazelcast.client.impl.protocol.codec.MapGetCodec;
+import com.hazelcast.client.impl.protocol.codec.builtin.ErrorsCodec;
+import com.hazelcast.client.impl.protocol.exception.ErrorHolder;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.util.HashUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
+import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
+import static com.hazelcast.internal.nio.IOUtil.readFully;
+import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
+import static com.hazelcast.test.Accessors.getClientEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.assertContains;
+import static com.hazelcast.test.HazelcastTestSupport.assertNotContains;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({ SlowTest.class })
+public class AuthenticationLeakTest {
+
+    static byte serVersion;
+    HazelcastInstance instance;
+    String clusterName;
+
+    @BeforeClass
+    public static void setupClass() {
+        InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+        serVersion = ss.getVersion();
+    }
+
+    @Before
+    public void setup() {
+        clusterName = randomString();
+        Config config = new Config();
+        config.setClusterName(clusterName);
+        instance = Hazelcast.newHazelcastInstance(config);
+    }
+
+    @After
+    public void cleanUp() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testAuthenticationExceptionDoesNotLeakInfo() throws Exception {
+        SerializationService ss = new DefaultSerializationServiceBuilder().build();
+        InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
+        try (Socket socket = new Socket()) {
+            socket.setReuseAddress(true);
+            socket.connect(endpoint);
+            try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
+                getKeyValue(ss, os, is);
+            }
+        } catch (RuntimeException runtimeException) {
+            String message = runtimeException.getMessage();
+            assertContains(message, "AuthenticationException");
+            assertContains(message, "must authenticate before any operation");
+            assertNotContains(message, "connection");
+            assertNotContains(message, "Connection");
+        }
+    }
+
+    @Test
+    public void testFailedAuthenticationDoesNotLeakInfoCredentialsFailed() throws Exception {
+        authenticateAndAssert(AuthenticationStatus.CREDENTIALS_FAILED, serVersion, true, clusterName);
+    }
+
+    @Test
+    public void testFailedAuthenticationDoesNotLeakInfoSerializationVersionMismatch() throws Exception {
+        authenticateAndAssert(AuthenticationStatus.SERIALIZATION_VERSION_MISMATCH, (byte) (serVersion + 1), false, clusterName);
+    }
+
+    @Test
+    public void testFailedAuthenticationDoesNotLeakInfoClientNotAllowed() throws Exception {
+        // No client is allowed in the cluster
+        getClientEngineImpl(instance).applySelector(ClientSelectors.none());
+        authenticateAndAssert(AuthenticationStatus.NOT_ALLOWED_IN_CLUSTER, serVersion, false, clusterName);
+    }
+
+    private void authenticateAndAssert(AuthenticationStatus status, byte serVersion, boolean useWrongClusterName, String clusterName) throws IOException {
+        InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
+        try (Socket socket = new Socket()) {
+            socket.setReuseAddress(true);
+            socket.connect(endpoint);
+            try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
+                os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
+                String clientClusterName = useWrongClusterName ? clusterName + 'a' : clusterName;
+                ClientMessage res = authenticate(clientClusterName, serVersion, os, is);
+                ClientAuthenticationCodec.ResponseParameters responseParameters = ClientAuthenticationCodec.decodeResponse(res);
+                assertEquals(status.getId(), responseParameters.status);
+                assertEquals(-1, responseParameters.partitionCount);
+                assertNull(responseParameters.address);
+                assertNull(responseParameters.memberUuid);
+                assertNull(responseParameters.clusterId);
+            }
+        }
+    }
+
+    private ClientMessage authenticate(String clusterName, byte serVersion, OutputStream os, InputStream is)
+            throws IOException {
+        UUID uuid = new UUID(0, 0);
+        ClientMessage msg = ClientAuthenticationCodec.encodeRequest(clusterName, null, null, uuid, "", serVersion, "", "", new ArrayList<>());
+        writeClientMessage(os, msg);
+        return readResponse(is, ClientAuthenticationCodec.RESPONSE_MESSAGE_TYPE);
+    }
+
+    private void getKeyValue(SerializationService ss, OutputStream os, InputStream is)
+            throws IOException {
+        Data keyData = ss.toData("key");
+        ClientMessage msg = MapGetCodec.encodeRequest("mapName", keyData, 0);
+        msg.setPartitionId(getPartitionId(keyData));
+        writeClientMessage(os, msg);
+        readResponse(is, MapGetCodec.RESPONSE_MESSAGE_TYPE);
+    }
+
+    private int getPartitionId(Data keyData) {
+        int hash = keyData.getPartitionHash();
+        return HashUtil.hashToIndex(hash, 271);
+    }
+
+    private void writeClientMessage(OutputStream os, final ClientMessage clientMessage) throws IOException {
+        for (ClientMessage.ForwardFrameIterator it = clientMessage.frameIterator(); it.hasNext();) {
+            ClientMessage.Frame frame = it.next();
+            os.write(frameAsBytes(frame, !it.hasNext()));
+        }
+        os.flush();
+    }
+
+    private byte[] frameAsBytes(ClientMessage.Frame frame, boolean isLastFrame) {
+        byte[] content = frame.content != null ? frame.content : new byte[0];
+        int frameSize = content.length + SIZE_OF_FRAME_LENGTH_AND_FLAGS;
+        ByteBuffer buffer = ByteBuffer.allocateDirect(frameSize);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        buffer.putInt(frameSize);
+        if (!isLastFrame) {
+            buffer.putShort((short) frame.flags);
+        } else {
+            buffer.putShort((short) (frame.flags | IS_FINAL_FLAG));
+        }
+        buffer.put(content);
+        return byteBufferToBytes(buffer);
+    }
+
+    private static byte[] byteBufferToBytes(ByteBuffer buffer) {
+        upcast(buffer).flip();
+        byte[] requestBytes = new byte[buffer.limit()];
+        buffer.get(requestBytes);
+        return requestBytes;
+    }
+
+    private ClientMessage readResponse(InputStream is, int expectedMsgType) throws IOException {
+        ClientMessage clientMessage = ClientMessage.createForEncode();
+        int msgType;
+        do {
+            while (true) {
+                ByteBuffer frameSizeBuffer = ByteBuffer.allocate(SIZE_OF_FRAME_LENGTH_AND_FLAGS);
+                frameSizeBuffer.order(ByteOrder.LITTLE_ENDIAN);
+                readFully(is, frameSizeBuffer.array());
+                int frameSize = frameSizeBuffer.getInt();
+                int flags = frameSizeBuffer.getShort() & 0xffff;
+                byte[] content = new byte[frameSize - SIZE_OF_FRAME_LENGTH_AND_FLAGS];
+                readFully(is, content);
+                clientMessage.add(new ClientMessage.Frame(content, flags));
+                if (ClientMessage.isFlagSet(flags, IS_FINAL_FLAG)) {
+                    break;
+                }
+            }
+            msgType = clientMessage.getMessageType();
+            if (msgType == ErrorsCodec.EXCEPTION_MESSAGE_TYPE) {
+                List<ErrorHolder> err = ErrorsCodec.decode(clientMessage);
+                throw new RuntimeException(err.get(0).getMessage());
+            }
+        } while (msgType != expectedMsgType);
+        return clientMessage;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationLeakTest.java
@@ -141,6 +141,7 @@ public class AuthenticationLeakTest {
                 ClientAuthenticationCodec.ResponseParameters responseParameters = ClientAuthenticationCodec.decodeResponse(res);
                 assertEquals(status.getId(), responseParameters.status);
                 assertEquals(-1, responseParameters.partitionCount);
+                assertEquals(-1, responseParameters.serializationVersion);
                 assertNull(responseParameters.address);
                 assertNull(responseParameters.memberUuid);
                 assertNull(responseParameters.clusterId);

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
@@ -31,11 +31,13 @@ import com.hazelcast.test.starter.HazelcastStarter;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.ServerSocket;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
 import static java.lang.reflect.Proxy.isProxyClass;
 import static org.junit.Assert.fail;
@@ -250,5 +252,12 @@ public final class TestUtil {
      */
     public static String setSystemProperty(String key, String value) {
         return value == null ? System.clearProperty(key) : System.setProperty(key, value);
+    }
+
+    public static byte[] byteBufferToBytes(ByteBuffer buffer) {
+        upcast(buffer).flip();
+        byte[] requestBytes = new byte[buffer.limit()];
+        buffer.get(requestBytes);
+        return requestBytes;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/TestUtil.java
@@ -32,8 +32,6 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
@@ -41,9 +39,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
-import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
-import static com.hazelcast.internal.nio.IOUtil.readFully;
 import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
 
 public class TestUtil {
@@ -122,25 +117,7 @@ public class TestUtil {
             InputStream is = socket.getInputStream();
             os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
             ClientTestUtil.writeClientMessage(os, authenticationRequest);
-            readResponse(is);
-        }
-
-        private ClientMessage readResponse(InputStream is) throws IOException {
-            ClientMessage clientMessage = ClientMessage.createForEncode();
-            while (true) {
-                ByteBuffer frameSizeBuffer = ByteBuffer.allocate(SIZE_OF_FRAME_LENGTH_AND_FLAGS);
-                frameSizeBuffer.order(ByteOrder.LITTLE_ENDIAN);
-                readFully(is, frameSizeBuffer.array());
-                int frameSize = frameSizeBuffer.getInt();
-                int flags = frameSizeBuffer.getShort() & 0xffff;
-                byte[] content = new byte[frameSize - SIZE_OF_FRAME_LENGTH_AND_FLAGS];
-                readFully(is, content);
-                clientMessage.add(new ClientMessage.Frame(content, flags));
-                if (ClientMessage.isFlagSet(flags, IS_FINAL_FLAG)) {
-                    break;
-                }
-            }
-            return clientMessage;
+            ClientTestUtil.readResponse(is);
         }
     }
 


### PR DESCRIPTION
 This PR fixes the leaks mentioned in the issue. I added a new `toSecureString()` method to hide important details from unauthenticated entities. 

**From authentication failures I have removed:**

- partitionCount
- clusterId (I don't think requester needs to get this info but not sure if I did right)
- serverHazelcastVersion

**From `AuthenticationException` I have removed** (which happens when a request (e.g `Map.get()` in our test scenario) sent before authentication):

- connection related data (connection id being most important)
- client attributes

 **Regarding the test**, I could not find a way to trigger the leak using just the client (without using Socket). Therefore, I had to use real network.

**Breaking changes** (list specific methods/types/messages):
- None (as longs as our clients does not depend on information in authentication responses when auth fails)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
