### PR TITLE
Don't allow overriding default serializers with Compact

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -695,21 +695,12 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     /**
      * Makes sure that the classes registered as Compact serializable are not
-     * overriding the default serializers, if the
-     * {@link #allowOverrideDefaultSerializers} configuration option is set to
-     * {@code false}.
+     * overriding the default serializers.
      * <p>
      * Must be called in the constructor of the child classes after they
      * complete registering default serializers.
      */
     protected void verifyDefaultSerializersNotOverriddenWithCompact() {
-        // If the user explicitly set to override default serializers, we should
-        // respect that and allow it to register Compact serializers for such
-        // types. No need to perform further checks.
-        if (allowOverrideDefaultSerializers) {
-            return;
-        }
-
         for (Class clazz : compactStreamSerializer.getCompactSerializableClasses()) {
             if (!constantTypesMap.containsKey(clazz)) {
                 continue;
@@ -718,10 +709,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             throw new IllegalArgumentException("Compact serializer for the "
                     + "class '" + clazz + " can not be registered as it "
                     + "overrides the default serializer for that class "
-                    + "provided by Hazelcast. If you want to override the "
-                    + "default serializer, set the "
-                    + "'allowOverrideDefaultSerializers' to 'true' in the "
-                    + "serialization configuration."
+                    + "provided by Hazelcast."
             );
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -169,7 +169,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
 
         // Called here so that we can make sure that we are not overriding
         // any of the default serializers registered above with the Compact
-        // serialization, unless the user configured to do so explicitly.
+        // serialization.
         verifyDefaultSerializersNotOverriddenWithCompact();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -82,24 +82,7 @@ public class CompactSerializationTest {
 
         assertThatThrownBy(() -> createSerializationService(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("allowOverrideDefaultSerializers");
-    }
-
-    @Test
-    public void testOverridingDefaultSerializers_withAllowOverrideDefaultSerializers() {
-        SerializationConfig config = new SerializationConfig();
-        config.setAllowOverrideDefaultSerializers(true);
-        config.getCompactSerializationConfig()
-                .addSerializer(new IntegerSerializer());
-
-        SerializationService service = createSerializationService(config);
-        Data data = service.toData(42);
-
-        assertTrue(data.isCompact());
-
-        int i = service.toObject(data);
-
-        assertEquals(42, i);
+                .hasMessageContaining("overrides the default serializer");
     }
 
     @Test


### PR DESCRIPTION
Overriding default serializers with Compact might allow easier use for some of the field types, but it can lead to quite subtle problems to debug, when used incorrectly.

Therefore, we have decided to not allow it for 5.2, and this PR removes the integration of the Compact serialization with the `allowOverrideDefaultSerializers` configuration option.