### PR TITLE
Fix Throwable.initCause when exception already has cause API-1387

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -300,7 +300,8 @@ public final class ExceptionUtil {
                 try {
                     cloned.initCause(cause);
                 } catch (IllegalStateException ignored) {
-                    // Cause can be already set by the exception. See https://github.com/hazelcast/hazelcast/issues/21414
+                    // Cause can be already set by the exception. It can be set to null as well.
+                    // So doing null check is not the solution here. See https://github.com/hazelcast/hazelcast/issues/21414
                 }
                 return cloned;
             }
@@ -319,7 +320,8 @@ public final class ExceptionUtil {
                 try {
                     cloned.initCause(cause);
                 } catch (IllegalStateException ignored) {
-                    // Cause can be already set by the exception. See https://github.com/hazelcast/hazelcast/issues/21414
+                    // Cause can be already set by the exception. It can be set to null as well.
+                    // So doing null check is not the solution here. See https://github.com/hazelcast/hazelcast/issues/21414
                 }
                 return cloned;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -297,7 +297,11 @@ public final class ExceptionUtil {
             <T extends Throwable> T cloneWith(MethodHandle constructor, String message,
                                               @Nullable Throwable cause) throws Throwable {
                 T cloned = (T) constructor.invokeWithArguments(message);
-                cloned.initCause(cause);
+                try {
+                    cloned.initCause(cause);
+                } catch (IllegalStateException ignored) {
+                    // Cause can be already set by the exception. See https://github.com/hazelcast/hazelcast/issues/21414
+                }
                 return cloned;
             }
         },
@@ -312,7 +316,11 @@ public final class ExceptionUtil {
             <T extends Throwable> T cloneWith(MethodHandle constructor, String message,
                                               @Nullable Throwable cause) throws Throwable {
                 T cloned = (T) constructor.invokeWithArguments();
-                cloned.initCause(cause);
+                try {
+                    cloned.initCause(cause);
+                } catch (IllegalStateException ignored) {
+                    // Cause can be already set by the exception. See https://github.com/hazelcast/hazelcast/issues/21414
+                }
                 return cloned;
             }
         };

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
@@ -140,6 +140,20 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
         rethrowFromCollection(Collections.singleton(new TestException()), TestException.class);
     }
 
+    @Test
+    public void testCanCreateExceptionsWithMessageAndCauseWhenExceptionHasCauseSetImplicitlyByNoArgumentConstructor() {
+        ExceptionUtil.tryCreateExceptionWithMessageAndCause(
+                ExceptionThatHasCauseImplicitlyByNoArgumentConstructor.class, "", new RuntimeException()
+        );
+    }
+
+    @Test
+    public void testCanCreateExceptionsWithMessageAndCauseWhenExceptionHasCauseSetImplicitlyByMessageConstructor() {
+        ExceptionUtil.tryCreateExceptionWithMessageAndCause(
+                ExceptionThatHasCauseImplicitlyByMessageConstructor.class, "", new RuntimeException()
+        );
+    }
+
     private void assertNoAsyncTrace(Throwable result) {
         for (StackTraceElement stackTraceElement : result.getStackTrace()) {
             if (stackTraceElement.getClassName().equals(ExceptionUtil.EXCEPTION_SEPARATOR)) {
@@ -153,6 +167,19 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
             super(cause);
         }
     }
+
+    public static class ExceptionThatHasCauseImplicitlyByNoArgumentConstructor extends RuntimeException {
+        public ExceptionThatHasCauseImplicitlyByNoArgumentConstructor() {
+            super((Throwable) null);
+        }
+    }
+
+    public static class ExceptionThatHasCauseImplicitlyByMessageConstructor extends RuntimeException {
+        public ExceptionThatHasCauseImplicitlyByMessageConstructor(String message) {
+            super(message, null);
+        }
+    }
+
     public static class NonStandardException extends RuntimeException {
         private NonStandardException(Integer iDontCareAboutStandardSignatures, Throwable cause) {
             super("" + iDontCareAboutStandardSignatures, cause);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -40,7 +40,6 @@ import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -1105,6 +1105,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
         assertEquals(1_500, map.size());
     }
 
+    // See https://github.com/hazelcast/hazelcast/issues/21414
     @Test(timeout = 120000)
     public void testCanCloneExceptionsWhoseCauseIsAlreadySet() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -1107,7 +1107,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
 
     // See https://github.com/hazelcast/hazelcast/issues/21414
     @Test(timeout = 120000)
-    public void testCanCloneExceptionsWhoseCauseIsAlreadySet() {
+    public void testBugFix_21414() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         Config config = getConfig();
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
@@ -1136,6 +1136,10 @@ public class MapStoreTest extends AbstractMapStoreTest {
         try {
             map.get("key1");
         } catch (RuntimeException e) {
+            // Exceptions that are thrown from MapLoader.load() is cloned using ExceptionUtil.
+            // If the exception already has cause, Throwable.initCause() will throw. Some libraries
+            // may set cause to null even when the no cause is passed in the constructor. This test
+            // verifies that we handle that case.
             assertTrue(e instanceof ExceptionThatHasCause);
         }
     }


### PR DESCRIPTION
Some libraries may set cause even no cause is provided like this exception (its parents set cause to null by default): https://github.com/datastax/java-driver/blob/4.x/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java

`Throwable.initCause()` check if cause is set before. Even if it's set to `null`, it will throw `IllegalStateException`. If that happens we ignore now.

Fixes #21414

Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
