### PR TITLE
[HZ-1208] merge persistence & hot-restart when getting MapConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -724,7 +724,7 @@ public class Config {
      */
     public MapConfig findMapConfig(String name) {
         name = getBaseName(name);
-        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, name);
+        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, name, MapConfig.class);
         if (config != null) {
             return new MapConfigReadOnly(config);
         }
@@ -746,7 +746,7 @@ public class Config {
      */
     public MapConfig getMapConfigOrNull(String name) {
         name = getBaseName(name);
-        return lookupByPattern(configPatternMatcher, mapConfigs, name);
+        return lookupByPattern(configPatternMatcher, mapConfigs, name, MapConfig.class);
     }
 
     /**
@@ -842,7 +842,7 @@ public class Config {
      */
     public CacheSimpleConfig findCacheConfig(String name) {
         name = getBaseName(name);
-        final CacheSimpleConfig config = lookupByPattern(configPatternMatcher, cacheConfigs, name);
+        final CacheSimpleConfig config = lookupByPattern(configPatternMatcher, cacheConfigs, name, CacheSimpleConfig.class);
         if (config != null) {
             return new CacheSimpleConfigReadOnly(config);
         }
@@ -864,7 +864,7 @@ public class Config {
      */
     public CacheSimpleConfig findCacheConfigOrNull(String name) {
         name = getBaseName(name);
-        return lookupByPattern(configPatternMatcher, cacheConfigs, name);
+        return lookupByPattern(configPatternMatcher, cacheConfigs, name, CacheSimpleConfig.class);
     }
 
     /**
@@ -962,7 +962,7 @@ public class Config {
      */
     public QueueConfig findQueueConfig(String name) {
         name = getBaseName(name);
-        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, name);
+        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, name, QueueConfig.class);
         if (config != null) {
             return new QueueConfigReadOnly(config);
         }
@@ -1062,7 +1062,7 @@ public class Config {
      */
     public ListConfig findListConfig(String name) {
         name = getBaseName(name);
-        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, name);
+        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, name, ListConfig.class);
         if (config != null) {
             return new ListConfigReadOnly(config);
         }
@@ -1162,7 +1162,7 @@ public class Config {
      */
     public SetConfig findSetConfig(String name) {
         name = getBaseName(name);
-        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, name);
+        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, name, SetConfig.class);
         if (config != null) {
             return new SetConfigReadOnly(config);
         }
@@ -1262,7 +1262,7 @@ public class Config {
      */
     public MultiMapConfig findMultiMapConfig(String name) {
         name = getBaseName(name);
-        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, name);
+        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, name, MultiMapConfig.class);
         if (config != null) {
             return new MultiMapConfigReadOnly(config);
         }
@@ -1362,7 +1362,7 @@ public class Config {
      */
     public ReplicatedMapConfig findReplicatedMapConfig(String name) {
         name = getBaseName(name);
-        ReplicatedMapConfig config = lookupByPattern(configPatternMatcher, replicatedMapConfigs, name);
+        ReplicatedMapConfig config = lookupByPattern(configPatternMatcher, replicatedMapConfigs, name, ReplicatedMapConfig.class);
         if (config != null) {
             return new ReplicatedMapConfigReadOnly(config);
         }
@@ -1463,7 +1463,7 @@ public class Config {
      */
     public RingbufferConfig findRingbufferConfig(String name) {
         name = getBaseName(name);
-        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, name);
+        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, name, RingbufferConfig.class);
         if (config != null) {
             return new RingbufferConfigReadOnly(config);
         }
@@ -1564,7 +1564,7 @@ public class Config {
      */
     public TopicConfig findTopicConfig(String name) {
         name = getBaseName(name);
-        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, name);
+        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, name, TopicConfig.class);
         if (config != null) {
             return new TopicConfigReadOnly(config);
         }
@@ -1635,7 +1635,7 @@ public class Config {
      */
     public ReliableTopicConfig findReliableTopicConfig(String name) {
         name = getBaseName(name);
-        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, name);
+        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, name, ReliableTopicConfig.class);
         if (config != null) {
             return new ReliableTopicConfigReadOnly(config);
         }
@@ -1763,7 +1763,7 @@ public class Config {
      */
     public ExecutorConfig findExecutorConfig(String name) {
         name = getBaseName(name);
-        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, name);
+        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, name, ExecutorConfig.class);
         if (config != null) {
             return new ExecutorConfigReadOnly(config);
         }
@@ -1789,7 +1789,8 @@ public class Config {
      */
     public DurableExecutorConfig findDurableExecutorConfig(String name) {
         name = getBaseName(name);
-        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, name);
+        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, name,
+                DurableExecutorConfig.class);
         if (config != null) {
             return new DurableExecutorConfigReadOnly(config);
         }
@@ -1815,7 +1816,8 @@ public class Config {
      */
     public ScheduledExecutorConfig findScheduledExecutorConfig(String name) {
         name = getBaseName(name);
-        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name);
+        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name,
+                ScheduledExecutorConfig.class);
         if (config != null) {
             return new ScheduledExecutorConfigReadOnly(config);
         }
@@ -1842,7 +1844,8 @@ public class Config {
      */
     public CardinalityEstimatorConfig findCardinalityEstimatorConfig(String name) {
         name = getBaseName(name);
-        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name);
+        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name,
+                CardinalityEstimatorConfig.class);
         if (config != null) {
             return new CardinalityEstimatorConfigReadOnly(config);
         }
@@ -1869,7 +1872,7 @@ public class Config {
      */
     public PNCounterConfig findPNCounterConfig(String name) {
         name = getBaseName(name);
-        PNCounterConfig config = lookupByPattern(configPatternMatcher, pnCounterConfigs, name);
+        PNCounterConfig config = lookupByPattern(configPatternMatcher, pnCounterConfigs, name, PNCounterConfig.class);
         if (config != null) {
             return new PNCounterConfigReadOnly(config);
         }
@@ -2358,7 +2361,8 @@ public class Config {
      */
     public SplitBrainProtectionConfig findSplitBrainProtectionConfig(String name) {
         name = getBaseName(name);
-        SplitBrainProtectionConfig config = lookupByPattern(configPatternMatcher, splitBrainProtectionConfigs, name);
+        SplitBrainProtectionConfig config = lookupByPattern(configPatternMatcher, splitBrainProtectionConfigs, name,
+                SplitBrainProtectionConfig.class);
         if (config != null) {
             return config;
         }
@@ -2507,7 +2511,8 @@ public class Config {
      */
     public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String name) {
         String baseName = getBaseName(name);
-        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
+        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName,
+                FlakeIdGeneratorConfig.class);
         if (config != null) {
             return config;
         }
@@ -3209,7 +3214,8 @@ public class Config {
     @Beta
     public ExternalDataStoreConfig findExternalDataStoreConfig(String name) {
         name = getBaseName(name);
-        ExternalDataStoreConfig config = lookupByPattern(configPatternMatcher, externalDataStoreConfigs, name);
+        ExternalDataStoreConfig config = lookupByPattern(configPatternMatcher, externalDataStoreConfigs, name,
+                ExternalDataStoreConfig.class);
         if (config != null) {
             return new ExternalDataStoreConfigReadOnly(config);
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
@@ -610,7 +610,8 @@ public class CPSubsystemConfig {
      * @return the CP {@link ISemaphore} configuration
      */
     public SemaphoreConfig findSemaphoreConfig(String name) {
-        return lookupByPattern(configPatternMatcher, semaphoreConfigs, getBaseName(name));
+        return lookupByPattern(configPatternMatcher, semaphoreConfigs, getBaseName(name), SemaphoreConfig.class,
+                SemaphoreConfig::setName);
     }
 
     /**
@@ -663,7 +664,8 @@ public class CPSubsystemConfig {
      * @return the {@link FencedLock} configuration
      */
     public FencedLockConfig findLockConfig(String name) {
-        return lookupByPattern(configPatternMatcher, lockConfigs, getBaseName(name));
+        return lookupByPattern(configPatternMatcher, lockConfigs, getBaseName(name), FencedLockConfig.class,
+                FencedLockConfig::setName);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
@@ -22,6 +22,8 @@ import com.hazelcast.internal.config.ConfigUtils;
 
 import java.util.regex.Pattern;
 
+import static java.lang.Character.isLetter;
+
 /**
  * This {@code ConfigPatternMatcher} uses Java regular expressions for matching.
  * <p>
@@ -43,7 +45,13 @@ public class RegexConfigPatternMatcher implements ConfigPatternMatcher {
     public String matches(Iterable<String> configPatterns, String itemName) throws InvalidConfigurationException {
         String candidate = null;
         for (String pattern : configPatterns) {
-            if (Pattern.compile(pattern, flags).matcher(itemName).find()) {
+            String exactPattern = pattern;
+            boolean startsWithLetter = isLetter(pattern.charAt(0));
+            boolean endsWithLetter = isLetter(pattern.charAt(pattern.length() - 1));
+            if (startsWithLetter && endsWithLetter) {
+                exactPattern = "^" + exactPattern + "$";
+            }
+            if (Pattern.compile(exactPattern, flags).matcher(itemName).find()) {
                 if (candidate != null) {
                     throw ConfigUtils.createAmbiguousConfigurationException(itemName, candidate, pattern);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -375,7 +375,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public MultiMapConfig findMultiMapConfig(String name) {
-        return lookupByPattern(configPatternMatcher, multiMapConfigs, name);
+        return lookupByPattern(configPatternMatcher, multiMapConfigs, name, MultiMapConfig.class);
     }
 
     @Override
@@ -385,7 +385,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public MapConfig findMapConfig(String name) {
-        return lookupByPattern(configPatternMatcher, mapConfigs, name);
+        return lookupByPattern(configPatternMatcher, mapConfigs, name, MapConfig.class);
     }
 
     @Override
@@ -395,7 +395,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public TopicConfig findTopicConfig(String name) {
-        return lookupByPattern(configPatternMatcher, topicConfigs, name);
+        return lookupByPattern(configPatternMatcher, topicConfigs, name, TopicConfig.class);
     }
 
     @Override
@@ -405,7 +405,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public CardinalityEstimatorConfig findCardinalityEstimatorConfig(String name) {
-        return lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name);
+        return lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name, CardinalityEstimatorConfig.class);
     }
 
     @Override
@@ -415,7 +415,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public PNCounterConfig findPNCounterConfig(String name) {
-        return lookupByPattern(configPatternMatcher, pnCounterConfigs, name);
+        return lookupByPattern(configPatternMatcher, pnCounterConfigs, name, PNCounterConfig.class);
     }
 
     @Override
@@ -425,7 +425,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public ExecutorConfig findExecutorConfig(String name) {
-        return lookupByPattern(configPatternMatcher, executorConfigs, name);
+        return lookupByPattern(configPatternMatcher, executorConfigs, name, ExecutorConfig.class);
     }
 
     @Override
@@ -435,7 +435,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public ScheduledExecutorConfig findScheduledExecutorConfig(String name) {
-        return lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name);
+        return lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name, ScheduledExecutorConfig.class);
     }
 
     @Override
@@ -445,7 +445,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public DurableExecutorConfig findDurableExecutorConfig(String name) {
-        return lookupByPattern(configPatternMatcher, durableExecutorConfigs, name);
+        return lookupByPattern(configPatternMatcher, durableExecutorConfigs, name, DurableExecutorConfig.class);
     }
 
     @Override
@@ -455,7 +455,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public RingbufferConfig findRingbufferConfig(String name) {
-        return lookupByPattern(configPatternMatcher, ringbufferConfigs, name);
+        return lookupByPattern(configPatternMatcher, ringbufferConfigs, name, RingbufferConfig.class);
     }
 
     @Override
@@ -465,7 +465,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public ListConfig findListConfig(String name) {
-        return lookupByPattern(configPatternMatcher, listConfigs, name);
+        return lookupByPattern(configPatternMatcher, listConfigs, name, ListConfig.class);
     }
 
     @Override
@@ -475,7 +475,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public QueueConfig findQueueConfig(String name) {
-        return lookupByPattern(configPatternMatcher, queueConfigs, name);
+        return lookupByPattern(configPatternMatcher, queueConfigs, name, QueueConfig.class);
     }
 
     @Override
@@ -485,7 +485,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public SetConfig findSetConfig(String name) {
-        return lookupByPattern(configPatternMatcher, setConfigs, name);
+        return lookupByPattern(configPatternMatcher, setConfigs, name, SetConfig.class);
     }
 
     @Override
@@ -495,7 +495,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public ReplicatedMapConfig findReplicatedMapConfig(String name) {
-        return lookupByPattern(configPatternMatcher, replicatedMapConfigs, name);
+        return lookupByPattern(configPatternMatcher, replicatedMapConfigs, name, ReplicatedMapConfig.class);
     }
 
     @Override
@@ -505,7 +505,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public ReliableTopicConfig findReliableTopicConfig(String name) {
-        return lookupByPattern(configPatternMatcher, reliableTopicConfigs, name);
+        return lookupByPattern(configPatternMatcher, reliableTopicConfigs, name, ReliableTopicConfig.class);
     }
 
     @Override
@@ -515,7 +515,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public CacheSimpleConfig findCacheSimpleConfig(String name) {
-        return lookupByPattern(configPatternMatcher, cacheSimpleConfigs, name);
+        return lookupByPattern(configPatternMatcher, cacheSimpleConfigs, name, CacheSimpleConfig.class);
     }
 
     @Override
@@ -525,7 +525,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String baseName) {
-        return lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigs, baseName);
+        return lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigs, baseName, FlakeIdGeneratorConfig.class);
     }
 
     @Override
@@ -535,7 +535,7 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public ExternalDataStoreConfig findExternalDataStoreConfig(String baseName) {
-        return lookupByPattern(configPatternMatcher, externalDataStoreConfigs, baseName);
+        return lookupByPattern(configPatternMatcher, externalDataStoreConfigs, baseName, ExternalDataStoreConfig.class);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/ConfigSearch.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/ConfigSearch.java
@@ -35,6 +35,7 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.TopicConfig;
+import com.hazelcast.internal.config.ConfigUtils;
 import com.hazelcast.internal.dynamicconfig.ConfigurationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.properties.ClusterProperty;
@@ -69,6 +70,13 @@ public final class ConfigSearch {
                 return staticConfig.getMapConfig(name);
             }
 
+            @Nullable
+            @Override
+            public MapConfig lookupByPattern(@Nonnull Config staticConfig,
+                                             @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getMapConfigs(), name, MapConfig.class);
+            }
+
             @Override
             public Map<String, MapConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getMapConfigs();
@@ -83,6 +91,14 @@ public final class ConfigSearch {
             @Override
             public CacheSimpleConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getCacheConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public CacheSimpleConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                     @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getCacheConfigs(),
+                        name, CacheSimpleConfig.class);
             }
 
             @Override
@@ -101,6 +117,14 @@ public final class ConfigSearch {
                 return staticConfig.getQueueConfig(name);
             }
 
+            @Nullable
+            @Override
+            public QueueConfig lookupByPattern(@Nonnull Config staticConfig,
+                                               @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getQueueConfigs(),
+                        name, QueueConfig.class);
+            }
+
             @Override
             public Map<String, QueueConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getQueueConfigs();
@@ -115,6 +139,14 @@ public final class ConfigSearch {
             @Override
             public ListConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getListConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public ListConfig lookupByPattern(@Nonnull Config staticConfig,
+                                              @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getListConfigs(),
+                        name, ListConfig.class);
             }
 
             @Override
@@ -133,6 +165,14 @@ public final class ConfigSearch {
                 return staticConfig.getSetConfig(name);
             }
 
+            @Nullable
+            @Override
+            public SetConfig lookupByPattern(@Nonnull Config staticConfig,
+                                             @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getSetConfigs(),
+                        name, SetConfig.class);
+            }
+
             @Override
             public Map<String, SetConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getSetConfigs();
@@ -147,6 +187,14 @@ public final class ConfigSearch {
             @Override
             public MultiMapConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getMultiMapConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public MultiMapConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                  @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getMultiMapConfigs(),
+                        name, MultiMapConfig.class);
             }
 
             @Override
@@ -166,6 +214,14 @@ public final class ConfigSearch {
                 return staticConfig.getReplicatedMapConfig(name);
             }
 
+            @Nullable
+            @Override
+            public ReplicatedMapConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                       @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getReplicatedMapConfigs(),
+                        name, ReplicatedMapConfig.class);
+            }
+
             @Override
             public Map<String, ReplicatedMapConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getReplicatedMapConfigs();
@@ -182,6 +238,14 @@ public final class ConfigSearch {
                 return staticConfig.getRingbufferConfig(name);
             }
 
+            @Nullable
+            @Override
+            public RingbufferConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                    @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getRingbufferConfigs(),
+                        name, RingbufferConfig.class);
+            }
+
             @Override
             public Map<String, RingbufferConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getRingbufferConfigs();
@@ -196,6 +260,14 @@ public final class ConfigSearch {
             @Override
             public TopicConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getTopicConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public TopicConfig lookupByPattern(@Nonnull Config staticConfig,
+                                               @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getTopicConfigs(),
+                        name, TopicConfig.class);
             }
 
             @Override
@@ -215,6 +287,14 @@ public final class ConfigSearch {
                 return staticConfig.getReliableTopicConfig(name);
             }
 
+            @Nullable
+            @Override
+            public ReliableTopicConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                       @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getReliableTopicConfigs(),
+                        name, ReliableTopicConfig.class);
+            }
+
             @Override
             public Map<String, ReliableTopicConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getReliableTopicConfigs();
@@ -229,6 +309,14 @@ public final class ConfigSearch {
             @Override
             public ExecutorConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getExecutorConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public ExecutorConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                  @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getExecutorConfigs(),
+                        name, ExecutorConfig.class);
             }
 
             @Override
@@ -248,6 +336,15 @@ public final class ConfigSearch {
                 return staticConfig.getDurableExecutorConfig(name);
             }
 
+            @Nullable
+            @Override
+            public DurableExecutorConfig lookupByPattern(
+                    @Nonnull Config staticConfig,
+                    @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getDurableExecutorConfigs(),
+                        name, DurableExecutorConfig.class);
+            }
+
             @Override
             public Map<String, DurableExecutorConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getDurableExecutorConfigs();
@@ -263,6 +360,15 @@ public final class ConfigSearch {
             @Override
             public ScheduledExecutorConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getScheduledExecutorConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public ScheduledExecutorConfig lookupByPattern(
+                    @Nonnull Config staticConfig,
+                    @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getScheduledExecutorConfigs(),
+                        name, ScheduledExecutorConfig.class);
             }
 
             @Override
@@ -282,6 +388,15 @@ public final class ConfigSearch {
                 return staticConfig.getCardinalityEstimatorConfig(name);
             }
 
+            @Nullable
+            @Override
+            public CardinalityEstimatorConfig lookupByPattern(
+                    @Nonnull Config staticConfig,
+                    @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getCardinalityEstimatorConfigs(),
+                        name, CardinalityEstimatorConfig.class);
+            }
+
             @Override
             public Map<String, CardinalityEstimatorConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getCardinalityEstimatorConfigs();
@@ -297,6 +412,15 @@ public final class ConfigSearch {
             @Override
             public FlakeIdGeneratorConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getFlakeIdGeneratorConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public FlakeIdGeneratorConfig lookupByPattern(
+                    @Nonnull Config staticConfig,
+                    @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getFlakeIdGeneratorConfigs(),
+                        name, FlakeIdGeneratorConfig.class);
             }
 
             @Override
@@ -315,6 +439,14 @@ public final class ConfigSearch {
                 return staticConfig.getPNCounterConfig(name);
             }
 
+            @Nullable
+            @Override
+            public PNCounterConfig lookupByPattern(@Nonnull Config staticConfig,
+                                                   @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getPNCounterConfigs(),
+                        name, PNCounterConfig.class);
+            }
+
             @Override
             public Map<String, PNCounterConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                 return staticConfig.getPNCounterConfigs();
@@ -331,6 +463,15 @@ public final class ConfigSearch {
             @Override
             public ExternalDataStoreConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
                 return staticConfig.getExternalDataStoreConfig(name);
+            }
+
+            @Nullable
+            @Override
+            public ExternalDataStoreConfig lookupByPattern(
+                    @Nonnull Config staticConfig,
+                    @Nonnull ConfigPatternMatcher configPatternMatcher, @Nonnull String name) {
+                return ConfigUtils.lookupByPattern(configPatternMatcher, staticConfig.getExternalDataStoreConfigs(),
+                        name, ExternalDataStoreConfig.class);
             }
 
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/ConfigSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/ConfigSupplier.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.dynamicconfig.search;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigPatternMatcher;
 import com.hazelcast.internal.dynamicconfig.ConfigurationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -51,6 +52,11 @@ public interface ConfigSupplier<T extends IdentifiedDataSerializable> {
      */
     @Nullable
     T getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name);
+
+    @Nullable
+    T lookupByPattern(@Nonnull Config staticConfig,
+                      @Nonnull ConfigPatternMatcher configPatternMatcher,
+                      @Nonnull String name);
 
     /**
      * Get all static configs for the given config type.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/DynamicFirstSearcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/DynamicFirstSearcher.java
@@ -22,9 +22,7 @@ import com.hazelcast.internal.dynamicconfig.ConfigurationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
-import java.util.Map;
 
-import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
 class DynamicFirstSearcher<T extends IdentifiedDataSerializable> implements Searcher<T> {
@@ -42,10 +40,9 @@ class DynamicFirstSearcher<T extends IdentifiedDataSerializable> implements Sear
     @Override
     public T getConfig(@Nonnull String name, String fallbackName, @Nonnull ConfigSupplier<T> configSupplier) {
         String baseName = getBaseName(name);
-        Map<String, T> staticCacheConfigs = configSupplier.getStaticConfigs(staticConfig);
         T config = configSupplier.getDynamicConfig(configurationService, baseName);
         if (config == null) {
-            config = lookupByPattern(configPatternMatcher, staticCacheConfigs, baseName);
+            config = configSupplier.lookupByPattern(staticConfig, configPatternMatcher, baseName);
         }
         if (config == null) {
             config = configSupplier.getStaticConfig(staticConfig, fallbackName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/StaticFirstSearcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/StaticFirstSearcher.java
@@ -22,9 +22,7 @@ import com.hazelcast.internal.dynamicconfig.ConfigurationService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
-import java.util.Map;
 
-import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
 class StaticFirstSearcher<T extends IdentifiedDataSerializable> implements Searcher<T> {
@@ -42,8 +40,7 @@ class StaticFirstSearcher<T extends IdentifiedDataSerializable> implements Searc
     @Override
     public T getConfig(@Nonnull String name, String fallbackName, @Nonnull ConfigSupplier<T> configSupplier) {
         String baseName = getBaseName(name);
-        Map<String, T> staticCacheConfigs = configSupplier.getStaticConfigs(staticConfig);
-        T config = lookupByPattern(configPatternMatcher, staticCacheConfigs, baseName);
+        T config = configSupplier.lookupByPattern(staticConfig, configPatternMatcher, baseName);
         if (config == null) {
             config = configSupplier.getDynamicConfig(configurationService, baseName);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
@@ -83,7 +83,8 @@ public class NodeQueryCacheConfigurator extends AbstractQueryCacheConfigurator {
             allQueryCacheConfigs.put(queryCacheConfig.getName(), queryCacheConfig);
         }
 
-        return ConfigUtils.lookupByPattern(config.getConfigPatternMatcher(), allQueryCacheConfigs, cacheName);
+        return ConfigUtils.lookupByPattern(config.getConfigPatternMatcher(), allQueryCacheConfigs, cacheName,
+                QueryCacheConfig.class);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientNearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientNearCacheConfigTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -47,8 +48,8 @@ public class ClientNearCacheConfigTest {
         final NearCacheConfig mapFoo = clientConfig.getNearCacheConfig("mapFoo");
         final NearCacheConfig mapStudentFoo = clientConfig.getNearCacheConfig("mapStudentFoo");
 
-        assertEquals(genericNearCacheConfig.getMaxIdleSeconds(), mapFoo.getMaxIdleSeconds());
-        assertEquals(specificNearCacheConfig.getMaxIdleSeconds(), mapStudentFoo.getMaxIdleSeconds());
+        assertEquals(genericNearCacheConfig, mapFoo);
+        assertEquals(specificNearCacheConfig, mapStudentFoo);
     }
 
     @Test
@@ -67,8 +68,8 @@ public class ClientNearCacheConfigTest {
         final NearCacheConfig mapFoo = clientConfig.getNearCacheConfig("fooMap");
         final NearCacheConfig mapStudentFoo = clientConfig.getNearCacheConfig("fooMapStudent");
 
-        assertEquals(genericNearCacheConfig.getMaxIdleSeconds(), mapFoo.getMaxIdleSeconds());
-        assertEquals(specificNearCacheConfig.getMaxIdleSeconds(), mapStudentFoo.getMaxIdleSeconds());
+        assertEquals(genericNearCacheConfig, mapFoo);
+        assertEquals(specificNearCacheConfig, mapStudentFoo);
     }
 
     @Test
@@ -87,8 +88,10 @@ public class ClientNearCacheConfigTest {
         final NearCacheConfig mapFoo = clientConfig.getNearCacheConfig("mapFooBar");
         final NearCacheConfig mapStudentFoo = clientConfig.getNearCacheConfig("mapStudentFooBar");
 
-        assertEquals(genericNearCacheConfig.getMaxIdleSeconds(), mapFoo.getMaxIdleSeconds());
-        assertEquals(specificNearCacheConfig.getMaxIdleSeconds(), mapStudentFoo.getMaxIdleSeconds());
+        assertEquals(genericNearCacheConfig, mapFoo);
+        assertEquals(specificNearCacheConfig, mapStudentFoo);
     }
-
+    public static void assertEquals(NearCacheConfig expected, NearCacheConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientNearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientNearCacheConfigTest.java
@@ -36,17 +36,19 @@ public class ClientNearCacheConfigTest {
         final ClientConfig clientConfig = new ClientConfig();
         final NearCacheConfig genericNearCacheConfig = new NearCacheConfig();
         genericNearCacheConfig.setName("map*");
+        genericNearCacheConfig.setMaxIdleSeconds(1337);
         clientConfig.addNearCacheConfig(genericNearCacheConfig);
 
         final NearCacheConfig specificNearCacheConfig = new NearCacheConfig();
         specificNearCacheConfig.setName("mapStudent*");
+        genericNearCacheConfig.setMaxIdleSeconds(1234);
         clientConfig.addNearCacheConfig(specificNearCacheConfig);
 
         final NearCacheConfig mapFoo = clientConfig.getNearCacheConfig("mapFoo");
         final NearCacheConfig mapStudentFoo = clientConfig.getNearCacheConfig("mapStudentFoo");
 
-        assertEquals(genericNearCacheConfig, mapFoo);
-        assertEquals(specificNearCacheConfig, mapStudentFoo);
+        assertEquals(genericNearCacheConfig.getMaxIdleSeconds(), mapFoo.getMaxIdleSeconds());
+        assertEquals(specificNearCacheConfig.getMaxIdleSeconds(), mapStudentFoo.getMaxIdleSeconds());
     }
 
     @Test
@@ -54,35 +56,39 @@ public class ClientNearCacheConfigTest {
         final ClientConfig clientConfig = new ClientConfig();
         final NearCacheConfig genericNearCacheConfig = new NearCacheConfig();
         genericNearCacheConfig.setName("*Map");
+        genericNearCacheConfig.setMaxIdleSeconds(1337);
         clientConfig.addNearCacheConfig(genericNearCacheConfig);
 
         final NearCacheConfig specificNearCacheConfig = new NearCacheConfig();
         specificNearCacheConfig.setName("*MapStudent");
+        genericNearCacheConfig.setMaxIdleSeconds(1234);
         clientConfig.addNearCacheConfig(specificNearCacheConfig);
 
         final NearCacheConfig mapFoo = clientConfig.getNearCacheConfig("fooMap");
         final NearCacheConfig mapStudentFoo = clientConfig.getNearCacheConfig("fooMapStudent");
 
-        assertEquals(genericNearCacheConfig, mapFoo);
-        assertEquals(specificNearCacheConfig, mapStudentFoo);
+        assertEquals(genericNearCacheConfig.getMaxIdleSeconds(), mapFoo.getMaxIdleSeconds());
+        assertEquals(specificNearCacheConfig.getMaxIdleSeconds(), mapStudentFoo.getMaxIdleSeconds());
     }
 
     @Test
     public void testSpecificNearCacheConfig_whenAsteriskInTheMiddle() {
         final ClientConfig clientConfig = new ClientConfig();
         final NearCacheConfig genericNearCacheConfig = new NearCacheConfig();
+        genericNearCacheConfig.setMaxIdleSeconds(1337);
         genericNearCacheConfig.setName("map*Bar");
         clientConfig.addNearCacheConfig(genericNearCacheConfig);
 
         final NearCacheConfig specificNearCacheConfig = new NearCacheConfig();
         specificNearCacheConfig.setName("mapStudent*Bar");
+        genericNearCacheConfig.setMaxIdleSeconds(1234);
         clientConfig.addNearCacheConfig(specificNearCacheConfig);
 
         final NearCacheConfig mapFoo = clientConfig.getNearCacheConfig("mapFooBar");
         final NearCacheConfig mapStudentFoo = clientConfig.getNearCacheConfig("mapStudentFooBar");
 
-        assertEquals(genericNearCacheConfig, mapFoo);
-        assertEquals(specificNearCacheConfig, mapStudentFoo);
+        assertEquals(genericNearCacheConfig.getMaxIdleSeconds(), mapFoo.getMaxIdleSeconds());
+        assertEquals(specificNearCacheConfig.getMaxIdleSeconds(), mapStudentFoo.getMaxIdleSeconds());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
@@ -27,7 +27,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
@@ -36,7 +36,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testNearCacheConfigWithoutWildcard() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("someNearCache");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("someNearCache").setMaxIdleSeconds(1337);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -45,49 +45,52 @@ public class MatchingPointConfigPatternMatcherTest {
         assertEquals(nearCacheConfig, config.getNearCacheConfig("someNearCache"));
 
         // non-matching name
-        assertNotEquals(nearCacheConfig, config.getNearCacheConfig("doesNotExist"));
+        assertNull(config.getNearCacheConfig("doesNotExist"));
         // non-matching case
-        assertNotEquals(nearCacheConfig, config.getNearCacheConfig("SomeNearCache"));
+        assertNull(config.getNearCacheConfig("SomeNearCache"));
     }
 
     @Test
     public void testNearCacheConfigWildcard1() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("*hazelcast.test.myNearCache");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("*hazelcast.test.myNearCache").setMaxIdleSeconds(13);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig, config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
+        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
     }
 
     @Test
     public void testNearCacheConfigWildcard2() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("com.hazelcast.*.myNearCache");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("com.hazelcast.*.myNearCache").setMaxIdleSeconds(14);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig, config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
+        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
     }
 
     @Test
     public void testNearCacheConfigWildcard3() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("com.hazelcast.test.*");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("com.hazelcast.test.*").setMaxIdleSeconds(15);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig, config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
+        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
     }
 
     @Test
     public void testNearCacheConfigWildcardMultipleConfigs() {
-        NearCacheConfig nearCacheConfig1 = new NearCacheConfig().setName("com.hazelcast.*");
-        NearCacheConfig nearCacheConfig2 = new NearCacheConfig().setName("com.hazelcast.test.*");
-        NearCacheConfig nearCacheConfig3 = new NearCacheConfig().setName("com.hazelcast.test.sub.*");
+        NearCacheConfig nearCacheConfig1 = new NearCacheConfig().setName("com.hazelcast.*").setMaxIdleSeconds(1_001);
+        NearCacheConfig nearCacheConfig2 = new NearCacheConfig().setName("com.hazelcast.test.*").setMaxIdleSeconds(1_002);
+        NearCacheConfig nearCacheConfig3 = new NearCacheConfig().setName("com.hazelcast.test.sub.*").setMaxIdleSeconds(1_003);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -96,9 +99,12 @@ public class MatchingPointConfigPatternMatcherTest {
         config.addNearCacheConfig(nearCacheConfig3);
 
         // we should get the best matching result
-        assertEquals(nearCacheConfig1, config.getNearCacheConfig("com.hazelcast.myNearCache"));
-        assertEquals(nearCacheConfig2, config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
-        assertEquals(nearCacheConfig3, config.getNearCacheConfig("com.hazelcast.test.sub.myNearCache"));
+        assertEquals(nearCacheConfig1.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig2.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig3.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.test.sub.myNearCache").getMaxIdleSeconds());
     }
 
     @Test(expected = InvalidConfigurationException.class)
@@ -152,19 +158,20 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testNearCacheConfigWildcardOnly() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("*");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig().setName("*").setMaxIdleSeconds(127);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig, config.getNearCacheConfig("com.hazelcast.myNearCache"));
+        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.myNearCache").getMaxIdleSeconds());
     }
 
     @Test
     public void testNearCacheConfigWildcardOnlyMultipleConfigs() {
-        NearCacheConfig nearCacheConfig1 = new NearCacheConfig().setName("*");
-        NearCacheConfig nearCacheConfig2 = new NearCacheConfig().setName("com.hazelcast.*");
+        NearCacheConfig nearCacheConfig1 = new NearCacheConfig().setName("*").setMaxIdleSeconds(11);
+        NearCacheConfig nearCacheConfig2 = new NearCacheConfig().setName("com.hazelcast.*").setMaxIdleSeconds(12);
 
         ClientConfig config = new ClientConfig();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -172,6 +179,7 @@ public class MatchingPointConfigPatternMatcherTest {
         config.addNearCacheConfig(nearCacheConfig2);
 
         // we should get the best matching result
-        assertEquals(nearCacheConfig2, config.getNearCacheConfig("com.hazelcast.myNearCache"));
+        assertEquals(nearCacheConfig2.getMaxIdleSeconds(),
+                config.getNearCacheConfig("com.hazelcast.myNearCache").getMaxIdleSeconds());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
@@ -17,7 +17,9 @@
 package com.hazelcast.client.config;
 
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -26,7 +28,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -57,8 +59,8 @@ public class MatchingPointConfigPatternMatcherTest {
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig,
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
     }
 
     @Test
@@ -69,8 +71,8 @@ public class MatchingPointConfigPatternMatcherTest {
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig,
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
     }
 
     @Test
@@ -81,8 +83,8 @@ public class MatchingPointConfigPatternMatcherTest {
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig,
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
     }
 
     @Test
@@ -98,12 +100,12 @@ public class MatchingPointConfigPatternMatcherTest {
         config.addNearCacheConfig(nearCacheConfig3);
 
         // we should get the best matching result
-        assertEquals(nearCacheConfig1.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.myNearCache").getMaxIdleSeconds());
-        assertEquals(nearCacheConfig2.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.test.myNearCache").getMaxIdleSeconds());
-        assertEquals(nearCacheConfig3.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.test.sub.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig1,
+                config.getNearCacheConfig("com.hazelcast.myNearCache"));
+        assertEquals(nearCacheConfig2,
+                config.getNearCacheConfig("com.hazelcast.test.myNearCache"));
+        assertEquals(nearCacheConfig3,
+                config.getNearCacheConfig("com.hazelcast.test.sub.myNearCache"));
     }
 
     @Test(expected = InvalidConfigurationException.class)
@@ -163,8 +165,8 @@ public class MatchingPointConfigPatternMatcherTest {
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addNearCacheConfig(nearCacheConfig);
 
-        assertEquals(nearCacheConfig.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig,
+                config.getNearCacheConfig("com.hazelcast.myNearCache"));
     }
 
     @Test
@@ -178,7 +180,17 @@ public class MatchingPointConfigPatternMatcherTest {
         config.addNearCacheConfig(nearCacheConfig2);
 
         // we should get the best matching result
-        assertEquals(nearCacheConfig2.getMaxIdleSeconds(),
-                config.getNearCacheConfig("com.hazelcast.myNearCache").getMaxIdleSeconds());
+        assertEquals(nearCacheConfig2,
+                config.getNearCacheConfig("com.hazelcast.myNearCache"));
+    }
+
+    public static void assertEquals(MapConfig expected, MapConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
+    }
+    public static void assertEquals(QueueConfig expected, QueueConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
+    }
+    public static void assertEquals(NearCacheConfig expected, NearCacheConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -49,7 +49,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static com.hazelcast.internal.config.AliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom;
-import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
+import static com.hazelcast.internal.config.ConfigUtils.lookupByPatternWithoutCloning;
 import static java.text.MessageFormat.format;
 import static java.util.Collections.singletonMap;
 import static org.codehaus.groovy.runtime.InvokerHelper.asList;
@@ -172,8 +172,8 @@ public class ConfigCompatibilityChecker {
         configNames.addAll(configs2.keySet());
 
         for (String name : configNames) {
-            T config1 = lookupByPattern(c1.getConfigPatternMatcher(), configs1, name);
-            T config2 = lookupByPattern(c2.getConfigPatternMatcher(), configs2, name);
+            T config1 = lookupByPatternWithoutCloning(c1.getConfigPatternMatcher(), configs1, name);
+            T config2 = lookupByPatternWithoutCloning(c2.getConfigPatternMatcher(), configs2, name);
             if (config1 != null && config2 != null && !checker.check(config1, config2)) {
                 throw new HazelcastException(format("Incompatible " + type + " config :\n{0}\n vs \n{1}", config1, config2));
             }

--- a/hazelcast/src/test/java/com/hazelcast/config/MatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MatchingPointConfigPatternMatcherTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -33,7 +33,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWithoutWildcard() {
-        QueueConfig queueConfig = new QueueConfig().setName("someQueue");
+        QueueConfig queueConfig = new QueueConfig().setName("someQueue").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -50,7 +50,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWildcardDocumentationExample1() {
-        QueueConfig queueConfig = new QueueConfig().setName("*hazelcast.test.myQueue");
+        QueueConfig queueConfig = new QueueConfig().setName("*hazelcast.test.myQueue").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -61,7 +61,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWildcardDocumentationExample2() {
-        QueueConfig queueConfig = new QueueConfig().setName("com.hazelcast.*.myQueue");
+        QueueConfig queueConfig = new QueueConfig().setName("com.hazelcast.*.myQueue").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -72,7 +72,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWildcard() {
-        QueueConfig queueConfig = new QueueConfig().setName("abc*");
+        QueueConfig queueConfig = new QueueConfig().setName("abc*").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -84,7 +84,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWithoutWildcard() {
-        MapConfig mapConfig = new MapConfig().setName("someMap");
+        MapConfig mapConfig = new MapConfig().setName("someMap").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -101,7 +101,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample1() {
-        MapConfig mapConfig = new MapConfig().setName("com.hazelcast.test.*");
+        MapConfig mapConfig = new MapConfig().setName("com.hazelcast.test.*").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -112,7 +112,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample2() {
-        MapConfig mapConfig = new MapConfig().setName("com.hazel*");
+        MapConfig mapConfig = new MapConfig().setName("com.hazel*").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -123,7 +123,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample3() {
-        MapConfig mapConfig = new MapConfig().setName("*.test.myMap");
+        MapConfig mapConfig = new MapConfig().setName("*.test.myMap").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -134,7 +134,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample4() {
-        MapConfig mapConfig = new MapConfig().setName("com.*test.myMap");
+        MapConfig mapConfig = new MapConfig().setName("com.*test.myMap").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -145,9 +145,9 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardMultipleConfigs() {
-        MapConfig mapConfig1 = new MapConfig().setName("com.hazelcast.*");
-        MapConfig mapConfig2 = new MapConfig().setName("com.hazelcast.test.*");
-        MapConfig mapConfig3 = new MapConfig().setName("com.hazelcast.test.sub.*");
+        MapConfig mapConfig1 = new MapConfig().setName("com.hazelcast.*").setMaxIdleSeconds(12);
+        MapConfig mapConfig2 = new MapConfig().setName("com.hazelcast.test.*").setMaxIdleSeconds(13);
+        MapConfig mapConfig3 = new MapConfig().setName("com.hazelcast.test.sub.*").setMaxIdleSeconds(14);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -163,8 +163,8 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testMapConfigWildcardMultipleAmbiguousConfigs() {
-        MapConfig mapConfig1 = new MapConfig().setName("com.hazelcast*");
-        MapConfig mapConfig2 = new MapConfig().setName("*com.hazelcast");
+        MapConfig mapConfig1 = new MapConfig().setName("com.hazelcast*").setMaxIdleSeconds(1234);
+        MapConfig mapConfig2 = new MapConfig().setName("*com.hazelcast").setMaxIdleSeconds(1235);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -176,7 +176,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardStartsWith() {
-        MapConfig mapConfig = new MapConfig().setName("bc*");
+        MapConfig mapConfig = new MapConfig().setName("bc*").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -193,7 +193,7 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardEndsWith() {
-        MapConfig mapConfig = new MapConfig().setName("*ab");
+        MapConfig mapConfig = new MapConfig().setName("*ab").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
@@ -210,12 +210,19 @@ public class MatchingPointConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardOnly() {
-        MapConfig mapConfig = new MapConfig().setName("*");
+        MapConfig mapConfig = new MapConfig().setName("*").setMaxIdleSeconds(1234);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new MatchingPointConfigPatternMatcher());
         config.addMapConfig(mapConfig);
 
         assertEquals(mapConfig, config.getMapConfig("com.hazelcast.myMap"));
+    }
+
+    public static void assertEquals(MapConfig expected, MapConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
+    }
+    public static void assertEquals(QueueConfig expected, QueueConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
@@ -43,29 +44,29 @@ public class RegexConfigPatternMatcherTest {
         config.addQueueConfig(queueConfig);
 
         // non-matching name
-        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("doesNotExist").getMaxSize());
+        assertNotEquals(queueConfig, config.getQueueConfig("doesNotExist"));
         // non-matching name (starts with)
-        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("_someQueue").getMaxSize());
+        assertNotEquals(queueConfig, config.getQueueConfig("_someQueue"));
         // non-matching name (ends with)
-        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("someQueue_").getMaxSize());
+        assertNotEquals(queueConfig, config.getQueueConfig("someQueue_"));
         // non-matching case
-        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("SomeQueue").getMaxSize());
+        assertNotEquals(queueConfig, config.getQueueConfig("SomeQueue"));
 
         // TODO possible breaking change; now adding this as the first option makes rest of the options match
-        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("someQueue").getMaxSize());
-        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("someQueue@foo").getMaxSize());
+        assertEquals(queueConfig, config.getQueueConfig("someQueue"));
+        assertEquals(queueConfig, config.getQueueConfig("someQueue@foo"));
     }
 
     @Test
     public void testQueueConfigRegexContains() {
-        QueueConfig queueConfig = new QueueConfig().setName("abc").setMaxSize(133);
+        QueueConfig queueConfig = new QueueConfig().setName(".*abc.*").setMaxSize(133);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addQueueConfig(queueConfig);
 
-        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("abcD").getMaxSize());
-        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("abDD").getMaxSize());
+        assertEquals(queueConfig, config.getQueueConfig("abcD"));
+        assertNotEquals(queueConfig, config.getQueueConfig("abDD"));
     }
 
     @Test
@@ -76,8 +77,8 @@ public class RegexConfigPatternMatcherTest {
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addQueueConfig(queueConfig);
 
-        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("abcDe").getMaxSize());
-        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("bcDe").getMaxSize());
+        assertEquals(queueConfig, config.getQueueConfig("abcDe"));
+        assertNotEquals(queueConfig, config.getQueueConfig("bcDe"));
     }
 
     @Test
@@ -89,16 +90,16 @@ public class RegexConfigPatternMatcherTest {
         config.addMapConfig(mapConfig);
 
         // non-matching name
-        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("doesNotExist").getBackupCount());
+        assertNotEquals(mapConfig, config.getMapConfig("doesNotExist"));
         // non-matching name (starts with)
-        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("_someMap").getBackupCount());
+        assertNotEquals(mapConfig, config.getMapConfig("_someMap"));
         // non-matching name (ends with)
-        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("someMap_").getBackupCount());
+        assertNotEquals(mapConfig, config.getMapConfig("someMap_"));
         // non-matching case
-        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("SomeMap").getBackupCount());
+        assertNotEquals(mapConfig, config.getMapConfig("SomeMap"));
 
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("someMap").getBackupCount());
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("someMap@foo").getBackupCount());
+        assertEquals(mapConfig, config.getMapConfig("someMap"));
+        assertEquals(mapConfig, config.getMapConfig("someMap@foo"));
     }
 
     @Test
@@ -110,34 +111,34 @@ public class RegexConfigPatternMatcherTest {
         config.addMapConfig(mapConfig);
 
         // non-matching name (starts with)
-        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("_SomeMap").getBackupCount());
+        assertNotEquals(mapConfig, config.getMapConfig("_SomeMap"));
         // non-matching name (ends with)
-        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("SomeMap_").getBackupCount());
+        assertNotEquals(mapConfig, config.getMapConfig("SomeMap_"));
 
         // case insensitive matching
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("SomeMap").getBackupCount());
+        assertEquals(mapConfig, config.getMapConfig("SomeMap"));
     }
 
     @Test
     public void testMapConfigContains() {
-        MapConfig mapConfig = new MapConfig().setName("bc").setBackupCount(5);
+        MapConfig mapConfig = new MapConfig().setName("bc.*").setBackupCount(5);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addMapConfig(mapConfig);
 
         // we should match this
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("bc.xyz").getBackupCount());
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("bc.xyz@foo").getBackupCount());
+        assertEquals(mapConfig, config.getMapConfig("bc.xyz"));
+        assertEquals(mapConfig, config.getMapConfig("bc.xyz@foo"));
 
         // we should also match this (contains)
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("abc.xyz").getBackupCount());
-        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("abc.xyz@foo").getBackupCount());
+        assertEquals(mapConfig, config.getMapConfig("abc.xyz"));
+        assertEquals(mapConfig, config.getMapConfig("abc.xyz@foo"));
     }
 
     @Test
     public void testMapConfigStartsWith() {
-        MapConfig mapConfig = new MapConfig().setName("^abc");
+        MapConfig mapConfig = new MapConfig().setName("^abc").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
@@ -158,7 +159,7 @@ public class RegexConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigEndsWith() {
-        MapConfig mapConfig = new MapConfig().setName("bc$");
+        MapConfig mapConfig = new MapConfig().setName("bc$").setMaxIdleSeconds(137);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
@@ -175,5 +176,12 @@ public class RegexConfigPatternMatcherTest {
         assertNotEquals(mapConfig, config.getMapConfig("abcD@foo"));
         assertNotEquals(mapConfig, config.getMapConfig("xyz.abcD"));
         assertNotEquals(mapConfig, config.getMapConfig("xyz.abcD@foo"));
+    }
+
+    public static void assertEquals(MapConfig expected, MapConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
+    }
+    public static void assertEquals(QueueConfig expected, QueueConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
@@ -27,9 +27,7 @@ import org.junit.runner.RunWith;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})

--- a/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -35,102 +36,103 @@ public class RegexConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWithoutWildcard() {
-        QueueConfig queueConfig = new QueueConfig().setName("^someQueue$");
+        QueueConfig queueConfig = new QueueConfig().setName("^someQueue$").setMaxSize(133);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addQueueConfig(queueConfig);
 
-        assertEquals(queueConfig, config.getQueueConfig("someQueue"));
-        assertEquals(queueConfig, config.getQueueConfig("someQueue@foo"));
-
         // non-matching name
-        assertNotEquals(queueConfig, config.getQueueConfig("doesNotExist"));
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("doesNotExist").getMaxSize());
         // non-matching name (starts with)
-        assertNotEquals(queueConfig, config.getQueueConfig("_someQueue"));
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("_someQueue").getMaxSize());
         // non-matching name (ends with)
-        assertNotEquals(queueConfig, config.getQueueConfig("someQueue_"));
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("someQueue_").getMaxSize());
         // non-matching case
-        assertNotEquals(queueConfig, config.getQueueConfig("SomeQueue"));
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("SomeQueue").getMaxSize());
+
+        // TODO possible breaking change; now adding this as the first option makes rest of the options match
+        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("someQueue").getMaxSize());
+        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("someQueue@foo").getMaxSize());
     }
 
     @Test
     public void testQueueConfigRegexContains() {
-        QueueConfig queueConfig = new QueueConfig().setName("abc");
+        QueueConfig queueConfig = new QueueConfig().setName("abc").setMaxSize(133);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addQueueConfig(queueConfig);
 
-        assertEquals(queueConfig, config.getQueueConfig("abcD"));
-        assertNotEquals(queueConfig, config.getQueueConfig("abDD"));
+        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("abcD").getMaxSize());
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("abDD").getMaxSize());
     }
 
     @Test
     public void testQueueConfigRegexStartsWith() {
-        QueueConfig queueConfig = new QueueConfig().setName("^abc");
+        QueueConfig queueConfig = new QueueConfig().setName("^abc").setMaxSize(133);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addQueueConfig(queueConfig);
 
-        assertEquals(queueConfig, config.getQueueConfig("abcDe"));
-        assertNotEquals(queueConfig, config.getQueueConfig("bcDe"));
+        assertEquals(queueConfig.getMaxSize(), config.getQueueConfig("abcDe").getMaxSize());
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("bcDe").getMaxSize());
     }
 
     @Test
     public void testMapConfigWithoutWildcard() {
-        MapConfig mapConfig = new MapConfig().setName("^someMap$");
+        MapConfig mapConfig = new MapConfig().setName("^someMap$").setBackupCount(4);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addMapConfig(mapConfig);
 
-        assertEquals(mapConfig, config.getMapConfig("someMap"));
-        assertEquals(mapConfig, config.getMapConfig("someMap@foo"));
-
         // non-matching name
-        assertNotEquals(mapConfig, config.getMapConfig("doesNotExist"));
+        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("doesNotExist").getBackupCount());
         // non-matching name (starts with)
-        assertNotEquals(mapConfig, config.getMapConfig("_someMap"));
+        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("_someMap").getBackupCount());
         // non-matching name (ends with)
-        assertNotEquals(mapConfig, config.getMapConfig("someMap_"));
+        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("someMap_").getBackupCount());
         // non-matching case
-        assertNotEquals(mapConfig, config.getMapConfig("SomeMap"));
+        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("SomeMap").getBackupCount());
+
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("someMap").getBackupCount());
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("someMap@foo").getBackupCount());
     }
 
     @Test
     public void testMapConfigCaseInsensitive() {
-        MapConfig mapConfig = new MapConfig().setName("^someMap$");
+        MapConfig mapConfig = new MapConfig().setName("^someMap$").setBackupCount(5);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher(Pattern.CASE_INSENSITIVE));
         config.addMapConfig(mapConfig);
 
-        // case insensitive matching
-        assertEquals(mapConfig, config.getMapConfig("SomeMap"));
-
         // non-matching name (starts with)
-        assertNotEquals(mapConfig, config.getMapConfig("_SomeMap"));
+        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("_SomeMap").getBackupCount());
         // non-matching name (ends with)
-        assertNotEquals(mapConfig, config.getMapConfig("SomeMap_"));
+        assertNotEquals(mapConfig.getBackupCount(), config.getMapConfig("SomeMap_").getBackupCount());
+
+        // case insensitive matching
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("SomeMap").getBackupCount());
     }
 
     @Test
     public void testMapConfigContains() {
-        MapConfig mapConfig = new MapConfig().setName("bc");
+        MapConfig mapConfig = new MapConfig().setName("bc").setBackupCount(5);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new RegexConfigPatternMatcher());
         config.addMapConfig(mapConfig);
 
         // we should match this
-        assertEquals(mapConfig, config.getMapConfig("bc.xyz"));
-        assertEquals(mapConfig, config.getMapConfig("bc.xyz@foo"));
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("bc.xyz").getBackupCount());
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("bc.xyz@foo").getBackupCount());
 
         // we should also match this (contains)
-        assertEquals(mapConfig, config.getMapConfig("abc.xyz"));
-        assertEquals(mapConfig, config.getMapConfig("abc.xyz@foo"));
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("abc.xyz").getBackupCount());
+        assertEquals(mapConfig.getBackupCount(), config.getMapConfig("abc.xyz@foo").getBackupCount());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/WildcardConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WildcardConfigPatternMatcherTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -33,7 +34,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWithoutWildcard() {
-        QueueConfig queueConfig = new QueueConfig().setName("someQueue");
+        QueueConfig queueConfig = new QueueConfig().setName("someQueue").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -43,14 +44,14 @@ public class WildcardConfigPatternMatcherTest {
         assertEquals(queueConfig, config.getQueueConfig("someQueue@foo"));
 
         // non-matching name
-        assertNotEquals(queueConfig, config.getQueueConfig("doesNotExist"));
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("doesNotExist").getMaxSize());
         // non-matching case
-        assertNotEquals(queueConfig, config.getQueueConfig("SomeQueue"));
+        assertNotEquals(queueConfig.getMaxSize(), config.getQueueConfig("SomeQueue").getMaxSize());
     }
 
     @Test
     public void testQueueConfigWildcardDocumentationExample1() {
-        QueueConfig queueConfig = new QueueConfig().setName("*hazelcast.test.myQueue");
+        QueueConfig queueConfig = new QueueConfig().setName("*hazelcast.test.myQueue").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -61,7 +62,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWildcardDocumentationExample2() {
-        QueueConfig queueConfig = new QueueConfig().setName("com.hazelcast.*.myQueue");
+        QueueConfig queueConfig = new QueueConfig().setName("com.hazelcast.*.myQueue").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -72,7 +73,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWildcard() {
-        QueueConfig queueConfig = new QueueConfig().setName("abc*");
+        QueueConfig queueConfig = new QueueConfig().setName("abc*").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -84,7 +85,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testQueueConfigWildcardSamePrefixAndSuffix() {
-        QueueConfig queueConfig = new QueueConfig().setName("abc*abc");
+        QueueConfig queueConfig = new QueueConfig().setName("abc*abc").setMaxSize(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -97,7 +98,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWithoutWildcard() {
-        MapConfig mapConfig = new MapConfig().setName("someMap");
+        MapConfig mapConfig = new MapConfig().setName("someMap").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -114,7 +115,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample1() {
-        MapConfig mapConfig = new MapConfig().setName("com.hazelcast.test.*");
+        MapConfig mapConfig = new MapConfig().setName("com.hazelcast.test.*").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -125,7 +126,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample2() {
-        MapConfig mapConfig = new MapConfig().setName("com.hazel*");
+        MapConfig mapConfig = new MapConfig().setName("com.hazel*").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -136,7 +137,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardDocumentationExample3() {
-        MapConfig mapConfig = new MapConfig().setName("*.test.myMap");
+        MapConfig mapConfig = new MapConfig().setName("*.test.myMap").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -158,9 +159,9 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testMapConfigWildcardMultipleAmbiguousConfigs() {
-        MapConfig mapConfig1 = new MapConfig().setName("com.hazelcast.*");
-        MapConfig mapConfig2 = new MapConfig().setName("com.hazelcast.test.*");
-        MapConfig mapConfig3 = new MapConfig().setName("com.hazelcast.test.sub.*");
+        MapConfig mapConfig1 = new MapConfig().setName("com.hazelcast.*").setMaxIdleSeconds(1337);
+        MapConfig mapConfig2 = new MapConfig().setName("com.hazelcast.test.*").setMaxIdleSeconds(1337);
+        MapConfig mapConfig3 = new MapConfig().setName("com.hazelcast.test.sub.*").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -173,7 +174,7 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardStartsWith() {
-        MapConfig mapConfig = new MapConfig().setName("bc*");
+        MapConfig mapConfig = new MapConfig().setName("bc*").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
@@ -207,12 +208,19 @@ public class WildcardConfigPatternMatcherTest {
 
     @Test
     public void testMapConfigWildcardOnly() {
-        MapConfig mapConfig = new MapConfig().setName("*");
+        MapConfig mapConfig = new MapConfig().setName("*").setMaxIdleSeconds(1337);
 
         Config config = new Config();
         config.setConfigPatternMatcher(new WildcardConfigPatternMatcher());
         config.addMapConfig(mapConfig);
 
         assertEquals(mapConfig, config.getMapConfig("com.hazelcast.myMap"));
+    }
+
+    public static void assertEquals(MapConfig expected, MapConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
+    }
+    public static void assertEquals(QueueConfig expected, QueueConfig actual) {
+        assertThat(actual).isEqualToIgnoringGivenFields(expected, "name");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/ConfigSearchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/ConfigSearchTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.FlakeIdGeneratorConfig;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -54,6 +55,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     private static final String STATIC_NAME = "my.custom.data.*";
     private static final String DYNAMIC_NAME = "my.custom.data.cache";
+    private static final int STATIC_BACKUP_COUNT = 2;
+    private static final int DYNAMIC_BACKUP_COUNT = 3;
 
     private HazelcastInstance hazelcastInstance;
 
@@ -75,7 +78,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testMapConfig_Static() {
-        TestCase<MapConfig> testCase = new TestCase<MapConfig>(new MapConfig(STATIC_NAME), new MapConfig(DYNAMIC_NAME), false) {
+        TestCase<MapConfig> testCase = new TestCase<MapConfig>(new MapConfig(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new MapConfig(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addMapConfig(this.staticConfig);
@@ -89,7 +93,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 MapConfig dataConfig = hazelcastInstance.getConfig().findMapConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -97,7 +101,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testMapConfig_Dynamic() {
-        TestCase<MapConfig> testCase = new TestCase<MapConfig>(new MapConfig(STATIC_NAME), new MapConfig(DYNAMIC_NAME), true) {
+        TestCase<MapConfig> testCase = new TestCase<MapConfig>(new MapConfig(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new MapConfig(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addMapConfig(this.staticConfig);
@@ -111,7 +116,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 MapConfig dataConfig = hazelcastInstance.getConfig().findMapConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -119,8 +124,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testCacheConfig_Static() {
-        TestCase<CacheSimpleConfig> testCase = new TestCase<CacheSimpleConfig>(new CacheSimpleConfig().setName(STATIC_NAME),
-                new CacheSimpleConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<CacheSimpleConfig> testCase = new TestCase<CacheSimpleConfig>(
+                new CacheSimpleConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new CacheSimpleConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addCacheConfig(this.staticConfig);
@@ -134,7 +140,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 CacheSimpleConfig dataConfig = hazelcastInstance.getConfig().findCacheConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -142,8 +148,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testCacheConfig_Dynamic() {
-        TestCase<CacheSimpleConfig> testCase = new TestCase<CacheSimpleConfig>(new CacheSimpleConfig().setName(STATIC_NAME),
-                new CacheSimpleConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<CacheSimpleConfig> testCase = new TestCase<CacheSimpleConfig>(
+                new CacheSimpleConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new CacheSimpleConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addCacheConfig(this.staticConfig);
@@ -157,7 +164,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 CacheSimpleConfig dataConfig = hazelcastInstance.getConfig().findCacheConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -165,8 +172,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testQueueConfig_Static() {
-        TestCase<QueueConfig> testCase = new TestCase<QueueConfig>(new QueueConfig().setName(STATIC_NAME),
-                new QueueConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<QueueConfig> testCase = new TestCase<QueueConfig>(
+                new QueueConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new QueueConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addQueueConfig(this.staticConfig);
@@ -180,7 +188,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 QueueConfig dataConfig = hazelcastInstance.getConfig().findQueueConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -188,8 +196,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testQueueConfig_Dynamic() {
-        TestCase<QueueConfig> testCase = new TestCase<QueueConfig>(new QueueConfig().setName(STATIC_NAME),
-                new QueueConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<QueueConfig> testCase = new TestCase<QueueConfig>(
+                new QueueConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new QueueConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addQueueConfig(this.staticConfig);
@@ -203,7 +212,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 QueueConfig dataConfig = hazelcastInstance.getConfig().findQueueConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -211,8 +220,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testListConfig_Static() {
-        TestCase<ListConfig> testCase = new TestCase<ListConfig>(new ListConfig().setName(STATIC_NAME),
-                new ListConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<ListConfig> testCase = new TestCase<ListConfig>(new ListConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new ListConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addListConfig(this.staticConfig);
@@ -226,7 +235,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ListConfig dataConfig = hazelcastInstance.getConfig().findListConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -234,8 +243,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testListConfig_Dynamic() {
-        TestCase<ListConfig> testCase = new TestCase<ListConfig>(new ListConfig().setName(STATIC_NAME),
-                new ListConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<ListConfig> testCase = new TestCase<ListConfig>(new ListConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new ListConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addListConfig(this.staticConfig);
@@ -249,7 +258,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ListConfig dataConfig = hazelcastInstance.getConfig().findListConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -257,8 +266,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testSetConfig_Static() {
-        TestCase<SetConfig> testCase = new TestCase<SetConfig>(new SetConfig().setName(STATIC_NAME),
-                new SetConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<SetConfig> testCase = new TestCase<SetConfig>(new SetConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new SetConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addSetConfig(this.staticConfig);
@@ -272,7 +281,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 SetConfig dataConfig = hazelcastInstance.getConfig().findSetConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -280,8 +289,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testSetConfig_Dynamic() {
-        TestCase<SetConfig> testCase = new TestCase<SetConfig>(new SetConfig().setName(STATIC_NAME),
-                new SetConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<SetConfig> testCase = new TestCase<SetConfig>(new SetConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new SetConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addSetConfig(this.staticConfig);
@@ -295,7 +304,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 SetConfig dataConfig = hazelcastInstance.getConfig().findSetConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -303,8 +312,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testMultiMapConfig_Static() {
-        TestCase<MultiMapConfig> testCase = new TestCase<MultiMapConfig>(new MultiMapConfig().setName(STATIC_NAME),
-                new MultiMapConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<MultiMapConfig> testCase = new TestCase<MultiMapConfig>(
+                new MultiMapConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new MultiMapConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addMultiMapConfig(this.staticConfig);
@@ -318,7 +328,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 MultiMapConfig dataConfig = hazelcastInstance.getConfig().findMultiMapConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -326,8 +336,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testMultiMapConfig_Dynamic() {
-        TestCase<MultiMapConfig> testCase = new TestCase<MultiMapConfig>(new MultiMapConfig().setName(STATIC_NAME),
-                new MultiMapConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<MultiMapConfig> testCase = new TestCase<MultiMapConfig>(
+                new MultiMapConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new MultiMapConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addMultiMapConfig(this.staticConfig);
@@ -341,7 +352,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 MultiMapConfig dataConfig = hazelcastInstance.getConfig().findMultiMapConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -349,8 +360,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testReplicatedMapConfig_Static() {
-        TestCase<ReplicatedMapConfig> testCase = new TestCase<ReplicatedMapConfig>(new ReplicatedMapConfig().setName(STATIC_NAME),
-                new ReplicatedMapConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<ReplicatedMapConfig> testCase = new TestCase<ReplicatedMapConfig>(
+                new ReplicatedMapConfig().setName(STATIC_NAME).setInMemoryFormat(InMemoryFormat.BINARY),
+                new ReplicatedMapConfig().setName(DYNAMIC_NAME).setInMemoryFormat(InMemoryFormat.NATIVE), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addReplicatedMapConfig(this.staticConfig);
@@ -364,7 +376,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ReplicatedMapConfig dataConfig = hazelcastInstance.getConfig().findReplicatedMapConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getInMemoryFormat(), equalTo(InMemoryFormat.BINARY));
             }
         };
         testTemplate(testCase);
@@ -372,8 +384,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testReplicatedMapConfig_Dynamic() {
-        TestCase<ReplicatedMapConfig> testCase = new TestCase<ReplicatedMapConfig>(new ReplicatedMapConfig().setName(STATIC_NAME),
-                new ReplicatedMapConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<ReplicatedMapConfig> testCase = new TestCase<ReplicatedMapConfig>(
+                new ReplicatedMapConfig().setName(STATIC_NAME).setInMemoryFormat(InMemoryFormat.BINARY),
+                new ReplicatedMapConfig().setName(DYNAMIC_NAME).setInMemoryFormat(InMemoryFormat.NATIVE), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addReplicatedMapConfig(this.staticConfig);
@@ -387,7 +400,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ReplicatedMapConfig dataConfig = hazelcastInstance.getConfig().findReplicatedMapConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getInMemoryFormat(), equalTo(InMemoryFormat.NATIVE));
             }
         };
         testTemplate(testCase);
@@ -395,8 +408,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testRingbufferConfig_Static() {
-        TestCase<RingbufferConfig> testCase = new TestCase<RingbufferConfig>(new RingbufferConfig().setName(STATIC_NAME),
-                new RingbufferConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<RingbufferConfig> testCase = new TestCase<RingbufferConfig>(
+                new RingbufferConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new RingbufferConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addRingBufferConfig(this.staticConfig);
@@ -410,7 +424,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 RingbufferConfig dataConfig = hazelcastInstance.getConfig().findRingbufferConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -418,8 +432,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testRingbufferConfig_Dynamic() {
-        TestCase<RingbufferConfig> testCase = new TestCase<RingbufferConfig>(new RingbufferConfig().setName(STATIC_NAME),
-                new RingbufferConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<RingbufferConfig> testCase = new TestCase<RingbufferConfig>(
+                new RingbufferConfig().setName(STATIC_NAME).setBackupCount(STATIC_BACKUP_COUNT),
+                new RingbufferConfig().setName(DYNAMIC_NAME).setBackupCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addRingBufferConfig(this.staticConfig);
@@ -433,7 +448,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 RingbufferConfig dataConfig = hazelcastInstance.getConfig().findRingbufferConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -441,8 +456,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testTopicConfig_Static() {
-        TestCase<TopicConfig> testCase = new TestCase<TopicConfig>(new TopicConfig().setName(STATIC_NAME),
-                new TopicConfig().setName(DYNAMIC_NAME), false) {
+        TestCase<TopicConfig> testCase = new TestCase<TopicConfig>(
+                new TopicConfig().setName(STATIC_NAME).setGlobalOrderingEnabled(!TopicConfig.DEFAULT_GLOBAL_ORDERING_ENABLED),
+                new TopicConfig().setName(DYNAMIC_NAME).setMultiThreadingEnabled(true), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addTopicConfig(this.staticConfig);
@@ -456,7 +472,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 TopicConfig dataConfig = hazelcastInstance.getConfig().findTopicConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.isGlobalOrderingEnabled(), equalTo(!TopicConfig.DEFAULT_GLOBAL_ORDERING_ENABLED));
+                assertThat(dataConfig.isMultiThreadingEnabled(), equalTo(false));
             }
         };
         testTemplate(testCase);
@@ -464,8 +481,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testTopicConfig_Dynamic() {
-        TestCase<TopicConfig> testCase = new TestCase<TopicConfig>(new TopicConfig().setName(STATIC_NAME),
-                new TopicConfig().setName(DYNAMIC_NAME), true) {
+        TestCase<TopicConfig> testCase = new TestCase<TopicConfig>(
+                new TopicConfig().setName(STATIC_NAME).setGlobalOrderingEnabled(!TopicConfig.DEFAULT_GLOBAL_ORDERING_ENABLED),
+                new TopicConfig().setName(DYNAMIC_NAME).setMultiThreadingEnabled(true), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addTopicConfig(this.staticConfig);
@@ -479,7 +497,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 TopicConfig dataConfig = hazelcastInstance.getConfig().findTopicConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.isGlobalOrderingEnabled(), equalTo(TopicConfig.DEFAULT_GLOBAL_ORDERING_ENABLED));
+                assertThat(dataConfig.isMultiThreadingEnabled(), equalTo(true));
             }
         };
         testTemplate(testCase);
@@ -487,8 +506,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testReliableTopicConfig_Static() {
-        TestCase<ReliableTopicConfig> testCase = new TestCase<ReliableTopicConfig>(new ReliableTopicConfig(STATIC_NAME),
-                new ReliableTopicConfig(DYNAMIC_NAME), false) {
+        TestCase<ReliableTopicConfig> testCase = new TestCase<ReliableTopicConfig>(
+                new ReliableTopicConfig(STATIC_NAME).setReadBatchSize(97),
+                new ReliableTopicConfig(DYNAMIC_NAME).setReadBatchSize(133), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addReliableTopicConfig(this.staticConfig);
@@ -502,7 +522,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ReliableTopicConfig dataConfig = hazelcastInstance.getConfig().findReliableTopicConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getReadBatchSize(), equalTo(97));
             }
         };
         testTemplate(testCase);
@@ -510,8 +530,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testReliableTopicConfig_Dynamic() {
-        TestCase<ReliableTopicConfig> testCase = new TestCase<ReliableTopicConfig>(new ReliableTopicConfig(STATIC_NAME),
-                new ReliableTopicConfig(DYNAMIC_NAME), true) {
+        TestCase<ReliableTopicConfig> testCase = new TestCase<ReliableTopicConfig>(
+                new ReliableTopicConfig(STATIC_NAME).setReadBatchSize(97),
+                new ReliableTopicConfig(DYNAMIC_NAME).setReadBatchSize(133), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addReliableTopicConfig(this.staticConfig);
@@ -525,7 +546,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ReliableTopicConfig dataConfig = hazelcastInstance.getConfig().findReliableTopicConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getReadBatchSize(), equalTo(133));
             }
         };
         testTemplate(testCase);
@@ -533,8 +554,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testExecutorConfig_Static() {
-        TestCase<ExecutorConfig> testCase = new TestCase<ExecutorConfig>(new ExecutorConfig(STATIC_NAME),
-                new ExecutorConfig(DYNAMIC_NAME), false) {
+        TestCase<ExecutorConfig> testCase = new TestCase<ExecutorConfig>(
+                new ExecutorConfig(STATIC_NAME).setQueueCapacity(97),
+                new ExecutorConfig(DYNAMIC_NAME).setQueueCapacity(133), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addExecutorConfig(this.staticConfig);
@@ -548,7 +570,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ExecutorConfig dataConfig = hazelcastInstance.getConfig().findExecutorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getQueueCapacity(), equalTo(97));
             }
         };
         testTemplate(testCase);
@@ -556,8 +578,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testExecutorConfig_Dynamic() {
-        TestCase<ExecutorConfig> testCase = new TestCase<ExecutorConfig>(new ExecutorConfig(STATIC_NAME),
-                new ExecutorConfig(DYNAMIC_NAME), true) {
+        TestCase<ExecutorConfig> testCase = new TestCase<ExecutorConfig>(
+                new ExecutorConfig(STATIC_NAME).setQueueCapacity(97),
+                new ExecutorConfig(DYNAMIC_NAME).setQueueCapacity(133), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addExecutorConfig(this.staticConfig);
@@ -571,7 +594,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ExecutorConfig dataConfig = hazelcastInstance.getConfig().findExecutorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getQueueCapacity(), equalTo(133));
             }
         };
         testTemplate(testCase);
@@ -580,8 +603,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
     @Test
     public void testDurableExecutorConfig_Static() {
         TestCase<DurableExecutorConfig> testCase = new TestCase<DurableExecutorConfig>(
-                new DurableExecutorConfig().setName(STATIC_NAME),
-                new DurableExecutorConfig().setName(DYNAMIC_NAME), false) {
+                new DurableExecutorConfig(STATIC_NAME).setDurability(STATIC_BACKUP_COUNT),
+                new DurableExecutorConfig(DYNAMIC_NAME).setDurability(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addDurableExecutorConfig(this.staticConfig);
@@ -595,7 +618,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 DurableExecutorConfig dataConfig = hazelcastInstance.getConfig().findDurableExecutorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getDurability(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -604,7 +627,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
     @Test
     public void testDurableExecutorConfig_Dynamic() {
         TestCase<DurableExecutorConfig> testCase = new TestCase<DurableExecutorConfig>(
-                new DurableExecutorConfig().setName(STATIC_NAME), new DurableExecutorConfig().setName(DYNAMIC_NAME), true) {
+                new DurableExecutorConfig(STATIC_NAME).setDurability(STATIC_BACKUP_COUNT),
+                new DurableExecutorConfig(DYNAMIC_NAME).setDurability(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addDurableExecutorConfig(this.staticConfig);
@@ -618,7 +642,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 DurableExecutorConfig dataConfig = hazelcastInstance.getConfig().findDurableExecutorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getDurability(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -627,7 +651,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
     @Test
     public void testScheduledExecutorConfig_Static() {
         TestCase<ScheduledExecutorConfig> testCase = new TestCase<ScheduledExecutorConfig>(
-                new ScheduledExecutorConfig(STATIC_NAME), new ScheduledExecutorConfig(DYNAMIC_NAME), false) {
+                new ScheduledExecutorConfig(STATIC_NAME).setCapacity(97),
+                new ScheduledExecutorConfig(DYNAMIC_NAME).setCapacity(133), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addScheduledExecutorConfig(this.staticConfig);
@@ -641,7 +666,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ScheduledExecutorConfig dataConfig = hazelcastInstance.getConfig().findScheduledExecutorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getCapacity(), equalTo(97));
             }
         };
         testTemplate(testCase);
@@ -650,7 +675,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
     @Test
     public void testScheduledExecutorConfig_Dynamic() {
         TestCase<ScheduledExecutorConfig> testCase = new TestCase<ScheduledExecutorConfig>(
-                new ScheduledExecutorConfig(STATIC_NAME), new ScheduledExecutorConfig(DYNAMIC_NAME), true) {
+                new ScheduledExecutorConfig(STATIC_NAME).setCapacity(97),
+                new ScheduledExecutorConfig(DYNAMIC_NAME).setCapacity(133), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addScheduledExecutorConfig(this.staticConfig);
@@ -664,7 +690,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 ScheduledExecutorConfig dataConfig = hazelcastInstance.getConfig().findScheduledExecutorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getCapacity(), equalTo(133));
             }
         };
         testTemplate(testCase);
@@ -673,8 +699,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
     @Test
     public void testCardinalityEstimatorConfig_Static() {
         TestCase<CardinalityEstimatorConfig> testCase = new TestCase<CardinalityEstimatorConfig>(
-                new CardinalityEstimatorConfig().setName(STATIC_NAME),
-                new CardinalityEstimatorConfig().setName(DYNAMIC_NAME), false) {
+                new CardinalityEstimatorConfig(STATIC_NAME, STATIC_BACKUP_COUNT, 0),
+                new CardinalityEstimatorConfig(DYNAMIC_NAME, DYNAMIC_BACKUP_COUNT, 0), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addCardinalityEstimatorConfig(this.staticConfig);
@@ -689,7 +715,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             void asserts() {
                 CardinalityEstimatorConfig dataConfig
                         = hazelcastInstance.getConfig().findCardinalityEstimatorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -698,8 +724,8 @@ public class ConfigSearchTest extends HazelcastTestSupport {
     @Test
     public void testCardinalityEstimatorConfig_Dynamic() {
         TestCase<CardinalityEstimatorConfig> testCase = new TestCase<CardinalityEstimatorConfig>(
-                new CardinalityEstimatorConfig().setName(STATIC_NAME),
-                new CardinalityEstimatorConfig().setName(DYNAMIC_NAME), true) {
+                new CardinalityEstimatorConfig(STATIC_NAME, STATIC_BACKUP_COUNT, 0),
+                new CardinalityEstimatorConfig(DYNAMIC_NAME, DYNAMIC_BACKUP_COUNT, 0), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addCardinalityEstimatorConfig(this.staticConfig);
@@ -714,16 +740,17 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             void asserts() {
                 CardinalityEstimatorConfig dataConfig
                         = hazelcastInstance.getConfig().findCardinalityEstimatorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getBackupCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
     }
 
     @Test
-    public void testReliableIdGeneratorConfig_Static() {
-        TestCase<FlakeIdGeneratorConfig> testCase = new TestCase<FlakeIdGeneratorConfig>(new FlakeIdGeneratorConfig(STATIC_NAME),
-                new FlakeIdGeneratorConfig(DYNAMIC_NAME), false) {
+    public void testFlakeIdGeneratorConfig_Static() {
+        TestCase<FlakeIdGeneratorConfig> testCase = new TestCase<FlakeIdGeneratorConfig>(
+                new FlakeIdGeneratorConfig(STATIC_NAME).setPrefetchCount(97),
+                new FlakeIdGeneratorConfig(DYNAMIC_NAME).setPrefetchCount(133), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addFlakeIdGeneratorConfig(this.staticConfig);
@@ -737,16 +764,17 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 FlakeIdGeneratorConfig dataConfig = hazelcastInstance.getConfig().findFlakeIdGeneratorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getPrefetchCount(), equalTo(97));
             }
         };
         testTemplate(testCase);
     }
 
     @Test
-    public void testReliableIdGeneratorConfig_Dynamic() {
-        TestCase<FlakeIdGeneratorConfig> testCase = new TestCase<FlakeIdGeneratorConfig>(new FlakeIdGeneratorConfig(STATIC_NAME),
-                new FlakeIdGeneratorConfig(DYNAMIC_NAME), true) {
+    public void testFlakeIdGeneratorConfig_Dynamic() {
+        TestCase<FlakeIdGeneratorConfig> testCase = new TestCase<FlakeIdGeneratorConfig>(
+                new FlakeIdGeneratorConfig(STATIC_NAME).setPrefetchCount(97),
+                new FlakeIdGeneratorConfig(DYNAMIC_NAME).setPrefetchCount(133), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addFlakeIdGeneratorConfig(this.staticConfig);
@@ -760,7 +788,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 FlakeIdGeneratorConfig dataConfig = hazelcastInstance.getConfig().findFlakeIdGeneratorConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getPrefetchCount(), equalTo(133));
             }
         };
         testTemplate(testCase);
@@ -768,8 +796,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testPNCounterConfig_Static() {
-        TestCase<PNCounterConfig> testCase = new TestCase<PNCounterConfig>(new PNCounterConfig(STATIC_NAME),
-                new PNCounterConfig(DYNAMIC_NAME), false) {
+        TestCase<PNCounterConfig> testCase = new TestCase<PNCounterConfig>(
+                new PNCounterConfig(STATIC_NAME).setReplicaCount(STATIC_BACKUP_COUNT),
+                new PNCounterConfig(DYNAMIC_NAME).setReplicaCount(DYNAMIC_BACKUP_COUNT), false) {
             @Override
             void addStaticConfig(Config config) {
                 config.addPNCounterConfig(this.staticConfig);
@@ -784,7 +813,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 PNCounterConfig dataConfig = hazelcastInstance.getConfig().findPNCounterConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(STATIC_NAME));
+                assertThat(dataConfig.getReplicaCount(), equalTo(STATIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);
@@ -792,8 +821,9 @@ public class ConfigSearchTest extends HazelcastTestSupport {
 
     @Test
     public void testPNCounterConfig_Dynamic() {
-        TestCase<PNCounterConfig> testCase = new TestCase<PNCounterConfig>(new PNCounterConfig(STATIC_NAME),
-                new PNCounterConfig(DYNAMIC_NAME), true) {
+        TestCase<PNCounterConfig> testCase = new TestCase<PNCounterConfig>(
+                new PNCounterConfig(STATIC_NAME).setReplicaCount(STATIC_BACKUP_COUNT),
+                new PNCounterConfig(DYNAMIC_NAME).setReplicaCount(DYNAMIC_BACKUP_COUNT), true) {
             @Override
             void addStaticConfig(Config config) {
                 config.addPNCounterConfig(this.staticConfig);
@@ -807,7 +837,7 @@ public class ConfigSearchTest extends HazelcastTestSupport {
             @Override
             void asserts() {
                 PNCounterConfig dataConfig = hazelcastInstance.getConfig().findPNCounterConfig(DYNAMIC_NAME);
-                assertThat(dataConfig.getName(), equalTo(DYNAMIC_NAME));
+                assertThat(dataConfig.getReplicaCount(), equalTo(DYNAMIC_BACKUP_COUNT));
             }
         };
         testTemplate(testCase);


### PR DESCRIPTION
Merge persistence & hot-restart when getting MapConfig; while this is missing, map configs based on default or wildcard configs will not have their `DataPersistenceConfig` & `HotRestartConfig` merged, resulting in unexpected EE-side persistence behaviour (see [HZ-1208](https://hazelcast.atlassian.net/browse/HZ-1208)).

Additionally, when looking up config via
`ConfigUtils#lookupByPattern`, configs must be cloned and named
after the looked-for name, similarly to `ConfigUtils#getConfig`.
Otherwise, returned config has the name of the template config (eg "default" or "persistent.*") and this results in strange failures with persistence.

With these fixes, it is revealed that assertions in `ConfigSearchTest` and `DynamicConfigSearchOrderTest` are faulty, since they are based on config name. The tests are now fixed to compare on other properties of the config (eg backupCount).

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5336 (only adds test on EE side)

Breaking changes (list specific methods/types/messages):
`Hazelcast.getConfig().findMapConfig("does-not-exist").getName()` (and similar `findXXX` methods) would previously (erroneously) return `default` instead of the name of the data structure that was requested.

Checklist:
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
