### PR TITLE
Fix cooperative emission in stream-to-stream join

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -167,8 +167,8 @@ public class StreamToStreamJoinP extends AbstractProcessor {
     @Override
     public boolean tryProcess(int ordinal, @Nonnull Object item) {
         assert ordinal == 0 || ordinal == 1; // bad DAG
-        if (!pendingOutput.isEmpty()) {
-            return processPendingOutput();
+        if (!processPendingOutput()) {
+            return false;
         }
 
         if (buffer[0].size() + buffer[1].size() >= maxProcessorAccumulatedRecords) {
@@ -241,18 +241,16 @@ public class StreamToStreamJoinP extends AbstractProcessor {
             }
         }
 
-        iterator = null;
-
         if (avoidBuffer && !joinInfo.isInner() && unusedEventsTracker.remove(currItem)) {
             JetSqlRow joinedRow = composeRowWithNulls(currItem, ordinal);
             if (joinedRow != null && !tryEmit(joinedRow)) {
-                currItem = null;
                 pendingOutput.add(joinedRow);
                 return false;
             }
         }
-        currItem = null;
 
+        iterator = null;
+        currItem = null;
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapLoader.java
@@ -25,23 +25,23 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * Hazelcast distributed map implementation is an in-memory data store but
+ * Hazelcast distributed map implementation is an in-memory data store, but
  * it can be backed by any type of data store such as RDBMS, OODBMS, or simply
- * a file based data store.
+ * a file-based data store.
  * <p>
  * {@link IMap#get(Object)} normally returns the value that
- * is available in-memory. If the entry doesn't exist in-memory, Hazelcast
- * returns {@code null}. If a Loader implementation is provided then, instead
+ * is available in memory. If the entry doesn't exist in memory, Hazelcast
+ * returns {@code null}. If a MapLoader implementation is provided, then instead
  * of returning {@code null}, Hazelcast will attempt to load the unknown entry
  * by calling the implementation's {@link #load(Object)} or
- * {@link #loadAll(Collection)}  methods. Loaded entries will be placed into
- * the distributed map and they will stay in-memory until they are explicitly
+ * {@link #loadAll(Collection)} methods. Loaded entries will be placed into
+ * the distributed map, and they will stay in memory until they are explicitly
  * removed or implicitly evicted (if eviction is configured).
  * <p>
  * MapLoader implementations are executed by a partition thread, therefore care
  * should be taken not to block the thread with an expensive operation or an
  * operation that may potentially never return, the partition thread does not
- * time out the operation. Whilst the partition thread is executing the
+ * time out the operation. While the partition thread is executing the
  * MapLoader it is unable to respond to requests for data on any other
  * structure that may reside in the same partition, or to respond to other
  * partitions mapped to the same partition thread. For example a very slow
@@ -61,7 +61,7 @@ import java.util.Map;
  * If a blocked partition thread is called from a Hazelcast Client the caller
  * will also block indefinitely, for example
  * {@link IMap#get(Object)}. If the same call is made from
- * another cluster member the operation will eventually timeout with a
+ * another cluster member the operation will eventually time out with an
  * {@link OperationTimeoutException}.
  *
  * @param <K> type of the MapLoader key

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ColumnExpression.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/expression/ColumnExpression.java
@@ -134,4 +134,9 @@ public final class ColumnExpression<T> implements Expression<T>, IdentifiedDataS
 
         return index == that.index && type.equals(that.type);
     }
+
+    @Override
+    public String toString() {
+        return "$" + index;
+    }
 }


### PR DESCRIPTION
When multiple rows in the buffer matched, and we couldn't emit them all because the outbox was full, we'll add the last item to `pendingOutput`. The next call to `tryProcess` will emit the `pendingOutput`, but then it will return `true` and miss the remaining matches in the buffer, causing incorrect results.

Also contains:

* Add outer join test for non-late off-limit
* Unrelated grammar fixes
