### PR TITLE
[HZ-1364] Filter replication name during sync allmaps (#22023)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanPublisher.java
@@ -57,9 +57,10 @@ public interface InternalWanPublisher<T> extends WanPublisher<T> {
      * event or trigger processing.
      * NOTE: used only in Hazelcast Enterprise.
      *
-     * @param event the WAN anti-entropy event
+     * @param event              the WAN anti-entropy event
+     * @param wanReplicationName the WAN replication config name
      */
-    default void publishAntiEntropyEvent(WanAntiEntropyEvent event) {
+    default void publishAntiEntropyEvent(WanAntiEntropyEvent event, String wanReplicationName) {
     }
 
     /**


### PR DESCRIPTION
Filter replication name during sync allmaps

re-adding after being reverted due to deadlock with EE PR builder