### PR TITLE
Fix CVE-2022-34917 #22311 [5.1]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <json-surfer.version>0.10</json-surfer.version>
         <jsr107.api.version>1.1.1</jsr107.api.version> <!-- JCache -->
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
-        <kafka.version>2.2.2</kafka.version>
+        <kafka.version>2.8.2</kafka.version>
         <kotlin.version>1.5.32</kotlin.version>
         <log4j.version>1.2.17.redhat-00008</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>


### PR DESCRIPTION
Fixes CVE-2022-34917 - Kafka vunerability in 2.8.1, fixes in 2.8.2

Fixes #22311 
Backport of #22312

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
