### PR TITLE
Remove hazelcast-hibernate53 from main HZ distribution [HZ-1486]

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -249,17 +249,6 @@
 
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-hibernate53</artifactId>
-            <version>2.2.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-wm</artifactId>
             <version>4.0</version>
             <exclusions>

--- a/distribution/src/assembly/assembly-descriptor-slim.xml
+++ b/distribution/src/assembly/assembly-descriptor-slim.xml
@@ -29,7 +29,6 @@
             <includes>
                 <include>com.hazelcast:hazelcast</include>
                 <include>com.hazelcast:hazelcast-sql</include>
-                <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>com.hazelcast:hazelcast-wm</include>
                 <include>com.hazelcast:hazelcast-distribution</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>

--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -28,7 +28,6 @@
             <includes>
                 <include>com.hazelcast:hazelcast</include>
                 <include>com.hazelcast:hazelcast-sql</include>
-                <include>com.hazelcast:hazelcast-hibernate53</include>
                 <include>com.hazelcast:hazelcast-wm</include>
                 <include>io.prometheus.jmx:jmx_prometheus_javaagent</include>
                 <include>javax.cache:cache-api</include>

--- a/hazelcast-it/distribution-it/pom.xml
+++ b/hazelcast-it/distribution-it/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -11,13 +11,64 @@
 
     <artifactId>distribution-it</artifactId>
 
+    <properties>
+        <jaxb.version>2.3.1</jaxb.version>
+        <jaxb-core.version>2.3.0.1</jaxb-core.version>
+        <activation.version>1.1.1</activation.version>
+        <hsqldb.version>2.7.0</hsqldb.version>
+        <hibernate-core.version>5.3.7.Final</hibernate-core.version>
+        <hazelcast-hibernate53.version>2.2.1</hazelcast-hibernate53.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-hibernate53</artifactId>
+            <version>${hazelcast-hibernate53.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${jaxb.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>${jaxb-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${activation.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>${hsqldb.version}</version>
+            <classifier>jdk8</classifier>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>

--- a/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/AnnotatedEntity.java
+++ b/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/AnnotatedEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.it.hibernate;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@NaturalIdCache
+@Entity
+@Table(name = "ANNOTATED_ENTITIES")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class AnnotatedEntity {
+    private Long id;
+
+    private String title;
+
+    public AnnotatedEntity() {
+    }
+
+    public AnnotatedEntity(String title) {
+        this.title = title;
+    }
+
+    @NaturalId(mutable = true)
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Id
+    @GeneratedValue(generator = "increment")
+    @GenericGenerator(name = "increment", strategy = "increment")
+    public Long getId() {
+        return id;
+    }
+
+    private void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/HibernateIT.java
+++ b/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/HibernateIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.it.hibernate;
+
+import com.hazelcast.hibernate.HazelcastCacheRegionFactory;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.Statistics;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class HibernateIT extends HazelcastTestSupport {
+
+    private static final ILogger log = Logger.getLogger(HibernateIT.class);
+
+    private Process process;
+    private String clusterName;
+    private SessionFactory sessionFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        assumeThatNoWindowsOS();
+        clusterName = this.getClass().getSimpleName() + "_" + UUID.randomUUID();
+        startHzMember();
+        sessionFactory = createSessionFactory(getCacheProperties());
+    }
+
+    @Test
+    public void testInsertLoad() {
+        Session session = sessionFactory.openSession();
+        Transaction tx = session.beginTransaction();
+        AnnotatedEntity e = new AnnotatedEntity("some-title");
+        session.save(e);
+        tx.commit();
+        session.close();
+
+        for (int i = 0; i < 10; i++) {
+            session = sessionFactory.openSession();
+            AnnotatedEntity retrieved = session.get(AnnotatedEntity.class, (long) 1);
+            assertThat(retrieved.getTitle()).isEqualTo("some-title");
+            session.close();
+        }
+
+        Statistics stats = sessionFactory.getStatistics();
+        assertThat(stats.getEntityInsertCount()).isEqualTo(1);
+        assertThat(stats.getSecondLevelCachePutCount()).isEqualTo(1);
+        assertThat(stats.getSecondLevelCacheHitCount()).isEqualTo(10);
+    }
+
+    private SessionFactory createSessionFactory(Properties props) {
+        Configuration conf = new Configuration();
+        conf.configure(HibernateIT.class.getClassLoader().getResource("test-hibernate-client.cfg.xml"));
+        conf.addAnnotatedClass(AnnotatedEntity.class);
+        conf.addProperties(props);
+
+        final SessionFactory sessionFactory = conf.buildSessionFactory();
+        sessionFactory.getStatistics().setStatisticsEnabled(true);
+        return sessionFactory;
+    }
+
+    private Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty("hibernate.cache.hazelcast.native_client_cluster_name", clusterName);
+        return props;
+    }
+
+    private void startHzMember() throws IOException {
+        ProcessBuilder builder = new ProcessBuilder("bin/hz", "start")
+                .directory(new File("./target/hazelcast"))
+                .inheritIO();
+        builder.environment().put("HZ_CLUSTERNAME", clusterName);
+        builder.environment().put("JAVA_OPTS", "-Dhazelcast.phone.home.enabled=false");
+        // Remove classpath set by Maven
+        builder.environment().remove("CLASSPATH");
+
+        process = builder.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (sessionFactory != null) {
+            sessionFactory.close();
+        }
+        log.info("Destroying Hazelcast process");
+        process.destroy();
+        boolean destroyed = process.waitFor(30, TimeUnit.SECONDS);
+        if (!destroyed) {
+            log.info("Hazelcast process not destroyed, trying Process#destroyForcibly()");
+            process.destroyForcibly()
+                    .waitFor();
+        }
+    }
+
+}

--- a/hazelcast-it/distribution-it/src/test/resources/test-hibernate-client.cfg.xml
+++ b/hazelcast-it/distribution-it/src/test/resources/test-hibernate-client.cfg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.dialect">org.hibernate.dialect.HSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.hsqldb.jdbcDriver</property>
+        <property name="hibernate.connection.url">jdbc:hsqldb:mem:testdb</property>
+        <property name="hibernate.connection.username">sa</property>
+        <property name="hibernate.connection.password"/>
+
+        <property name="hibernate.connection.pool_size">2</property>
+        <property name="hibernate.show_sql">true</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.use_query_cache">true</property>
+
+        <property name="hibernate.cache.hazelcast.use_native_client">true</property>
+        <property name="hibernate.cache.hazelcast.native_client_address">localhost</property>
+        <property name="hibernate.cache.hazelcast.native_client_cluster_name">dev-custom</property>
+    </session-factory>
+</hibernate-configuration>

--- a/owasp-check-suppressions.xml
+++ b/owasp-check-suppressions.xml
@@ -16,13 +16,6 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-      False positive. The hazelcast:hazelcast component vulnerabilities are related to Hazelcast IMDG version and not the integration - hazelcast-hibernate.
-      ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-hibernate.*$</packageUrl>
-        <cpe>cpe:/a:hazelcast:hazelcast</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
       False positive. The hazelcast:hazelcast component vulnerabilities are related to Hazelcast IMDG version and not the integration - hazelcast-wm.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast-wm@.*$</packageUrl>


### PR DESCRIPTION
Remove hazelcast-hibernate53 from main HZ distribution as it's not needed anymore

Fixes https://hazelcast.atlassian.net/browse/HZ-1486

Tested locally:
```shell
 mvn clean install -Dnot-quick -Pquick #build distribution package
 mvn -Dit.test=com.hazelcast.it.hibernate.HibernateIT verify -P LOCAL,nightly-build -pl hazelcast-it/distribution-it
```

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
