### PR TITLE
Fix SuspendExecutionOnFailureTest assertions (backport of #20286)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
@@ -153,7 +153,7 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
     @Test
     public void when_jobSuspendedDueToFailure_then_canBeResumed() {
         int numItems = 100;
-        int interuptItem = 50;
+        int interruptItem = 50;
 
         StreamSource<Integer> source = SourceBuilder.stream("src", procCtx -> new int[1])
                 .<Integer>fillBufferFn((ctx, buf) -> {
@@ -172,7 +172,7 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
                 .<String, Boolean, Map.Entry<Integer, Integer>>mapUsingIMap("SuspendExecutionOnFailureTest_failureMap",
                         item -> "key",
                         (item, value) -> {
-                            if (value && item == interuptItem) {
+                            if (value && item == interruptItem) {
                                 throw new RuntimeException("Fail deliberately");
                             }
                             return entry(item, item);
@@ -189,10 +189,11 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
         assertJobStatusEventually(job, SUSPENDED);
 
         IMap<Integer, Integer> sinkMap = hz().getMap("SuspendExecutionOnFailureTest_sinkMap");
-        assertTrueEventually(() -> assertEquals(interuptItem, sinkMap.size()));
 
         counterMap.put("key", false);
         job.resume();
+        // sinkMap is an idempotent sink, so even though we're using at-least-once, no key will be duplicated, so it
+        // must contain the expected number of items.
         assertTrueEventually(() -> assertEquals(numItems, sinkMap.size()));
         assertTrueEventually(() -> assertEquals(JobStatus.RUNNING, job.getStatus()));
 


### PR DESCRIPTION
I think the assertion on line 192 was wrong. If a vertex fails after a certain item, there's no guarantee that a downstream vertex already processed all previous items. The test failed rarely because the source emits items one by one with 5ms delay, so it was very likely that all items were sunk, but if there was some hiccup, it could fail.

Fixes #19836

(cherry picked from commit 3fa69fca16baf1e2ede7162031207495a2c03689)
