### PR TITLE
[API-1552] Do not invoke urgent invocations that contains serialized data immediately

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientSchemaService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientSchemaService.java
@@ -130,6 +130,10 @@ public class ClientSchemaService implements SchemaService {
         invocation.invokeUrgent().joinInternal();
     }
 
+    public boolean hasAnySchemas() {
+        return !schemas.isEmpty();
+    }
+
     private boolean replicateSchemaInCluster(Schema schema) {
         ClientMessage clientMessage = ClientSendSchemaCodec.encodeRequest(schema);
         outer:

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -895,6 +895,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         clientStatisticsService.collectAndSendStatsNow();
     }
 
+    /**
+     * Returns {@code true} if we need to check the urgent invocations, by
+     * examining the local registry of the schema service.
+     */
+    public boolean shouldCheckUrgentInvocations() {
+        return schemaService.hasAnySchemas();
+    }
 
     public void waitForInitialMembershipEvents() {
         clusterService.waitInitialMemberListFetched();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnectionManager.java
@@ -56,6 +56,12 @@ public interface ClientConnectionManager extends ConnectionListenable<ClientConn
      */
     void checkInvocationAllowed() throws IOException;
 
+    /**
+     * Returns {@code true} if the client is initialized on the cluster, by
+     * sending its local state, if necessary.
+     */
+    boolean clientInitializedOnCluster();
+
     Collection<Connection> getActiveConnections();
 
     UUID getClientUuid();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -579,6 +579,11 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
         }
     }
 
+    @Override
+    public boolean clientInitializedOnCluster() {
+        return clientState == ClientState.INITIALIZED_ON_CLUSTER;
+    }
+
     Collection<Address> getPossibleMemberAddresses(AddressProvider addressProvider) {
         Collection<Address> addresses = new LinkedHashSet<>();
         try {
@@ -1130,7 +1135,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (credentials instanceof TokenCredentials) {
                 secretBytes = ((TokenCredentials) credentials).getToken();
             } else {
-                secretBytes = ss.toData(credentials).toByteArray();
+                secretBytes = ss.toDataWithSchema(credentials).toByteArray();
             }
             return ClientAuthenticationCustomCodec.encodeRequest(clusterName, secretBytes, clientUuid, connectionType,
                     serializationVersion, BuildInfoProvider.getBuildInfo().getVersion(), client.getName(), labels);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -339,6 +339,7 @@ public final class ClientMessage implements OutboundFrame {
 
         newMessage.isRetryable = isRetryable;
         newMessage.operationName = operationName;
+        newMessage.containsSerializedDataInRequest = containsSerializedDataInRequest;
 
         return newMessage;
     }
@@ -359,6 +360,7 @@ public final class ClientMessage implements OutboundFrame {
 
         newMessage.isRetryable = isRetryable;
         newMessage.operationName = operationName;
+        newMessage.containsSerializedDataInRequest = containsSerializedDataInRequest;
 
         return newMessage;
     }
@@ -380,6 +382,9 @@ public final class ClientMessage implements OutboundFrame {
         if (isRetryable != message.isRetryable) {
             return false;
         }
+        if (containsSerializedDataInRequest != message.containsSerializedDataInRequest) {
+            return false;
+        }
         if (!Objects.equals(operationName, message.operationName)) {
             return false;
         }
@@ -390,6 +395,7 @@ public final class ClientMessage implements OutboundFrame {
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + (isRetryable ? 1 : 0);
+        result = 31 * result + (containsSerializedDataInRequest ? 1 : 0);
         result = 31 * result + (operationName != null ? operationName.hashCode() : 0);
         result = 31 * result + (connection != null ? connection.hashCode() : 0);
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -135,6 +135,7 @@ public final class ClientMessage implements OutboundFrame {
     private transient boolean isRetryable;
     private transient String operationName;
     private transient Connection connection;
+    private transient boolean containsSerializedDataInRequest;
 
     private ClientMessage() {
 
@@ -280,6 +281,14 @@ public final class ClientMessage implements OutboundFrame {
 
     public void dropFragmentationFrame() {
         startFrame = startFrame.next;
+    }
+
+    public boolean isContainsSerializedDataInRequest() {
+        return containsSerializedDataInRequest;
+    }
+
+    public void setContainsSerializedDataInRequest(boolean containsSerializedDataInRequest) {
+        this.containsSerializedDataInRequest = containsSerializedDataInRequest;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAlterCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongAlterCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Alters the currently stored value by applying a function on it.
  */
-@Generated("24b6356409b031de1dbb47eb29c2320c")
+@Generated("1fb59f3dfa6e584c483017a4f9e7bc47")
 public final class AtomicLongAlterCodec {
     //hex: 0x090200
     public static final int REQUEST_MESSAGE_TYPE = 590336;
@@ -76,6 +76,7 @@ public final class AtomicLongAlterCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId, java.lang.String name, com.hazelcast.internal.serialization.Data function, int returnValueType) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("AtomicLong.Alter");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongApplyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicLongApplyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies a function on the value, the actual stored value will not change
  */
-@Generated("3fd958d74761216830d4044e2d8164f5")
+@Generated("89b4649af61604d100bab83b357f14a3")
 public final class AtomicLongApplyCodec {
     //hex: 0x090100
     public static final int REQUEST_MESSAGE_TYPE = 590080;
@@ -70,6 +70,7 @@ public final class AtomicLongApplyCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId, java.lang.String name, com.hazelcast.internal.serialization.Data function) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("AtomicLong.Apply");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefApplyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefApplyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies a function on the value
  */
-@Generated("74dc69fdf92239819ea4f1526209b8f9")
+@Generated("c98a1a17e1cb88bbd1c8e1c63a116923")
 public final class AtomicRefApplyCodec {
     //hex: 0x0A0100
     public static final int REQUEST_MESSAGE_TYPE = 655616;
@@ -83,6 +83,7 @@ public final class AtomicRefApplyCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId, java.lang.String name, com.hazelcast.internal.serialization.Data function, int returnValueType, boolean alter) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("AtomicRef.Apply");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefCompareAndSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefCompareAndSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Alters the currently stored value by applying a function on it.
  */
-@Generated("e672200e2d3930f1ca8647da85536689")
+@Generated("c3fb3023b946d03b992f82a5c784af16")
 public final class AtomicRefCompareAndSetCodec {
     //hex: 0x0A0200
     public static final int REQUEST_MESSAGE_TYPE = 655872;
@@ -75,6 +75,7 @@ public final class AtomicRefCompareAndSetCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId, java.lang.String name, @Nullable com.hazelcast.internal.serialization.Data oldValue, @Nullable com.hazelcast.internal.serialization.Data newValue) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("AtomicRef.CompareAndSet");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefContainsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks if the reference contains the value.
  */
-@Generated("98f7aa9e8bbb87b422a6d0fae9892c64")
+@Generated("00656e8628be74c0413cb7f8f46158b3")
 public final class AtomicRefContainsCodec {
     //hex: 0x0A0300
     public static final int REQUEST_MESSAGE_TYPE = 656128;
@@ -70,6 +70,7 @@ public final class AtomicRefContainsCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId, java.lang.String name, @Nullable com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("AtomicRef.Contains");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AtomicRefSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically sets the given value
  */
-@Generated("051645cb28d38a0f9bd09a9373607926")
+@Generated("1d61fec14ba3395add8dbfde42f42ab7")
 public final class AtomicRefSetCodec {
     //hex: 0x0A0500
     public static final int REQUEST_MESSAGE_TYPE = 656640;
@@ -75,6 +75,7 @@ public final class AtomicRefSetCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.cp.internal.RaftGroupId groupId, java.lang.String name, @Nullable com.hazelcast.internal.serialization.Data newValue, boolean returnOldValue) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("AtomicRef.Set");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheContainsKeyCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Determines if the Cache contains an entry for the specified key. More formally, returns true if and only if this
  * cache contains a mapping for a key k such that key.equals(k). (There can be at most one such mapping.)
  */
-@Generated("6866331b0b5bbc6d37636b4124440ffb")
+@Generated("54be6a5e451796cc774a42a56b4f6149")
 public final class CacheContainsKeyCodec {
     //hex: 0x130500
     public static final int REQUEST_MESSAGE_TYPE = 1246464;
@@ -66,6 +66,7 @@ public final class CacheContainsKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Cache.ContainsKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheCreateConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheCreateConfigCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates the given cache configuration on Hazelcast members.
  */
-@Generated("c179100955249b203f80ee392f46b238")
+@Generated("57c5e532ea8ba3e4dd6de3e1c660d023")
 public final class CacheCreateConfigCodec {
     //hex: 0x130600
     public static final int REQUEST_MESSAGE_TYPE = 1246720;
@@ -65,6 +65,7 @@ public final class CacheCreateConfigCodec {
 
     public static ClientMessage encodeRequest(com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder cacheConfig, boolean createAlsoOnOthers) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Cache.CreateConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEntryProcessorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEntryProcessorCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to entry mapped by the key.
  * Returns the result of the processing, if any, defined by the implementation.
  */
-@Generated("3206438b6acc3ee7f5f40fb446f4432d")
+@Generated("4809a075b362ba6ee3feef0617183134")
 public final class CacheEntryProcessorCodec {
     //hex: 0x130800
     public static final int REQUEST_MESSAGE_TYPE = 1247232;
@@ -83,6 +83,7 @@ public final class CacheEntryProcessorCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data entryProcessor, java.util.Collection<com.hazelcast.internal.serialization.Data> arguments, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.EntryProcessor");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventJournalReadCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("05e4495ab8a160dd39f05e0ba666a084")
+@Generated("00cfd4e7959132747baa1c2af5b986b7")
 public final class CacheEventJournalReadCodec {
     //hex: 0x132000
     public static final int REQUEST_MESSAGE_TYPE = 1253376;
@@ -96,6 +96,7 @@ public final class CacheEventJournalReadCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, long startSequence, int minSize, int maxSize, @Nullable com.hazelcast.internal.serialization.Data predicate, @Nullable com.hazelcast.internal.serialization.Data projection) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Cache.EventJournalRead");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * configured javax.cache.integration.CacheLoader might be called to retrieve the values of the keys from any kind
  * of external resource.
  */
-@Generated("7229a96d90c84f612a2e74691f7aeb7c")
+@Generated("84b0d93b6d181237de3729b2d9834eb0")
 public final class CacheGetAllCodec {
     //hex: 0x130900
     public static final int REQUEST_MESSAGE_TYPE = 1247488;
@@ -73,6 +73,7 @@ public final class CacheGetAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.GetAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically removes the entry for a key only if currently mapped to some value.
  */
-@Generated("6914b431873c7c2bd1c35a524a43abef")
+@Generated("bf781033c5b1ba2586592e4abacac621")
 public final class CacheGetAndRemoveCodec {
     //hex: 0x130A00
     public static final int REQUEST_MESSAGE_TYPE = 1247744;
@@ -71,6 +71,7 @@ public final class CacheGetAndRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.GetAndRemove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetAndReplaceCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * write-through operation mode, the underlying configured javax.cache.integration.CacheWriter might be called to
  * store the value of the key to any kind of external resource.
  */
-@Generated("9456af9977a683396875223ac66e5cda")
+@Generated("de2927f310638cf5dd6d11346b5c353d")
 public final class CacheGetAndReplaceCodec {
     //hex: 0x130B00
     public static final int REQUEST_MESSAGE_TYPE = 1248000;
@@ -85,6 +85,7 @@ public final class CacheGetAndReplaceCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.GetAndReplace");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheGetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * null is returned. If the cache is configured for read-through operation mode, the underlying configured
  * javax.cache.integration.CacheLoader might be called to retrieve the value of the key from any kind of external resource.
  */
-@Generated("07c8e91bfacd1dc5084818a120fc65d3")
+@Generated("3d08168e9fedd603cf2a1c42262e6f15")
 public final class CacheGetCodec {
     //hex: 0x130D00
     public static final int REQUEST_MESSAGE_TYPE = 1248512;
@@ -72,6 +72,7 @@ public final class CacheGetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Cache.Get");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheListenerRegistrationCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheListenerRegistrationCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Tries to register the listener configuration for the cache specified by its name
  * to the given member.
  */
-@Generated("4ee1bd9aae4e3be47630c47fb45822ec")
+@Generated("2791bf150e46e415e0cc2a10ecc15612")
 public final class CacheListenerRegistrationCodec {
     //hex: 0x130F00
     public static final int REQUEST_MESSAGE_TYPE = 1249024;
@@ -78,6 +78,7 @@ public final class CacheListenerRegistrationCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data listenerConfig, boolean shouldRegister, java.util.UUID uuid) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.ListenerRegistration");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheLoadAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheLoadAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Loads all the keys into the CacheRecordStore in batch.
  */
-@Generated("72b0c74205470fa8abc40fd170a67213")
+@Generated("21769d83a814084c5bf95768fd9442f2")
 public final class CacheLoadAllCodec {
     //hex: 0x131000
     public static final int REQUEST_MESSAGE_TYPE = 1249280;
@@ -71,6 +71,7 @@ public final class CacheLoadAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys, boolean replaceExistingValues) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.LoadAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Copies all the mappings from the specified map to this cache with the given expiry policy.
  */
-@Generated("52efeb1289ec16d980769dff2cd6a520")
+@Generated("66ee964e780fbc2f83795b7e1b351b57")
 public final class CachePutAllCodec {
     //hex: 0x131B00
     public static final int REQUEST_MESSAGE_TYPE = 1252096;
@@ -77,6 +77,7 @@ public final class CachePutAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.PutAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Puts the entry with the given key, value and the expiry policy to the cache.
  */
-@Generated("aca2fc3ba5b0fa3dc9a8e8a407916416")
+@Generated("2a0c3f6a64ffdf0e2d6f54575eac5fc7")
 public final class CachePutCodec {
     //hex: 0x131300
     public static final int REQUEST_MESSAGE_TYPE = 1250048;
@@ -88,6 +88,7 @@ public final class CachePutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy, boolean get, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CachePutIfAbsentCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * specified key. If the cache is configured for write-through operation mode, the underlying configured
  * javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
  */
-@Generated("fc35f4ad4f6719049280cd25f0eb854d")
+@Generated("455ad132a80609df2bf439c92aefc01f")
 public final class CachePutIfAbsentCodec {
     //hex: 0x131200
     public static final int REQUEST_MESSAGE_TYPE = 1249792;
@@ -85,6 +85,7 @@ public final class CachePutIfAbsentCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.PutIfAbsent");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveAllKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveAllKeysCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * For every entry in the key set, the following are called: any registered CacheEntryRemovedListeners if the cache
  * is a write-through cache, the CacheWriter. If the key set is empty, the CacheWriter is not called.
  */
-@Generated("6ef5d972fe52f79af060788264c447b9")
+@Generated("55f1d0a4cf980aaf01af78f142dd89d0")
 public final class CacheRemoveAllKeysCodec {
     //hex: 0x130300
     public static final int REQUEST_MESSAGE_TYPE = 1245952;
@@ -73,6 +73,7 @@ public final class CacheRemoveAllKeysCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.RemoveAllKeys");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Atomically removes the mapping for a key only if currently mapped to the given value.
  */
-@Generated("d5e92dda58694a88162d5d6599a1f389")
+@Generated("8fa41ca3bd5a1a5ade623c419384929d")
 public final class CacheRemoveCodec {
     //hex: 0x131600
     public static final int REQUEST_MESSAGE_TYPE = 1250816;
@@ -77,6 +77,7 @@ public final class CacheRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data currentValue, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheReplaceCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the cache is configured for write-through operation mode, the underlying configured
  * javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
  */
-@Generated("4b08f95820d72dbacbdf6376fdb4e8ce")
+@Generated("89080d16f1c391c324fb0c791ab5baea")
 public final class CacheReplaceCodec {
     //hex: 0x131700
     public static final int REQUEST_MESSAGE_TYPE = 1251072;
@@ -90,6 +90,7 @@ public final class CacheReplaceCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, @Nullable com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data newValue, @Nullable com.hazelcast.internal.serialization.Data expiryPolicy, int completionId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.Replace");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSetExpiryPolicyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheSetExpiryPolicyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
  * If some keys in {@code keys} do not exist or are already expired, this call has no effect for those.
  */
-@Generated("817a0d4998f8779d59066cf7b6a86f3d")
+@Generated("beb0cee65c631216eb0762aeaa9ffdbd")
 public final class CacheSetExpiryPolicyCodec {
     //hex: 0x132100
     public static final int REQUEST_MESSAGE_TYPE = 1253632;
@@ -72,6 +72,7 @@ public final class CacheSetExpiryPolicyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys, com.hazelcast.internal.serialization.Data expiryPolicy) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Cache.SetExpiryPolicy");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a publisher that does not include value for the cache events it sends.
  */
-@Generated("8e95c0655731cd818141f19f5f7b8302")
+@Generated("5af46e6f2ab382bcb9756d134abc2b5d")
 public final class ContinuousQueryPublisherCreateCodec {
     //hex: 0x160200
     public static final int REQUEST_MESSAGE_TYPE = 1442304;
@@ -100,6 +100,7 @@ public final class ContinuousQueryPublisherCreateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String mapName, java.lang.String cacheName, com.hazelcast.internal.serialization.Data predicate, int batchSize, int bufferSize, long delaySeconds, boolean populate, boolean coalesce) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ContinuousQuery.PublisherCreate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryPublisherCreateWithValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Creates a publisher that includes value for the cache events it sends.
  */
-@Generated("8f222e2256827f433e14c422e0a13df6")
+@Generated("20df894c24e2156bc08af880cf081f6f")
 public final class ContinuousQueryPublisherCreateWithValueCodec {
     //hex: 0x160100
     public static final int REQUEST_MESSAGE_TYPE = 1442048;
@@ -100,6 +100,7 @@ public final class ContinuousQueryPublisherCreateWithValueCodec {
 
     public static ClientMessage encodeRequest(java.lang.String mapName, java.lang.String cacheName, com.hazelcast.internal.serialization.Data predicate, int batchSize, int bufferSize, long delaySeconds, boolean populate, boolean coalesce) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ContinuousQuery.PublisherCreateWithValue");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DurableExecutorSubmitToPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to partition for execution
  */
-@Generated("9b2969b872d4e7cb88c34529f224121c")
+@Generated("f3eaf0c0814a650db250b8df2ea20023")
 public final class DurableExecutorSubmitToPartitionCodec {
     //hex: 0x180300
     public static final int REQUEST_MESSAGE_TYPE = 1573632;
@@ -65,6 +65,7 @@ public final class DurableExecutorSubmitToPartitionCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data callable) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("DurableExecutor.SubmitToPartition");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddCacheConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddCacheConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a cache configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("1ca0fc0d694ebecae93286bee6506a2c")
+@Generated("a5d7b920ee7efdd9bc2a8287ed9e622b")
 public final class DynamicConfigAddCacheConfigCodec {
     //hex: 0x1B0E00
     public static final int REQUEST_MESSAGE_TYPE = 1773056;
@@ -223,6 +223,7 @@ public final class DynamicConfigAddCacheConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, @Nullable java.lang.String keyType, @Nullable java.lang.String valueType, boolean statisticsEnabled, boolean managementEnabled, boolean readThrough, boolean writeThrough, @Nullable java.lang.String cacheLoaderFactory, @Nullable java.lang.String cacheWriterFactory, @Nullable java.lang.String cacheLoader, @Nullable java.lang.String cacheWriter, int backupCount, int asyncBackupCount, java.lang.String inMemoryFormat, @Nullable java.lang.String splitBrainProtectionName, @Nullable java.lang.String mergePolicy, int mergeBatchSize, boolean disablePerEntryInvalidationEvents, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> partitionLostListenerConfigs, @Nullable java.lang.String expiryPolicyFactoryClassName, @Nullable com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig, @Nullable java.util.Collection<com.hazelcast.config.CacheSimpleEntryListenerConfig> cacheEntryListeners, @Nullable com.hazelcast.client.impl.protocol.task.dynamicconfig.EvictionConfigHolder evictionConfig, @Nullable com.hazelcast.config.WanReplicationRef wanReplicationRef, @Nullable com.hazelcast.config.EventJournalConfig eventJournalConfig, @Nullable com.hazelcast.config.HotRestartConfig hotRestartConfig, @Nullable com.hazelcast.config.MerkleTreeConfig merkleTreeConfig, com.hazelcast.config.DataPersistenceConfig dataPersistenceConfig) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddCacheConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddListConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddListConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a list configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("e037757d5aa169907f407c0c849c3bc4")
+@Generated("fa41e4a85ec055aed23ad65fc19f1b7f")
 public final class DynamicConfigAddListConfigCodec {
     //hex: 0x1B0400
     public static final int REQUEST_MESSAGE_TYPE = 1770496;
@@ -109,6 +109,7 @@ public final class DynamicConfigAddListConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, int backupCount, int asyncBackupCount, int maxSize, boolean statisticsEnabled, @Nullable java.lang.String splitBrainProtectionName, java.lang.String mergePolicy, int mergeBatchSize) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddListConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMapConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a map configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("036e4bd18f2a155e900af6d842045286")
+@Generated("56ec2bc81aa8adf45d58ed177ac4f1bc")
 public final class DynamicConfigAddMapConfigCodec {
     //hex: 0x1B0C00
     public static final int REQUEST_MESSAGE_TYPE = 1772544;
@@ -243,6 +243,7 @@ public final class DynamicConfigAddMapConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, int backupCount, int asyncBackupCount, int timeToLiveSeconds, int maxIdleSeconds, @Nullable com.hazelcast.client.impl.protocol.task.dynamicconfig.EvictionConfigHolder evictionConfig, boolean readBackupData, java.lang.String cacheDeserializedValues, java.lang.String mergePolicy, int mergeBatchSize, java.lang.String inMemoryFormat, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> partitionLostListenerConfigs, boolean statisticsEnabled, @Nullable java.lang.String splitBrainProtectionName, @Nullable com.hazelcast.client.impl.protocol.task.dynamicconfig.MapStoreConfigHolder mapStoreConfig, @Nullable com.hazelcast.client.impl.protocol.task.dynamicconfig.NearCacheConfigHolder nearCacheConfig, @Nullable com.hazelcast.config.WanReplicationRef wanReplicationRef, @Nullable java.util.Collection<com.hazelcast.config.IndexConfig> indexConfigs, @Nullable java.util.Collection<com.hazelcast.config.AttributeConfig> attributeConfigs, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.QueryCacheConfigHolder> queryCacheConfigs, @Nullable java.lang.String partitioningStrategyClassName, @Nullable com.hazelcast.internal.serialization.Data partitioningStrategyImplementation, @Nullable com.hazelcast.config.HotRestartConfig hotRestartConfig, @Nullable com.hazelcast.config.EventJournalConfig eventJournalConfig, @Nullable com.hazelcast.config.MerkleTreeConfig merkleTreeConfig, int metadataPolicy, boolean perEntryStatsEnabled, com.hazelcast.config.DataPersistenceConfig dataPersistenceConfig, com.hazelcast.config.TieredStoreConfig tieredStoreConfig) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddMapConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMultiMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddMultiMapConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a multimap configuration with the given {@code name} already exists, then
  * the new multimap config is ignored and the existing one is preserved.
  */
-@Generated("8d0077d622debd2a065b41eff501962b")
+@Generated("1fa9483ed5dff6aa1cec7a8f657b81e1")
 public final class DynamicConfigAddMultiMapConfigCodec {
     //hex: 0x1B0100
     public static final int REQUEST_MESSAGE_TYPE = 1769728;
@@ -115,6 +115,7 @@ public final class DynamicConfigAddMultiMapConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.lang.String collectionType, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, boolean binary, int backupCount, int asyncBackupCount, boolean statisticsEnabled, @Nullable java.lang.String splitBrainProtectionName, java.lang.String mergePolicy, int mergeBatchSize) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddMultiMapConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddQueueConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddQueueConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a queue configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("fe498a2751effe7fb5569c349ef2ab00")
+@Generated("4f18a71a626a782ce8f63f14a497fd40")
 public final class DynamicConfigAddQueueConfigCodec {
     //hex: 0x1B0B00
     public static final int REQUEST_MESSAGE_TYPE = 1772288;
@@ -130,6 +130,7 @@ public final class DynamicConfigAddQueueConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, int backupCount, int asyncBackupCount, int maxSize, int emptyQueueTtl, boolean statisticsEnabled, @Nullable java.lang.String splitBrainProtectionName, @Nullable com.hazelcast.client.impl.protocol.task.dynamicconfig.QueueStoreConfigHolder queueStoreConfig, java.lang.String mergePolicy, int mergeBatchSize, @Nullable java.lang.String priorityComparatorClassName) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddQueueConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReliableTopicConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReliableTopicConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a reliable topic configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("3d227f6db2b92e8c89a1adb06fd4af88")
+@Generated("f2334616da5d7c46bc786e736578c672")
 public final class DynamicConfigAddReliableTopicConfigCodec {
     //hex: 0x1B0D00
     public static final int REQUEST_MESSAGE_TYPE = 1772800;
@@ -90,6 +90,7 @@ public final class DynamicConfigAddReliableTopicConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, int readBatchSize, boolean statisticsEnabled, java.lang.String topicOverloadPolicy, @Nullable com.hazelcast.internal.serialization.Data executor) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddReliableTopicConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReplicatedMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddReplicatedMapConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a replicated map configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("b5cf542bd4c2c4937c2c8c61abd0c3e2")
+@Generated("7106f707ab4ad7a6bcd877334b160020")
 public final class DynamicConfigAddReplicatedMapConfigCodec {
     //hex: 0x1B0600
     public static final int REQUEST_MESSAGE_TYPE = 1771008;
@@ -105,6 +105,7 @@ public final class DynamicConfigAddReplicatedMapConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.lang.String inMemoryFormat, boolean asyncFillup, boolean statisticsEnabled, java.lang.String mergePolicy, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, @Nullable java.lang.String splitBrainProtectionName, int mergeBatchSize) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddReplicatedMapConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddRingbufferConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddRingbufferConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a ringbuffer configuration with the given {@code name} already exists, then
  * the new ringbuffer config is ignored and the existing one is preserved.
  */
-@Generated("800a45e3528614622ebfd40e33c83e18")
+@Generated("9707888e1bd7733b7f40fa8bcfd7f455")
 public final class DynamicConfigAddRingbufferConfigCodec {
     //hex: 0x1B0200
     public static final int REQUEST_MESSAGE_TYPE = 1769984;
@@ -115,6 +115,7 @@ public final class DynamicConfigAddRingbufferConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, int capacity, int backupCount, int asyncBackupCount, int timeToLiveSeconds, java.lang.String inMemoryFormat, @Nullable com.hazelcast.client.impl.protocol.task.dynamicconfig.RingbufferStoreConfigHolder ringbufferStoreConfig, @Nullable java.lang.String splitBrainProtectionName, java.lang.String mergePolicy, int mergeBatchSize) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddRingbufferConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddSetConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddSetConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a set configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("ab4ddd10c65807b8134e829c22e486b3")
+@Generated("af028eacb9bc35e8493e83a13c231590")
 public final class DynamicConfigAddSetConfigCodec {
     //hex: 0x1B0500
     public static final int REQUEST_MESSAGE_TYPE = 1770752;
@@ -109,6 +109,7 @@ public final class DynamicConfigAddSetConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs, int backupCount, int asyncBackupCount, int maxSize, boolean statisticsEnabled, @Nullable java.lang.String splitBrainProtectionName, java.lang.String mergePolicy, int mergeBatchSize) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddSetConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddTopicConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/DynamicConfigAddTopicConfigCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If a topic configuration with the given {@code name} already exists, then
  * the new configuration is ignored and the existing one is preserved.
  */
-@Generated("551cb9cfad723eb9f7e8ddf11fd5fb99")
+@Generated("a6f071ffe87f1dffcf2c56ef69f11008")
 public final class DynamicConfigAddTopicConfigCodec {
     //hex: 0x1B0700
     public static final int REQUEST_MESSAGE_TYPE = 1771264;
@@ -86,6 +86,7 @@ public final class DynamicConfigAddTopicConfigCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, boolean globalOrderingEnabled, boolean statisticsEnabled, boolean multiThreadingEnabled, @Nullable java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder> listenerConfigs) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("DynamicConfig.AddTopicConfig");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to member specified by the address.
  */
-@Generated("6a5bec320fd9f84394a98953a223f80e")
+@Generated("d8811f2c6fdfa070bf2dd1a9a20a6ba7")
 public final class ExecutorServiceSubmitToMemberCodec {
     //hex: 0x080600
     public static final int REQUEST_MESSAGE_TYPE = 525824;
@@ -76,6 +76,7 @@ public final class ExecutorServiceSubmitToMemberCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID uuid, com.hazelcast.internal.serialization.Data callable, java.util.UUID memberUUID) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ExecutorService.SubmitToMember");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ExecutorServiceSubmitToPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to the member that owns the partition with the given id.
  */
-@Generated("ed8e212313bd71af9850e5ba57fd6c28")
+@Generated("9bf49e4560e4272f3fcbcba2161ace74")
 public final class ExecutorServiceSubmitToPartitionCodec {
     //hex: 0x080500
     public static final int REQUEST_MESSAGE_TYPE = 525568;
@@ -70,6 +70,7 @@ public final class ExecutorServiceSubmitToPartitionCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID uuid, com.hazelcast.internal.serialization.Data callable) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ExecutorService.SubmitToPartition");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/JetSubmitJobCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/JetSubmitJobCodec.java
@@ -35,7 +35,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 
 /**
  */
-@Generated("11ce695accf2a457749dfa8a39e26f69")
+@Generated("0fbc699a96838a9ed9e4881cd2f9f236")
 public final class JetSubmitJobCodec {
     //hex: 0xFE0100
     public static final int REQUEST_MESSAGE_TYPE = 16646400;
@@ -77,6 +77,7 @@ public final class JetSubmitJobCodec {
 
     public static ClientMessage encodeRequest(long jobId, com.hazelcast.internal.serialization.Data dag, @Nullable com.hazelcast.internal.serialization.Data jobConfig, @Nullable java.util.UUID lightJobCoordinator) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Jet.SubmitJob");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
  * (Note that this will occur if the specified collection is this list, and it's nonempty.)
  */
-@Generated("86966a7bc1e4f6f19f7d505a63cac8fb")
+@Generated("045a53fa16c76f1e53f20f1e412ec8e8")
 public final class ListAddAllCodec {
     //hex: 0x050600
     public static final int REQUEST_MESSAGE_TYPE = 329216;
@@ -68,6 +68,7 @@ public final class ListAddAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> valueList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.AddAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllWithIndexCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddAllWithIndexCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
  * (Note that this will occur if the specified collection is this list, and it's nonempty.)
  */
-@Generated("dbf1cd287073b84e0919e0a923db666d")
+@Generated("951bbd4e323f0c508dd2f867a2db2574")
 public final class ListAddAllWithIndexCodec {
     //hex: 0x050E00
     public static final int REQUEST_MESSAGE_TYPE = 331264;
@@ -75,6 +75,7 @@ public final class ListAddAllWithIndexCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, int index, java.util.Collection<com.hazelcast.internal.serialization.Data> valueList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.AddAllWithIndex");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * elements, and others will impose restrictions on the type of elements that may be added. List classes should
  * clearly specify in their documentation any restrictions on what elements may be added.
  */
-@Generated("39899f804bd50f5e96ed127bc425007d")
+@Generated("b8953359dfb8c2f72f1b1824802032cd")
 public final class ListAddCodec {
     //hex: 0x050400
     public static final int REQUEST_MESSAGE_TYPE = 328704;
@@ -68,6 +68,7 @@ public final class ListAddCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.Add");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddWithIndexCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListAddWithIndexCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Inserts the specified element at the specified position in this list (optional operation). Shifts the element
  * currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
  */
-@Generated("b3fafb72d8143f3c0b4b62ebc3641788")
+@Generated("816291155ab16ef3580096cb105583ac")
 public final class ListAddWithIndexCodec {
     //hex: 0x051100
     public static final int REQUEST_MESSAGE_TYPE = 332032;
@@ -71,6 +71,7 @@ public final class ListAddWithIndexCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, int index, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.AddWithIndex");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRemoveAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes from this list all of its elements that are contained in the specified collection (optional operation).
  */
-@Generated("bdfaa4327e601dc204a5799880d0d14c")
+@Generated("4a2fc18e6d7bd7d215df44d189f789de")
 public final class ListCompareAndRemoveAllCodec {
     //hex: 0x050700
     public static final int REQUEST_MESSAGE_TYPE = 329472;
@@ -65,6 +65,7 @@ public final class ListCompareAndRemoveAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> values) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.CompareAndRemoveAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRetainAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListCompareAndRetainAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retains only the elements in this list that are contained in the specified collection (optional operation).
  * In other words, removes from this list all of its elements that are not contained in the specified collection.
  */
-@Generated("7adefe4d1dcae94993ce324a5a683bde")
+@Generated("b04eecaa33033a5d75e79640babb6961")
 public final class ListCompareAndRetainAllCodec {
     //hex: 0x050800
     public static final int REQUEST_MESSAGE_TYPE = 329728;
@@ -66,6 +66,7 @@ public final class ListCompareAndRetainAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> values) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.CompareAndRetainAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this list contains all of the elements of the specified collection.
  */
-@Generated("ec3ddf06d2e3462dc0789e54cff2d79f")
+@Generated("d64380be0652fb9ece8bac7a78678b3d")
 public final class ListContainsAllCodec {
     //hex: 0x050300
     public static final int REQUEST_MESSAGE_TYPE = 328448;
@@ -65,6 +65,7 @@ public final class ListContainsAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> values) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("List.ContainsAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListContainsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this list contains the specified element.
  */
-@Generated("98c882851ef5d096cfd49eedbf624471")
+@Generated("2930c304fe4f43624d2213ba34e6ac1f")
 public final class ListContainsCodec {
     //hex: 0x050200
     public static final int REQUEST_MESSAGE_TYPE = 328192;
@@ -65,6 +65,7 @@ public final class ListContainsCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("List.Contains");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIndexOfCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListIndexOfCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
  * contain the element.
  */
-@Generated("3331d530018861c91dd52a63a0fd1b68")
+@Generated("d5d2803d573b2328db5cc1fc2c798539")
 public final class ListIndexOfCodec {
     //hex: 0x051400
     public static final int REQUEST_MESSAGE_TYPE = 332800;
@@ -66,6 +66,7 @@ public final class ListIndexOfCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("List.IndexOf");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListLastIndexOfCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListLastIndexOfCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
  * contain the element.
  */
-@Generated("d5bf6163aa2dde22b085369fbf8db1a1")
+@Generated("ecd1c340989d7bfff4db18d8c56f2722")
 public final class ListLastIndexOfCodec {
     //hex: 0x051300
     public static final int REQUEST_MESSAGE_TYPE = 332544;
@@ -66,6 +66,7 @@ public final class ListLastIndexOfCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("List.LastIndexOf");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If this list does not contain the element, it is unchanged.
  * Returns true if this list contained the specified element (or equivalently, if this list changed as a result of the call).
  */
-@Generated("8b01d2b26fdd85cecdaae4006f717d11")
+@Generated("0262f4a99b42f9bdad41c0074d0abb54")
 public final class ListRemoveCodec {
     //hex: 0x050500
     public static final int REQUEST_MESSAGE_TYPE = 328960;
@@ -67,6 +67,7 @@ public final class ListRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ListSetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * The element previously at the specified position
  */
-@Generated("da176ebd96ae620eb5d72b5cbb72a56f")
+@Generated("77d984c0d418151effbd3a64560bcb45")
 public final class ListSetCodec {
     //hex: 0x051000
     public static final int REQUEST_MESSAGE_TYPE = 331776;
@@ -70,6 +70,7 @@ public final class ListSetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, int index, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("List.Set");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("c79f0177630baab6d80356705fe2627e")
+@Generated("f137c7dce4fd12c5a48a6c723c0b4ec3")
 public final class MapAddEntryListenerToKeyCodec {
     //hex: 0x011800
     public static final int REQUEST_MESSAGE_TYPE = 71680;
@@ -91,6 +91,7 @@ public final class MapAddEntryListenerToKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, boolean includeValue, int listenerFlags, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.AddEntryListenerToKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerToKeyWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
  * sub-interface for that event.
  */
-@Generated("0c183d37254dc784cac0162d112f6179")
+@Generated("d8297bd2e479bde9e26bf3bf3acad916")
 public final class MapAddEntryListenerToKeyWithPredicateCodec {
     //hex: 0x011600
     public static final int REQUEST_MESSAGE_TYPE = 71168;
@@ -97,6 +97,7 @@ public final class MapAddEntryListenerToKeyWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data predicate, boolean includeValue, int listenerFlags, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.AddEntryListenerToKeyWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddEntryListenerWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
  * filtered by the given predicate.
  */
-@Generated("d1b69506de51ac78e6202dbf7ad5ab21")
+@Generated("82d295c82e6dc1ccf2195de6985db8c5")
 public final class MapAddEntryListenerWithPredicateCodec {
     //hex: 0x011700
     public static final int REQUEST_MESSAGE_TYPE = 71424;
@@ -92,6 +92,7 @@ public final class MapAddEntryListenerWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data predicate, boolean includeValue, int listenerFlags, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.AddEntryListenerWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddInterceptorCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAddInterceptorCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an interceptor for this map. Added interceptor will intercept operations
  * and execute user defined methods and will cancel operations if user defined method throw exception.
  */
-@Generated("99c57e2be94c3d7223f8f93ab9595be8")
+@Generated("9d785c4e975a207b6347a3be5ef73c39")
 public final class MapAddInterceptorCodec {
     //hex: 0x011400
     public static final int REQUEST_MESSAGE_TYPE = 70656;
@@ -65,6 +65,7 @@ public final class MapAddInterceptorCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data interceptor) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.AddInterceptor");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the aggregation logic on all map entries and returns the result
  */
-@Generated("620828bc28d22803b3198bee72f3da2b")
+@Generated("c0bd9f65e9b7a11da060d45b4ce12c8a")
 public final class MapAggregateCodec {
     //hex: 0x013900
     public static final int REQUEST_MESSAGE_TYPE = 80128;
@@ -64,6 +64,7 @@ public final class MapAggregateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data aggregator) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.Aggregate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapAggregateWithPredicateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the aggregation logic on map entries filtered with the Predicate and returns the result
  */
-@Generated("c946d4c0f440a545296fb2d00403e1c6")
+@Generated("983f8bf4b10159f0e123df30e2cde36a")
 public final class MapAggregateWithPredicateCodec {
     //hex: 0x013A00
     public static final int REQUEST_MESSAGE_TYPE = 80384;
@@ -69,6 +69,7 @@ public final class MapAggregateWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data aggregator, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.AggregateWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains a mapping for the specified key.
  */
-@Generated("deaeeceb24e011a3d6849a8ea3cd75b4")
+@Generated("7c6da8501ecbaa5969dd3725d8fa443b")
 public final class MapContainsKeyCodec {
     //hex: 0x010600
     public static final int REQUEST_MESSAGE_TYPE = 67072;
@@ -71,6 +71,7 @@ public final class MapContainsKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ContainsKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapContainsValueCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this map maps one or more keys to the specified value.This operation will probably require time
  * linear in the map size for most implementations of the Map interface.
  */
-@Generated("eedee7732916b48f75aceb760b24d578")
+@Generated("3a37d47ceecc186e01429c8335de0cfc")
 public final class MapContainsValueCodec {
     //hex: 0x010700
     public static final int REQUEST_MESSAGE_TYPE = 67328;
@@ -66,6 +66,7 @@ public final class MapContainsValueCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ContainsValue");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapDeleteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapDeleteCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method breaks the contract of EntryListener. When an entry is removed by delete(), it fires an EntryEvent
  * with a null oldValue. Also, a listener with predicates will have null values, so only keys can be queried via predicates
  */
-@Generated("228dfff9aa2de5a942ff6765e7d43139")
+@Generated("391877ccf2e91585e58f96f026238813")
 public final class MapDeleteCodec {
     //hex: 0x010900
     public static final int REQUEST_MESSAGE_TYPE = 67840;
@@ -75,6 +75,7 @@ public final class MapDeleteCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.Delete");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("077fbff7a1c7cdab9733eb5b81bc42c3")
+@Generated("4f995b9fd4455b228b768c52b7d8a348")
 public final class MapEntriesWithPagingPredicateCodec {
     //hex: 0x013600
     public static final int REQUEST_MESSAGE_TYPE = 79360;
@@ -67,6 +67,7 @@ public final class MapEntriesWithPagingPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.client.impl.protocol.codec.holder.PagingPredicateHolder predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.EntriesWithPagingPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEntriesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("5feb5780ae13db24844415190698fa2a")
+@Generated("229fd1511bf83cb7b7841741b119012d")
 public final class MapEntriesWithPredicateCodec {
     //hex: 0x012800
     public static final int REQUEST_MESSAGE_TYPE = 75776;
@@ -67,6 +67,7 @@ public final class MapEntriesWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.EntriesWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  */
-@Generated("279cde2b5923cc29d77ec15a93d6c0df")
+@Generated("f82832d5af795f473a27f455d92ea239")
 public final class MapEventJournalReadCodec {
     //hex: 0x014200
     public static final int REQUEST_MESSAGE_TYPE = 82432;
@@ -96,6 +96,7 @@ public final class MapEventJournalReadCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, long startSequence, int minSize, int maxSize, @Nullable com.hazelcast.internal.serialization.Data predicate, @Nullable com.hazelcast.internal.serialization.Data projection) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.EventJournalRead");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEvictCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
  * from the underlying MapStore, evict only removes the entry from the memory.
  */
-@Generated("c6ef4175b4437772f4ce271f27a4ecd4")
+@Generated("e73197a005d914a12923f46198047ba6")
 public final class MapEvictCodec {
     //hex: 0x011E00
     public static final int REQUEST_MESSAGE_TYPE = 73216;
@@ -72,6 +72,7 @@ public final class MapEvictCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.Evict");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnAllKeysCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
  */
-@Generated("a5ea827401805d975ba156d0489cf029")
+@Generated("bd6f0458061fb9cfa165a1c6240090be")
 public final class MapExecuteOnAllKeysCodec {
     //hex: 0x013000
     public static final int REQUEST_MESSAGE_TYPE = 77824;
@@ -64,6 +64,7 @@ public final class MapExecuteOnAllKeysCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data entryProcessor) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.ExecuteOnAllKeys");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeyCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
  * the process() method of EntryProcessor.
  */
-@Generated("d2fe1d5d0e1c7eeb3000395ca46eabbe")
+@Generated("e0d790959442e9fa57848b5e0f1bfbbc")
 public final class MapExecuteOnKeyCodec {
     //hex: 0x012E00
     public static final int REQUEST_MESSAGE_TYPE = 77312;
@@ -76,6 +76,7 @@ public final class MapExecuteOnKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data entryProcessor, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.ExecuteOnKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteOnKeysCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
  * each key in the collection.
  */
-@Generated("a870bbeabb28fbebcda0bc6dbbd4b1ef")
+@Generated("9105a036cbeca5d62bab0ef36db44f62")
 public final class MapExecuteOnKeysCodec {
     //hex: 0x013200
     public static final int REQUEST_MESSAGE_TYPE = 78336;
@@ -70,6 +70,7 @@ public final class MapExecuteOnKeysCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data entryProcessor, java.util.Collection<com.hazelcast.internal.serialization.Data> keys) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.ExecuteOnKeys");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapExecuteWithPredicateCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
  * Returns the results mapped by each key in the map.
  */
-@Generated("0df28786eb71f45dfbc0f62df3604f5b")
+@Generated("5ee6c68942768fe1a0a1e3ca1ed7b98b")
 public final class MapExecuteWithPredicateCodec {
     //hex: 0x013100
     public static final int REQUEST_MESSAGE_TYPE = 78080;
@@ -70,6 +70,7 @@ public final class MapExecuteWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data entryProcessor, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.ExecuteWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchWithQueryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchWithQueryCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches the specified number of entries from the specified partition starting from specified table index
  * that match the predicate and applies the projection logic on them.
  */
-@Generated("e874aa3a807c3cef59167e9aabc5e7cd")
+@Generated("d9b50a0019048b4bd79c7c5ddb11d3ed")
 public final class MapFetchWithQueryCodec {
     //hex: 0x014000
     public static final int REQUEST_MESSAGE_TYPE = 81920;
@@ -81,6 +81,7 @@ public final class MapFetchWithQueryCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<java.util.Map.Entry<java.lang.Integer, java.lang.Integer>> iterationPointers, int batch, com.hazelcast.internal.serialization.Data projection, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.FetchWithQuery");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapForceUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapForceUnlockCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,
  * never blocks,and returns immediately.
  */
-@Generated("0c1989e1fa5cd50140ea3274ccf06836")
+@Generated("ef0d476a7dc6fb04c5ce3e89718ff28e")
 public final class MapForceUnlockCodec {
     //hex: 0x013300
     public static final int REQUEST_MESSAGE_TYPE = 78592;
@@ -71,6 +71,7 @@ public final class MapForceUnlockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ForceUnlock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetAllCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("0e1b2ec736626946569383789cbb5215")
+@Generated("37cacc16483c3ded03e1c630ee97b77f")
 public final class MapGetAllCodec {
     //hex: 0x012300
     public static final int REQUEST_MESSAGE_TYPE = 74496;
@@ -68,6 +68,7 @@ public final class MapGetAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.GetAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns a clone of the original value, so modifying the returned value does not change the actual
  * value in the map. You should put the modified value back to make changes visible to all nodes.
  */
-@Generated("b093fb8ac7c6d141b5a0a9ed937aba1c")
+@Generated("13b360447cba4138be8a249a8b57c0fe")
 public final class MapGetCodec {
     //hex: 0x010200
     public static final int REQUEST_MESSAGE_TYPE = 66048;
@@ -71,6 +71,7 @@ public final class MapGetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.Get");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetEntryViewCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapGetEntryViewCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This method returns a clone of original mapping, modifying the returned value does not change the actual value
  * in the map. One should put modified value back to make changes visible to all nodes.
  */
-@Generated("3c4d5bdef132e1c6263039cdc2b7ab18")
+@Generated("010de4782af3b9b5cc2990d4f77be9e5")
 public final class MapGetEntryViewCodec {
     //hex: 0x011D00
     public static final int REQUEST_MESSAGE_TYPE = 72960;
@@ -73,6 +73,7 @@ public final class MapGetEntryViewCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.GetEntryView");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsLockedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapIsLockedCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
  */
-@Generated("64622e0efddfe5142c93bcb3da4dba08")
+@Generated("b4a713c87f866e1d5c7171d0cc873de3")
 public final class MapIsLockedCodec {
     //hex: 0x011200
     public static final int REQUEST_MESSAGE_TYPE = 70144;
@@ -65,6 +65,7 @@ public final class MapIsLockedCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.IsLocked");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("e556617145faa66ec5f1792cf2973eaf")
+@Generated("8dce73c4a1ddeb905894fb001cbe4ae3")
 public final class MapKeySetWithPagingPredicateCodec {
     //hex: 0x013400
     public static final int REQUEST_MESSAGE_TYPE = 78848;
@@ -67,6 +67,7 @@ public final class MapKeySetWithPagingPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.client.impl.protocol.codec.holder.PagingPredicateHolder predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.KeySetWithPagingPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapKeySetWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("54ccc4bc6d4b4a2849d7f015ee267d9b")
+@Generated("019616ec5c4fa04e0f3a02e56e8ba24a")
 public final class MapKeySetWithPredicateCodec {
     //hex: 0x012600
     public static final int REQUEST_MESSAGE_TYPE = 75264;
@@ -67,6 +67,7 @@ public final class MapKeySetWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.KeySetWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLoadGivenKeysCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLoadGivenKeysCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
  */
-@Generated("497f1f0593f40eda14a7a1e3f719c313")
+@Generated("e61d458cf0202c2bc6aba3cfeebe534b")
 public final class MapLoadGivenKeysCodec {
     //hex: 0x012100
     public static final int REQUEST_MESSAGE_TYPE = 73984;
@@ -70,6 +70,7 @@ public final class MapLoadGivenKeysCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> keys, boolean replaceExistingValues) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.LoadGivenKeys");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapLockCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Scope of the lock is this map only. Acquired lock is only for the key in this map. Locks are re-entrant,
  * so if the key is locked N times then it should be unlocked N times before another thread can acquire it.
  */
-@Generated("b5b682626855b88b94fcf6116a6589db")
+@Generated("cadd787219fc2274df00a130fdc542af")
 public final class MapLockCodec {
     //hex: 0x011000
     public static final int REQUEST_MESSAGE_TYPE = 69632;
@@ -86,6 +86,7 @@ public final class MapLockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long ttl, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.Lock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the projection logic on all map entries and returns the result
  */
-@Generated("72dcfd6f49ea4d2aa09dd32dda43d6e2")
+@Generated("c3ff99dd8da12c5038afb8d9ef58044a")
 public final class MapProjectCodec {
     //hex: 0x013B00
     public static final int REQUEST_MESSAGE_TYPE = 80640;
@@ -64,6 +64,7 @@ public final class MapProjectCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data projection) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.Project");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapProjectWithPredicateCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Applies the projection logic on map entries filtered with the Predicate and returns the result
  */
-@Generated("a5b469795c8d9249db075a4ecdf4b94b")
+@Generated("240015e7228b3279275f3cb9236e5769")
 public final class MapProjectWithPredicateCodec {
     //hex: 0x013C00
     public static final int REQUEST_MESSAGE_TYPE = 80896;
@@ -69,6 +69,7 @@ public final class MapProjectWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data projection, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ProjectWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutAllCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
  * of these request messages for filling a request for a key set if the keys belong to different partitions.
  */
-@Generated("a8e19cfa49f448d5b2d903b3ddc11160")
+@Generated("d6b6a82c6a38fb30de66e09e2d2558e3")
 public final class MapPutAllCodec {
     //hex: 0x012C00
     public static final int REQUEST_MESSAGE_TYPE = 76800;
@@ -82,6 +82,7 @@ public final class MapPutAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries, boolean triggerMapLoader) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.PutAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
  * rounded to the next closest second value.
  */
-@Generated("0fcdcab8e68f8f6cc29aac7adf6dd380")
+@Generated("cfc3350ae811232522a4a3632b382b3f")
 public final class MapPutCodec {
     //hex: 0x010100
     public static final int REQUEST_MESSAGE_TYPE = 65792;
@@ -84,6 +84,7 @@ public final class MapPutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
  * with a value. Entry will expire and get evicted after the ttl.
  */
-@Generated("6407d6c7210b59551a9e649f52f94103")
+@Generated("34ddec25bb7af8ba126050dbfcb0e65d")
 public final class MapPutIfAbsentCodec {
     //hex: 0x010E00
     public static final int REQUEST_MESSAGE_TYPE = 69120;
@@ -82,6 +82,7 @@ public final class MapPutIfAbsentCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.PutIfAbsent");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutIfAbsentWithMaxIdleCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
  * with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
  */
-@Generated("34137265b0794ad3c486a22ee5361a7b")
+@Generated("8b244111186ce283ab71bddcbe5f62e1")
 public final class MapPutIfAbsentWithMaxIdleCodec {
     //hex: 0x014600
     public static final int REQUEST_MESSAGE_TYPE = 83456;
@@ -89,6 +89,7 @@ public final class MapPutIfAbsentWithMaxIdleCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl, long maxIdle) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.PutIfAbsentWithMaxIdle");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
  * If ttl is 0, then the entry lives forever.
  */
-@Generated("7a741055b40fd6cb18c1ba343ee0d55f")
+@Generated("ce542d056f4b4aed27768f5a29fea838")
 public final class MapPutTransientCodec {
     //hex: 0x010D00
     public static final int REQUEST_MESSAGE_TYPE = 68864;
@@ -82,6 +82,7 @@ public final class MapPutTransientCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.PutTransient");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutTransientWithMaxIdleCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
  * If ttl and maxIdle are 0, then the entry lives forever.
  */
-@Generated("a8c666e53dd0287fc8f6a937498cf152")
+@Generated("ca12c5dbb99d8cb82d24a1ab9c5b7644")
 public final class MapPutTransientWithMaxIdleCodec {
     //hex: 0x014500
     public static final int REQUEST_MESSAGE_TYPE = 83200;
@@ -89,6 +89,7 @@ public final class MapPutTransientWithMaxIdleCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl, long maxIdle) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.PutTransientWithMaxIdle");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapPutWithMaxIdleCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
  * rounded to the next closest second value.
  */
-@Generated("0830f89ac571f4b96da4fed352af96ab")
+@Generated("c520941c63a23cebeefcc3443123d6f4")
 public final class MapPutWithMaxIdleCodec {
     //hex: 0x014400
     public static final int REQUEST_MESSAGE_TYPE = 82944;
@@ -91,6 +91,7 @@ public final class MapPutWithMaxIdleCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl, long maxIdle) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.PutWithMaxIdle");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all entries which match with the supplied predicate
  */
-@Generated("501b09c52be72679d579c3f910b8f2d7")
+@Generated("f6dabe40d6128ddfebf307e64cc769ef")
 public final class MapRemoveAllCodec {
     //hex: 0x013E00
     public static final int REQUEST_MESSAGE_TYPE = 81408;
@@ -64,6 +64,7 @@ public final class MapRemoveAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.RemoveAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * possible that the map explicitly mapped the key to null. The map will not contain a mapping for the specified key once the
  * call returns.
  */
-@Generated("afcfd453f579205de12e67c09f81d5a9")
+@Generated("fe0411f226af4f40f051585905e2de4d")
 public final class MapRemoveCodec {
     //hex: 0x010300
     public static final int REQUEST_MESSAGE_TYPE = 66304;
@@ -74,6 +74,7 @@ public final class MapRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapRemoveIfSameCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the mapping for a key from this map if existing value equal to the this value
  */
-@Generated("b6fcb209976aeec65ec05df783ce6e01")
+@Generated("f443ad21907df2c80d3adf0f87b3c3c1")
 public final class MapRemoveIfSameCodec {
     //hex: 0x010800
     public static final int REQUEST_MESSAGE_TYPE = 67584;
@@ -76,6 +76,7 @@ public final class MapRemoveIfSameCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.RemoveIfSame");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceAllCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * function on that entry until all entries have been processed in the targetted partition
  * or the function throws an exception.
  */
-@Generated("f85c7a9af0294462501aaae087a32f2b")
+@Generated("7609514baf2e4ef58220e01547e0b00e")
 public final class MapReplaceAllCodec {
     //hex: 0x014800
     public static final int REQUEST_MESSAGE_TYPE = 83968;
@@ -66,6 +66,7 @@ public final class MapReplaceAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data function) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ReplaceAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Replaces the entry for a key only if currently mapped to a given value.
  */
-@Generated("bb8a7b579af9e874a70aa61096c6fbee")
+@Generated("5f863bb2e63434badb33279c6a09028a")
 public final class MapReplaceCodec {
     //hex: 0x010400
     public static final int REQUEST_MESSAGE_TYPE = 66560;
@@ -75,6 +75,7 @@ public final class MapReplaceCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.Replace");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapReplaceIfSameCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Replaces the the entry for a key only if existing values equal to the testValue
  */
-@Generated("237780d45f7ecf5f4b146e8d4feee8e1")
+@Generated("3a03840f65fc9566977f1439fddc5886")
 public final class MapReplaceIfSameCodec {
     //hex: 0x010500
     public static final int REQUEST_MESSAGE_TYPE = 66816;
@@ -81,6 +81,7 @@ public final class MapReplaceIfSameCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data testValue, com.hazelcast.internal.serialization.Data value, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.ReplaceIfSame");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
  * return the old value, which is more efficient.
  */
-@Generated("b4545e7116543ca28a3e2a7b292dc419")
+@Generated("1a69e92a944dc20f4cf27f32ed8aa716")
 public final class MapSetCodec {
     //hex: 0x010F00
     public static final int REQUEST_MESSAGE_TYPE = 69376;
@@ -83,6 +83,7 @@ public final class MapSetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.Set");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetTtlCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetTtlCodec.java
@@ -48,7 +48,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * <p>
  * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
  */
-@Generated("f3ff196ec784d6fb732f3fd02fd31405")
+@Generated("f5c352ef2e5aea26eb874bb20ab8a232")
 public final class MapSetTtlCodec {
     //hex: 0x014300
     public static final int REQUEST_MESSAGE_TYPE = 82688;
@@ -83,6 +83,7 @@ public final class MapSetTtlCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.SetTtl");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetWithMaxIdleCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSetWithMaxIdleCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * 
  * Similar to the put operation except that set doesn't return the old value, which is more efficient.
  */
-@Generated("94410bbe14d386e598144876c1de7b2f")
+@Generated("c66798bb70f9ed04505b36e689133804")
 public final class MapSetWithMaxIdleCodec {
     //hex: 0x014700
     public static final int REQUEST_MESSAGE_TYPE = 83712;
@@ -92,6 +92,7 @@ public final class MapSetWithMaxIdleCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long ttl, long maxIdle) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.SetWithMaxIdle");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSubmitToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapSubmitToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
  * operation of EntryProcessor.
  */
-@Generated("9b0936ab46a4fec23f1bde7f7b7ca19e")
+@Generated("c39a0bce038b5b7587096ba0c6894acb")
 public final class MapSubmitToKeyCodec {
     //hex: 0x012F00
     public static final int REQUEST_MESSAGE_TYPE = 77568;
@@ -77,6 +77,7 @@ public final class MapSubmitToKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data entryProcessor, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.SubmitToKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryLockCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * purposes and lies dormant until one of two things happens the lock is acquired by the current thread, or
  * the specified waiting time elapses.
  */
-@Generated("025763eb1b4176ffc993938f848ba13c")
+@Generated("46c112f74d05704681fc2aee1994fbb9")
 public final class MapTryLockCodec {
     //hex: 0x011100
     public static final int REQUEST_MESSAGE_TYPE = 69888;
@@ -92,6 +92,7 @@ public final class MapTryLockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long lease, long timeout, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.TryLock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryPutCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * it means that the caller thread could not acquire the lock for the key within the timeout duration,
  * thus the put operation is not successful.
  */
-@Generated("07357a26b4e72bf0ced4db535a5662fb")
+@Generated("f5c11a4be542abc65a3323b954307bf4")
 public final class MapTryPutCodec {
     //hex: 0x010C00
     public static final int REQUEST_MESSAGE_TYPE = 68608;
@@ -84,6 +84,7 @@ public final class MapTryPutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId, long timeout) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.TryPut");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapTryRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the key is already locked by another thread and/or member, then this operation will wait the timeout
  * amount for acquiring the lock.
  */
-@Generated("e5daf6ed41e0d9de63c081776b778b69")
+@Generated("02091810927f7f2eb432830c8b6d470f")
 public final class MapTryRemoveCodec {
     //hex: 0x010B00
     public static final int REQUEST_MESSAGE_TYPE = 68352;
@@ -79,6 +79,7 @@ public final class MapTryRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long timeout) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Map.TryRemove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapUnlockCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * then the lock is released.  If the current thread is not the holder of this lock,
  * then ILLEGAL_MONITOR_STATE is thrown.
  */
-@Generated("a2acdd48b10414ffd02a20268bc93232")
+@Generated("6b1ee00065a6713f15c20839085fdabc")
 public final class MapUnlockCodec {
     //hex: 0x011300
     public static final int REQUEST_MESSAGE_TYPE = 70400;
@@ -79,6 +79,7 @@ public final class MapUnlockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.Unlock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPagingPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("ebf12e52a7bd1844fefcf5ac7880ff16")
+@Generated("2db64062aac26a0319e782edbce3d913")
 public final class MapValuesWithPagingPredicateCodec {
     //hex: 0x013500
     public static final int REQUEST_MESSAGE_TYPE = 79104;
@@ -67,6 +67,7 @@ public final class MapValuesWithPagingPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.client.impl.protocol.codec.holder.PagingPredicateHolder predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ValuesWithPagingPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapValuesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("ce15e53048a5bcca8f57cc66eca62761")
+@Generated("1b985848e6fc1e76ef565671795dfcc2")
 public final class MapValuesWithPredicateCodec {
     //hex: 0x012700
     public static final int REQUEST_MESSAGE_TYPE = 75520;
@@ -67,6 +67,7 @@ public final class MapValuesWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Map.ValuesWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapAddEntryListenerToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds the specified entry listener for the specified key.The listener will be notified for all
  * add/remove/update/evict events for the specified key only.
  */
-@Generated("c223d51f73d9f112e1d64dbf590201e4")
+@Generated("cebd4c5fc7575d0f041ea51fb3249d46")
 public final class MultiMapAddEntryListenerToKeyCodec {
     //hex: 0x020D00
     public static final int REQUEST_MESSAGE_TYPE = 134400;
@@ -85,6 +85,7 @@ public final class MultiMapAddEntryListenerToKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, boolean includeValue, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("MultiMap.AddEntryListenerToKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsEntryCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns whether the multimap contains the given key-value pair.
  */
-@Generated("87dd2f1e4044301e566c94781cf82cfe")
+@Generated("cdaa85b2e6b1e7752e643a0a25135056")
 public final class MultiMapContainsEntryCodec {
     //hex: 0x020900
     public static final int REQUEST_MESSAGE_TYPE = 133376;
@@ -76,6 +76,7 @@ public final class MultiMapContainsEntryCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.ContainsEntry");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns whether the multimap contains an entry with the key.
  */
-@Generated("fa542443f835d252726c0ff689a5a6d7")
+@Generated("613df12d621143bf80abbd9ffdd50398")
 public final class MultiMapContainsKeyCodec {
     //hex: 0x020700
     public static final int REQUEST_MESSAGE_TYPE = 132864;
@@ -71,6 +71,7 @@ public final class MultiMapContainsKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.ContainsKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapContainsValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns whether the multimap contains an entry with the value.
  */
-@Generated("ba2c4fdcdac9e6f003223621cf2e315e")
+@Generated("6a85548152b143dc579265401e14727e")
 public final class MultiMapContainsValueCodec {
     //hex: 0x020800
     public static final int REQUEST_MESSAGE_TYPE = 133120;
@@ -65,6 +65,7 @@ public final class MultiMapContainsValueCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.ContainsValue");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapDeleteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapDeleteCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all the entries with the given key.
  */
-@Generated("9e043899db1969079dcca0bd872dcd2b")
+@Generated("1c16932e43f9799d9548e5fa7ec2ed43")
 public final class MultiMapDeleteCodec {
     //hex: 0x021600
     public static final int REQUEST_MESSAGE_TYPE = 136704;
@@ -70,6 +70,7 @@ public final class MultiMapDeleteCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("MultiMap.Delete");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapForceUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapForceUnlockCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
  * never blocks and returns immediately.
  */
-@Generated("68642058a9f650389cdcb0a395f9c2ca")
+@Generated("b1589cf06bc3ce64935301d9f2732c00")
 public final class MultiMapForceUnlockCodec {
     //hex: 0x021400
     public static final int REQUEST_MESSAGE_TYPE = 136192;
@@ -71,6 +71,7 @@ public final class MultiMapForceUnlockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.ForceUnlock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapGetCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
  * the map are NOT reflected in the collection, and vice-versa.
  */
-@Generated("775d8a25e842f09013e2035838e3d208")
+@Generated("b59a082caf7d45e97a7c3c4c8a86a39b")
 public final class MultiMapGetCodec {
     //hex: 0x020200
     public static final int REQUEST_MESSAGE_TYPE = 131584;
@@ -71,6 +71,7 @@ public final class MultiMapGetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.Get");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapIsLockedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapIsLockedCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
  */
-@Generated("00b7431ab1d3495e010c75d4be243a26")
+@Generated("0ecdab4d75f08834e92ee089f597e96c")
 public final class MultiMapIsLockedCodec {
     //hex: 0x021200
     public static final int REQUEST_MESSAGE_TYPE = 135680;
@@ -65,6 +65,7 @@ public final class MultiMapIsLockedCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.IsLocked");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapLockCodec.java
@@ -40,7 +40,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * lock is only for the key in this map.Locks are re-entrant, so if the key is locked N times, then it should be
  * unlocked N times before another thread can acquire it.
  */
-@Generated("3f227822a31df353b572941bef0d6ecc")
+@Generated("c68dc07cf287ac48e9405e9b56270e53")
 public final class MultiMapLockCodec {
     //hex: 0x021000
     public static final int REQUEST_MESSAGE_TYPE = 135168;
@@ -86,6 +86,7 @@ public final class MultiMapLockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long ttl, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.Lock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapPutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapPutAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * v in the specified MultiMap. The behavior of this operation is undefined if the specified map is modified while the
  * operation is in progress.
  */
-@Generated("8764723cb34f6c616e37b46e978e6c77")
+@Generated("374061fdfa4af8127e90d49993b89a39")
 public final class MultiMapPutAllCodec {
     //hex: 0x021700
     public static final int REQUEST_MESSAGE_TYPE = 136960;
@@ -67,6 +67,7 @@ public final class MultiMapPutAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, java.util.Collection<com.hazelcast.internal.serialization.Data>>> entries) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("MultiMap.PutAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapPutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Stores a key-value pair in the multimap.
  */
-@Generated("d9a26cf2d18f88f63b0ab7b26dce2c8d")
+@Generated("4c9a2b16a176c0c8f104c960d3db0b88")
 public final class MultiMapPutCodec {
     //hex: 0x020100
     public static final int REQUEST_MESSAGE_TYPE = 131328;
@@ -76,6 +76,7 @@ public final class MultiMapPutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("MultiMap.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("c69615d85edbf4b6f507cca203c17e53")
+@Generated("56752c76f06c67f7a50e6ed7815dd90c")
 public final class MultiMapRemoveCodec {
     //hex: 0x020300
     public static final int REQUEST_MESSAGE_TYPE = 131840;
@@ -70,6 +70,7 @@ public final class MultiMapRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("MultiMap.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapRemoveEntryCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
  * NOT reflected in the collection, and vice-versa.
  */
-@Generated("d507045c30023c7949c9e8ea5fd74216")
+@Generated("f7ad62daf2093a610a688ef95a498c25")
 public final class MultiMapRemoveEntryCodec {
     //hex: 0x021500
     public static final int REQUEST_MESSAGE_TYPE = 136448;
@@ -77,6 +77,7 @@ public final class MultiMapRemoveEntryCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("MultiMap.RemoveEntry");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapTryLockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapTryLockCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * and lies dormant until one of two things happens:the lock is acquired by the current thread, or the specified
  * waiting time elapses.
  */
-@Generated("ce7936c63f85369159bc9e2c1db9b9d1")
+@Generated("dc6c7d715824de7b68a009c22942d817")
 public final class MultiMapTryLockCodec {
     //hex: 0x021100
     public static final int REQUEST_MESSAGE_TYPE = 135424;
@@ -92,6 +92,7 @@ public final class MultiMapTryLockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long lease, long timeout, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.TryLock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapUnlockCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapUnlockCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
  * never blocks and returns immediately.
  */
-@Generated("b04d496b424d325886b0b5f0e11d1be6")
+@Generated("5103fc2504391f626fd476483fbf3551")
 public final class MultiMapUnlockCodec {
     //hex: 0x021300
     public static final int REQUEST_MESSAGE_TYPE = 135936;
@@ -77,6 +77,7 @@ public final class MultiMapUnlockCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId, long referenceId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.Unlock");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValueCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MultiMapValueCountCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of values that match the given key in the multimap.
  */
-@Generated("629a3ea00be76a92100aead3a51bd2c6")
+@Generated("b0a6cd58cd285fc9fe60f7b4c2c9276d")
 public final class MultiMapValueCountCodec {
     //hex: 0x020C00
     public static final int REQUEST_MESSAGE_TYPE = 134144;
@@ -71,6 +71,7 @@ public final class MultiMapValueCountCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, long threadId) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("MultiMap.ValueCount");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueAddAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * (This implies that the behavior of this call is undefined if the specified collection is this collection,
  * and this collection is nonempty.)
  */
-@Generated("378257a0026e047838c7d165ac3e2ee4")
+@Generated("529334afbe5b254c4cc31f37ae6a5b16")
 public final class QueueAddAllCodec {
     //hex: 0x031000
     public static final int REQUEST_MESSAGE_TYPE = 200704;
@@ -68,6 +68,7 @@ public final class QueueAddAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> dataList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.AddAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRemoveAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes all of this collection's elements that are also contained in the specified collection (optional operation).
  * After this call returns, this collection will contain no elements in common with the specified collection.
  */
-@Generated("19157a23421d5447f271d0cbcd2bf348")
+@Generated("d8e5c6cd3186e5caa53bdc4a0441c9be")
 public final class QueueCompareAndRemoveAllCodec {
     //hex: 0x030D00
     public static final int REQUEST_MESSAGE_TYPE = 199936;
@@ -66,6 +66,7 @@ public final class QueueCompareAndRemoveAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> dataList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.CompareAndRemoveAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRetainAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueCompareAndRetainAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retains only the elements in this collection that are contained in the specified collection (optional operation).
  * In other words, removes from this collection all of its elements that are not contained in the specified collection.
  */
-@Generated("2450e3b7cd1dd1a6ef0b4cae83042cfc")
+@Generated("7d6a25ffb49b116039ab8f6fc777645c")
 public final class QueueCompareAndRetainAllCodec {
     //hex: 0x030E00
     public static final int REQUEST_MESSAGE_TYPE = 200192;
@@ -66,6 +66,7 @@ public final class QueueCompareAndRetainAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> dataList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.CompareAndRetainAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Return true if this collection contains all of the elements in the specified collection.
  */
-@Generated("4b18cd851ec9c7d15228906c65bdc2fd")
+@Generated("b0846dfc1dfcedd77b444a1aa4f671f4")
 public final class QueueContainsAllCodec {
     //hex: 0x030C00
     public static final int REQUEST_MESSAGE_TYPE = 199680;
@@ -65,6 +65,7 @@ public final class QueueContainsAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> dataList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.ContainsAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueContainsCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
  * contains at least one element e such that value.equals(e)
  */
-@Generated("f0209aa307282bef97376124cda470c7")
+@Generated("fd09d39d6bd75f4edc3346a428ac69a4")
 public final class QueueContainsCodec {
     //hex: 0x030B00
     public static final int REQUEST_MESSAGE_TYPE = 199424;
@@ -66,6 +66,7 @@ public final class QueueContainsCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.Contains");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueOfferCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueOfferCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
  * become available.
  */
-@Generated("fa851194b9d3f36bb006aab7705c8ab4")
+@Generated("018a825b3adf5a8e1dae7a7995d5ff57")
 public final class QueueOfferCodec {
     //hex: 0x030100
     public static final int REQUEST_MESSAGE_TYPE = 196864;
@@ -72,6 +72,7 @@ public final class QueueOfferCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value, long timeoutMillis) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.Offer");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueuePutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueuePutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Inserts the specified element into this queue, waiting if necessary for space to become available.
  */
-@Generated("011e12047c81e8e3664fa296fb217557")
+@Generated("88355af4fed882f2e7c520072aa467e9")
 public final class QueuePutCodec {
     //hex: 0x030200
     public static final int REQUEST_MESSAGE_TYPE = 197120;
@@ -64,6 +64,7 @@ public final class QueuePutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/QueueRemoveCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
  * if this queue is empty.
  */
-@Generated("d522c259ec0573d6c4a9aa8a2fdbaf9d")
+@Generated("e3e163f841306d782462c5c369789548")
 public final class QueueRemoveCodec {
     //hex: 0x030400
     public static final int REQUEST_MESSAGE_TYPE = 197632;
@@ -66,6 +66,7 @@ public final class QueueRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Queue.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds the specified entry listener for the specified key. The listener will be notified for all
  * add/remove/update/evict events of the specified key only.
  */
-@Generated("d242750f9e8d01967444359c8da7de22")
+@Generated("e7d3c7f82f65ef88ac90dbe318ff2c1a")
 public final class ReplicatedMapAddEntryListenerToKeyCodec {
     //hex: 0x0D0C00
     public static final int REQUEST_MESSAGE_TYPE = 855040;
@@ -79,6 +79,7 @@ public final class ReplicatedMapAddEntryListenerToKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ReplicatedMap.AddEntryListenerToKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
  * events filtered by the given predicate.
  */
-@Generated("1d6e88d0d66a389c2ffdd5fe3e6eb330")
+@Generated("9419750f523318406ad613ebfabd77e8")
 public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
     //hex: 0x0D0A00
     public static final int REQUEST_MESSAGE_TYPE = 854528;
@@ -84,6 +84,7 @@ public final class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data predicate, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ReplicatedMap.AddEntryListenerToKeyWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
  * events filtered by the given predicate.
  */
-@Generated("1673c840b3c5ef4800acd837136c7413")
+@Generated("f67080bfa52cc71ff36609049a35a082")
 public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
     //hex: 0x0D0B00
     public static final int REQUEST_MESSAGE_TYPE = 854784;
@@ -79,6 +79,7 @@ public final class ReplicatedMapAddEntryListenerWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data predicate, boolean localOnly) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ReplicatedMap.AddEntryListenerWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains a mapping for the specified key.
  */
-@Generated("c20bf6b05893c20ddfca850e66b5d27e")
+@Generated("4bfaf527781d972fe4fdf293dfa69ab3")
 public final class ReplicatedMapContainsKeyCodec {
     //hex: 0x0D0400
     public static final int REQUEST_MESSAGE_TYPE = 852992;
@@ -65,6 +65,7 @@ public final class ReplicatedMapContainsKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ReplicatedMap.ContainsKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapContainsValueCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this map maps one or more keys to the specified value.
  * This operation will probably require time linear in the map size for most implementations of the Map interface.
  */
-@Generated("f03c5fb258212cf8971347ba10c7e45c")
+@Generated("f254fcec8aa207c040f994bd9906650f")
 public final class ReplicatedMapContainsValueCodec {
     //hex: 0x0D0500
     public static final int REQUEST_MESSAGE_TYPE = 853248;
@@ -66,6 +66,7 @@ public final class ReplicatedMapContainsValueCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ReplicatedMap.ContainsValue");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapGetCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * necessarily indicate that the map contains no mapping for the key; it's also possible that the map
  * explicitly maps the key to null.  The #containsKey operation may be used to distinguish these two cases.
  */
-@Generated("9744a8cf318c38dfce1747f0ccafbfda")
+@Generated("da4079d34e22707cfb78ca176b21e341")
 public final class ReplicatedMapGetCodec {
     //hex: 0x0D0600
     public static final int REQUEST_MESSAGE_TYPE = 853504;
@@ -67,6 +67,7 @@ public final class ReplicatedMapGetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ReplicatedMap.Get");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * v in the specified map. The behavior of this operation is undefined if the specified map is modified while the
  * operation is in progress.
  */
-@Generated("d331408153b2ccf7f85532689e352117")
+@Generated("13c6f8abb3ec6127a16dbb364d4ab0f5")
 public final class ReplicatedMapPutAllCodec {
     //hex: 0x0D0800
     public static final int REQUEST_MESSAGE_TYPE = 854016;
@@ -67,6 +67,7 @@ public final class ReplicatedMapPutAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>> entries) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ReplicatedMap.PutAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapPutCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
  * to define when the value is outdated and thus should be removed from the replicated map.
  */
-@Generated("13efb3ff5f88941d58122e8dcb60d4ee")
+@Generated("e035475e54421d79ea198be4aec25669")
 public final class ReplicatedMapPutCodec {
     //hex: 0x0D0100
     public static final int REQUEST_MESSAGE_TYPE = 852224;
@@ -77,6 +77,7 @@ public final class ReplicatedMapPutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ReplicatedMap.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ReplicatedMapRemoveCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * null does not necessarily indicate that the map contained no mapping for the key; it's also possible that the map
  * explicitly mapped the key to null. The map will not contain a mapping for the specified key once the call returns.
  */
-@Generated("b0c49f5baaf06b0a1a869738a30f874e")
+@Generated("b7f14de48a2ad37ffcd5a120f06aef36")
 public final class ReplicatedMapRemoveCodec {
     //hex: 0x0D0700
     public static final int REQUEST_MESSAGE_TYPE = 853760;
@@ -67,6 +67,7 @@ public final class ReplicatedMapRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("ReplicatedMap.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddAllCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
  * The result of the future contains the sequenceId of the last written item
  */
-@Generated("99333bffe5583085de2e33f295a3041b")
+@Generated("b9cbdb3e85f2a5be381454c1f2aa5773")
 public final class RingbufferAddAllCodec {
     //hex: 0x170800
     public static final int REQUEST_MESSAGE_TYPE = 1509376;
@@ -78,6 +78,7 @@ public final class RingbufferAddAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> valueList, int overflowPolicy) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Ringbuffer.AddAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferAddCodec.java
@@ -46,7 +46,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
  * to find that item.
  */
-@Generated("41b3bd407e1df798d4dfd90a6d7d1585")
+@Generated("b26c07fc7654387a4c086b818edfd02e")
 public final class RingbufferAddCodec {
     //hex: 0x170600
     public static final int REQUEST_MESSAGE_TYPE = 1508864;
@@ -81,6 +81,7 @@ public final class RingbufferAddCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, int overflowPolicy, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Ringbuffer.Add");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
@@ -42,7 +42,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
  * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
  */
-@Generated("b5b4643d17b18b04ab5aaf2130a9882f")
+@Generated("f7d65397ec97b7378fb0d430ebd22712")
 public final class RingbufferReadManyCodec {
     //hex: 0x170900
     public static final int REQUEST_MESSAGE_TYPE = 1509632;
@@ -90,6 +90,7 @@ public final class RingbufferReadManyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, long startSequence, int minCount, int maxCount, @Nullable com.hazelcast.internal.serialization.Data filter) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("Ringbuffer.ReadMany");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToMemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToMemberCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to a member for execution. Member is provided with its uuid.
  */
-@Generated("82d5fe595489cb8ad17e862c9c30077b")
+@Generated("7fef9e769942681a53bb442375fc1eae")
 public final class ScheduledExecutorSubmitToMemberCodec {
     //hex: 0x1A0300
     public static final int REQUEST_MESSAGE_TYPE = 1704704;
@@ -105,6 +105,7 @@ public final class ScheduledExecutorSubmitToMemberCodec {
 
     public static ClientMessage encodeRequest(java.lang.String schedulerName, java.util.UUID memberUuid, byte type, java.lang.String taskName, com.hazelcast.internal.serialization.Data task, long initialDelayInMillis, long periodInMillis, boolean autoDisposable) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ScheduledExecutor.SubmitToMember");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToPartitionCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledExecutorSubmitToPartitionCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
  */
-@Generated("9e05e762cc9442a8cfa2ab32722dd212")
+@Generated("117ec3302254041502541eafef4c9c47")
 public final class ScheduledExecutorSubmitToPartitionCodec {
     //hex: 0x1A0200
     public static final int REQUEST_MESSAGE_TYPE = 1704448;
@@ -99,6 +99,7 @@ public final class ScheduledExecutorSubmitToPartitionCodec {
 
     public static ClientMessage encodeRequest(java.lang.String schedulerName, byte type, java.lang.String taskName, com.hazelcast.internal.serialization.Data task, long initialDelayInMillis, long periodInMillis, boolean autoDisposable) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(true);
         clientMessage.setOperationName("ScheduledExecutor.SubmitToPartition");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set so that its value is the union of the two sets. The behavior of this operation is undefined if the specified
  * collection is modified while the operation is in progress.
  */
-@Generated("169ddf317423b3971cc251df7516555f")
+@Generated("44724453aa05fe0e7eab52e27a66d633")
 public final class SetAddAllCodec {
     //hex: 0x060600
     public static final int REQUEST_MESSAGE_TYPE = 394752;
@@ -68,6 +68,7 @@ public final class SetAddAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> valueList) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.AddAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetAddCodec.java
@@ -41,7 +41,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * element, including null, and throw an exception, as described in the specification for Collection
  * Individual set implementations should clearly document any restrictions on the elements that they may contain.
  */
-@Generated("e743f7f122c51b0b310fcba6e00ef99a")
+@Generated("63e60b39d3e66f53080e43a1a1e44994")
 public final class SetAddCodec {
     //hex: 0x060400
     public static final int REQUEST_MESSAGE_TYPE = 394240;
@@ -70,6 +70,7 @@ public final class SetAddCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.Add");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRemoveAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRemoveAllCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
  * asymmetric set difference of the two sets.
  */
-@Generated("e65e6039c82cf5d50ba4d7e00416c696")
+@Generated("2ac1c7956c96c3829dd5b14d3ef93188")
 public final class SetCompareAndRemoveAllCodec {
     //hex: 0x060700
     public static final int REQUEST_MESSAGE_TYPE = 395008;
@@ -67,6 +67,7 @@ public final class SetCompareAndRemoveAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> values) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.CompareAndRemoveAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRetainAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetCompareAndRetainAllCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
  * intersection of the two sets.
  */
-@Generated("d91f1853965bce9f88e733d298930904")
+@Generated("2685bf4c34848df80a3f7b193ce7024d")
 public final class SetCompareAndRetainAllCodec {
     //hex: 0x060800
     public static final int REQUEST_MESSAGE_TYPE = 395264;
@@ -68,6 +68,7 @@ public final class SetCompareAndRetainAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> values) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.CompareAndRetainAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsAllCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this set contains all of the elements of the specified collection. If the specified collection is
  * also a set, this method returns true if it is a subset of this set.
  */
-@Generated("afe5976332585591555710c70a897b54")
+@Generated("c345abb7bd2c91644e2d799da07411bd")
 public final class SetContainsAllCodec {
     //hex: 0x060300
     public static final int REQUEST_MESSAGE_TYPE = 393984;
@@ -66,6 +66,7 @@ public final class SetContainsAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> items) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.ContainsAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetContainsCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this set contains the specified element.
  */
-@Generated("374ed138180fe2336d7621c669e6bbaa")
+@Generated("0b77a307ad7f15d170a397b3e47bfbaf")
 public final class SetContainsCodec {
     //hex: 0x060200
     public static final int REQUEST_MESSAGE_TYPE = 393728;
@@ -65,6 +65,7 @@ public final class SetContainsCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.Contains");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SetRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
  * (This set will not contain the element once the call returns.)
  */
-@Generated("a177caec41ea1e9aa5eba2bfcceb5eac")
+@Generated("4d92d1c2a9ae1fe1d57f2e9443a51cdf")
 public final class SetRemoveCodec {
     //hex: 0x060500
     public static final int REQUEST_MESSAGE_TYPE = 394496;
@@ -67,6 +67,7 @@ public final class SetRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Set.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecuteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecuteCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Starts execution of an SQL query (as of 4.2).
  */
-@Generated("9b95472501ff4d52610e2c2c6fc44819")
+@Generated("9f40e52be313b1c09e1cbe449b0b5574")
 public final class SqlExecuteCodec {
     //hex: 0x210400
     public static final int REQUEST_MESSAGE_TYPE = 2163712;
@@ -109,6 +109,7 @@ public final class SqlExecuteCodec {
 
     public static ClientMessage encodeRequest(java.lang.String sql, java.util.Collection<com.hazelcast.internal.serialization.Data> parameters, long timeoutMillis, int cursorBufferSize, @Nullable java.lang.String schema, byte expectedResultType, com.hazelcast.sql.impl.QueryId queryId, boolean skipUpdateStatistics) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Sql.Execute");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecute_reservedCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/SqlExecute_reservedCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * THIS MESSAGE IS NO LONGER USED BUT KEPT FOR BACKWARD COMPATIBILITY TESTS
  * Starts execution of an SQL query.
  */
-@Generated("8e2a6e088afccc96c868a22f648c5b12")
+@Generated("7337cfec2b0a43cc7eb35309ccd7cd78")
 public final class SqlExecute_reservedCodec {
     //hex: 0x210100
     public static final int REQUEST_MESSAGE_TYPE = 2162944;
@@ -79,6 +79,7 @@ public final class SqlExecute_reservedCodec {
 
     public static ClientMessage encodeRequest(java.lang.String sql, java.util.Collection<com.hazelcast.internal.serialization.Data> parameters, long timeoutMillis, int cursorBufferSize) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Sql.Execute_reserved");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicPublishAllCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicPublishAllCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Publishes all messages to all subscribers of this topic
  */
-@Generated("f62cc5036f3c1f6aae5293a827ca767b")
+@Generated("2ac5c33b2c9c4756a56bba8052a588af")
 public final class TopicPublishAllCodec {
     //hex: 0x040400
     public static final int REQUEST_MESSAGE_TYPE = 263168;
@@ -64,6 +64,7 @@ public final class TopicPublishAllCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.Collection<com.hazelcast.internal.serialization.Data> messages) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Topic.PublishAll");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicPublishCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TopicPublishCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Publishes the message to all subscribers of this topic
  */
-@Generated("8a1d2be30b25e21323586296b55e2fe7")
+@Generated("b57b222a82941cb8ed3cd22c209095fa")
 public final class TopicPublishCodec {
     //hex: 0x040100
     public static final int REQUEST_MESSAGE_TYPE = 262400;
@@ -64,6 +64,7 @@ public final class TopicPublishCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, com.hazelcast.internal.serialization.Data message) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("Topic.Publish");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListAddCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Adds a new item to the transactional list.
  */
-@Generated("4096d3cdf9700090ccd6d8fdf2954585")
+@Generated("358d3b98d312606d5f8dab48186d4d8f")
 public final class TransactionalListAddCodec {
     //hex: 0x110100
     public static final int REQUEST_MESSAGE_TYPE = 1114368;
@@ -77,6 +77,7 @@ public final class TransactionalListAddCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data item) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalList.Add");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalListRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Remove item from the transactional list
  */
-@Generated("77dabf0123d8c16ae3dbb94f27e2f82b")
+@Generated("54d58ba9427b4190152f6eb200155cbd")
 public final class TransactionalListRemoveCodec {
     //hex: 0x110200
     public static final int REQUEST_MESSAGE_TYPE = 1114624;
@@ -77,6 +77,7 @@ public final class TransactionalListRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data item) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalList.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsKeyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsKeyCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains an entry for the specified key.
  */
-@Generated("080406338cbbeccd9b65706ed75e91fb")
+@Generated("f6e7ef948344980c59e415d6e4825312")
 public final class TransactionalMapContainsKeyCodec {
     //hex: 0x0E0100
     public static final int REQUEST_MESSAGE_TYPE = 917760;
@@ -77,6 +77,7 @@ public final class TransactionalMapContainsKeyCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.ContainsKey");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsValueCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapContainsValueCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns true if this map contains an entry for the specified value.
  */
-@Generated("bc05aa6f37c8545449ada1705e4e9c1b")
+@Generated("eabcb675b7f891b18d88d580ecd6a8fe")
 public final class TransactionalMapContainsValueCodec {
     //hex: 0x0E1200
     public static final int REQUEST_MESSAGE_TYPE = 922112;
@@ -77,6 +77,7 @@ public final class TransactionalMapContainsValueCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.ContainsValue");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapDeleteCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapDeleteCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * key once the call returns. This method is preferred to #remove(Object) if the old value is not needed. The object
  * to be deleted will be removed from only the current transaction context until the transaction is committed.
  */
-@Generated("c1af66e4669efca68bca5e0437ff3193")
+@Generated("ee5858a10f6f8e660e803edd22aadfc8")
 public final class TransactionalMapDeleteCodec {
     //hex: 0x0E0C00
     public static final int REQUEST_MESSAGE_TYPE = 920576;
@@ -78,6 +78,7 @@ public final class TransactionalMapDeleteCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.Delete");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the value for the specified key, or null if this map does not contain this key.
  */
-@Generated("e775c4665c0baa17fdbbcc78f20d3faf")
+@Generated("7877721230f7957c53ee6b242fbf784e")
 public final class TransactionalMapGetCodec {
     //hex: 0x0E0200
     public static final int REQUEST_MESSAGE_TYPE = 918016;
@@ -76,6 +76,7 @@ public final class TransactionalMapGetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.Get");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetForUpdateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapGetForUpdateCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
  * the end of the transaction (either commit or rollback).
  */
-@Generated("f075537044b71c9eb664ce76941939d6")
+@Generated("dfc03024c5e253f36dd8924fc13240eb")
 public final class TransactionalMapGetForUpdateCodec {
     //hex: 0x0E0300
     public static final int REQUEST_MESSAGE_TYPE = 918272;
@@ -77,6 +77,7 @@ public final class TransactionalMapGetForUpdateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.GetForUpdate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapKeySetWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
  * QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("0ebeffdc80ab7a79bafa4f44e286703c")
+@Generated("32dae3d5b010983d9ddb13c78566c811")
 public final class TransactionalMapKeySetWithPredicateCodec {
     //hex: 0x0E0F00
     public static final int REQUEST_MESSAGE_TYPE = 921344;
@@ -79,6 +79,7 @@ public final class TransactionalMapKeySetWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.KeySetWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
  * current transaction context till transaction is committed.
  */
-@Generated("a2c8e2143459ff6b2fbc3c86e8590c3a")
+@Generated("4d177a0193a0266fea15461c2206e27e")
 public final class TransactionalMapPutCodec {
     //hex: 0x0E0600
     public static final int REQUEST_MESSAGE_TYPE = 919040;
@@ -89,6 +89,7 @@ public final class TransactionalMapPutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value, long ttl) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutIfAbsentCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapPutIfAbsentCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * If the specified key is not already associated with a value, associate it with the given value.
  * The object to be put will be accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("673eed6ff7f28982e4c00fdf61ef257e")
+@Generated("810b4ab9ba2525cc1b876d816f1387a2")
 public final class TransactionalMapPutIfAbsentCodec {
     //hex: 0x0E0800
     public static final int REQUEST_MESSAGE_TYPE = 919552;
@@ -82,6 +82,7 @@ public final class TransactionalMapPutIfAbsentCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.PutIfAbsent");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * specified key once the call returns. The object to be removed will be accessible only in the current transaction
  * context until the transaction is committed.
  */
-@Generated("f04e99ee8848cf026e1695632961d5a5")
+@Generated("dc043bd2057c9a94e16704ad63b99e99")
 public final class TransactionalMapRemoveCodec {
     //hex: 0x0E0B00
     public static final int REQUEST_MESSAGE_TYPE = 920320;
@@ -78,6 +78,7 @@ public final class TransactionalMapRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapRemoveIfSameCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
  * from only the current transaction context until the transaction is committed.
  */
-@Generated("3b0ffdd854b854c4f1e8932086de3846")
+@Generated("1b89f7c113f71e0fa7c21378ce9a0f6f")
 public final class TransactionalMapRemoveIfSameCodec {
     //hex: 0x0E0D00
     public static final int REQUEST_MESSAGE_TYPE = 920832;
@@ -83,6 +83,7 @@ public final class TransactionalMapRemoveIfSameCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.RemoveIfSame");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
  * accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("a711f9a6275ae80b8c32a3410cb92d96")
+@Generated("086e7df0cfdbdf53f961b2f2f5662060")
 public final class TransactionalMapReplaceCodec {
     //hex: 0x0E0900
     public static final int REQUEST_MESSAGE_TYPE = 919808;
@@ -82,6 +82,7 @@ public final class TransactionalMapReplaceCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.Replace");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceIfSameCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapReplaceIfSameCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
  * accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("9052ab495b0c447e49d8c66e58cbcc9c")
+@Generated("e47e28d52bc4f21c6ba400bdca201cad")
 public final class TransactionalMapReplaceIfSameCodec {
     //hex: 0x0E0A00
     public static final int REQUEST_MESSAGE_TYPE = 920064;
@@ -88,6 +88,7 @@ public final class TransactionalMapReplaceIfSameCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data oldValue, com.hazelcast.internal.serialization.Data newValue) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.ReplaceIfSame");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapSetCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * if the old value is not needed.
  * The object to be set will be accessible only in the current transaction context until the transaction is committed.
  */
-@Generated("b60b76a50c4d534a70b80fa88dabaab9")
+@Generated("a795211fed641800ba5282d1a0058ae6")
 public final class TransactionalMapSetCodec {
     //hex: 0x0E0700
     public static final int REQUEST_MESSAGE_TYPE = 919296;
@@ -84,6 +84,7 @@ public final class TransactionalMapSetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.Set");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMapValuesWithPredicateCodec.java
@@ -39,7 +39,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw
  * a QueryResultSizeExceededException if query result size limit is configured.
  */
-@Generated("bc51d64b774f3316423378f1db112f84")
+@Generated("6f47af79c407b9b95b887556418f1d6e")
 public final class TransactionalMapValuesWithPredicateCodec {
     //hex: 0x0E1100
     public static final int REQUEST_MESSAGE_TYPE = 921856;
@@ -79,6 +79,7 @@ public final class TransactionalMapValuesWithPredicateCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data predicate) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMap.ValuesWithPredicate");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapGetCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the collection of values associated with the key.
  */
-@Generated("832dd86206b2f9620e73eeceb0ec1a39")
+@Generated("4e01790bb13888bbe9ac05be0b6389a5")
 public final class TransactionalMultiMapGetCodec {
     //hex: 0x0F0200
     public static final int REQUEST_MESSAGE_TYPE = 983552;
@@ -76,6 +76,7 @@ public final class TransactionalMultiMapGetCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMultiMap.Get");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapPutCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapPutCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Stores a key-value pair in the multimap.
  */
-@Generated("37708dbf1c7102bfbbff00b3527c6beb")
+@Generated("80945f26c3adcd27a1e572d44e97d6a1")
 public final class TransactionalMultiMapPutCodec {
     //hex: 0x0F0100
     public static final int REQUEST_MESSAGE_TYPE = 983296;
@@ -82,6 +82,7 @@ public final class TransactionalMultiMapPutCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMultiMap.Put");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes the given key value pair from the multimap.
  */
-@Generated("5d430733cf818599a71ff31f570d3172")
+@Generated("5d37fb4695ed30f37437499bcafb479d")
 public final class TransactionalMultiMapRemoveCodec {
     //hex: 0x0F0300
     public static final int REQUEST_MESSAGE_TYPE = 983808;
@@ -76,6 +76,7 @@ public final class TransactionalMultiMapRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMultiMap.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveEntryCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapRemoveEntryCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Removes all the entries associated with the given key.
  */
-@Generated("c1312008ffb1a02cef50c21b7be8ae79")
+@Generated("0e747ead23c3a9cdb25f659580a6f052")
 public final class TransactionalMultiMapRemoveEntryCodec {
     //hex: 0x0F0400
     public static final int REQUEST_MESSAGE_TYPE = 984064;
@@ -82,6 +82,7 @@ public final class TransactionalMultiMapRemoveEntryCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key, com.hazelcast.internal.serialization.Data value) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMultiMap.RemoveEntry");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapValueCountCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalMultiMapValueCountCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Returns the number of values matching the given key in the multimap.
  */
-@Generated("df00c902670f6f61758c3b9fade19229")
+@Generated("926df90d7b9c67a358cf7c29c90cf8f7")
 public final class TransactionalMultiMapValueCountCodec {
     //hex: 0x0F0500
     public static final int REQUEST_MESSAGE_TYPE = 984320;
@@ -77,6 +77,7 @@ public final class TransactionalMultiMapValueCountCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data key) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalMultiMap.ValueCount");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
  * become available.
  */
-@Generated("fb989b5ab0aa3a14c668068fe1894c3b")
+@Generated("a225379fc19922e57531e4bbd5da700c")
 public final class TransactionalQueueOfferCodec {
     //hex: 0x120100
     public static final int REQUEST_MESSAGE_TYPE = 1179904;
@@ -84,6 +84,7 @@ public final class TransactionalQueueOfferCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data item, long timeout) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalQueue.Offer");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetAddCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetAddCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Add new item to transactional set.
  */
-@Generated("9067e28e4f297fb72aea5846da0cad1d")
+@Generated("e4228601224faeda36815ebb997bceca")
 public final class TransactionalSetAddCodec {
     //hex: 0x100100
     public static final int REQUEST_MESSAGE_TYPE = 1048832;
@@ -77,6 +77,7 @@ public final class TransactionalSetAddCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data item) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalSet.Add");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetRemoveCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalSetRemoveCodec.java
@@ -36,7 +36,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 /**
  * Remove item from transactional set.
  */
-@Generated("2082a420ca1d4eba262680544766650f")
+@Generated("23d44626c6f899d25f0af6148bd6be91")
 public final class TransactionalSetRemoveCodec {
     //hex: 0x100200
     public static final int REQUEST_MESSAGE_TYPE = 1049088;
@@ -77,6 +77,7 @@ public final class TransactionalSetRemoveCodec {
 
     public static ClientMessage encodeRequest(java.lang.String name, java.util.UUID txnId, long threadId, com.hazelcast.internal.serialization.Data item) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
+        clientMessage.setContainsSerializedDataInRequest(true);
         clientMessage.setRetryable(false);
         clientMessage.setOperationName("TransactionalSet.Remove");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -174,7 +174,9 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
     private void invokeOnSelection() {
         try {
             INVOKE_COUNT.incrementAndGet(this);
-            if (!urgent) {
+            if (urgent) {
+                invocationService.checkUrgentInvocationAllowed(this);
+            } else {
                 invocationService.checkInvocationAllowed();
             }
 
@@ -399,6 +401,10 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
     }
 
     private boolean shouldRetry(Throwable t) {
+        if (t instanceof InvocationMightContainCompactDataException) {
+            return true;
+        }
+
         if (isBindToSingleConnection() && (t instanceof IOException || t instanceof TargetDisconnectedException)) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
@@ -295,19 +295,19 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
     }
 
     void checkUrgentInvocationAllowed(ClientInvocation invocation) {
-        if (!client.shouldCheckUrgentInvocations()) {
-            // If there were no Compact schemas to begin with, we don't need
-            // to perform the checks below. If the client didn't send a Compact
-            // schema up until this point, the retries or listener registrations
-            // could not send a schema, because if they were, we wouldn't hit
-            // this line.
-            return;
-        }
-
         if (connectionManager.clientInitializedOnCluster()) {
             // If the client is initialized on the cluster, that means we
             // have sent all the schemas to the cluster, even if we are
             // reconnected to it
+            return;
+        }
+
+        if (!client.shouldCheckUrgentInvocations()) {
+            // If there were no Compact schemas to begin with, we don't need
+            // to perform the check below. If the client didn't send a Compact
+            // schema up until this point, the retries or listener registrations
+            // could not send a schema, because if they were, we wouldn't hit
+            // this line.
             return;
         }
 
@@ -320,7 +320,7 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         // is initialized on the cluster, which means schemas are replicated
         // in the cluster.
         if (invocation.getClientMessage().isContainsSerializedDataInRequest()) {
-            throw new InvocationMightContainCompactDataException();
+            throw new InvocationMightContainCompactDataException(invocation);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImpl.java
@@ -294,6 +294,36 @@ public class ClientInvocationServiceImpl implements ClientInvocationService {
         connectionManager.checkInvocationAllowed();
     }
 
+    void checkUrgentInvocationAllowed(ClientInvocation invocation) {
+        if (!client.shouldCheckUrgentInvocations()) {
+            // If there were no Compact schemas to begin with, we don't need
+            // to perform the checks below. If the client didn't send a Compact
+            // schema up until this point, the retries or listener registrations
+            // could not send a schema, because if they were, we wouldn't hit
+            // this line.
+            return;
+        }
+
+        if (connectionManager.clientInitializedOnCluster()) {
+            // If the client is initialized on the cluster, that means we
+            // have sent all the schemas to the cluster, even if we are
+            // reconnected to it
+            return;
+        }
+
+        // We are not yet initialized on cluster, so the Compact schemas might
+        // not be sent yet. This message contains some serialized classes,
+        // and it is possible that it can also contain Compact serialized data.
+        // In that case, allowing this invocation to go through now could
+        // violate the invariant that the schema must come to cluster before
+        // the data. We will retry this invocation and wait until the client
+        // is initialized on the cluster, which means schemas are replicated
+        // in the cluster.
+        if (invocation.getClientMessage().isContainsSerializedDataInRequest()) {
+            throw new InvocationMightContainCompactDataException();
+        }
+    }
+
     boolean shouldFailOnIndeterminateOperationState() {
         return shouldFailOnIndeterminateOperationState;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/InvocationMightContainCompactDataException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/InvocationMightContainCompactDataException.java
@@ -25,9 +25,9 @@ import com.hazelcast.core.HazelcastException;
  * reconnects or retries urgent invocations.
  */
 class InvocationMightContainCompactDataException extends HazelcastException {
-    InvocationMightContainCompactDataException() {
-        super("The invocation might contain Compact serialized data and it is "
-                + "not safe to invoke it when the client is not yet initialized "
-                + "on the cluster");
+    InvocationMightContainCompactDataException(ClientInvocation invocation) {
+        super("The invocation" + invocation +" might contain Compact serialized "
+                + "data and it is not safe to invoke it when the client is not "
+                + "yet initialized on the cluster");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/InvocationMightContainCompactDataException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/InvocationMightContainCompactDataException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.spi.impl;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Signals that the invocation might contain Compact classes, and it would
+ * not be safe to send that invocation now to make sure that the invariant
+ * regarding not sending the data before the schemas are hold while the client
+ * reconnects or retries urgent invocations.
+ */
+class InvocationMightContainCompactDataException extends HazelcastException {
+    InvocationMightContainCompactDataException() {
+        super("The invocation might contain Compact serialized data and it is "
+                + "not safe to invoke it when the client is not yet initialized "
+                + "on the cluster");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/InvocationMightContainCompactDataException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/InvocationMightContainCompactDataException.java
@@ -26,7 +26,7 @@ import com.hazelcast.core.HazelcastException;
  */
 class InvocationMightContainCompactDataException extends HazelcastException {
     InvocationMightContainCompactDataException(ClientInvocation invocation) {
-        super("The invocation" + invocation +" might contain Compact serialized "
+        super("The invocation" + invocation + " might contain Compact serialized "
                 + "data and it is not safe to invoke it when the client is not "
                 + "yet initialized on the cluster");
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/SerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/SerializationService.java
@@ -49,14 +49,13 @@ public interface SerializationService {
      *     <li>it is registered for compact serialization via
      *     {@link com.hazelcast.config.CompactSerializationConfig}</li>
      *     <li>there is no serializer registered for it, and it can serialized
-     *     reflectively with {@link com.hazelcast.internal.serialization.impl.compact.ReflectiveCompactSerializer}</li>
+     *     reflectively</li>
      * </ul>
      * <p>
-     * This method can safely be called with a {@link Data} instance. The schema
-     * will be included only if the type of the data instance is {@code TYPE_COMPACT}.
-     * For any other data type, the instance will be returned as it is. Note that,
-     * if the data type is already {@code TYPE_COMPACT_WITH_SCHEMA}, it will also
-     * be returned as it is, since the schema is already included in it.
+     * This method can safely be called with a {@link Data} instance with a
+     * caveat. To include all the possible schemas, the data will be
+     * deserialized and serialized again, if it does not already include
+     * the schema.
      *
      * @param obj the object to serialize.
      * @return the serialized object.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -164,15 +164,11 @@ public abstract class AbstractSerializationService implements InternalSerializat
         }
         if (obj instanceof Data) {
             Data data = (Data) obj;
-            if (data.getType() == SerializationConstants.TYPE_COMPACT) {
-                // we need to deserialize and serialize back completely because the root schema
-                // is not enough to deserialize an data. Because nested levels, there could be multiple schemas
-                // accompanying the single data
-                obj = toObject(data);
-            } else {
-                // for other types data and data with schema is same
-                return (B) data;
-            }
+            // we need to deserialize and serialize back completely to include
+            // all the schemas, even if the top level class is not Compact, in
+            // case the Compact is used with other serialization mechanisms
+            // (like array list of Compact serialized objects).
+            obj = toObject(data);
         }
         byte[] bytes = toBytes(obj, 0, true, globalPartitioningStrategy, getByteOrder(), true);
         return (B) new HeapData(bytes);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -164,6 +164,10 @@ public abstract class AbstractSerializationService implements InternalSerializat
         }
         if (obj instanceof Data) {
             Data data = (Data) obj;
+            if (data.getType() == SerializationConstants.TYPE_COMPACT_WITH_SCHEMA) {
+                return (B) data;
+            }
+
             // we need to deserialize and serialize back completely to include
             // all the schemas, even if the top level class is not Compact, in
             // case the Compact is used with other serialization mechanisms

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -133,11 +133,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
     }
 
     private void putToSchemaService(boolean includeSchemaOnBinary, Schema schema) {
-        if (includeSchemaOnBinary) {
-            //if we will include the schema on binary, the schema will be delivered anyway.
-            //No need to put it to cluster. Putting it local only in order not to ask from remote on read.
-            schemaService.putLocal(schema);
-        } else {
+        if (!includeSchemaOnBinary) {
             schemaService.put(schema);
         }
     }
@@ -213,7 +209,6 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
                 throw new HazelcastSerializationException("Invalid schema id found. Expected " + schemaId
                         + ", actual " + incomingSchemaId + " for schema " + schema);
             }
-            schemaService.putLocal(schema);
             return schema;
         }
         throw new HazelcastSerializationException("The schema can not be found with id " + schemaId);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImplTest.java
@@ -41,7 +41,6 @@ import java.util.UUID;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -77,13 +76,13 @@ public class ClientInvocationServiceImplTest extends ClientTestSupport {
     }
 
     private ClientConnection closedConnection() {
-        ClientConnection conn = mock(ClientConnection.class, RETURNS_DEEP_STUBS);
+        ClientConnection conn = mock(ClientConnection.class);
         when(conn.isAlive()).thenReturn(false);
         return conn;
     }
 
     private ClientConnection mockConnection() {
-        ClientConnection connection = mock(ClientConnection.class, RETURNS_DEEP_STUBS);
+        ClientConnection connection = mock(ClientConnection.class);
         when(connection.write(any())).thenReturn(true);
         return connection;
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationServiceImplTest.java
@@ -18,23 +18,34 @@ package com.hazelcast.client.impl.spi.impl;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.ClientConnection;
+import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientPingCodec;
+import com.hazelcast.client.impl.protocol.codec.SetAddCodec;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import example.serialization.EmployeeDTO;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -42,6 +53,7 @@ import static org.mockito.Mockito.when;
 public class ClientInvocationServiceImplTest extends ClientTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
     private HazelcastClientInstanceImpl client;
 
     @After
@@ -51,7 +63,7 @@ public class ClientInvocationServiceImplTest extends ClientTestSupport {
 
     @Before
     public void setUp() {
-        hazelcastFactory.newHazelcastInstance();
+        member = hazelcastFactory.newHazelcastInstance();
         client = getHazelcastClientInstanceImpl(hazelcastFactory.newHazelcastClient());
     }
 
@@ -68,6 +80,12 @@ public class ClientInvocationServiceImplTest extends ClientTestSupport {
         ClientConnection conn = mock(ClientConnection.class, RETURNS_DEEP_STUBS);
         when(conn.isAlive()).thenReturn(false);
         return conn;
+    }
+
+    private ClientConnection mockConnection() {
+        ClientConnection connection = mock(ClientConnection.class, RETURNS_DEEP_STUBS);
+        when(connection.write(any())).thenReturn(true);
+        return connection;
     }
 
     @Test
@@ -133,5 +151,109 @@ public class ClientInvocationServiceImplTest extends ClientTestSupport {
 
         //Simulate the stalled old response trying to notify the invocation
         assertFalse(invocation.getPermissionToNotify(correlationId));
+    }
+
+    @Test
+    public void testInvokeUrgent_whenThereAreNoCompactSchemas_andClientIsInitializedOnCluster() {
+        // No compact schemas, no need to check urgent invocations
+        assertFalse(client.shouldCheckUrgentInvocations());
+
+        // client is connected to the member and initialized on it since this
+        // is the initial cluster connection
+        assertTrue(client.getConnectionManager().clientInitializedOnCluster());
+
+        ClientConnection connection = mockConnection();
+
+        // Urgent invocations should be done
+        ClientInvocation pingInvocation = checkUrgentInvocation_withNoData(connection);
+        ClientInvocation setAddInvocation = checkUrgentInvocation_withData(connection);
+
+        verify(connection, times(1)).write(pingInvocation.getClientMessage());
+        verify(connection, times(1)).write(setAddInvocation.getClientMessage());
+    }
+
+    @Test
+    public void testInvokeUrgent_whenThereAreCompactSchemas_andClientIsInitializedOnCluster() {
+        client.getMap("testMap").put("test", new EmployeeDTO());
+
+        // Some compact schemas, need to check urgent invocations
+        assertTrue(client.shouldCheckUrgentInvocations());
+
+        // client is connected to the member and initialized on it since this
+        // is the initial cluster connection
+        assertTrue(client.getConnectionManager().clientInitializedOnCluster());
+
+        ClientConnection connection = mockConnection();
+
+        // Urgent invocations should be done
+        ClientInvocation pingInvocation = checkUrgentInvocation_withNoData(connection);
+        ClientInvocation setAddInvocation = checkUrgentInvocation_withData(connection);
+
+        verify(connection, times(1)).write(pingInvocation.getClientMessage());
+        verify(connection, times(1)).write(setAddInvocation.getClientMessage());
+    }
+
+    @Test
+    public void testInvokeUrgent_whenThereAreNoCompactSchemas_andClientIsNotInitializedOnCluster() {
+        UUID memberUuid = member.getLocalEndpoint().getUuid();
+        member.shutdown();
+        makeSureDisconnectedFromServer(client, memberUuid);
+
+        // No compact schemas, no need to check urgent invocations
+        assertFalse(client.shouldCheckUrgentInvocations());
+
+        // client is disconnected, so not initialized on cluster
+        assertTrueEventually(() -> assertFalse(client.getConnectionManager().clientInitializedOnCluster()));
+
+        ClientConnection connection = mockConnection();
+
+        // Urgent invocations should be done
+        ClientInvocation pingInvocation = checkUrgentInvocation_withNoData(connection);
+        ClientInvocation setAddInvocation = checkUrgentInvocation_withData(connection);
+
+        verify(connection, times(1)).write(pingInvocation.getClientMessage());
+        verify(connection, times(1)).write(setAddInvocation.getClientMessage());
+    }
+
+    @Test
+    public void testInvokeUrgent_whenThereAreCompactSchemas_andClientIsNotInitializedOnCluster() {
+        client.getMap("testMap").put("test", new EmployeeDTO());
+
+        UUID memberUuid = member.getLocalEndpoint().getUuid();
+        member.shutdown();
+        makeSureDisconnectedFromServer(client, memberUuid);
+
+        // Some compact schemas, need to check urgent invocations
+        assertTrue(client.shouldCheckUrgentInvocations());
+
+        // client is disconnected, so not initialized on cluster
+        assertTrueEventually(() -> assertFalse(client.getConnectionManager().clientInitializedOnCluster()));
+
+        ClientConnection connection = mockConnection();
+
+        // Urgent invocations should be done, if they contain no data
+        ClientInvocation pingInvocation = checkUrgentInvocation_withNoData(connection);
+        ClientInvocation setAddInvocation = checkUrgentInvocation_withData(connection);
+
+        verify(connection, times(1)).write(pingInvocation.getClientMessage());
+        verify(connection, never()).write(setAddInvocation.getClientMessage());
+    }
+
+
+    private ClientInvocation checkUrgentInvocation_withNoData(ClientConnection connection) {
+        ClientMessage request = ClientPingCodec.encodeRequest();
+        assertFalse(request.isContainsSerializedDataInRequest());
+        ClientInvocation invocation = new ClientInvocation(client, request, null, connection);
+        invocation.invokeUrgent();
+        return invocation;
+    }
+
+    private ClientInvocation checkUrgentInvocation_withData(ClientConnection connection) {
+        Data data = client.getSerializationService().toData("test");
+        ClientMessage request = SetAddCodec.encodeRequest("test", data);
+        assertTrue(request.isContainsSerializedDataInRequest());
+        ClientInvocation invocation = new ClientInvocation(client, request, null, connection);
+        invocation.invokeUrgent();
+        return invocation;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -81,6 +81,9 @@ public class ClientTestSupport extends HazelcastTestSupport {
     }
 
     protected static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
+        if (client instanceof HazelcastClientInstanceImpl) {
+            return (HazelcastClientInstanceImpl) client;
+        }
         HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
         return clientProxy.client;
     }


### PR DESCRIPTION
Although we believe it was a mistake, the urgent invocations on the
client-side are used for some user invocations like listener registrations,
apart from the actual urgent invocations like heartbeats, authentication, etc.

When the client reconnects to some cluster, it sends the local state
in some executor. So, there might be some time between the local state is
sent. However, during that time, urgent invocations are allowed to
go through from the client. That might violate our assumption that
the schema is received by the cluster before the data.

To solve this, we will not invoke urgent invocations that contain
serialized data if the client is not initialized on the cluster, and there
were some compact schemas sent to the previous clusters. Such
invocations are only related to user invocations so we will not delay
invoking actual urgent invocations like heartbeats.

This PR also serializes custom credentials with the schema-in-binary format
as there is no way to send Compact schemas before the authentication.

protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/437