### PR TITLE
Fix Throwable.initCause when exception already has cause [5.1.z] API-1387

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ExceptionUtil.java
@@ -296,7 +296,12 @@ public final class ExceptionUtil {
             <T extends Throwable> T cloneWith(MethodHandle constructor, String message,
                                               @Nullable Throwable cause) throws Throwable {
                 T cloned = (T) constructor.invokeWithArguments(message);
-                cloned.initCause(cause);
+                try {
+                    cloned.initCause(cause);
+                } catch (IllegalStateException ignored) {
+                    // Cause can be already set by the exception. It can be set to null as well.
+                    // So doing null check is not the solution here. See https://github.com/hazelcast/hazelcast/issues/21414
+                }
                 return cloned;
             }
         },
@@ -311,7 +316,12 @@ public final class ExceptionUtil {
             <T extends Throwable> T cloneWith(MethodHandle constructor, String message,
                                               @Nullable Throwable cause) throws Throwable {
                 T cloned = (T) constructor.invokeWithArguments();
-                cloned.initCause(cause);
+                try {
+                    cloned.initCause(cause);
+                } catch (IllegalStateException ignored) {
+                    // Cause can be already set by the exception. It can be set to null as well.
+                    // So doing null check is not the solution here. See https://github.com/hazelcast/hazelcast/issues/21414
+                }
                 return cloned;
             }
         };

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ExceptionUtilTest.java
@@ -82,4 +82,30 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
         assertEquals(result.getClass(), IllegalStateException.class);
         assertEquals(result.getCause(), expectedException);
     }
+
+    @Test
+    public void testCanCreateExceptionsWithMessageAndCauseWhenExceptionHasCauseSetImplicitlyByNoArgumentConstructor() {
+        ExceptionUtil.tryCreateExceptionWithMessageAndCause(
+                ExceptionThatHasCauseImplicitlyByNoArgumentConstructor.class, "", new RuntimeException()
+        );
+    }
+
+    @Test
+    public void testCanCreateExceptionsWithMessageAndCauseWhenExceptionHasCauseSetImplicitlyByMessageConstructor() {
+        ExceptionUtil.tryCreateExceptionWithMessageAndCause(
+                ExceptionThatHasCauseImplicitlyByMessageConstructor.class, "", new RuntimeException()
+        );
+    }
+
+    public static class ExceptionThatHasCauseImplicitlyByNoArgumentConstructor extends RuntimeException {
+        public ExceptionThatHasCauseImplicitlyByNoArgumentConstructor() {
+            super((Throwable) null);
+        }
+    }
+
+    public static class ExceptionThatHasCauseImplicitlyByMessageConstructor extends RuntimeException {
+        public ExceptionThatHasCauseImplicitlyByMessageConstructor(String message) {
+            super(message, null);
+        }
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/22168

Breaking changes (list specific methods/types/messages):
* None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
