### PR TITLE
[HZ-1010] Allow EP to ignore TTL set by earlier put/set operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/ExtendedMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/ExtendedMapEntry.java
@@ -22,15 +22,29 @@ import java.util.concurrent.TimeUnit;
 /**
  * Interface to provide parity with IMap set and put operations. For use in EntryProcessors.
  *
- * @see com.hazelcast.map.IMap#set(Object, Object, long, TimeUnit)
- * @see com.hazelcast.map.IMap#put(Object, Object, long, TimeUnit)
- *
  * @param <K> key type
  * @param <V> value type
+ * @see com.hazelcast.map.IMap#set(Object, Object, long, TimeUnit)
+ * @see com.hazelcast.map.IMap#put(Object, Object, long, TimeUnit)
  */
 public interface ExtendedMapEntry<K, V> extends Entry<K, V> {
 
-    /** Set the value and set the TTL to a non-default value for the IMap */
+    /**
+     * Set the value and set the TTL to a non-default value for the IMap
+     */
     V setValue(V value, long ttl, TimeUnit ttlUnit);
+
+    /**
+     * Calling this method can result with one of these two cases:
+     * <ul>
+     *     <li>When there is no previous entry, this method
+     *     works same as {@link Entry#setValue} and creates
+     *     entry with existing expiry settings</li>
+     *     <li>When an entry already exists, it updates
+     *     value without changing expiry time of it</li>
+     * </ul>
+     * @since 5.2
+     */
+    V setValueWithoutChangingExpiryTime(V value);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -63,9 +63,8 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
 
     private static final long serialVersionUID = 0L;
 
-    private transient boolean modified;
-
     private transient long newTtl = UNSET;
+    private transient boolean modified;
     private transient boolean changeExpiryOnUpdate = true;
 
     public LazyMapEntry() {
@@ -105,19 +104,23 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
         V oldValue = getValue();
         this.valueObject = value;
         this.valueData = null;
+        this.changeExpiryOnUpdate = true;
+        this.newTtl = UNSET;
         return oldValue;
     }
 
     @Override
     public V setValue(V value, long ttl, TimeUnit ttlUnit) {
+        V v = setValue(value);
         newTtl = ttlUnit.toMillis(ttl);
-        return setValue(value);
+        return v;
     }
 
     @Override
     public V setValueWithoutChangingExpiryTime(V value) {
+        V v = setValue(value);
         changeExpiryOnUpdate = false;
-        return setValue(value);
+        return v;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -66,6 +66,7 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
     private transient boolean modified;
 
     private transient long newTtl = UNSET;
+    private transient boolean changeExpiryOnUpdate = true;
 
     public LazyMapEntry() {
     }
@@ -79,10 +80,12 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
     }
 
     public LazyMapEntry init(InternalSerializationService serializationService,
-                             Object key, Object value, Extractors extractors, long ttl) {
+                             Object key, Object value, Extractors extractors, long ttl,
+                             boolean changeExpiryOnUpdate) {
         super.init(serializationService, key, value, extractors);
-        modified = false;
-        newTtl = ttl;
+        this.modified = false;
+        this.newTtl = ttl;
+        this.changeExpiryOnUpdate = changeExpiryOnUpdate;
         return this;
     }
 
@@ -111,6 +114,12 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
         return setValue(value);
     }
 
+    @Override
+    public V setValueWithoutChangingExpiryTime(V value) {
+        changeExpiryOnUpdate = false;
+        return setValue(value);
+    }
+
     /**
      * Similar to calling {@link #setValue} with null but doesn't return old-value hence no extra deserialization.
      */
@@ -135,6 +144,10 @@ public class LazyMapEntry<K, V> extends CachedQueryEntry<K, V>
 
     public long getNewTtl() {
         return newTtl;
+    }
+
+    public boolean isChangeExpiryOnUpdate() {
+        return changeExpiryOnUpdate;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LockAwareLazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LockAwareLazyMapEntry.java
@@ -43,8 +43,9 @@ public class LockAwareLazyMapEntry extends LazyMapEntry implements LockAware {
     }
 
     public LockAwareLazyMapEntry init(InternalSerializationService serializationService,
-                                      Data key, Object value, Extractors extractors, Boolean locked, long ttl) {
-        super.init(serializationService, key, value, extractors, ttl);
+                                      Data key, Object value, Extractors extractors, Boolean locked,
+                                      long ttl, boolean changeExpiryOnUpdate) {
+        super.init(serializationService, key, value, extractors, ttl, changeExpiryOnUpdate);
         this.locked = locked;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.Data;
@@ -45,6 +46,7 @@ import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         implements BackupAwareOperation, Notifier, Versioned {
 
+    protected boolean changeExpiryOnUpdate;
     protected long begin;
     protected long newTtl;
     protected UUID caller;
@@ -56,8 +58,10 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
     public EntryOffloadableSetUnlockOperation() {
     }
 
-    public EntryOffloadableSetUnlockOperation(String name, EntryEventType modificationType, long newTtl,
-                                              Data key, Data oldValue, Data newValue, UUID caller,
+    @SuppressWarnings("checkstyle:parameternumber")
+    public EntryOffloadableSetUnlockOperation(String name, EntryEventType modificationType,
+                                              boolean changeExpiryOnUpdate,
+                                              long newTtl, Data key, Data oldValue, Data newValue, UUID caller,
                                               long threadId, long begin, EntryProcessor entryBackupProcessor) {
         super(name, key, newValue);
         this.newValue = newValue;
@@ -67,6 +71,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         this.modificationType = modificationType;
         this.entryBackupProcessor = entryBackupProcessor;
         this.setThreadId(threadId);
+        this.changeExpiryOnUpdate = changeExpiryOnUpdate;
         this.newTtl = newTtl;
     }
 
@@ -77,7 +82,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
             verifyLock();
             try {
                 operator(this).init(dataKey, oldValue, newValue,
-                                null, modificationType, null, newTtl)
+                                null, modificationType, null, changeExpiryOnUpdate, newTtl)
                         .doPostOperateOps();
             } finally {
                 unlockKey();
@@ -175,6 +180,11 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         out.writeLong(begin);
         out.writeObject(entryBackupProcessor);
         out.writeLong(newTtl);
+
+        // RU_COMPAT 5.1
+        if (out.getVersion().isGreaterOrEqual(Versions.V5_2)) {
+            out.writeBoolean(changeExpiryOnUpdate);
+        }
     }
 
     @Override
@@ -189,6 +199,10 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         begin = in.readLong();
         entryBackupProcessor = in.readObject();
         newTtl = in.readLong();
-    }
 
+        // RU_COMPAT 5.1
+        if (in.getVersion().isGreaterOrEqual(Versions.V5_2)) {
+            changeExpiryOnUpdate = in.readBoolean();
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -444,9 +444,11 @@ public class EntryOperation extends LockAwareOperation
                         EntryEventType modificationType = entryOperator.getEventType();
                         if (modificationType != null) {
                             long newTtl = entryOperator.getEntry().getNewTtl();
+                            boolean changeExpiryOnUpdate = entryOperator.getEntry().isChangeExpiryOnUpdate();
                             Data newValue = serializationService.toData(entryOperator.getByPreferringDataNewValue());
                             updateAndUnlock(serializationService.toData(oldValue),
-                                    newValue, modificationType, newTtl, finalCaller, finalThreadId, result, finalBegin);
+                                    newValue, modificationType, changeExpiryOnUpdate, newTtl, finalCaller,
+                                    finalThreadId, result, finalBegin);
                         } else {
                             unlockOnly(result, finalCaller, finalThreadId, finalBegin);
                         }
@@ -495,16 +497,19 @@ public class EntryOperation extends LockAwareOperation
         }
 
         private void unlockOnly(final Object result, UUID caller, long threadId, long now) {
-            updateAndUnlock(null, null, null, UNSET, caller, threadId, result, now);
+            updateAndUnlock(null, null, null,
+                    true, UNSET, caller, threadId, result, now);
         }
 
-        @SuppressWarnings({"unchecked", "checkstyle:methodlength"})
+        @SuppressWarnings({"unchecked", "checkstyle:methodlength", "checkstyle:parameternumber"})
         private void updateAndUnlock(Data previousValue, Data newValue,
                                      EntryEventType modificationType,
+                                     boolean changeExpiryOnUpdate,
                                      long newTtl, UUID caller,
                                      long threadId, final Object result, long now) {
-            EntryOffloadableSetUnlockOperation updateOperation = new EntryOffloadableSetUnlockOperation(name, modificationType,
-                    newTtl, dataKey, previousValue, newValue, caller,
+            EntryOffloadableSetUnlockOperation updateOperation
+                    = new EntryOffloadableSetUnlockOperation(name, modificationType,
+                    changeExpiryOnUpdate, newTtl, dataKey, previousValue, newValue, caller,
                     threadId, now, entryProcessor.getBackupProcessor());
 
             updateOperation.setPartitionId(getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -72,6 +72,7 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
                 outComes.add(operator.getByPreferringDataNewValue());
                 outComes.add(eventType);
                 outComes.add(operator.getEntry().getNewTtl());
+                outComes.add(operator.getEntry().isChangeExpiryOnUpdate());
             }
         }, true);
 
@@ -87,9 +88,10 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
             Object newValue = outComes.poll();
             EntryEventType eventType = (EntryEventType) outComes.poll();
             long newTtl = (long) outComes.poll();
+            boolean changeExpiryOnUpdate = (boolean) outComes.poll();
 
             operator.init(dataKey, oldValue, newValue, null, eventType,
-                    null, newTtl).doPostOperateOps();
+                    null, changeExpiryOnUpdate, newTtl).doPostOperateOps();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -194,6 +194,7 @@ public class PartitionWideEntryOperation extends MapOperation
                 outComes.add(operator.getByPreferringDataNewValue());
                 outComes.add(eventType);
                 outComes.add(operator.getEntry().getNewTtl());
+                outComes.add(operator.getEntry().isChangeExpiryOnUpdate());
             }
         }, false);
 
@@ -209,9 +210,10 @@ public class PartitionWideEntryOperation extends MapOperation
             Object newValue = outComes.poll();
             EntryEventType eventType = (EntryEventType) outComes.poll();
             long newTtl = (long) outComes.poll();
+            boolean changeExpiryOnUpdate = (boolean) outComes.poll();
 
             operator.init(dataKey, oldValue, newValue, null, eventType,
-                    null, newTtl).doPostOperateOps();
+                    null, changeExpiryOnUpdate, newTtl).doPostOperateOps();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
@@ -34,7 +34,7 @@ public enum EntryOpSteps implements Step<State> {
         public void runStep(State state) {
             EntryOperator operator = operator(state.getOperation(), state.getEntryProcessor());
             operator.init(state.getKey(), state.getOldValue(), state.getNewValue(),
-                    null, null, null, state.getTtl());
+                    null, null, null, state.isChangeExpiryOnUpdate(), state.getTtl());
             state.setEntryOperator(operator);
 
             if (operator.belongsAnotherPartition(state.getKey())) {
@@ -136,12 +136,14 @@ public enum EntryOpSteps implements Step<State> {
 
             EntryOperator entryOperator = state.getOperator();
             entryOperator.init(state.getKey(), state.getOldValue(),
-                    null, null, null, recordStore.isLocked(state.getKey()), state.getTtl());
+                    null, null, null, recordStore.isLocked(state.getKey()),
+                    state.isChangeExpiryOnUpdate(), state.getTtl());
 
             Object clonedOldValue = entryOperator.clonedOrRawOldValue();
 
             entryOperator.init(state.getKey(), clonedOldValue,
-                    null, null, null, recordStore.isLocked(state.getKey()), state.getTtl());
+                    null, null, null, recordStore.isLocked(state.getKey()),
+                    state.isChangeExpiryOnUpdate(), state.getTtl());
 
             if (!entryOperator.checkCanProceed()) {
                 entryOperator.onTouched();
@@ -186,6 +188,7 @@ public enum EntryOpSteps implements Step<State> {
                                 state.getOldValue(), newValue);
                         state.setNewValue(newValue);
                         state.setTtl(entryOperator.getEntry().getNewTtl());
+                        state.setChangeExpiryOnUpdate(entryOperator.getEntry().isChangeExpiryOnUpdate());
                         break;
                     case REMOVED:
                         DeleteOpSteps.READ.runStep(state);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
@@ -176,8 +176,8 @@ public enum PutOpSteps implements Step<State> {
                         ? record.getValue() : mapServiceContext.toData(record.getValue()));
                 recordStore.updateRecord0(record, state.getNow(), state.getStaticParams().isCountAsAccess());
                 recordStore.updateMemory(record, state.getKey(), state.getOldValue(), state.getNewValue(),
-                        state.getTtl(), state.getMaxIdle(), state.getExpiryTime(), state.getNow(),
-                        state.getStaticParams().isBackup());
+                        state.isChangeExpiryOnUpdate(), state.getTtl(), state.getMaxIdle(), state.getExpiryTime(),
+                        state.getNow(), state.getStaticParams().isBackup());
             }
 
             state.setRecord(record);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
@@ -77,6 +77,7 @@ public class State {
     private volatile boolean disableWanReplicationEvent;
     private volatile boolean triggerMapLoader;
     private volatile boolean shouldLoad;
+    private volatile boolean changeExpiryOnUpdate;
     private volatile Object oldValue;
     private volatile Object newValue;
     private volatile Object result;
@@ -112,6 +113,7 @@ public class State {
 
         setTtl(state.getTtl())
                 .setMaxIdle(state.getMaxIdle())
+                .setChangeExpiryOnUpdate(state.isChangeExpiryOnUpdate())
                 .setVersion(state.getVersion())
                 .setExpiryTime(state.getExpiryTime())
                 .setNow(state.getNow())
@@ -504,5 +506,14 @@ public class State {
 
     public List getBackupPairs() {
         return backupPairs;
+    }
+
+    public State setChangeExpiryOnUpdate(boolean changeExpiryOnUpdate) {
+        this.changeExpiryOnUpdate = changeExpiryOnUpdate;
+        return this;
+    }
+
+    public boolean isChangeExpiryOnUpdate() {
+        return changeExpiryOnUpdate;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -89,8 +89,8 @@ public interface RecordStore<R extends Record> {
      * @param provenance origin of call to this method.
      * @return current record after put.
      */
-    R putBackup(Data key, Object value, long ttl, long maxIdle,
-                long nowOrExpiryTime, CallerProvenance provenance);
+    R putBackup(Data key, Object value, boolean changeExpiryOnUpdate,
+                long ttl, long maxIdle, long nowOrExpiryTime, CallerProvenance provenance);
 
     /**
      * @return current record after put.
@@ -111,7 +111,8 @@ public interface RecordStore<R extends Record> {
      * Does exactly the same thing as {@link #set(Data, Object, long, long)} except the invocation is not counted as
      * a read access while updating the access statics.
      */
-    boolean setWithUncountedAccess(Data dataKey, Object value, long ttl, long maxIdle);
+    boolean setWithUncountedAccess(Data dataKey, Object value,
+                                   boolean changeExpiryOnUpdate, long ttl, long maxIdle);
 
     /**
      * @param key        the key to be removed

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorExpiryTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorExpiryTimeTest.java
@@ -162,14 +162,15 @@ public class EntryProcessorExpiryTimeTest extends HazelcastTestSupport {
 
     private void test(Set<Integer> keySet, boolean update,
                       EntryProcessor entryProcessor, boolean expectShiftExpiry, RUN_METHOD runMethod) {
-        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(getConfig(), 2);
-        HazelcastInstance instance1 = hazelcastInstances[0];
-        HazelcastInstance instance2 = hazelcastInstances[1];
+        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(getConfig(), 3);
+        HazelcastInstance instance = hazelcastInstances[2];
+        waitAllForSafeState(hazelcastInstances);
+        warmUpPartitions(Arrays.asList(hazelcastInstances));
 
         MapBackupAccessor mapBackupAccessor = (MapBackupAccessor) TestBackupUtils
                 .newMapAccessor(hazelcastInstances, mapName, 1);
 
-        IMap<Integer, Integer> instance1Map = instance1.getMap(mapName);
+        IMap<Integer, Integer> instance1Map = instance.getMap(mapName);
         Map<Integer, EntryView> cacheEntryViewPerKey1 = null;
 
         // when update is true, first create entries

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorExpiryTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorExpiryTimeTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.EntryView;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Offloadable;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.backup.MapBackupAccessor;
+import com.hazelcast.test.backup.TestBackupUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class EntryProcessorExpiryTimeTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(1)
+    public boolean forceOffload;
+
+    @Parameterized.Parameters(name = "inMemoryFormat: {0}, forceOffload: {1}")
+    public static Collection<Object[]> data() {
+        return asList(new Object[][]{
+                {BINARY, false},
+                {OBJECT, false},
+                {OBJECT, true}
+        });
+    }
+
+    @Override
+    public Config getConfig() {
+        Config config = smallInstanceConfig();
+        config.getMetricsConfig().setEnabled(false);
+        config.setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(),
+                String.valueOf(forceOffload));
+        config.getMapConfig("default")
+                .setInMemoryFormat(inMemoryFormat)
+                .setPerEntryStatsEnabled(true)
+                .setTimeToLiveSeconds(100);
+        return config;
+    }
+
+    @Test
+    public void executeOnKey_sets_expiry_time_when_creating_new_entry() {
+        test(Collections.singleton(1), false, false);
+    }
+
+    @Test
+    public void executeOnKeys_sets_expiry_time_when_creating_new_entries() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), false, false);
+    }
+
+    @Test
+    public void executeOnKey_does_not_change_expiry_time_when_updating_entry() {
+        test(Collections.singleton(1), true, false);
+    }
+
+    @Test
+    public void executeOnKeys_does_not_change_expiry_time_when_updating_entries() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true, false);
+    }
+
+    @Test
+    public void executeOnKey_sets_expiry_time_when_creating_new_entry_with_offloadable_EP() {
+        test(Collections.singleton(1), false, true);
+    }
+
+    @Test
+    public void executeOnKeys_sets_expiry_time_when_creating_new_entries_with_offloadable_EP() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), false, true);
+    }
+
+    @Test
+    public void executeOnKey_does_not_change_expiry_time_when_updating_entry_with_offloadable_EP() {
+        test(Collections.singleton(1), true, true);
+    }
+
+    @Test
+    public void executeOnKeys_does_not_change_expiry_time_when_updating_entries_with_offloadable_EP() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true, true);
+    }
+
+    private void test(Set<Integer> keySet, boolean update, boolean withOffloadable) {
+        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(getConfig(), 2);
+
+        HazelcastInstance instance1 = hazelcastInstances[0];
+        HazelcastInstance instance2 = hazelcastInstances[1];
+
+        String mapName = "test-map";
+        MapBackupAccessor mapBackupAccessor = (MapBackupAccessor) TestBackupUtils
+                .newMapAccessor(hazelcastInstances, mapName, 1);
+
+        IMap<Integer, Integer> instance1Map = instance1.getMap(mapName);
+        Map<Integer, EntryView> cacheEntryViewPerKey1 = null;
+        if (!update) {
+            for (Integer key : keySet) {
+                instance1Map.set(key, 1, 100, TimeUnit.SECONDS);
+            }
+            cacheEntryViewPerKey1 = cacheEntryViewPerKey(instance1Map, keySet);
+
+            sleepAtLeastSeconds(1);
+        }
+
+        EntryProcessor entryProcessor = withOffloadable
+                ? new SetValueWithoutChangingExpiryTimeOffloadable<>(2)
+                : new SetValueWithoutChangingExpiryTime<>(2);
+
+        if (keySet.size() == 1) {
+            Integer key = keySet.iterator().next();
+            instance1Map.executeOnKey(key, entryProcessor);
+        } else {
+            instance1Map.executeOnKeys(keySet, entryProcessor);
+        }
+
+        Map<Integer, EntryView> cacheEntryViewPerKey2 = cacheEntryViewPerKey(instance1Map, keySet);
+
+        if (!update) {
+            for (Integer key : keySet) {
+                long expirationTime1 = cacheEntryViewPerKey1.get(key).getExpirationTime();
+                long expirationTime2 = cacheEntryViewPerKey2.get(key).getExpirationTime();
+                long lastUpdateTime1 = cacheEntryViewPerKey1.get(key).getLastUpdateTime();
+                long lastUpdateTime2 = cacheEntryViewPerKey2.get(key).getLastUpdateTime();
+
+                assertTrue(format("key: %d ==> lastUpdateTime1: %d, lastUpdateTime2: %d",
+                        key, lastUpdateTime1, lastUpdateTime2), lastUpdateTime1 < lastUpdateTime2);
+                assertEquals(format("key: %d ==> expirationTime1: %d, expirationTime2: %d",
+                        key, expirationTime1, expirationTime2), expirationTime1, expirationTime2);
+
+                assertTrueEventually(() -> {
+                    long expirationTimeOnBackup1 = mapBackupAccessor.getExpiryTime(key);
+                    assertEquals(format("key: %d ==> expirationTime1: %d, expirationTimeOnBackup1: %d",
+                            key, expirationTime1, expirationTimeOnBackup1), expirationTime1, expirationTimeOnBackup1);
+                });
+            }
+        } else {
+            for (Integer key : keySet) {
+                long expirationTime1 = cacheEntryViewPerKey2.get(key).getExpirationTime();
+                long lastUpdateTime1 = cacheEntryViewPerKey2.get(key).getLastUpdateTime();
+
+                assertTrue(format("key: %d ==> lastUpdateTime1: %d", key, lastUpdateTime1), lastUpdateTime1 > 0);
+                assertTrue(format("key: %d ==> expirationTime1: %d", key, expirationTime1), expirationTime1 > 0);
+
+                assertTrueEventually(() -> {
+                    long expirationTimeOnBackup1 = mapBackupAccessor.getExpiryTime(key);
+                    assertTrue(format("key: %d ==> expirationTimeOnBackup1: %d", key, expirationTimeOnBackup1),
+                            expirationTimeOnBackup1 > 0);
+                });
+            }
+        }
+    }
+
+    private static Map<Integer, EntryView> cacheEntryViewPerKey(IMap<Integer, Integer> instance1Map,
+                                                                Set<Integer> keySet) {
+        Map<Integer, EntryView> entryViewHashMap = new HashMap<>();
+        for (Integer key : keySet) {
+            entryViewHashMap.put(key, instance1Map.getEntryView(key));
+        }
+
+        return entryViewHashMap;
+    }
+
+    private static class SetValueWithoutChangingExpiryTime<K, V>
+            implements EntryProcessor<K, V, V> {
+
+        private final V newValue;
+
+        SetValueWithoutChangingExpiryTime(V newValue) {
+            this.newValue = newValue;
+        }
+
+        @Override
+        public V process(Map.Entry<K, V> entry) {
+            return ((ExtendedMapEntry<K, V>) entry).setValueWithoutChangingExpiryTime(newValue);
+        }
+    }
+
+    private static class SetValueWithoutChangingExpiryTimeOffloadable<K, V>
+            extends SetValueWithoutChangingExpiryTime implements Offloadable {
+
+        SetValueWithoutChangingExpiryTimeOffloadable(V newValue) {
+            super(newValue);
+        }
+
+        @Override
+        public String getExecutorName() {
+            return OFFLOADABLE_EXECUTOR;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorExpiryTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorExpiryTimeTest.java
@@ -45,6 +45,9 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.map.EntryProcessorExpiryTimeTest.RUN_METHOD.EXECUTE_ON_ENTRIES;
+import static com.hazelcast.map.EntryProcessorExpiryTimeTest.RUN_METHOD.EXECUTE_ON_KEY;
+import static com.hazelcast.map.EntryProcessorExpiryTimeTest.RUN_METHOD.EXECUTE_ON_KEYS;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -70,13 +73,15 @@ public class EntryProcessorExpiryTimeTest extends HazelcastTestSupport {
         });
     }
 
+    private final String mapName = "ep-test-map";
+
     @Override
     public Config getConfig() {
         Config config = smallInstanceConfig();
         config.getMetricsConfig().setEnabled(false);
         config.setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(),
                 String.valueOf(forceOffload));
-        config.getMapConfig("default")
+        config.getMapConfig(mapName)
                 .setInMemoryFormat(inMemoryFormat)
                 .setPerEntryStatsEnabled(true)
                 .setTimeToLiveSeconds(100);
@@ -85,57 +90,90 @@ public class EntryProcessorExpiryTimeTest extends HazelcastTestSupport {
 
     @Test
     public void executeOnKey_sets_expiry_time_when_creating_new_entry() {
-        test(Collections.singleton(1), false, false);
+        test(Collections.singleton(1), false,
+                new SetValueWithoutChangingExpiryTime<>(2), false, EXECUTE_ON_KEY);
     }
 
     @Test
     public void executeOnKeys_sets_expiry_time_when_creating_new_entries() {
-        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), false, false);
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), false,
+                new SetValueWithoutChangingExpiryTime<>(2), false, EXECUTE_ON_KEYS);
     }
 
     @Test
     public void executeOnKey_does_not_change_expiry_time_when_updating_entry() {
-        test(Collections.singleton(1), true, false);
+        test(Collections.singleton(1), true,
+                new SetValueWithoutChangingExpiryTime<>(2), false, EXECUTE_ON_KEY);
     }
 
     @Test
     public void executeOnKeys_does_not_change_expiry_time_when_updating_entries() {
-        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true, false);
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true,
+                new SetValueWithoutChangingExpiryTime<>(2), false, EXECUTE_ON_KEYS);
+    }
+
+    @Test
+    public void executeOnEntries_does_not_change_expiry_time_when_updating_entries() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true,
+                new SetValueWithoutChangingExpiryTime<>(2), false, EXECUTE_ON_ENTRIES);
     }
 
     @Test
     public void executeOnKey_sets_expiry_time_when_creating_new_entry_with_offloadable_EP() {
-        test(Collections.singleton(1), false, true);
+        test(Collections.singleton(1), false,
+                new SetValueWithoutChangingExpiryTimeOffloadable<>(2), false, EXECUTE_ON_KEY);
     }
 
     @Test
     public void executeOnKeys_sets_expiry_time_when_creating_new_entries_with_offloadable_EP() {
-        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), false, true);
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), false,
+                new SetValueWithoutChangingExpiryTimeOffloadable<>(2), false, EXECUTE_ON_KEYS);
     }
 
     @Test
     public void executeOnKey_does_not_change_expiry_time_when_updating_entry_with_offloadable_EP() {
-        test(Collections.singleton(1), true, true);
+        test(Collections.singleton(1), true,
+                new SetValueWithoutChangingExpiryTimeOffloadable<>(2), false, EXECUTE_ON_KEY);
     }
 
     @Test
     public void executeOnKeys_does_not_change_expiry_time_when_updating_entries_with_offloadable_EP() {
-        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true, true);
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true,
+                new SetValueWithoutChangingExpiryTimeOffloadable<>(2), false, EXECUTE_ON_KEYS);
     }
 
-    private void test(Set<Integer> keySet, boolean update, boolean withOffloadable) {
-        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(getConfig(), 2);
+    @Test
+    public void executeOnEntries_does_not_change_expiry_time_when_updating_entries_with_offloadable_EP() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true,
+                new SetValueWithoutChangingExpiryTimeOffloadable<>(2), false, EXECUTE_ON_ENTRIES);
+    }
 
+    @Test
+    public void first_setValueWithoutChangingExpiryTime_then_setValue_shifts_expiry_time() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true,
+                new First_SetValueWithoutChangingExpiryTime_Then_SetValue<>(2), true, EXECUTE_ON_KEYS);
+    }
+
+    @Test
+    public void first_setValue_then_setValueWithoutChangingExpiryTime_does_not_shift_expiry_time() {
+        test(new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7)), true,
+                new First_SetValue_Then_SetValueWithoutChangingExpiryTime(2), false, EXECUTE_ON_ENTRIES);
+    }
+
+    private void test(Set<Integer> keySet, boolean update,
+                      EntryProcessor entryProcessor, boolean expectShiftExpiry, RUN_METHOD runMethod) {
+        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(getConfig(), 2);
         HazelcastInstance instance1 = hazelcastInstances[0];
         HazelcastInstance instance2 = hazelcastInstances[1];
 
-        String mapName = "test-map";
         MapBackupAccessor mapBackupAccessor = (MapBackupAccessor) TestBackupUtils
                 .newMapAccessor(hazelcastInstances, mapName, 1);
 
         IMap<Integer, Integer> instance1Map = instance1.getMap(mapName);
         Map<Integer, EntryView> cacheEntryViewPerKey1 = null;
-        if (!update) {
+
+        // when update is true, first create entries
+        if (update) {
             for (Integer key : keySet) {
                 instance1Map.set(key, 1, 100, TimeUnit.SECONDS);
             }
@@ -144,36 +182,53 @@ public class EntryProcessorExpiryTimeTest extends HazelcastTestSupport {
             sleepAtLeastSeconds(1);
         }
 
-        EntryProcessor entryProcessor = withOffloadable
-                ? new SetValueWithoutChangingExpiryTimeOffloadable<>(2)
-                : new SetValueWithoutChangingExpiryTime<>(2);
-
-        if (keySet.size() == 1) {
-            Integer key = keySet.iterator().next();
-            instance1Map.executeOnKey(key, entryProcessor);
-        } else {
-            instance1Map.executeOnKeys(keySet, entryProcessor);
+        switch (runMethod) {
+            case EXECUTE_ON_KEY:
+                Integer key = keySet.iterator().next();
+                instance1Map.executeOnKey(key, entryProcessor);
+                break;
+            case EXECUTE_ON_KEYS:
+                instance1Map.executeOnKeys(keySet, entryProcessor);
+                break;
+            case EXECUTE_ON_ENTRIES:
+                instance1Map.executeOnEntries(entryProcessor);
+                break;
+            default:
+                throw new UnsupportedOperationException("Not known run method: " + runMethod);
         }
 
         Map<Integer, EntryView> cacheEntryViewPerKey2 = cacheEntryViewPerKey(instance1Map, keySet);
 
-        if (!update) {
+        if (update) {
             for (Integer key : keySet) {
                 long expirationTime1 = cacheEntryViewPerKey1.get(key).getExpirationTime();
                 long expirationTime2 = cacheEntryViewPerKey2.get(key).getExpirationTime();
                 long lastUpdateTime1 = cacheEntryViewPerKey1.get(key).getLastUpdateTime();
                 long lastUpdateTime2 = cacheEntryViewPerKey2.get(key).getLastUpdateTime();
 
-                assertTrue(format("key: %d ==> lastUpdateTime1: %d, lastUpdateTime2: %d",
-                        key, lastUpdateTime1, lastUpdateTime2), lastUpdateTime1 < lastUpdateTime2);
-                assertEquals(format("key: %d ==> expirationTime1: %d, expirationTime2: %d",
-                        key, expirationTime1, expirationTime2), expirationTime1, expirationTime2);
+                if (!expectShiftExpiry) {
+                    assertTrue(format("key: %d ==> lastUpdateTime1: %d, lastUpdateTime2: %d",
+                            key, lastUpdateTime1, lastUpdateTime2), lastUpdateTime1 < lastUpdateTime2);
+                    assertEquals(format("key: %d ==> expirationTime1: %d, expirationTime2: %d",
+                            key, expirationTime1, expirationTime2), expirationTime1, expirationTime2);
 
-                assertTrueEventually(() -> {
-                    long expirationTimeOnBackup1 = mapBackupAccessor.getExpiryTime(key);
-                    assertEquals(format("key: %d ==> expirationTime1: %d, expirationTimeOnBackup1: %d",
-                            key, expirationTime1, expirationTimeOnBackup1), expirationTime1, expirationTimeOnBackup1);
-                });
+                    assertTrueEventually(() -> {
+                        long expirationTimeOnBackup1 = mapBackupAccessor.getExpiryTime(key);
+                        assertEquals(format("key: %d ==> expirationTime1: %d, expirationTimeOnBackup1: %d",
+                                key, expirationTime1, expirationTimeOnBackup1), expirationTime1, expirationTimeOnBackup1);
+                    });
+                } else {
+                    assertTrue(format("key: %d ==> lastUpdateTime1: %d, lastUpdateTime2: %d",
+                            key, lastUpdateTime1, lastUpdateTime2), lastUpdateTime1 < lastUpdateTime2);
+                    assertTrue(format("key: %d ==> expirationTime1: %d, expirationTime2: %d",
+                            key, expirationTime1, expirationTime2), expirationTime1 < expirationTime2);
+
+                    assertTrueEventually(() -> {
+                        long expirationTimeOnBackup1 = mapBackupAccessor.getExpiryTime(key);
+                        assertTrue(format("key: %d ==> expirationTime1: %d, expirationTimeOnBackup1: %d",
+                                key, expirationTime1, expirationTimeOnBackup1), expirationTime1 < expirationTimeOnBackup1);
+                    });
+                }
             }
         } else {
             for (Integer key : keySet) {
@@ -228,5 +283,47 @@ public class EntryProcessorExpiryTimeTest extends HazelcastTestSupport {
         public String getExecutorName() {
             return OFFLOADABLE_EXECUTOR;
         }
+    }
+
+    private static class First_SetValueWithoutChangingExpiryTime_Then_SetValue<K, V>
+            implements EntryProcessor<K, V, V> {
+
+        private final V newValue;
+
+        First_SetValueWithoutChangingExpiryTime_Then_SetValue(V newValue) {
+            this.newValue = newValue;
+        }
+
+        @Override
+        public V process(Map.Entry<K, V> entry) {
+            ExtendedMapEntry<K, V> extendedMapEntry = (ExtendedMapEntry<K, V>) entry;
+            V v = extendedMapEntry.setValueWithoutChangingExpiryTime(newValue);
+            v = extendedMapEntry.setValue(newValue);
+            return v;
+        }
+    }
+
+    private static class First_SetValue_Then_SetValueWithoutChangingExpiryTime<K, V>
+            implements EntryProcessor<K, V, V> {
+
+        private final V newValue;
+
+        First_SetValue_Then_SetValueWithoutChangingExpiryTime(V newValue) {
+            this.newValue = newValue;
+        }
+
+        @Override
+        public V process(Map.Entry<K, V> entry) {
+            ExtendedMapEntry<K, V> extendedMapEntry = (ExtendedMapEntry<K, V>) entry;
+            V v = extendedMapEntry.setValue(newValue);
+            v = extendedMapEntry.setValueWithoutChangingExpiryTime(newValue);
+            return v;
+        }
+    }
+
+    enum RUN_METHOD {
+        EXECUTE_ON_KEY,
+        EXECUTE_ON_KEYS,
+        EXECUTE_ON_ENTRIES,
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/MapBackupAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/MapBackupAccessor.java
@@ -102,6 +102,21 @@ public class MapBackupAccessor<K, V> extends AbstractBackupAccessor<K, V> implem
         return runOnPartitionThread(hz, new GetRecordCallable(serializationService, partitionContainer, key), partitionId);
     }
 
+    public long getExpiryTime(K key) {
+        IPartition partition = getPartitionForKey(key);
+        HazelcastInstance hz = getHazelcastInstance(partition);
+
+        Node node = getNode(hz);
+        SerializationService serializationService = node.getSerializationService();
+        MapService mapService = node.getNodeEngine().getService(MapService.SERVICE_NAME);
+        MapServiceContext context = mapService.getMapServiceContext();
+        int partitionId = partition.getPartitionId();
+        PartitionContainer partitionContainer = context.getPartitionContainer(partitionId);
+
+        return runOnPartitionThread(hz,
+                new GetExpiryTimeCallable(serializationService, partitionContainer, key), partitionId);
+    }
+
     private class SizeCallable extends AbstractClassLoaderAwareCallable<Integer> {
 
         private final PartitionContainer partitionContainer;
@@ -167,6 +182,29 @@ public class MapBackupAccessor<K, V> extends AbstractBackupAccessor<K, V> implem
             }
             Data keyData = serializationService.toData(key);
             return recordStore.getRecord(keyData);
+        }
+    }
+
+    private class GetExpiryTimeCallable extends AbstractClassLoaderAwareCallable<Long> {
+
+        private final SerializationService serializationService;
+        private final PartitionContainer partitionContainer;
+        private final K key;
+
+        GetExpiryTimeCallable(SerializationService serializationService, PartitionContainer partitionContainer, K key) {
+            this.serializationService = serializationService;
+            this.partitionContainer = partitionContainer;
+            this.key = key;
+        }
+
+        @Override
+        Long callInternal() {
+            RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
+            if (recordStore == null) {
+                return null;
+            }
+            Data keyData = serializationService.toData(key);
+            return recordStore.getExpirySystem().getExpiryMetadata(keyData).getExpirationTime();
         }
     }
 


### PR DESCRIPTION
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/5285

**Goal:**
Normally each update shifts expiration time. But there is some other use-cases which requires not-shifting on update. By putting a new method to `ExtendedMapEntry` api, we try to ease addressing of  this use-case for the users.

**Modification:**
- Added `setValueWithoutChangingExpiryTime` to `ExtendedMapEntry` interface for entry processing.