### PR TITLE
Fix running Jenkins jobs for Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,9 @@
                     <excludes>
                         <exclude>**/package-info.java</exclude>
                     </excludes>
+                    <testExcludes>
+                        <exclude>**/package-info.java</exclude>
+                    </testExcludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Tests in `hazelcast` module are not running in Jenkins jobs on windows due to:
```
There was an error in the forked process
com\hazelcast\test\package-info (wrong name: com/hazelcast/test/package-info)
org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
com\hazelcast\test\package-info (wrong name: com/hazelcast/test/package-info)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:656)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:282)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:245)
	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1183)
	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1011)
	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:857)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
	at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:190)
	at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:186)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```