### PR TITLE
[HZ-1482][HZ-1493] Make LikeFunction thread-safe w/o synchronized [backport of #22272]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ConcurrentInitialSetCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ConcurrentInitialSetCache.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.internal.util.Preconditions;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Implementation of fixed-capacity cache based on {@link ConcurrentHashMap}
+ * caching the initial set of keys.
+ * <p>
+ * The cache has no eviction policy, once an element is put into it, it stays
+ * there so long as the cache exists. Once the cache is full, no new items are
+ * cached.
+ * <p>
+ * It's designed for caching in scenarios where we can assume that there's a low
+ * number of keys that typically fit into the cache, and if not, that the keys
+ * come in arbitrary order. If the number of keys is larger than capacity, we
+ * assume that those that are more common are more likely to be observed at the
+ * beginning than those that are not, and we're likely to cache those items. If
+ * the number of expressions exceeds the capacity many times, we'll cache
+ * arbitrary few of them and the rest will be recalculated each time without
+ * caching - a similar behavior to what an LRU cache will provide, but without
+ * the overhead of usage tracking. Degenerate case is when items are sorted by
+ * the cache key - after the initial phase the cache will have zero hit rate.
+ * <p>
+ * The above assumptions are common for right-hand operand of SQL LIKE operator,
+ * JsonPath, XPath or regular expression, in the context of a single query
+ * execution and of a single operator evaluating them.
+ * <p>
+ * Note: The size of the inner map may become bigger than maxCapacity if there
+ * are multiple concurrent computeIfAbsent executions. We don't address this for
+ * the purpose of optimizing the read performance. The amount the size can
+ * exceed the limit is bounded by the number of concurrent writers.
+ */
+public class ConcurrentInitialSetCache<K, V> {
+    // package-visible for tests
+    final Map<K, V> cache;
+    private final int capacity;
+
+    public ConcurrentInitialSetCache(int capacity) {
+        Preconditions.checkPositive("capacity", capacity);
+        this.capacity = capacity;
+        this.cache = new ConcurrentHashMap<>(capacity);
+    }
+
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> valueFunction) {
+        V value = cache.get(key);
+        if (value == null) {
+            if (cache.size() < capacity) {
+                // use CHM.computeIfAbsent to avoid duplicate calculation of a single key
+                value = cache.computeIfAbsent(key, valueFunction);
+            } else {
+                value = valueFunction.apply(key);
+            }
+        }
+        return value;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/string/LikeFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/string/LikeFunction.java
@@ -61,8 +61,6 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
     /** Special characters which require escaping in Java. */
     private static final String ESCAPE_CHARACTERS_JAVA = "[]()|^+*?{}$\\.";
 
-    private final Object mux = new Object();
-
     private boolean negated;
 
     private transient ConcurrentInitialSetCache<Tuple2<String, String>, Pattern> patternCache;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/string/LikeFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/string/LikeFunction.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.sql.impl.expression.string;
 
+import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.SqlDataSerializerHook;
+import com.hazelcast.sql.impl.expression.ConcurrentInitialSetCache;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.expression.TriExpression;
@@ -29,6 +31,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,6 +42,7 @@ import static com.hazelcast.sql.impl.expression.string.StringFunctionUtils.asVar
  * LIKE string function.
  */
 public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDataSerializable {
+    private static final int PATTERN_CACHE_SIZE = 100;
 
     private static final long serialVersionUID = 4157617157954663651L;
 
@@ -60,7 +64,8 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
     private final Object mux = new Object();
 
     private boolean negated;
-    private transient volatile State state;
+
+    private transient ConcurrentInitialSetCache<Tuple2<String, String>, Pattern> patternCache;
 
     public LikeFunction() {
         // No-op.
@@ -70,13 +75,14 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
         super(source, pattern, escape);
 
         this.negated = negated;
+        this.patternCache = new ConcurrentInitialSetCache<>(PATTERN_CACHE_SIZE);
     }
 
     public static LikeFunction create(
-        Expression<?> source,
-        Expression<?> pattern,
-        Expression<?> escape,
-        boolean negated
+            Expression<?> source,
+            Expression<?> pattern,
+            Expression<?> escape,
+            boolean negated
     ) {
         return new LikeFunction(source, pattern, escape, negated);
     }
@@ -108,15 +114,7 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
             escape = null;
         }
 
-        if (state == null) {
-            synchronized (mux) {
-                if (state == null) {
-                    state = new State();
-                }
-            }
-        }
-
-        boolean res = state.like(source, pattern, escape);
+        boolean res = like(source, pattern, escape);
 
         if (negated) {
             res = !res;
@@ -152,6 +150,13 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
         super.readData(in);
 
         negated = in.readBoolean();
+        patternCache = new ConcurrentInitialSetCache<>(PATTERN_CACHE_SIZE);
+    }
+
+    private void readObject(ObjectInputStream stream) throws ClassNotFoundException, IOException {
+        stream.defaultReadObject();
+        // The transient fields are not initialized during Java deserialization, so we need to do it manually.
+        patternCache = new ConcurrentInitialSetCache<>(PATTERN_CACHE_SIZE);
     }
 
     @Override
@@ -178,104 +183,77 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
         return Objects.hash(super.hashCode(), negated);
     }
 
-    /**
-     * Helper class to execute LIKE function. Caches the last observed pattern to avoid constant re-compilation.
-     */
-    public static class State {
-        private final Object mux = new Object();
+    public boolean like(String source, String pattern, String escape) {
+        Pattern javaPattern = convertToJavaPattern(pattern, escape);
 
-        /** Last observed pattern. */
-        private String lastPattern;
+        Matcher matcher = javaPattern.matcher(source);
 
-        /** Last observed escape. */
-        private String lastEscape;
+        return matcher.matches();
+    }
 
-        /** Last Java pattern. */
-        private Pattern lastJavaPattern;
-
-        public boolean like(String source, String pattern, String escape) {
-            Pattern javaPattern = convertToJavaPattern(pattern, escape);
-
-            Matcher matcher = javaPattern.matcher(source);
-
-            return matcher.matches();
-        }
-
-        private Pattern convertToJavaPattern(String pattern, String escape) {
-            synchronized (mux) {
-                if (Objects.equals(pattern, lastPattern) && Objects.equals(escape, lastEscape)) {
-                    return lastJavaPattern;
-                }
-            }
-
+    private Pattern convertToJavaPattern(String pattern, String escape) {
+        Tuple2<String, String> cacheKey = Tuple2.tuple2(pattern, escape);
+        return patternCache.computeIfAbsent(cacheKey, key -> {
             String javaPatternStr = constructJavaPatternString(pattern, escape);
-            Pattern javaPattern = Pattern.compile(javaPatternStr, Pattern.DOTALL);
+            return Pattern.compile(javaPatternStr, Pattern.DOTALL);
+        });
+    }
 
-            synchronized (mux) {
-                lastPattern = pattern;
-                lastEscape = escape;
-                lastJavaPattern = javaPattern;
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    private static String constructJavaPatternString(String pattern, String escape) {
+        // Get the escape character.
+        Character escapeChar;
+
+        if (escape != null) {
+            if (escape.length() != 1) {
+                throw QueryException.error("ESCAPE parameter must be a single character");
             }
 
-            return javaPattern;
+            escapeChar = escape.charAt(0);
+        } else {
+            escapeChar = null;
         }
 
-        @SuppressWarnings("checkstyle:CyclomaticComplexity")
-        private static String constructJavaPatternString(String pattern, String escape) {
-            // Get the escape character.
-            Character escapeChar;
+        // Main logic.
+        StringBuilder javaPattern = new StringBuilder();
 
-            if (escape != null) {
-                if (escape.length() != 1) {
-                    throw QueryException.error("ESCAPE parameter must be a single character");
-                }
+        int i;
 
-                escapeChar = escape.charAt(0);
-            } else {
-                escapeChar = null;
+        for (i = 0; i < pattern.length(); i++) {
+            char patternChar = pattern.charAt(i);
+
+            // Escape special character as needed.
+            if (ESCAPE_CHARACTERS_JAVA.indexOf(patternChar) >= 0) {
+                javaPattern.append('\\');
             }
 
-            // Main logic.
-            StringBuilder javaPattern = new StringBuilder();
-
-            int i;
-
-            for (i = 0; i < pattern.length(); i++) {
-                char patternChar = pattern.charAt(i);
-
-                // Escape special character as needed.
-                if (ESCAPE_CHARACTERS_JAVA.indexOf(patternChar) >= 0) {
-                    javaPattern.append('\\');
+            if (escapeChar != null && patternChar == escapeChar) {
+                if (i == (pattern.length() - 1)) {
+                    throw escapeWildcardsOnly();
                 }
 
-                if (escapeChar != null && patternChar == escapeChar) {
-                    if (i == (pattern.length() - 1)) {
-                        throw escapeWildcardsOnly();
-                    }
+                char nextPatternChar = pattern.charAt(i + 1);
 
-                    char nextPatternChar = pattern.charAt(i + 1);
+                if ((nextPatternChar == ONE_SQL) || (nextPatternChar == MANY_SQL) || (nextPatternChar == escapeChar)) {
+                    javaPattern.append(nextPatternChar);
 
-                    if ((nextPatternChar == ONE_SQL) || (nextPatternChar == MANY_SQL) || (nextPatternChar == escapeChar)) {
-                        javaPattern.append(nextPatternChar);
-
-                        i++;
-                    } else {
-                        throw escapeWildcardsOnly();
-                    }
-                } else if (patternChar == ONE_SQL) {
-                    javaPattern.append(ONE_JAVA);
-                } else if (patternChar == MANY_SQL) {
-                    javaPattern.append(MANY_JAVA);
+                    i++;
                 } else {
-                    javaPattern.append(patternChar);
+                    throw escapeWildcardsOnly();
                 }
+            } else if (patternChar == ONE_SQL) {
+                javaPattern.append(ONE_JAVA);
+            } else if (patternChar == MANY_SQL) {
+                javaPattern.append(MANY_JAVA);
+            } else {
+                javaPattern.append(patternChar);
             }
-
-            return javaPattern.toString();
         }
 
-        private static QueryException escapeWildcardsOnly() {
-            return QueryException.error("Only '_', '%' and the escape character can be escaped");
-        }
+        return javaPattern.toString();
+    }
+
+    private static QueryException escapeWildcardsOnly() {
+        return QueryException.error("Only '_', '%' and the escape character can be escaped");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/string/LikeFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/string/LikeFunction.java
@@ -57,8 +57,10 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
     /** Special characters which require escaping in Java. */
     private static final String ESCAPE_CHARACTERS_JAVA = "[]()|^+*?{}$\\.";
 
+    private final Object mux = new Object();
+
     private boolean negated;
-    private transient State state;
+    private transient volatile State state;
 
     public LikeFunction() {
         // No-op.
@@ -107,7 +109,11 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
         }
 
         if (state == null) {
-            state = new State();
+            synchronized (mux) {
+                if (state == null) {
+                    state = new State();
+                }
+            }
         }
 
         boolean res = state.like(source, pattern, escape);
@@ -176,6 +182,8 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
      * Helper class to execute LIKE function. Caches the last observed pattern to avoid constant re-compilation.
      */
     public static class State {
+        private final Object mux = new Object();
+
         /** Last observed pattern. */
         private String lastPattern;
 
@@ -194,16 +202,20 @@ public class LikeFunction extends TriExpression<Boolean> implements IdentifiedDa
         }
 
         private Pattern convertToJavaPattern(String pattern, String escape) {
-            if (Objects.equals(pattern, lastPattern) && Objects.equals(escape, lastEscape)) {
-                return lastJavaPattern;
+            synchronized (mux) {
+                if (Objects.equals(pattern, lastPattern) && Objects.equals(escape, lastEscape)) {
+                    return lastJavaPattern;
+                }
             }
 
             String javaPatternStr = constructJavaPatternString(pattern, escape);
             Pattern javaPattern = Pattern.compile(javaPatternStr, Pattern.DOTALL);
 
-            lastPattern = pattern;
-            lastEscape = escape;
-            lastJavaPattern = javaPattern;
+            synchronized (mux) {
+                lastPattern = pattern;
+                lastEscape = escape;
+                lastJavaPattern = javaPattern;
+            }
 
             return javaPattern;
         }

--- a/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ConcurrentInitialSetCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/sql/impl/expression/ConcurrentInitialSetCacheTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.function.ConsumerEx;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ConcurrentInitialSetCacheTest {
+    @Test
+    public void when_addingElementsToCacheInSingleThread_then_properSizeAndElements() {
+        int capacity = 20;
+        int elementsToAdd = 100;
+        ConcurrentInitialSetCache<Integer, Integer> cache = new ConcurrentInitialSetCache<>(capacity);
+        for (int i = 0; i < elementsToAdd; i++) {
+            cache.computeIfAbsent(i, Function.identity());
+        }
+
+        assertEquals(capacity, cache.cache.size());
+        for (int i = 0; i < capacity; i++) {
+            assertTrue(cache.cache.containsKey(i));
+        }
+    }
+
+    @Test
+    public void when_addingElementsToCacheMultiThreaded_then_minProperSizeAndElements() {
+        int capacity = 20;
+        int elementsToAdd = 100;
+        int threadCount = 10;
+        ConcurrentInitialSetCache<Integer, Integer> cache = new ConcurrentInitialSetCache<>(capacity);
+        Runnable runnable = () -> {
+            for (int i = 0; i < elementsToAdd; i++) {
+                cache.computeIfAbsent(i, Function.identity());
+            }
+        };
+
+        List<Thread> threadList = IntStream.range(0, threadCount)
+                .mapToObj(value -> new Thread(runnable))
+                .collect(Collectors.toList());
+        threadList.forEach(Thread::start);
+        threadList.forEach((ConsumerEx<Thread>) Thread::join);
+
+        assertTrue(cache.cache.size() >= capacity);
+        for (int i = 0; i < capacity; i++) {
+            assertTrue(cache.cache.containsKey(i));
+        }
+    }
+
+    @Test
+    public void when_creatingEmptyCache_then_fail() {
+        assertThrows(IllegalArgumentException.class, () -> new ConcurrentInitialSetCache<>(0));
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/22272

In the master branch I changed ```serialVersionUID``` in the first commit, since I've added additional field there. The final version is in my opinion backward compatible in terms of serialization. I tested it locally, I serialized that class to a file with ```5.1.z``` branch and deserialized with that one - worked, but please, take a careful look if I'm right.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
