### PR TITLE
Fix CVE-2022-34917 #22311 [5.0]

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.impl;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.Properties;
+
+class DockerizedKafkaTestSupport extends KafkaTestSupport {
+
+    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.1.1");
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerizedKafkaTestSupport.class);
+
+    private KafkaContainer kafkaContainer;
+
+    public void createKafkaCluster() throws IOException {
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:" + TEST_KAFKA_VERSION))
+                .withEmbeddedZookeeper()
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+        kafkaContainer.start();
+
+        brokerConnectionString = kafkaContainer.getBootstrapServers();
+        Properties props = new Properties();
+        props.setProperty("bootstrap.servers", brokerConnectionString);
+        admin = Admin.create(props);
+    }
+
+    public void shutdownKafkaCluster() {
+        if (kafkaContainer != null) {
+            kafkaContainer.stop();
+            if (admin != null) {
+                admin.close();
+            }
+            if (producer != null) {
+                producer.close();
+            }
+            producer = null;
+            admin = null;
+            kafkaContainer = null;
+            brokerConnectionString = null;
+        }
+    }
+
+}

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/EmbeddedKafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/EmbeddedKafkaTestSupport.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.impl;
+
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.TestUtils;
+import kafka.zk.EmbeddedZookeeper;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.SystemTime;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import static com.hazelcast.internal.util.OsHelper.isWindows;
+
+class EmbeddedKafkaTestSupport extends KafkaTestSupport {
+    private static final String ZK_HOST = "127.0.0.1";
+    private static final String BROKER_HOST = "127.0.0.1";
+    private EmbeddedZookeeper zkServer;
+    private String zkConnect;
+    private KafkaServer kafkaServer;
+    private int brokerPort = -1;
+
+    @Override
+    public void createKafkaCluster() throws IOException {
+        System.setProperty("zookeeper.preAllocSize", Integer.toString(128));
+        zkServer = new EmbeddedZookeeper();
+        zkConnect = ZK_HOST + ':' + zkServer.port();
+
+        Properties brokerProps = new Properties();
+        brokerProps.setProperty("zookeeper.connect", zkConnect);
+        brokerProps.setProperty("broker.id", "0");
+        brokerProps.setProperty("log.dirs", Files.createTempDirectory("kafka-").toAbsolutePath().toString());
+        brokerProps.setProperty("listeners", "PLAINTEXT://" + BROKER_HOST + ":0");
+        brokerProps.setProperty("offsets.topic.replication.factor", "1");
+        brokerProps.setProperty("offsets.topic.num.partitions", "1");
+        // we need this due to avoid OOME while running tests, see https://issues.apache.org/jira/browse/KAFKA-3872
+        brokerProps.setProperty("log.cleaner.dedupe.buffer.size", Long.toString(2 * 1024 * 1024L));
+        brokerProps.setProperty("transaction.state.log.replication.factor", "1");
+        brokerProps.setProperty("transaction.state.log.num.partitions", "1");
+        brokerProps.setProperty("transaction.state.log.min.isr", "1");
+        brokerProps.setProperty("transaction.abort.timed.out.transaction.cleanup.interval.ms", "200");
+        brokerProps.setProperty("group.initial.rebalance.delay.ms", "0");
+        KafkaConfig config = new KafkaConfig(brokerProps);
+        kafkaServer = TestUtils.createServer(config, new SystemTime());
+        brokerPort = TestUtils.boundPort(kafkaServer, SecurityProtocol.PLAINTEXT);
+
+        brokerConnectionString = BROKER_HOST + ':' + brokerPort;
+        Properties props = new Properties();
+        props.setProperty("bootstrap.servers", brokerConnectionString);
+        admin = Admin.create(props);
+    }
+
+    @Override
+    public void shutdownKafkaCluster() {
+        if (kafkaServer != null) {
+            kafkaServer.shutdown();
+            if (admin != null) {
+                admin.close();
+            }
+            if (producer != null) {
+                producer.close();
+            }
+            try {
+                zkServer.shutdown();
+            } catch (Exception e) {
+                // ignore error on Windows, it fails there, see https://issues.apache.org/jira/browse/KAFKA-6291
+                if (!isWindows()) {
+                    throw e;
+                }
+            }
+            producer = null;
+            kafkaServer = null;
+            admin = null;
+            zkServer = null;
+        }
+    }
+}

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -16,163 +16,83 @@
 
 package com.hazelcast.jet.kafka.impl;
 
-import kafka.admin.AdminUtils;
-import kafka.admin.BrokerMetadata;
-import kafka.common.TopicAndPartition;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaServer;
-import kafka.utils.MockTime;
-import kafka.utils.TestUtils;
-import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
-import kafka.zk.EmbeddedZookeeper;
-import org.I0Itec.zkclient.ZkClient;
+import com.hazelcast.internal.util.OsHelper;
+import com.hazelcast.test.DockerTestUtil;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.common.utils.Time;
-
-import com.hazelcast.internal.util.StringUtil;
-
-import scala.Option;
-import scala.collection.Seq;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
-import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singleton;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static kafka.admin.RackAwareMode.Disabled$.MODULE$;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static scala.collection.JavaConversions.asScalaSet;
-import static scala.collection.JavaConversions.mapAsJavaMap;
-import static scala.collection.JavaConversions.mapAsScalaMap;
 
-public class KafkaTestSupport {
-
-    private static final String ZK_HOST = "127.0.0.1";
-    private static final String BROKER_HOST = "127.0.0.1";
-    private static final int SESSION_TIMEOUT = 30_000;
-    private static final int CONNECTION_TIMEOUT = 30_000;
-
-    private EmbeddedZookeeper zkServer;
-    private String zkConnect;
-    private ZkUtils zkUtils;
-
-    private KafkaServer kafkaServer;
-    private KafkaProducer<Integer, String> producer;
+public abstract class KafkaTestSupport {
+    protected Admin admin;
+    protected KafkaProducer<Integer, String> producer;
+    protected String brokerConnectionString;
     private KafkaProducer<String, String> stringStringProducer;
-    private int brokerPort = -1;
-    private String brokerConnectionString;
 
-    public void createKafkaCluster() throws IOException {
-        System.setProperty("zookeeper.preAllocSize", Integer.toString(128));
-        zkServer = new EmbeddedZookeeper();
-        zkConnect = ZK_HOST + ':' + zkServer.port();
-        ZkClient zkClient = new ZkClient(zkConnect, SESSION_TIMEOUT, CONNECTION_TIMEOUT, ZKStringSerializer$.MODULE$);
-        zkUtils = ZkUtils.apply(zkClient, false);
-
-        Properties brokerProps = new Properties();
-        brokerProps.setProperty("zookeeper.connect", zkConnect);
-        brokerProps.setProperty("broker.id", "0");
-        brokerProps.setProperty("log.dirs", Files.createTempDirectory("kafka-").toAbsolutePath().toString());
-        brokerProps.setProperty("listeners", "PLAINTEXT://" + BROKER_HOST + ":0");
-        brokerProps.setProperty("offsets.topic.replication.factor", "1");
-        brokerProps.setProperty("offsets.topic.num.partitions", "1");
-        // we need this due to avoid OOME while running tests, see https://issues.apache.org/jira/browse/KAFKA-3872
-        brokerProps.setProperty("log.cleaner.dedupe.buffer.size", Long.toString(2 * 1024 * 1024L));
-        brokerProps.setProperty("transaction.state.log.replication.factor", "1");
-        brokerProps.setProperty("transaction.state.log.num.partitions", "1");
-        brokerProps.setProperty("transaction.state.log.min.isr", "1");
-        brokerProps.setProperty("transaction.abort.timed.out.transaction.cleanup.interval.ms", "200");
-        brokerProps.setProperty("group.initial.rebalance.delay.ms", "0");
-        KafkaConfig config = new KafkaConfig(brokerProps);
-        Time mock = new MockTime();
-        kafkaServer = TestUtils.createServer(config, mock);
-        brokerPort = TestUtils.boundPort(kafkaServer, SecurityProtocol.PLAINTEXT);
-
-        brokerConnectionString = BROKER_HOST + ':' + brokerPort;
-    }
-
-    public void shutdownKafkaCluster() {
-        if (kafkaServer != null) {
-            kafkaServer.shutdown();
-            zkUtils.close();
-            if (producer != null) {
-                producer.close();
+    public static KafkaTestSupport create() {
+        if (!DockerTestUtil.dockerEnabled() || OsHelper.isArmMac()) {
+            if (System.getProperties().containsKey("test.kafka.version")) {
+                throw new IllegalArgumentException("'test.kafka.version' system property requires docker and x86_64 CPU");
             }
-            try {
-                zkServer.shutdown();
-            } catch (Exception e) {
-                // ignore error on Windows, it fails there, see https://issues.apache.org/jira/browse/KAFKA-6291
-                if (!isWindows()) {
-                    throw e;
-                }
-            }
-
-            producer = null;
-            kafkaServer = null;
-            zkUtils = null;
-            zkServer = null;
+            return new EmbeddedKafkaTestSupport();
+        } else {
+            return new DockerizedKafkaTestSupport();
         }
     }
 
-    public String getZookeeperConnectionString() {
-        return zkConnect;
-    }
+    public abstract void createKafkaCluster() throws IOException;
+
+    public abstract void shutdownKafkaCluster();
 
     public String getBrokerConnectionString() {
         return brokerConnectionString;
     }
 
-    private static boolean isWindows() {
-        return StringUtil.lowerCaseInternal(System.getProperty("os.name")).contains("windows");
-    }
-
     public void createTopic(String topicId, int partitionCount) {
-        AdminUtils.createTopic(zkUtils, topicId, partitionCount, 1, new Properties(), MODULE$);
+        List<NewTopic> newTopics = Collections.singletonList(new NewTopic(topicId, partitionCount, (short) 1));
+        CreateTopicsResult createTopicsResult = admin.createTopics(newTopics);
+        try {
+            createTopicsResult.all().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void setPartitionCount(String topicId, int numPartitions) {
-        Seq<String> topicSeq = asScalaSet(singleton(topicId)).toSeq();
-        Map<TopicAndPartition, Seq<Object>> replicaAssignments = mapAsJavaMap(
-                zkUtils.getReplicaAssignmentForTopics(topicSeq)
-        );
-        Map<Object, Seq<Object>> existingAssignment =
-                replicaAssignments.entrySet().stream()
-                                  .map(e -> entry(e.getKey().partition(), e.getValue()))
-                                  .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
-        Seq<BrokerMetadata> brokerMetadatas =
-                AdminUtils.getBrokerMetadatas(zkUtils, null, Option.apply(zkUtils.getSortedBrokerList()));
-        // doesn't actually add the given number to existing partitions, just sets to it
-        AdminUtils.addPartitions(
-                zkUtils, topicId, mapAsScalaMap(existingAssignment), brokerMetadatas, numPartitions, Option.empty(),
-                false
-        );
+        Map<String, NewPartitions> newPartitions = new HashMap<>();
+        newPartitions.put(topicId, NewPartitions.increaseTo(numPartitions));
+        admin.createPartitions(newPartitions);
     }
 
     public Future<RecordMetadata> produce(String topic, Integer key, String value) {
@@ -190,7 +110,7 @@ public class KafkaTestSupport {
     private KafkaProducer<Integer, String> getProducer() {
         if (producer == null) {
             Properties producerProps = new Properties();
-            producerProps.setProperty("bootstrap.servers", BROKER_HOST + ':' + brokerPort);
+            producerProps.setProperty("bootstrap.servers", brokerConnectionString);
             producerProps.setProperty("key.serializer", IntegerSerializer.class.getCanonicalName());
             producerProps.setProperty("value.serializer", StringSerializer.class.getCanonicalName());
             producer = new KafkaProducer<>(producerProps);
@@ -201,7 +121,7 @@ public class KafkaTestSupport {
     private KafkaProducer<String, String> getStringStringProducer() {
         if (stringStringProducer == null) {
             Properties producerProps = new Properties();
-            producerProps.setProperty("bootstrap.servers", BROKER_HOST + ':' + brokerPort);
+            producerProps.setProperty("bootstrap.servers", brokerConnectionString);
             producerProps.setProperty("key.serializer", StringSerializer.class.getCanonicalName());
             producerProps.setProperty("value.serializer", StringSerializer.class.getCanonicalName());
             stringStringProducer = new KafkaProducer<>(producerProps);
@@ -218,8 +138,8 @@ public class KafkaTestSupport {
     }
 
     public <K, V> KafkaConsumer<K, V> createConsumer(
-            Class<? extends Deserializer<K>> keyDeserializerClass,
-            Class<? extends Deserializer<V>> valueDeserializerClass,
+            Class<? extends Deserializer<? super K>> keyDeserializerClass,
+            Class<? extends Deserializer<? super V>> valueDeserializerClass,
             Map<String, String> properties,
             String... topicIds
     ) {
@@ -261,8 +181,8 @@ public class KafkaTestSupport {
     public <K, V> void assertTopicContentsEventually(
             String topic,
             Map<K, V> expected,
-            Class<? extends Deserializer<K>> keyDeserializerClass,
-            Class<? extends Deserializer<V>> valueDeserializerClass
+            Class<? extends Deserializer<? super K>> keyDeserializerClass,
+            Class<? extends Deserializer<? super V>> valueDeserializerClass
     ) {
         assertTopicContentsEventually(topic, expected, keyDeserializerClass, valueDeserializerClass, emptyMap());
     }
@@ -270,8 +190,8 @@ public class KafkaTestSupport {
     public <K, V> void assertTopicContentsEventually(
             String topic,
             Map<K, V> expected,
-            Class<? extends Deserializer<K>> keyDeserializerClass,
-            Class<? extends Deserializer<V>> valueDeserializerClass,
+            Class<? extends Deserializer<? super K>> keyDeserializerClass,
+            Class<? extends Deserializer<? super V>> valueDeserializerClass,
             Map<String, String> consumerProperties
     ) {
         try (KafkaConsumer<K, V> consumer = createConsumer(

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.internal.util;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
 /**
  * Helper methods related to operating system on which the code is actually running.
  */
@@ -54,5 +59,30 @@ public final class OsHelper {
      */
     public static boolean isMac() {
         return (OS.contains("mac") || OS.contains("darwin"));
+    }
+
+    /**
+     * Returns {@code true} if the system is a Mac OS with Arm CPU, e.g. M1.
+     *
+     * @return {@code true} if the system is a Mac OS with Arm CPU, e.g. M1.
+     */
+    public static boolean isArmMac() {
+        if (!isMac()) {
+            return false;
+        }
+        try {
+            Process process = new ProcessBuilder("sysctl", "-n", "hw.optional.arm64")
+                    .redirectErrorStream(true)
+                    .start();
+            process.waitFor();
+            try (InputStream is = process.getInputStream()) {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                String line = reader.readLine();
+                return line.equals("1");
+            }
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -85,4 +85,13 @@ public final class OsHelper {
             return false;
         }
     }
+
+    /**
+     * Returns {@code true} if the system is a Windows.
+     *
+     * @return {@code true} if the current system is a Windows one.
+     */
+    public static boolean isWindows() {
+        return OS.contains("windows");
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.test;
+
+import static org.junit.Assume.assumeTrue;
+
+public class DockerTestUtil {
+    public static boolean dockerEnabled() {
+        return !System.getProperties().containsKey("hazelcast.disable.docker.tests");
+    }
+
+    public static void assumeDockerEnabled() {
+        assumeTrue(DockerTestUtil.dockerEnabled());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <jms.api.version>2.0.1</jms.api.version>
         <jsr107.api.version>1.1.1</jsr107.api.version> <!-- JCache -->
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
-        <kafka.version>2.2.2</kafka.version>
+        <kafka.version>2.8.2</kafka.version>
         <kotlin.version>1.5.32</kotlin.version>
         <log4j.version>1.2.17.redhat-00008</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>


### PR DESCRIPTION
Fixes CVE-2022-34917 - Kafka vunerability in 2.8.1, fixes in 2.8.2

Fixes #22311 
Backport of #22312

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
