### PR TITLE
[API-1441] Invoke schema replication operations in parallel

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/schema/SendSchemaMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/schema/SendSchemaMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.impl.protocol.task.schema;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientSendSchemaCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractAsyncMessageTask;
-import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.impl.compact.Schema;
@@ -30,7 +29,6 @@ import java.security.Permission;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 public class SendSchemaMessageTask extends AbstractAsyncMessageTask<Schema, Collection<UUID>> {
 
@@ -46,12 +44,7 @@ public class SendSchemaMessageTask extends AbstractAsyncMessageTask<Schema, Coll
     @Override
     protected CompletableFuture<Collection<UUID>> processInternal() {
         MemberSchemaService memberSchemaService = getService(getServiceName());
-
-        // After replicating the schema, we will return the current member list
-        // in this member, as we for sure that the schema is replicated in these
-        // members.
-        return memberSchemaService.putAsync(parameters)
-                .thenApply(ignored -> getCurrentMemberUuids());
+        return memberSchemaService.putAsync(parameters);
     }
 
     @Override
@@ -82,12 +75,5 @@ public class SendSchemaMessageTask extends AbstractAsyncMessageTask<Schema, Coll
     @Override
     public Object[] getParameters() {
         return null;
-    }
-
-    private Collection<UUID> getCurrentMemberUuids() {
-        return nodeEngine.getClusterService().getMembers()
-                .stream()
-                .map(Member::getUuid)
-                .collect(Collectors.toList());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/AckSchemaReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/AckSchemaReplicationOperation.java
@@ -44,7 +44,7 @@ public class AckSchemaReplicationOperation extends AbstractSchemaReplicationOper
     @Override
     protected void runInternal() {
         MemberSchemaService service = getService();
-        service.onSchemaAckRequest(schemaId, executedLocally());
+        service.onSchemaAckRequest(schemaId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/MemberSchemaService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/MemberSchemaService.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -94,7 +95,7 @@ public class MemberSchemaService implements
      *
      * @param schema to replicate.
      */
-    public InternalCompletableFuture<Void> putAsync(Schema schema) {
+    public InternalCompletableFuture<Collection<UUID>> putAsync(Schema schema) {
         return replicator.replicate(schema);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicationsMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicationsMerger.java
@@ -18,10 +18,10 @@ package com.hazelcast.internal.serialization.impl.compact.schema;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.util.FutureUtil;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -45,7 +45,7 @@ public final class SchemaReplicationsMerger implements Runnable {
     public void run() {
         try {
             // Filter out replications already present in the larger cluster.
-            List<CompletableFuture<Void>> replicationFutures = replications.stream()
+            List<InternalCompletableFuture<Void>> replicationFutures = replications.stream()
                     .filter(replication -> {
                         SchemaReplicationStatus status = replicator.getReplicationStatus(replication.getSchema());
                         if (status == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicationsMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicationsMerger.java
@@ -22,6 +22,7 @@ import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -45,7 +46,7 @@ public final class SchemaReplicationsMerger implements Runnable {
     public void run() {
         try {
             // Filter out replications already present in the larger cluster.
-            List<InternalCompletableFuture<Void>> replicationFutures = replications.stream()
+            List<InternalCompletableFuture<Collection<UUID>>> replicationFutures = replications.stream()
                     .filter(replication -> {
                         SchemaReplicationStatus status = replicator.getReplicationStatus(replication.getSchema());
                         if (status == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicator.java
@@ -112,7 +112,7 @@ public class SchemaReplicator {
     public InternalCompletableFuture<Collection<UUID>> replicate(Schema schema) {
         long schemaId = schema.getSchemaId();
         if (isSchemaReplicated(schemaId)) {
-            return InternalCompletableFuture.newCompletedFuture(getCurrenMemberUuids());
+            return InternalCompletableFuture.newCompletedFuture(getCurrentMemberUuids());
         }
 
         InternalCompletableFuture<Collection<UUID>> future = inFlightOperations.get(schemaId);
@@ -122,7 +122,7 @@ public class SchemaReplicator {
 
         synchronized (mutex) {
             if (isSchemaReplicated(schemaId)) {
-                return InternalCompletableFuture.newCompletedFuture(getCurrenMemberUuids());
+                return InternalCompletableFuture.newCompletedFuture(getCurrentMemberUuids());
             }
 
             future = inFlightOperations.get(schemaId);
@@ -144,7 +144,7 @@ public class SchemaReplicator {
             case REPLICATED:
                 // Schema is already known to be replicated across cluster
                 inFlightOperations.remove(schemaId, future);
-                future.complete(getCurrenMemberUuids());
+                future.complete(getCurrentMemberUuids());
                 break;
             case PREPARED:
                 // The schema is prepared, but we need to make sure that it is
@@ -344,7 +344,7 @@ public class SchemaReplicator {
         );
     }
 
-    private Collection<UUID> getCurrenMemberUuids() {
+    private Collection<UUID> getCurrentMemberUuids() {
         return nodeEngine.getClusterService().getMembers()
                 .stream()
                 .map(Member::getUuid)

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.util;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.cluster.ClusterService;
@@ -34,17 +33,11 @@ import com.hazelcast.spi.properties.ClusterProperty;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static com.hazelcast.internal.util.IterableUtil.map;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
@@ -223,167 +216,6 @@ public final class InvocationUtil {
                         future.completeExceptionally(t);
                     }
                 });
-            }
-        }
-    }
-
-    private static final class ParallelOperationInvoker {
-        private final NodeEngine nodeEngine;
-        private final ClusterService clusterService;
-        private final Supplier<Operation> operationSupplier;
-        private final int maxRetries;
-        private final long retryDelayMillis;
-        private final AtomicInteger retryCount = new AtomicInteger(0);
-        private final InternalCompletableFuture<Collection<UUID>> future = new InternalCompletableFuture<>();
-        private volatile Set<Member> members;
-
-        ParallelOperationInvoker(NodeEngine nodeEngine, Supplier<Operation> operationSupplier, int maxRetries) {
-            this.nodeEngine = nodeEngine;
-            this.clusterService = nodeEngine.getClusterService();
-            this.operationSupplier = operationSupplier;
-            this.maxRetries = maxRetries;
-            this.retryDelayMillis = nodeEngine.getProperties().getMillis(ClusterProperty.INVOCATION_RETRY_PAUSE);
-        }
-
-        public InternalCompletableFuture<Collection<UUID>> invoke() {
-            doInvoke();
-            return future;
-        }
-
-        private void doInvoke() {
-            members = clusterService.getMembers();
-            InternalCompletableFuture[] futures = invokeOnAllMembersExcludingThis(members);
-            CompletableFuture.allOf(futures)
-                    .whenCompleteAsync(
-                            (ignored, throwable) -> completeFutureOrRetry(throwable == null, futures),
-                            ConcurrencyUtil.getDefaultAsyncExecutor());
-        }
-
-        private void doInvokeWithDelay() {
-            nodeEngine.getExecutionService().schedule(this::doInvoke, retryDelayMillis, TimeUnit.MILLISECONDS);
-        }
-
-        private InternalCompletableFuture[] invokeOnAllMembersExcludingThis(Collection<Member> members) {
-            return members.stream()
-                    .filter(member -> !nodeEngine.getThisAddress().equals(member.getAddress()))
-                    .map(this::invokeOnMember)
-                    .toArray(InternalCompletableFuture[]::new);
-        }
-
-        private InternalCompletableFuture<Void> invokeOnMember(Member member) {
-            Operation operation = operationSupplier.get();
-            String serviceName = operation.getServiceName();
-            Address target = member.getAddress();
-            return nodeEngine.getOperationService().invokeOnTarget(serviceName, operation, target);
-        }
-
-        private void completeFutureOrRetry(boolean noExceptionReceived, InternalCompletableFuture[] futures) {
-            Set<Member> currentMembers = clusterService.getMembers();
-            if (noExceptionReceived) {
-                // All futures completed successfully.
-                // If the member list at the start and now are equal to each
-                // other, we will complete the future. If not, we will retry
-                if (currentMembers.equals(members)) {
-                    List<UUID> memberUuids = convertMemberListToMemberUuidList(currentMembers);
-                    future.complete(memberUuids);
-                } else {
-                    retry();
-                }
-            } else {
-                // At least one of the futures completed exceptionally
-                onExceptionalCompletion(futures, currentMembers);
-            }
-        }
-
-        private void retry() {
-            if (retryCount.incrementAndGet() > maxRetries) {
-                Throwable t = new HazelcastException("Cluster topology was not stable for " + maxRetries + " retries");
-                future.completeExceptionally(t);
-                return;
-            }
-            doInvokeWithDelay();
-        }
-
-        private List<UUID> convertMemberListToMemberUuidList(Collection<Member> members) {
-            return members.stream()
-                    .map(Member::getUuid)
-                    .collect(Collectors.toList());
-        }
-
-        private boolean isExceptionCanBeIgnored(Throwable t) {
-            // Same as the ignored exceptions in the
-            // RestartingMemberIterator#handle
-            return t instanceof MemberLeftException
-                    || t instanceof TargetNotMemberException
-                    || t instanceof HazelcastInstanceNotActiveException;
-        }
-
-        private void onExceptionalCompletion(InternalCompletableFuture[] futures, Collection<Member> members) {
-            // We know all futures are done, and at least one of them completed
-            // with an exception. We will inspect all the futures, and act
-            // according to thrown exception(s)
-            boolean isTerminalExceptionReceived = false;
-            Throwable terminalException = null;
-
-            boolean isClusterTopologyChanged = false;
-
-            for (InternalCompletableFuture future : futures) {
-                assert future.isDone();
-
-                if (!future.isCompletedExceptionally()) {
-                    continue;
-                }
-
-                try {
-                    future.join();
-                } catch (CancellationException cancellationException) {
-                    // We cannot retry or ignore cancellation exception
-                    isTerminalExceptionReceived = true;
-                    terminalException = cancellationException;
-                    break;
-                } catch (CompletionException completionException) {
-                    // Exceptions are wrapped inside the completion exception
-                    Throwable cause = completionException.getCause();
-
-                    if (cause instanceof ClusterTopologyChangedException) {
-                        // This is not a terminal exception, and we would retry
-                        // the invocations if this was the only exception thrown
-                        isClusterTopologyChanged = true;
-                        // Not breaking, we should inspect other futures as well
-                    } else if (!isExceptionCanBeIgnored(cause)) {
-                        // Some exceptions are ignored. if the cause was one of
-                        // them we will continue inspecting other futures for
-                        // other failures. if it was not one of the exception
-                        // types that can be ignored, then it is terminal.
-                        isTerminalExceptionReceived = true;
-                        terminalException = cause != null ? cause : completionException;
-                        break;
-                    }
-                } catch (Throwable t) {
-                    // No other type of exception is expected as per the docs
-                    // of .join(), but no harm is done by being a bit defensive
-                    // here, and consider any other exception as a terminal one
-                    isTerminalExceptionReceived = true;
-                    terminalException = t;
-                    break;
-                }
-            }
-
-            if (isTerminalExceptionReceived) {
-                // If any of the futures are completed with a terminal exception,
-                // the others are not really important. The whole invocation should
-                // fail with that terminal exception
-                future.completeExceptionally(terminalException);
-            } else if (isClusterTopologyChanged) {
-                // If there were no terminal exception, but the cluster topology
-                // is changed, we should retry
-                retry();
-            } else {
-                // If the types of the exceptions can be ignored, we will
-                // assume the invocations are completed, similar to
-                // invokeOnStableClusterSerial
-                List<UUID> memberUuids = convertMemberListToMemberUuidList(members);
-                future.complete(memberUuids);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -18,20 +18,34 @@ package com.hazelcast.internal.util;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
 import com.hazelcast.internal.util.futures.ChainingFuture;
 import com.hazelcast.internal.util.iterator.RestartingMemberIterator;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
 import com.hazelcast.spi.properties.ClusterProperty;
 
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.hazelcast.internal.util.IterableUtil.map;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
@@ -110,6 +124,42 @@ public final class InvocationUtil {
         return execution;
     }
 
+    /**
+     * Invokes the given operation on all cluster members (excluding this
+     * member), in parallel.
+     * <p>
+     * The operation is retried until the cluster is stable between the start
+     * and the end of the invocations.
+     * <p>
+     * The operations invoked with this method should be idempotent.
+     * <p>
+     * If one of the invocations throw any exception other than the
+     * {@link ClusterTopologyChangedException}, {@link MemberLeftException},
+     * {@link TargetNotMemberException}, or
+     * {@link HazelcastInstanceNotActiveException} the method fails with that
+     * exception. When invocations fail with <b>only</b>
+     * {@code ClusterTopologyChangedException}, the invocations are retried.
+     * When invocations fail with <b>only<b/> {@code MemberLeftException},
+     * {@code TargetNotMemberException}, or
+     * {@code HazelcastInstanceNotActiveException} the exceptions are ignored
+     * and the method returns the current member UUIDs, in a similar manner to
+     * {@link #invokeOnStableClusterSerial(NodeEngine, Supplier, int)}.
+     * <p>
+     * Between each retry, the parallel invocations are delayed for
+     * {@link ClusterProperty#INVOCATION_RETRY_PAUSE} milliseconds.
+     *
+     * @return the collection of the member UUIDs that the operations are
+     * invoked on
+     */
+    public static InternalCompletableFuture<Collection<UUID>> invokeOnStableClusterParallel(
+            NodeEngine nodeEngine,
+            Supplier<Operation> operationSupplier,
+            int maxRetries
+    ) {
+        ParallelOperationInvoker invoker = new ParallelOperationInvoker(nodeEngine, operationSupplier, maxRetries);
+        return invoker.invoke();
+    }
+
     private static class InvokeOnMemberFunction implements Function<Member, InternalCompletableFuture<Object>> {
         private final transient Supplier<? extends Operation> operationSupplier;
         private final transient NodeEngine nodeEngine;
@@ -174,6 +224,167 @@ public final class InvocationUtil {
                         future.completeExceptionally(t);
                     }
                 });
+            }
+        }
+    }
+
+    private static final class ParallelOperationInvoker {
+        private final NodeEngine nodeEngine;
+        private final ClusterService clusterService;
+        private final Supplier<Operation> operationSupplier;
+        private final int maxRetries;
+        private final long retryDelayMillis;
+        private final AtomicInteger retryCount = new AtomicInteger(0);
+        private final InternalCompletableFuture<Collection<UUID>> future = new InternalCompletableFuture<>();
+        private volatile Set<Member> members;
+
+        ParallelOperationInvoker(NodeEngine nodeEngine, Supplier<Operation> operationSupplier, int maxRetries) {
+            this.nodeEngine = nodeEngine;
+            this.clusterService = nodeEngine.getClusterService();
+            this.operationSupplier = operationSupplier;
+            this.maxRetries = maxRetries;
+            this.retryDelayMillis = nodeEngine.getProperties().getMillis(ClusterProperty.INVOCATION_RETRY_PAUSE);
+        }
+
+        public InternalCompletableFuture<Collection<UUID>> invoke() {
+            doInvoke();
+            return future;
+        }
+
+        private void doInvoke() {
+            members = clusterService.getMembers();
+            InternalCompletableFuture[] futures = invokeOnAllMembersExcludingThis(members);
+            CompletableFuture.allOf(futures)
+                    .whenCompleteAsync(
+                            (ignored, throwable) -> completeFutureOrRetry(throwable == null, futures),
+                            ConcurrencyUtil.getDefaultAsyncExecutor());
+        }
+
+        private void doInvokeWithDelay() {
+            nodeEngine.getExecutionService().schedule(this::doInvoke, retryDelayMillis, TimeUnit.MILLISECONDS);
+        }
+
+        private InternalCompletableFuture[] invokeOnAllMembersExcludingThis(Collection<Member> members) {
+            return members.stream()
+                    .filter(member -> !nodeEngine.getThisAddress().equals(member.getAddress()))
+                    .map(this::invokeOnMember)
+                    .toArray(InternalCompletableFuture[]::new);
+        }
+
+        private InternalCompletableFuture<Void> invokeOnMember(Member member) {
+            Operation operation = operationSupplier.get();
+            String serviceName = operation.getServiceName();
+            Address target = member.getAddress();
+            return nodeEngine.getOperationService().invokeOnTarget(serviceName, operation, target);
+        }
+
+        private void completeFutureOrRetry(boolean noExceptionReceived, InternalCompletableFuture[] futures) {
+            Set<Member> currentMembers = clusterService.getMembers();
+            if (noExceptionReceived) {
+                // All futures completed successfully.
+                // If the member list at the start and now are equal to each
+                // other, we will complete the future. If not, we will retry
+                if (currentMembers.equals(members)) {
+                    List<UUID> memberUuids = convertMemberListToMemberUuidList(currentMembers);
+                    future.complete(memberUuids);
+                } else {
+                    retry();
+                }
+            } else {
+                // At least one of the futures completed exceptionally
+                onExceptionalCompletion(futures, currentMembers);
+            }
+        }
+
+        private void retry() {
+            if (retryCount.incrementAndGet() > maxRetries) {
+                Throwable t = new HazelcastException("Cluster topology was not stable for " + maxRetries + " retries");
+                future.completeExceptionally(t);
+                return;
+            }
+            doInvokeWithDelay();
+        }
+
+        private List<UUID> convertMemberListToMemberUuidList(Collection<Member> members) {
+            return members.stream()
+                    .map(Member::getUuid)
+                    .collect(Collectors.toList());
+        }
+
+        private boolean isExceptionCanBeIgnored(Throwable t) {
+            // Same as the ignored exceptions in the
+            // RestartingMemberIterator#handle
+            return t instanceof MemberLeftException
+                    || t instanceof TargetNotMemberException
+                    || t instanceof HazelcastInstanceNotActiveException;
+        }
+
+        private void onExceptionalCompletion(InternalCompletableFuture[] futures, Collection<Member> members) {
+            // We know all futures are done, and at least one of them completed
+            // with an exception. We will inspect all the futures, and act
+            // according to thrown exception(s)
+            boolean isTerminalExceptionReceived = false;
+            Throwable terminalException = null;
+
+            boolean isClusterTopologyChanged = false;
+
+            for (InternalCompletableFuture future : futures) {
+                assert future.isDone();
+
+                if (!future.isCompletedExceptionally()) {
+                    continue;
+                }
+
+                try {
+                    future.join();
+                } catch (CancellationException cancellationException) {
+                    // We cannot retry or ignore cancellation exception
+                    isTerminalExceptionReceived = true;
+                    terminalException = cancellationException;
+                    break;
+                } catch (CompletionException completionException) {
+                    // Exceptions are wrapped inside the completion exception
+                    Throwable cause = completionException.getCause();
+
+                    if (cause instanceof ClusterTopologyChangedException) {
+                        // This is not a terminal exception, and we would retry
+                        // the invocations if this was the only exception thrown
+                        isClusterTopologyChanged = true;
+                        // Not breaking, we should inspect other futures as well
+                    } else if (!isExceptionCanBeIgnored(cause)) {
+                        // Some exceptions are ignored. if the cause was one of
+                        // them we will continue inspecting other futures for
+                        // other failures. if it was not one of the exception
+                        // types that can be ignored, then it is terminal.
+                        isTerminalExceptionReceived = true;
+                        terminalException = cause != null ? cause : completionException;
+                        break;
+                    }
+                } catch (Throwable t) {
+                    // No other type of exception is expected as per the docs
+                    // of .join(), but no harm is done by being a bit defensive
+                    // here, and consider any other exception as a terminal one
+                    isTerminalExceptionReceived = true;
+                    terminalException = t;
+                    break;
+                }
+            }
+
+            if (isTerminalExceptionReceived) {
+                // If any of the futures are completed with a terminal exception,
+                // the others are not really important. The whole invocation should
+                // fail with that terminal exception
+                future.completeExceptionally(terminalException);
+            } else if (isClusterTopologyChanged) {
+                // If there were no terminal exception, but the cluster topology
+                // is changed, we should retry
+                retry();
+            } else {
+                // If the types of the exceptions can be ignored, we will
+                // assume the invocations are completed, similar to
+                // invokeOnStableClusterSerial
+                List<UUID> memberUuids = convertMemberListToMemberUuidList(members);
+                future.complete(memberUuids);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ParallelOperationInvoker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ParallelOperationInvoker.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.properties.ClusterProperty;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+
+/**
+ * See {@link InvocationUtil#invokeOnStableClusterParallel(NodeEngine, Supplier, int)}.
+ */
+class ParallelOperationInvoker {
+    private final NodeEngine nodeEngine;
+    private final ClusterService clusterService;
+    private final Supplier<Operation> operationSupplier;
+    private final int maxRetries;
+    private final long retryDelayMillis;
+    private final AtomicInteger retryCount = new AtomicInteger(0);
+    private final InternalCompletableFuture<Collection<UUID>> future = new InternalCompletableFuture<>();
+    private volatile Set<Member> members;
+
+    ParallelOperationInvoker(NodeEngine nodeEngine, Supplier<Operation> operationSupplier, int maxRetries) {
+        this.nodeEngine = nodeEngine;
+        this.clusterService = nodeEngine.getClusterService();
+        this.operationSupplier = operationSupplier;
+        this.maxRetries = maxRetries;
+        this.retryDelayMillis = nodeEngine.getProperties().getMillis(ClusterProperty.INVOCATION_RETRY_PAUSE);
+    }
+
+    public InternalCompletableFuture<Collection<UUID>> invoke() {
+        doInvoke();
+        return future;
+    }
+
+    private void doInvoke() {
+        members = clusterService.getMembers();
+        InternalCompletableFuture[] futures = invokeOnAllMembersExcludingThis(members);
+        CompletableFuture.allOf(futures)
+                .whenCompleteAsync(
+                        (ignored, throwable) -> completeFutureOrRetry(throwable == null, futures),
+                        ConcurrencyUtil.getDefaultAsyncExecutor());
+    }
+
+    private void doInvokeWithDelay() {
+        nodeEngine.getExecutionService().schedule(this::doInvoke, retryDelayMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private InternalCompletableFuture[] invokeOnAllMembersExcludingThis(Collection<Member> members) {
+        return members.stream()
+                .filter(member -> !nodeEngine.getThisAddress().equals(member.getAddress()))
+                .map(this::invokeOnMember)
+                .toArray(InternalCompletableFuture[]::new);
+    }
+
+    private InternalCompletableFuture<Void> invokeOnMember(Member member) {
+        Operation operation = operationSupplier.get();
+        String serviceName = operation.getServiceName();
+        Address target = member.getAddress();
+        return nodeEngine.getOperationService().invokeOnTarget(serviceName, operation, target);
+    }
+
+    private void completeFutureOrRetry(boolean noExceptionReceived, InternalCompletableFuture[] futures) {
+        Set<Member> currentMembers = clusterService.getMembers();
+        if (noExceptionReceived) {
+            // All futures completed successfully.
+            // If the member list at the start and now are equal to each
+            // other, we will complete the future. If not, we will retry
+            if (currentMembers.equals(members)) {
+                List<UUID> memberUuids = convertMemberListToMemberUuidList(currentMembers);
+                future.complete(memberUuids);
+            } else {
+                retry();
+            }
+        } else {
+            // At least one of the futures completed exceptionally
+            onExceptionalCompletion(futures, currentMembers);
+        }
+    }
+
+    private void retry() {
+        if (retryCount.incrementAndGet() > maxRetries) {
+            Throwable t = new HazelcastException("Cluster topology was not stable for " + maxRetries + " retries");
+            future.completeExceptionally(t);
+            return;
+        }
+        doInvokeWithDelay();
+    }
+
+    private List<UUID> convertMemberListToMemberUuidList(Collection<Member> members) {
+        return members.stream()
+                .map(Member::getUuid)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isIgnorableException(Throwable t) {
+        // Same as the ignored exceptions in the
+        // RestartingMemberIterator#handle
+        return t instanceof MemberLeftException
+                || t instanceof TargetNotMemberException
+                || t instanceof HazelcastInstanceNotActiveException;
+    }
+
+    private void onExceptionalCompletion(InternalCompletableFuture[] futures, Collection<Member> members) {
+        // We know all futures are done, and at least one of them completed
+        // with an exception. We will inspect all the futures, and act
+        // according to thrown exception(s)
+        boolean isTerminalExceptionReceived = false;
+        Throwable terminalException = null;
+
+        boolean isClusterTopologyChanged = false;
+
+        for (InternalCompletableFuture future : futures) {
+            assert future.isDone();
+
+            if (!future.isCompletedExceptionally()) {
+                continue;
+            }
+
+            try {
+                future.join();
+            } catch (CancellationException cancellationException) {
+                // We cannot retry or ignore cancellation exception
+                isTerminalExceptionReceived = true;
+                terminalException = cancellationException;
+                break;
+            } catch (CompletionException completionException) {
+                // Exceptions are wrapped inside the completion exception
+                Throwable cause = completionException.getCause();
+
+                if (cause instanceof ClusterTopologyChangedException) {
+                    // This is not a terminal exception, and we would retry
+                    // the invocations if this was the only exception thrown
+                    isClusterTopologyChanged = true;
+                    // Not breaking, we should inspect other futures as well
+                } else if (!isIgnorableException(cause)) {
+                    // Some exceptions are ignored. if the cause was one of
+                    // them we will continue inspecting other futures for
+                    // other failures. if it was not one of the exception
+                    // types that can be ignored, then it is terminal.
+                    isTerminalExceptionReceived = true;
+                    terminalException = cause != null ? cause : completionException;
+                    break;
+                }
+            } catch (Throwable t) {
+                // No other type of exception is expected as per the docs
+                // of .join(), but no harm is done by being a bit defensive
+                // here, and consider any other exception as a terminal one
+                isTerminalExceptionReceived = true;
+                terminalException = t;
+                break;
+            }
+        }
+
+        if (isTerminalExceptionReceived) {
+            // If any of the futures are completed with a terminal exception,
+            // the others are not really important. The whole invocation should
+            // fail with that terminal exception
+            future.completeExceptionally(terminalException);
+        } else if (isClusterTopologyChanged) {
+            // If there were no terminal exception, but the cluster topology
+            // is changed, we should retry
+            retry();
+        } else {
+            // If the types of the exceptions can be ignored, we will
+            // assume the invocations are completed, similar to
+            // invokeOnStableClusterSerial
+            List<UUID> memberUuids = convertMemberListToMemberUuidList(members);
+            future.complete(memberUuids);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicatorTest.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.internal.serialization.impl.compact.schema;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
+import com.hazelcast.instance.SimpleMemberImpl;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.serialization.impl.compact.Schema;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
@@ -26,17 +28,25 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.MemberVersion;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -51,12 +61,13 @@ import static org.mockito.Mockito.when;
 public class CompactSchemaReplicatorTest extends HazelcastTestSupport {
     private SchemaReplicator replicator;
     private MemberSchemaService schemaService;
+    private ClusterService clusterService;
 
     @Before
     public void setUp() {
         schemaService = mock(MemberSchemaService.class);
         replicator = spy(new SchemaReplicator(schemaService));
-        ClusterService clusterService = mock(ClusterService.class);
+        clusterService = mock(ClusterService.class);
         when(clusterService.getMembers()).thenReturn(Collections.emptySet());
         NodeEngine nodeEngine = mock(NodeEngine.class);
         when(nodeEngine.getClusterService()).thenReturn(clusterService);
@@ -75,6 +86,46 @@ public class CompactSchemaReplicatorTest extends HazelcastTestSupport {
         assertEquals(1, replicator.getReplications().size());
         assertEquals(SchemaReplicationStatus.REPLICATED, replicator.getReplicationStatus(schema));
         assertEquals(0, replicator.getInFlightOperations().size());
+    }
+
+    @Test
+    public void testReplicate_returnsReplicatedMemberUuids() {
+        makeSchemaServicePrepareImmediately();
+
+        SimpleMemberImpl member = new SimpleMemberImpl(MemberVersion.UNKNOWN, UUID.randomUUID(), new InetSocketAddress("127.0.0.1", 55555));
+
+        // start with a single member
+        when(clusterService.getMembers())
+                .thenReturn(Collections.singleton(member));
+
+        doReturn(InternalCompletableFuture.newCompletedFuture(Collections.singleton(member.getUuid())))
+                .when(replicator)
+                .sendRequestForPreparation(any());
+        doReturn(InternalCompletableFuture.newCompletedFuture(Collections.singleton(member.getUuid())))
+                .when(replicator)
+                .sendRequestForAcknowledgment(anyLong());
+
+        Schema schema = createSchema();
+        Collection<UUID> uuids = replicator.replicate(schema).join();
+
+        // the replication should return the member uuid
+        assertThat(uuids)
+                .containsExactlyInAnyOrder(member.getUuid());
+
+        Set<Member> members = new HashSet<>();
+        members.add(member);
+
+        SimpleMemberImpl newMember = new SimpleMemberImpl(MemberVersion.UNKNOWN, UUID.randomUUID(), new InetSocketAddress("127.0.0.1", 55556));
+        members.add(newMember);
+
+        // assume that the member list changes
+        when(clusterService.getMembers())
+                .thenReturn(members);
+
+        // for already replicated schemas, the new member list should be returned
+        uuids = replicator.replicate(schema).join();
+        assertThat(uuids)
+                .containsExactlyInAnyOrder(member.getUuid(), newMember.getUuid());
     }
 
     @Test
@@ -114,8 +165,8 @@ public class CompactSchemaReplicatorTest extends HazelcastTestSupport {
         InternalCompletableFuture<Void> future = makeSchemaServicePrepareLater();
 
         Schema schema = createSchema();
-        InternalCompletableFuture<Void> future1 = replicator.replicate(schema);
-        InternalCompletableFuture<Void> future2 = replicator.replicate(schema);
+        InternalCompletableFuture<Collection<UUID>> future1 = replicator.replicate(schema);
+        InternalCompletableFuture<Collection<UUID>> future2 = replicator.replicate(schema);
 
         assertSame(future1, future2);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ParallelOperationInvokerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ParallelOperationInvokerTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.operationservice.ExceptionAction;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.instance.impl.TestUtil.getNode;
+import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterParallel;
+import static com.hazelcast.spi.properties.ClusterProperty.INVOCATION_RETRY_PAUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ParallelOperationInvokerTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private Config config;
+    private HazelcastInstance instance1;
+    private HazelcastInstance instance2;
+    private HazelcastInstance instance3;
+
+    @Before
+    public void setup() {
+        config = smallInstanceConfig();
+        config.getJetConfig().setEnabled(false);
+        config.setProperty(INVOCATION_RETRY_PAUSE.getName(), "10");
+        instance1 = factory.newHazelcastInstance(config);
+        instance2 = factory.newHazelcastInstance(config);
+        instance3 = factory.newHazelcastInstance(config);
+    }
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testInvoke() {
+        Node node = getNode(instance1);
+        Collection<UUID> uuids = invokeOnStableClusterParallel(
+                node.getNodeEngine(),
+                NoOpOperation::new,
+                0
+        ).join();
+
+        Collection<UUID> expectedUuids = getExpectedUuids(instance1, instance2, instance3);
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withSingleMember() {
+        instance2.shutdown();
+        instance3.shutdown();
+
+        assertClusterSizeEventually(1, instance1);
+
+        Node node = getNode(instance1);
+        Collection<UUID> uuids = invokeOnStableClusterParallel(
+                node.getNodeEngine(),
+                NoOpOperation::new,
+                0
+        ).join();
+
+        Collection<UUID> expectedUuids = getExpectedUuids(instance1);
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withThrowingTerminalException() {
+        Node node = getNode(instance2);
+        assertThatThrownBy(() -> {
+            invokeOnStableClusterParallel(
+                    node.getNodeEngine(),
+                    () -> new ExceptionThrowingOperation(new RuntimeException("expected")),
+                    0
+            ).join();
+        }).isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(RuntimeException.class)
+                .hasStackTraceContaining("expected");
+    }
+
+    @Test
+    public void testInvoke_withThrowingCompletionExceptionWithNullCause() {
+        Node node = getNode(instance2);
+        assertThatThrownBy(() -> {
+            invokeOnStableClusterParallel(
+                    node.getNodeEngine(),
+                    () -> new ExceptionThrowingOperation(new CompletionException(null)),
+                    0
+            ).join();
+        }).isInstanceOf(CompletionException.class)
+                .hasCause(null);
+    }
+
+    @Test
+    public void testInvoke_withThrowingIgnorableException() {
+        Node node = getNode(instance3);
+        Collection<UUID> uuids = invokeOnStableClusterParallel(
+                node.getNodeEngine(),
+                () -> new ExceptionThrowingOperation(new HazelcastInstanceNotActiveException("expected")),
+                2
+        ).join();
+
+        Collection<UUID> expectedUuids = getExpectedUuids(instance1, instance2, instance3);
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withThrowingTopologyChangeException() {
+        Node node = getNode(instance3);
+        assertThatThrownBy(() -> {
+            invokeOnStableClusterParallel(
+                    node.getNodeEngine(),
+                    () -> new ExceptionThrowingOperation(new ClusterTopologyChangedException("expected")),
+                    2
+            ).join();
+        }).isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(HazelcastException.class)
+                .hasStackTraceContaining("Cluster topology was not stable");
+    }
+
+    @Test
+    public void testInvoke_whenNewMembersAreAdded() {
+        Node node = getNode(instance1);
+        InternalCompletableFuture<Collection<UUID>> future = invokeOnStableClusterParallel(
+                node.getNodeEngine(),
+                () -> new AwaitingOperation(4),
+                2
+        );
+
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        assertClusterSizeEventually(4, instance1, instance2, instance3, instance4);
+
+        Collection<UUID> expectedUuids = getExpectedUuids(instance1, instance2, instance3, instance4);
+
+        Collection<UUID> uuids = future.join();
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_whenNewMembersRemoved() {
+        Node node = getNode(instance2);
+        InternalCompletableFuture<Collection<UUID>> future = invokeOnStableClusterParallel(
+                node.getNodeEngine(),
+                () -> new AwaitingOperation(2),
+                2
+        );
+
+        instance3.shutdown();
+        assertClusterSizeEventually(2, instance1, instance2);
+
+        Collection<UUID> expectedUuids = getExpectedUuids(instance1, instance2);
+
+        Collection<UUID> uuids = future.join();
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    private Collection<UUID> getExpectedUuids(HazelcastInstance... instances) {
+        return Arrays.stream(instances)
+                .map(instance -> instance.getLocalEndpoint().getUuid())
+                .collect(Collectors.toList());
+    }
+
+    private static class NoOpOperation extends Operation {
+    }
+
+    private static class ExceptionThrowingOperation extends Operation {
+        private Exception exception;
+
+        ExceptionThrowingOperation() {
+        }
+
+        ExceptionThrowingOperation(Exception exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public void run() throws Exception {
+            throw exception;
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeObject(exception);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            exception = in.readObject();
+        }
+
+        @Override
+        public ExceptionAction onInvocationException(Throwable throwable) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+    }
+
+    private static class AwaitingOperation extends Operation {
+
+        private int expectedMemberCount;
+
+        AwaitingOperation() {
+        }
+
+        AwaitingOperation(int expectedMemberCount) {
+            this.expectedMemberCount = expectedMemberCount;
+        }
+
+        @Override
+        public void run() throws Exception {
+            while (getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
+                Thread.sleep(100);
+            }
+            super.run();
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeInt(expectedMemberCount);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            expectedMemberCount = in.readInt();
+        }
+    }
+}


### PR DESCRIPTION
We were using `InvocationUtil#invokeOnStableClusterSerial` to invoke schema replication related operations in all cluster members in serial, restarting the iterations in case of topology changes.

It works fine, but for the requirements of the schema replication, the process can happen in parallel as well, making it more scalable for large clusters.

This PR introduces a counterpart of the aforementioned method to run the given operation in stable a cluster in parallel, exhibiting the same behavior in case of exceptional cases.

The only difference of the new method is that it skips executing the operation on this member, to make the implementation in the schema replicator cleaner. If in the future, someone needs a variant of this method that needs to run the operation in this member as well, we can simply add a boolean flag for it.

Also, this PR replaces all usages of CompletableFuture in the Compact related parts with the InternalCompletableFuture to make sure that methods of the form `xxx` and
`xxxAsync(without the executor)` run in the default executor. In the CompletableFuture, the place to run the callbacks was undefined, so it is better to be safe and use what we use in the rest of the code base.