### PR TITLE
Fixed ClearBackupOperation [HZ-1210], BACKPORT

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -33,7 +33,7 @@ public class ClearBackupOperation extends MapOperation implements BackupOperatio
     @Override
     protected void runInternal() {
         if (recordStore != null) {
-            recordStore.clear();
+            recordStore.clear(true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -46,7 +46,7 @@ public class ClearOperation extends MapOperation
             return;
         }
 
-        numberOfClearedEntries = recordStore.clear();
+        numberOfClearedEntries = recordStore.clear(false);
         shouldBackup = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
@@ -100,24 +100,24 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
     }
 
     @Override
-    public void onRemoveRecord(Data key, R record) {
+    public void onRemoveRecord(Data key, R record, boolean backup) {
         if (isEmpty(mutationObservers)) {
             return;
         }
 
         for (MutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onRemoveRecord(key, record);
+            mutationObserver.onRemoveRecord(key, record, backup);
         }
     }
 
     @Override
-    public void onEvictRecord(Data key, R record) {
+    public void onEvictRecord(Data key, R record, boolean backup) {
         if (isEmpty(mutationObservers)) {
             return;
         }
 
         for (MutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onEvictRecord(key, record);
+            mutationObserver.onEvictRecord(key, record, backup);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -432,29 +432,30 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         return definedExpirationTime - System.currentTimeMillis();
     }
 
-    protected int removeBulk(ArrayList<Data> dataKeys, ArrayList<Record> records) {
-        return removeOrEvictEntries(dataKeys, records, false);
+    protected int removeBulk(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean backup) {
+        return removeOrEvictEntries(dataKeys, records, false, backup);
     }
 
-    protected int evictBulk(ArrayList<Data> dataKeys, ArrayList<Record> records) {
-        return removeOrEvictEntries(dataKeys, records, true);
+    protected int evictBulk(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean backup) {
+        return removeOrEvictEntries(dataKeys, records, true, backup);
     }
 
-    private int removeOrEvictEntries(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean eviction) {
+    private int removeOrEvictEntries(ArrayList<Data> dataKeys, ArrayList<Record> records, boolean eviction,
+                                     boolean backup) {
         for (int i = 0; i < dataKeys.size(); i++) {
             Data dataKey = dataKeys.get(i);
             Record record = records.get(i);
-            removeOrEvictEntry(dataKey, record, eviction);
+            removeOrEvictEntry(dataKey, record, eviction, backup);
         }
 
         return dataKeys.size();
     }
 
-    private void removeOrEvictEntry(Data dataKey, Record record, boolean eviction) {
+    private void removeOrEvictEntry(Data dataKey, Record record, boolean eviction, boolean backup) {
         if (eviction) {
-            mutationObserver.onEvictRecord(dataKey, record);
+            mutationObserver.onEvictRecord(dataKey, record, backup);
         } else {
-            mutationObserver.onRemoveRecord(dataKey, record);
+            mutationObserver.onRemoveRecord(dataKey, record, backup);
         }
         storage.removeRecord(dataKey, record);
     }
@@ -466,7 +467,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record != null) {
             value = record.getValue();
             mapDataStore.flush(key, value, backup);
-            mutationObserver.onEvictRecord(key, record);
+            mutationObserver.onEvictRecord(key, record, backup);
             storage.removeRecord(key, record);
             if (!backup) {
                 mapServiceContext.interceptRemove(interceptorRegistry, value);
@@ -492,7 +493,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             return;
         }
-        mutationObserver.onRemoveRecord(key, record);
+        mutationObserver.onRemoveRecord(key, record, true);
         storage.removeRecord(key, record);
         if (persistenceEnabledFor(provenance)) {
             mapDataStore.removeBackup(key, now, transactionId);
@@ -567,7 +568,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             mapDataStore.remove(key, now, null);
             if (record != null) {
                 onStore(record);
-                mutationObserver.onRemoveRecord(key, record);
+                mutationObserver.onRemoveRecord(key, record, false);
                 storage.removeRecord(key, record);
                 updateStatsOnRemove(now);
             }
@@ -849,7 +850,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                     mapDataStore.remove(key, now, null);
                 }
                 onStore(record);
-                mutationObserver.onRemoveRecord(key, record);
+                mutationObserver.onRemoveRecord(key, record, false);
                 storage.removeRecord(key, record);
                 return true;
             }
@@ -1074,7 +1075,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             }
             onStore(record);
         }
-        mutationObserver.onRemoveRecord(key, record);
+        mutationObserver.onRemoveRecord(key, record, false);
         storage.removeRecord(key, record);
         return oldValue;
     }
@@ -1256,12 +1257,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }, true);
 
         flush(keys, records, backup);
-        return evictBulk(keys, records);
+        return evictBulk(keys, records, backup);
     }
 
     // TODO optimize when no mapdatastore
     @Override
-    public int clear() {
+    public int clear(boolean backup) {
         checkIfLoaded();
 
         ArrayList<Data> keys = new ArrayList<>();
@@ -1282,7 +1283,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         // This conversion is required by mapDataStore#removeAll call.
         mapDataStore.removeAll(keys);
         mapDataStore.reset();
-        int removedKeyCount = removeBulk(keys, records);
+        int removedKeyCount = removeBulk(keys, records, backup);
         if (removedKeyCount > 0) {
             updateStatsOnRemove(Clock.currentTimeMillis());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
@@ -56,13 +56,13 @@ public class EventJournalWriterMutationObserver implements MutationObserver {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         eventJournal.writeRemoveEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
@@ -71,13 +71,17 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
     }
 
     @Override
-    public void onRemoveRecord(@Nonnull Data key, R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onRemoveRecord(@Nonnull Data key, R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override
-    public void onEvictRecord(@Nonnull Data key, @Nonnull R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
@@ -68,12 +68,12 @@ public class JsonMetadataMutationObserver implements MutationObserver<Record> {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         // no-op
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         // no-op
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
@@ -70,16 +70,18 @@ public interface MutationObserver<R extends Record> {
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      */
-    void onRemoveRecord(@Nonnull Data key, R record);
+    void onRemoveRecord(@Nonnull Data key, R record, boolean backup);
 
     /**
      * Called when a record is evicted from the observed {@link RecordStore}
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.*
      */
-    void onEvictRecord(@Nonnull Data key, @Nonnull R record);
+    void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup);
 
     /**
      * Called when a record is loaded into the observed {@link RecordStore}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -597,9 +597,10 @@ public interface RecordStore<R extends Record> {
      * <p>
      * Clears data in this record store.
      *
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      * @return number of cleared entries.
      */
-    int clear();
+    int clear(boolean backup);
 
     /**
      * Resets the record store to it's initial state.


### PR DESCRIPTION
Propagate backup flag into removeRecord method to disable
removeIndex calls on the replicas.
EE https://github.com/hazelcast/hazelcast-enterprise/pull/5329