### PR TITLE
Fix possible overtaking of barriers by items [HZ-1394]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -221,6 +221,7 @@ public final class ConcurrentInboundEdgeStream {
                     specialItemsStash.add(currentBarrier);
                     currentBarrier = null;
                     receivedBarriers.clear();
+                    break;
                 }
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -194,7 +194,8 @@ public class ConcurrentInboundEdgeStreamTest {
         add(q2, wm(1));
 
         // Then
-        drainAndAssert(MADE_PROGRESS, barrier(0), wm(1));
+        drainAndAssert(MADE_PROGRESS, barrier(0));
+        drainAndAssert(MADE_PROGRESS, wm(1));
     }
 
     @Test
@@ -263,8 +264,8 @@ public class ConcurrentInboundEdgeStreamTest {
 
         add(q1, barrier(1));
         add(q2, 1);
-        drainAndAssert(MADE_PROGRESS, 1);
         drainAndAssert(MADE_PROGRESS, barrier(1));
+        drainAndAssert(MADE_PROGRESS, 1);
     }
 
     private void drainAndAssert(ProgressState expectedState, Object... expectedItems) {


### PR DESCRIPTION
The scenario was this. In one `drainTo` call we observed a barrier on all queues but one. In the next call we observed the remaining barrier, but there was also an item in a queue after this barrier. When the barrier was observed, we cleared the `receivedBarriers` bitset, but because we continued to the next queue, if there was a normal item, it was returned before the barrier waiting in the `specialItemStash`.

The failing test passed 200 times, while it failed every 20th-40th run before the fix locally for me.

Fixes #21908