### PR TITLE
Add clientVersion to MemberState [MC-1611]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.management;
 
 import com.hazelcast.cache.impl.CacheService;
-import com.hazelcast.client.Client;
+import com.hazelcast.client.impl.ClientEndpoint;
 import com.hazelcast.client.impl.statistics.ClientStatistics;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
@@ -148,10 +148,11 @@ public class TimedMemberStateFactory {
                                    Collection<StatisticsAwareService> services) {
         Node node = instance.node;
 
-        final Collection<Client> clients = instance.node.clientEngine.getClients();
-        final Set<ClientEndPointDTO> serializableClientEndPoints = createHashSet(clients.size());
-        for (Client client : clients) {
-            serializableClientEndPoints.add(new ClientEndPointDTO(client));
+        final Collection<ClientEndpoint> clientEndpoints = instance.node.clientEngine.getEndpointManager()
+                .getEndpoints();
+        final Set<ClientEndPointDTO> serializableClientEndPoints = createHashSet(clientEndpoints.size());
+        for (ClientEndpoint endpoint : clientEndpoints) {
+            serializableClientEndPoints.add(new ClientEndPointDTO(endpoint));
         }
         memberState.setClients(serializableClientEndPoints);
         memberState.setName(instance.getName());

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.client.Client;
+import com.hazelcast.client.impl.ClientEndpoint;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
@@ -44,6 +44,7 @@ public class ClientEndPointDTO implements JsonSerializable {
      */
     public String address;
     public String clientType;
+    public String clientVersion;
     public String name;
     public Set<String> labels;
 
@@ -60,13 +61,14 @@ public class ClientEndPointDTO implements JsonSerializable {
     public ClientEndPointDTO() {
     }
 
-    public ClientEndPointDTO(Client client) {
-        this.uuid = client.getUuid();
-        this.clientType = client.getClientType();
-        this.name = client.getName();
-        this.labels = client.getLabels();
+    public ClientEndPointDTO(ClientEndpoint clientEndpoint) {
+        this.uuid = clientEndpoint.getUuid();
+        this.clientType = clientEndpoint.getClientType();
+        this.clientVersion = clientEndpoint.getClientVersion();
+        this.name = clientEndpoint.getName();
+        this.labels = clientEndpoint.getLabels();
 
-        InetSocketAddress socketAddress = client.getSocketAddress();
+        InetSocketAddress socketAddress = clientEndpoint.getSocketAddress();
         this.address = socketAddress.getHostName() + ":" + socketAddress.getPort();
 
         InetAddress address = socketAddress.getAddress();
@@ -80,6 +82,7 @@ public class ClientEndPointDTO implements JsonSerializable {
         root.add("uuid", uuid.toString());
         root.add("address", address);
         root.add("clientType", clientType);
+        root.add("clientVersion", clientVersion);
         root.add("name", name);
         JsonArray labelsObject = Json.array();
         for (String label : labels) {
@@ -96,6 +99,7 @@ public class ClientEndPointDTO implements JsonSerializable {
         uuid = UUID.fromString(getString(json, "uuid"));
         address = getString(json, "address");
         clientType = getString(json, "clientType");
+        clientVersion = getString(json, "clientVersion");
         name = getString(json, "name");
         JsonArray labelsArray = getArray(json, "labels");
         labels = new HashSet<>();

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/MemberStateImplTest.java
@@ -84,6 +84,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         client.uuid = clientUuid;
         client.address = "localhost";
         client.clientType = "undefined";
+        client.clientVersion = "5.2";
         client.name = "aClient";
         client.labels = new HashSet<>(Collections.singletonList("label"));
         client.ipAddress = "10.176.167.34";


### PR DESCRIPTION
Having a client version in a `MemberState#clients` allows MC to eliminate the delay in showing version info to the user.

Fixes [MC-1611](https://hazelcast.atlassian.net/browse/MC-1611)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
