### PR TITLE
[22155] Fix incorrect CP group leader rebalancing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -674,7 +674,7 @@ class RaftGroupMembershipManager {
                         continue;
                     }
                     int k = g.size();
-                    if (k < min) {
+                    if (k <= min) {
                         min = k;
                         to = member;
                         groupId = group.id();


### PR DESCRIPTION
Fixes #22155

Unfortunately, I can't provide reliable tests for this given logic because they would be too complicated. For example, they should tolerate the corner cases when all CP groups are formed from low-priority CP members. And the test results checker will need tests for itself.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
