### PR TITLE
[HZ-1287] Enable CodeQL for tests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,7 @@ jobs:
         
     - name: Custom Java build
       run: |
-        ./mvnw -B -V -e clean package -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Dspotbugs.skip -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dlicense.skip=true -Drat.skip=true -Dspotless.check.skip=true -Dmaven.test.skip -Dattribution.skip -Danimal.sniffer.skip=true -Dmaven.source.skip=true
+        ./mvnw -B -V -e clean package -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Dspotbugs.skip -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dlicense.skip=true -Drat.skip=true -Dspotless.check.skip=true -Dattribution.skip -Danimal.sniffer.skip=true -Dmaven.source.skip=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/hazelcast/src/test/java/com/hazelcast/internal/crdt/pncounter/AbstractPNCounterBasicIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/crdt/pncounter/AbstractPNCounterBasicIntegrationTest.java
@@ -75,8 +75,8 @@ public abstract class AbstractPNCounterBasicIntegrationTest extends HazelcastTes
         assertCounterValueEventually(finalValue.longValue(), counter1);
         assertCounterValueEventually(finalValue.longValue(), counter2);
 
-        int increments = 0;
-        int decrements = 0;
+        long increments = 0;
+        long decrements = 0;
         for (HazelcastInstance member : getMembers()) {
             final PNCounterService service = getNodeEngineImpl(member).getService(PNCounterService.SERVICE_NAME);
             for (LocalPNCounterStats stats : service.getStats().values()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/HeapMemoryManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/HeapMemoryManager.java
@@ -37,15 +37,15 @@ public class HeapMemoryManager implements MemoryManager {
 
     private final Accessor mem = new Accessor();
 
-    private final Long2LongHashMap allocatedAddrs = new Long2LongHashMap(1024, 0.7, -1);
+    final Long2LongHashMap allocatedAddrs = new Long2LongHashMap(1024, 0.7, -1);
 
-    private byte[] storage;
+    byte[] storage;
 
-    private int heapTop = HEAP_BOTTOM;
+    long heapTop = HEAP_BOTTOM;
 
-    private int lastAllocatedAddress;
+    long lastAllocatedAddress;
 
-    private int usedMemory;
+    long usedMemory;
 
     public HeapMemoryManager(int size) {
         this.storage = new byte[size];

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWrongTargetForPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWrongTargetForPartitionTest.java
@@ -53,7 +53,7 @@ public class MapPutAllWrongTargetForPartitionTest extends HazelcastTestSupport {
     private static final int INSTANCE_COUNT = 3;
 
     private TestHazelcastInstanceFactory factory;
-    private HazelcastInstance[] instances;
+    HazelcastInstance[] instances;
 
     @Before
     public void setUp() {
@@ -125,9 +125,9 @@ public class MapPutAllWrongTargetForPartitionTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                int totalBackups = 0;
+                long totalBackups = 0;
                 for (int i = 0; i < INSTANCE_COUNT; i++) {
-                    IMap map = instances[i].getMap(mapName);
+                    IMap<?, ?> map = instances[i].getMap(mapName);
                     assertEquals(format("Each member should own %d entries of the map", entriesPerPartition),
                             entriesPerPartition, map.getLocalMapStats().getOwnedEntryCount());
                     totalBackups += map.getLocalMapStats().getBackupEntryCount();


### PR DESCRIPTION
When `-Dmaven.test.skip` is used in the custom build command within the CodeQL workflow, the builds fail for new POM versions (hit by #22218). 

Moreover, we should use CodeQL scanning for test classes too to avoid unnecessary test errors. The `maven.test.skip` argument was a leftover from the investigation of hanging builds in #21663