### PR TITLE
Simplify partition assignment in Join processor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
@@ -66,13 +65,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -649,44 +644,6 @@ public final class Util {
         durationMs /= 24;
         String textUpToHours = format("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis);
         return sign + (durationMs > 0 ? durationMs + "d " : "") + textUpToHours;
-    }
-
-    /**
-     * Assigns given partitions to given {@code members}.
-     * Set of partitions belonging to non-members are assigned to
-     * {@code members} in a round robin fashion.
-     */
-    public static Map<Address, List<Integer>> assignPartitions(
-            Collection<Address> members0,
-            Map<Address, List<Integer>> partitionsByOwner
-    ) {
-        assert !members0.isEmpty();
-
-        LinkedHashSet<Address> members = new LinkedHashSet<>(members0);
-
-        Iterator<Address> iterator = members.iterator();
-
-        Map<Address, List<Integer>> partitionsByMember = new HashMap<>();
-        for (Entry<Address, List<Integer>> entry : partitionsByOwner.entrySet()) {
-            Address partitionOwner = entry.getKey();
-            List<Integer> partitions = entry.getValue();
-
-            Address target;
-            if (members.contains(partitionOwner)) {
-                target = partitionOwner;
-            } else {
-                if (!iterator.hasNext()) {
-                    iterator = members.iterator();
-                }
-                target = iterator.next();
-            }
-
-            partitionsByMember.merge(target, new ArrayList<>(partitions), (existing, incoming) -> {
-                existing.addAll(incoming);
-                return existing;
-            });
-        }
-        return partitionsByMember;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.util;
 
-import com.google.common.collect.ImmutableMap;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -27,11 +25,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import java.net.UnknownHostException;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -51,7 +46,6 @@ import static com.hazelcast.jet.impl.util.Util.memoizeConcurrent;
 import static com.hazelcast.jet.impl.util.Util.roundRobinPart;
 import static com.hazelcast.jet.impl.util.Util.subtractClamped;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
@@ -239,24 +233,6 @@ public class UtilTest {
         assertEquals("00:12:22.855", formatJobDuration(742_855));
         assertEquals("106751991167d 07:12:55.807", formatJobDuration(Long.MAX_VALUE));
         assertEquals("-9223372036854775808", formatJobDuration(Long.MIN_VALUE));
-    }
-
-    @Test
-    public void test_assignPartitions() throws UnknownHostException {
-        Map<Address, List<Integer>> partitionsByMember = Util.assignPartitions(
-                new LinkedHashSet<>(asList(new Address("localhost", 5701), new Address("localhost", 5702))),
-                ImmutableMap.of(
-                        new Address("localhost", 5701), singletonList(1),
-                        new Address("localhost", 5702), singletonList(2),
-                        new Address("localhost", 5703), singletonList(3),
-                        new Address("localhost", 5704), singletonList(4),
-                        new Address("localhost", 5705), singletonList(5)
-                )
-        );
-
-        assertEquals(2, partitionsByMember.size());
-        assertEquals(asList(1, 3, 5), partitionsByMember.get(new Address("localhost", 5701)));
-        assertEquals(asList(2, 4), partitionsByMember.get(new Address("localhost", 5702)));
     }
 
     @Test


### PR DESCRIPTION
Follow-up of #22247. Code similar to the code fixed in the #22247 was already in Jet, available to processors through the Context object.