### PR TITLE
Check op call-timeout only for first Step

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
@@ -44,6 +44,7 @@ public class StepSupplier implements Supplier<Runnable> {
 
     private volatile Runnable currentRunnable;
     private volatile Step currentStep;
+    private volatile boolean firstStep = true;
 
     /**
      * Only here to disable check for testing purposes.
@@ -131,8 +132,8 @@ public class StepSupplier implements Supplier<Runnable> {
     /**
      * Responsibilities of this method:
      * <lu>
-     *     <li>Runs passed step with passed state</li>
-     *     <li>Sets next step to run</li>
+     * <li>Runs passed step with passed state</li>
+     * <li>Sets next step to run</li>
      * </lu>
      */
     private void runStepWithState(Step step, State state) {
@@ -142,7 +143,7 @@ public class StepSupplier implements Supplier<Runnable> {
             try {
                 log(step, state);
 
-                if (runningOnPartitionThread && state.getThrowable() == null) {
+                if (runningOnPartitionThread && state.getThrowable() == null && firstStep) {
                     metWithPreconditions = operationRunner.metWithPreconditions(state.getOperation());
                     if (!metWithPreconditions) {
                         return;
@@ -177,6 +178,7 @@ public class StepSupplier implements Supplier<Runnable> {
      * otherwise finds next step by calling {@link Step#nextStep}
      */
     private Step nextStep(Step step) {
+        firstStep = false;
         if (state.getThrowable() != null
                 && currentStep != UtilSteps.HANDLE_ERROR) {
             return UtilSteps.HANDLE_ERROR;


### PR DESCRIPTION
Follow-up of https://github.com/hazelcast/hazelcast/pull/22195

fixing nightly test failure: http://jenkins.hazelcast.com/view/force-offload-map/job/force-offload-Hazelcast-EE-master-OracleJDK8-nightly-clone/lastCompletedBuild/testReport/com.hazelcast.client.map/HDClientMapIssueTest/testNoOperationTimeoutException_whenUserCodeLongRunning/

**Issue:**
Op timeout is checked for every step run. This is not same behavior with current op runner.

**Fix:**
Aligned behavior with current op runner. Now op timeout is checked only for first Step.