### PR TITLE
Revert "[HZ-1364] Filter replication name during sync allmaps"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanPublisher.java
@@ -57,10 +57,9 @@ public interface InternalWanPublisher<T> extends WanPublisher<T> {
      * event or trigger processing.
      * NOTE: used only in Hazelcast Enterprise.
      *
-     * @param event              the WAN anti-entropy event
-     * @param wanReplicationName the WAN replication config name
+     * @param event the WAN anti-entropy event
      */
-    default void publishAntiEntropyEvent(WanAntiEntropyEvent event, String wanReplicationName) {
+    default void publishAntiEntropyEvent(WanAntiEntropyEvent event) {
     }
 
     /**


### PR DESCRIPTION
Reverts hazelcast/hazelcast#22023

Temporarily reverting due to issues on EE side.