### PR TITLE
Break flow when operation timed out

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
@@ -95,7 +95,7 @@ public class StepSupplier implements Supplier<Runnable> {
                         assert !isRunningOnPartitionThread();
                     }
 
-                    runStepWith(step, state);
+                    runStepWithState(step, state);
                 }
 
                 @Override
@@ -113,7 +113,7 @@ public class StepSupplier implements Supplier<Runnable> {
                 if (checkCurrentThread) {
                     assert isRunningOnPartitionThread();
                 }
-                runStepWith(step, state);
+                runStepWithState(step, state);
             }
 
             @Override
@@ -131,11 +131,11 @@ public class StepSupplier implements Supplier<Runnable> {
     /**
      * Responsibilities of this method:
      * <lu>
-     *     <li>Runs this step</li>
+     *     <li>Runs passed step with passed state</li>
      *     <li>Sets next step to run</li>
      * </lu>
      */
-    private void runStepWith(Step step, State state) {
+    private void runStepWithState(Step step, State state) {
         boolean runningOnPartitionThread = isRunningOnPartitionThread();
         boolean metWithPreconditions = true;
         try {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplierTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplierTest.java
@@ -15,10 +15,16 @@
  */
 package com.hazelcast.map.impl.operation.steps.engine;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.Clock;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.SetOperation;
+import com.hazelcast.spi.impl.operationservice.OperationAccessor;
+import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -27,6 +33,9 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -68,5 +77,45 @@ public class StepSupplierTest extends HazelcastTestSupport {
         Runnable get1 = stepSupplier.get();
         Runnable get2 = stepSupplier.get();
         assertEquals(get1, get2);
+    }
+
+    @Test
+    public void step_supplier_ends_with_call_timeout_response_when_operation_timed_out() {
+        // create node with force offload
+        Config config = smallInstanceConfig();
+        config.setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(), "true");
+        HazelcastInstance node = createHazelcastInstance(config);
+
+        // create state to use for test verification
+        AtomicReference<Object> expectedResponse = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // create and call slow operation
+        Data data = Accessors.getSerializationService(node).toData("data");
+        int partitionId = Accessors.getPartitionService(node).getPartitionId(data);
+
+        MapOperation operation = new SetOperation("test-map", data, data) {
+            @Override
+            protected void innerBeforeRun() throws Exception {
+                super.innerBeforeRun();
+                sleepAtLeastSeconds(2);
+            }
+        };
+        operation.setNodeEngine(Accessors.getNodeEngineImpl(node));
+        operation.setPartitionId(partitionId);
+        operation.setServiceName(MapService.SERVICE_NAME);
+        operation.setOperationResponseHandler((op, response) -> {
+            expectedResponse.set(response);
+            latch.countDown();
+        });
+
+        // set op times out after 1 second
+        OperationAccessor.setCallTimeout(operation, 1000);
+        OperationAccessor.setInvocationTime(operation, Clock.currentTimeMillis());
+        Accessors.getOperationService(node).execute(operation);
+
+        // wait operation end
+        assertOpenEventually(latch);
+        assertInstanceOf(CallTimeoutResponse.class, expectedResponse.get());
     }
 }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/5269

**Issue:**
When timeout, flow was continuing in step-runner. As a result, we were seeing double response submission and removal of operation from live-operations which is needed for operation heart-beat procedure.

**Modification:**
Aligns op timeout behavior with operation-runnner-impl, so when there is op timeout, step-supplier will break flow and will return null as a next step to break flow.
https://github.com/hazelcast/hazelcast/blob/4252b4f340beedefaea4aec193d60e93a2ea9c28/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java#L240-L250