### PR TITLE
Allow enum members to define functions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
@@ -201,7 +201,7 @@ public final class ValueReaderWriters {
                     = createReaderWriterForArray(compactStreamSerializer, clazz, componentTypes.element2, fieldName + "!values");
             return new HashMapReaderWriter(fieldName, componentTypes.element1,
                     componentTypes.element2, keyReaderWriter, valueReaderWriter);
-        } else if (type.isEnum()) {
+        } else if (Enum.class.isAssignableFrom(type)) {
             return new EnumReaderWriter(fieldName, (Class<? extends Enum>) type);
         }
 
@@ -219,7 +219,7 @@ public final class ValueReaderWriters {
     private static ValueReaderWriter createReaderWriterForArray(CompactStreamSerializer compactStreamSerializer,
                                                                 Class<?> clazz, Class<?> componentType,
                                                                 String fieldName) {
-        if (componentType.isEnum()) {
+        if (Enum.class.isAssignableFrom(componentType)) {
             return new EnumArrayReaderWriter(fieldName, (Class<? extends Enum>) componentType);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -122,7 +122,7 @@ public abstract class BaseIndexStore implements IndexStore {
             Comparable value = (Comparable) input;
             if (value == null) {
                 value = NULL;
-            } else if (value.getClass().isEnum()) {
+            } else if (Enum.class.isAssignableFrom(value.getClass())) {
                 value = TypeConverters.ENUM_CONVERTER.convert(value);
             }
             return canonicalizeScalarForStorage(value);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexHeapMemoryCostUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexHeapMemoryCostUtil.java
@@ -103,7 +103,7 @@ public final class IndexHeapMemoryCostUtil {
             return DATE_COST;
         }
 
-        if (clazz.isEnum()) {
+        if (Enum.class.isAssignableFrom(clazz)) {
             // enum values are shared, so they don't cost anything
             return 0;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -89,7 +89,7 @@ public final class ReflectionHelper {
             return AttributeType.SQL_LOCAL_DATE_TIME;
         } else if (klass == OffsetDateTime.class) {
             return AttributeType.SQL_OFFSET_DATE_TIME;
-        } else if (klass.isEnum()) {
+        } else if (Enum.class.isAssignableFrom(klass)) {
             return AttributeType.ENUM;
         } else if (klass == UUID.class) {
             return AttributeType.UUID;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -157,7 +157,7 @@ public abstract class AbstractPredicate<K, V> implements Predicate<K, V>, Identi
     }
 
     Object convertEnumValue(Object attributeValue) {
-        if (attributeValue != null && attributeValue.getClass().isEnum()) {
+        if (attributeValue != null && Enum.class.isAssignableFrom(attributeValue.getClass())) {
             attributeValue = attributeValue.toString();
         }
         return attributeValue;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
@@ -40,12 +40,29 @@ public class ComplexTestDataStructure {
     private ComplexTestDataStructure() {
     }
 
+    enum Health {
+        DEAD {
+                @Override
+                public boolean isAlive() {
+                    return false;
+                }
+            },
+
+        SICK,
+        SPLENDID;
+
+        public boolean isAlive() {
+            return true;
+        }
+    }
+
     public static class Person implements Serializable, PortableAware {
         String name;
         List<Limb> limbs_list = new ArrayList<Limb>();
         Limb[] limbs_array;
         Limb firstLimb;
         Limb secondLimb;
+        Health health;
 
         transient PersonPortable portable;
 
@@ -55,6 +72,10 @@ public class ComplexTestDataStructure {
 
         public Limb getFirstLimb() {
             return firstLimb;
+        }
+
+        public Health getHealth() {
+            return health;
         }
 
         @Override
@@ -85,6 +106,7 @@ public class ComplexTestDataStructure {
         Portable[] limbs_portable;
         LimbPortable firstLimb;
         LimbPortable secondLimb;
+        Health health;
 
         @Override
         public boolean equals(Object o) {
@@ -116,6 +138,7 @@ public class ComplexTestDataStructure {
             writer.writePortableArray("limbs_portable", limbs_portable);
             writer.writePortable("firstLimb", firstLimb);
             writer.writePortable("secondLimb", secondLimb);
+            writer.writeInt("health", health == null ? -1 : health.ordinal());
         }
 
         @Override
@@ -124,6 +147,10 @@ public class ComplexTestDataStructure {
             limbs_portable = reader.readPortableArray("limbs_portable");
             firstLimb = reader.readPortable("firstLimb");
             secondLimb = reader.readPortable("secondLimb");
+            int healthOrdinal = reader.readInt("health");
+            if (healthOrdinal > 0) {
+                health = Health.values()[healthOrdinal];
+            }
         }
     }
 
@@ -353,8 +380,13 @@ public class ComplexTestDataStructure {
     }
 
     public static Person person(String name, Limb... limbs) {
+        return person(name, null, limbs);
+    }
+
+    public static Person person(String name, Health health, Limb... limbs) {
         Person person = new Person();
         person.name = name;
+        person.health = health;
         if (limbs.length > 0) {
             person.limbs_list.addAll(Arrays.asList(limbs));
         } else {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInCollectionSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInCollectionSpecTest.java
@@ -85,7 +85,7 @@ public class ExtractionInCollectionSpecTest extends AbstractExtractionTest {
     private static final Person HUNT_NULL_LIMB = person("Hunt");
 
     private static final Person HUNT_NULL_FIRST = person("Hunt",
-            null, limb("left", tattoos(null, "cross"), null, finger("thumbie"))
+        (ComplexTestDataStructure.Health) null, null, limb("left", tattoos(null, "cross"), null, finger("thumbie"))
     );
 
     private static final Person HUNT_PRIMITIVE_NULL_FIRST = person("Hunt",

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInSingleValueSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInSingleValueSpecTest.java
@@ -59,12 +59,12 @@ import static java.util.Arrays.asList;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ExtractionInSingleValueSpecTest extends AbstractExtractionTest {
 
-    private static final Person BOND = person("Bond",
+    private static final Person BOND = person("Bond",  ComplexTestDataStructure.Health.SICK,
             limb("left-hand", tattoos(), finger("thumb"), finger(null)),
             limb("right-hand", tattoos("knife"), finger("middle"), finger("index"))
     );
 
-    private static final Person KRUEGER = person("Krueger",
+    private static final Person KRUEGER = person("Krueger", ComplexTestDataStructure.Health.DEAD,
             limb("linke-hand", tattoos("bratwurst"), finger("Zeigefinger"), finger("Mittelfinger")),
             limb("rechte-hand", tattoos(), finger("Ringfinger"), finger("Daumen"))
     );
@@ -133,6 +133,13 @@ public class ExtractionInSingleValueSpecTest extends AbstractExtractionTest {
         execute(Input.of(BOND, KRUEGER, HUNT_WITH_NULLS),
                 Query.of(Predicates.equal("secondLimb.name", null), mv),
                 Expected.of(HUNT_WITH_NULLS));
+    }
+
+    @Test
+    public void enumWithMembers() {
+        execute(Input.of(BOND, KRUEGER),
+                Query.of(Predicates.equal("health", ComplexTestDataStructure.Health.DEAD), mv),
+                Expected.of(KRUEGER));
     }
 
     @Parameterized.Parameters(name = "{index}: {0}, {1}, {2}")

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MethodGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MethodGetterTest.java
@@ -71,7 +71,7 @@ public class MethodGetterTest {
         hand = new Limb("hand", whiteNail, blackNail);
 
         unnamedLimb = new Limb(null);
-        body = new Body("bodyName", leg, hand, unnamedLimb);
+        body = new Body("bodyName", Health.SPLENDID, leg, hand, unnamedLimb);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -95,6 +95,17 @@ public class MethodGetterTest {
     @Test(expected = IllegalArgumentException.class)
     public void constructor_whenModifierIsPositionAndMethodReturnTypeIsCollection_thenThrowIllegalArgumentException() {
         new MethodGetter(null, limbCollectionMethod, "[0]", null);
+    }
+
+    @Test
+    public void getValue_whenFieldIsEnum()
+        throws Exception {
+      MethodGetter limbGetter = new MethodGetter(null, limbArrayMethod, "[any]", null);
+      MethodGetter nailGetter = new MethodGetter(limbGetter, nailArrayMethod, "[any]", null);
+
+      MultiResult result = (MultiResult) nailGetter.getValue(body);
+
+      assertContainsInAnyOrder(result, whiteNail, blackNail, redNail, greenNail, null);
     }
 
     @Test
@@ -270,13 +281,23 @@ public class MethodGetterTest {
         }
     }
 
+    enum Health {
+        SICK,
+        SPLENDID
+    }
+
     @SuppressWarnings("unused")
     static class Body {
         String name;
         Limb[] limbArray;
         Collection<Limb> limbCollection;
 
+        Health health;
+
         Body(String name, Limb... limbs) {
+            this(name, Health.SPLENDID, limbs);
+        }
+        Body(String name, Health health, Limb... limbs) {
             this.name = name;
             this.limbCollection = Arrays.asList(limbs);
             this.limbArray = limbs;

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -135,7 +135,7 @@ public class HazelcastProxyFactory {
         if (DELEGATION_WHITE_LIST.contains(className)) {
             return RETURN_SAME;
         }
-        if (NO_PROXYING_WHITELIST.containsKey(className) || delegateClass.isEnum()) {
+        if (NO_PROXYING_WHITELIST.containsKey(className) || Enum.class.isAssignableFrom(delegateClass)) {
             return ProxyPolicy.NO_PROXY;
         }
         if (SUBCLASS_PROXYING_WHITELIST.contains(className) || ifaces.length == 0) {
@@ -297,7 +297,7 @@ public class HazelcastProxyFactory {
                 } catch (Exception e) {
                     throw new IllegalStateException(e);
                 }
-            } else if (input.isEnum()) {
+            } else if (Enum.class.isAssignableFrom(input)) {
                 return new EnumConstructor(input);
             }
             throw new UnsupportedOperationException("Cannot construct target object for target " + input

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
@@ -102,7 +102,7 @@ abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructo
                         otherList.add(otherItem);
                     }
                     updateConfig(setter, otherConfigObject, otherList);
-                } else if (returnType.isEnum()) {
+                } else if (Enum.class.isAssignableFrom(returnType.getClass())) {
                     Enum thisSubConfigObject = (Enum) method.invoke(thisConfigObject, null);
                     Class otherEnumClass = classloader.loadClass(thisSubConfigObject.getClass().getName());
                     Object otherEnumValue = Enum.valueOf(otherEnumClass, thisSubConfigObject.name());

--- a/hazelcast/src/test/java/example/serialization/HiringStatus.java
+++ b/hazelcast/src/test/java/example/serialization/HiringStatus.java
@@ -18,12 +18,19 @@ package example.serialization;
 
 public enum HiringStatus {
 
-    HIRING("Hiring"),
-    NOT_HIRING("Not hiring");
+    HIRING {
+        @Override
+        public String getHumanReadable() {
+            return "Hiring";
+        }
+    },
+    NOT_HIRING() {
+        @Override
+        public String getHumanReadable() {
+            return "Not hiring";
+        }
+    };
 
-    private final String humanReadable;
+    public abstract String getHumanReadable();
 
-    HiringStatus(String humanReadable) {
-        this.humanReadable = humanReadable;
-    }
 }


### PR DESCRIPTION
Enums which have method implementations cannot be used in queries. 

Fixes: https://github.com/hazelcast/hazelcast/issues/21800
Partially Fixes https://github.com/hazelcast/hazelcast/issues/8305

Breaking changes (list specific methods/types/messages):
Queries that used to throw exceptions will now work. 