### PR TITLE
Close datasource

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -38,6 +38,7 @@ public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource
     private ExternalDataStoreConfig config;
     private DataSource shareDataSource;
 
+    @Override
     public void init(ExternalDataStoreConfig config) {
         this.config = config;
         if (config.isShared()) {

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -22,7 +22,9 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.ExternalDataStoreService;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.internal.nio.IOUtil;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -63,5 +65,18 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }
         return externalDataStoreFactory;
+    }
+
+    public void shutDown(boolean terminate) {
+        if (terminate) {
+            return;
+        }
+
+        for (ExternalDataStoreFactory<?> dataStoreFactory : dataStoreFactories.values()) {
+            Object dataStore = dataStoreFactory.getDataStore();
+            if (dataStore instanceof Closeable) {
+                IOUtil.closeResource(((Closeable) dataStore));
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -132,7 +132,7 @@ public class NodeEngineImpl implements NodeEngine {
     private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
     private final ConcurrencyDetection concurrencyDetection;
     private final TenantControlServiceImpl tenantControlService;
-    private final ExternalDataStoreService externalDataStoreService;
+    private final ExternalDataStoreServiceImpl externalDataStoreService;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     public NodeEngineImpl(Node node) {
@@ -576,6 +576,8 @@ public class NodeEngineImpl implements NodeEngine {
         if (diagnostics != null) {
             diagnostics.shutdown();
         }
+
+        externalDataStoreService.shutDown(terminate);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
@@ -17,14 +17,17 @@
 package com.hazelcast.datastore;
 
 import com.hazelcast.config.ExternalDataStoreConfig;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.sql.DataSource;
+import java.io.Closeable;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +35,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JdbcDataStoreFactoryTest {
+
+    DataSource dataStore1;
+    DataSource dataStore2;
+
+    @After
+    public void tearDown() throws Exception {
+        closeDataStore(dataStore1);
+        closeDataStore(dataStore2);
+    }
+
+    private static void closeDataStore(DataSource dataSource) {
+        if (!(dataSource instanceof Closeable)) {
+            return;
+        }
+
+        IOUtil.closeResource(((Closeable) dataSource));
+    }
 
     @Test
     public void should_return_same_DataStore_when_shared() {
@@ -43,8 +63,8 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(true);
         jdbcDataStoreFactory.init(config);
 
-        DataSource dataStore1 = jdbcDataStoreFactory.getDataStore();
-        DataSource dataStore2 = jdbcDataStoreFactory.getDataStore();
+        dataStore1 = jdbcDataStoreFactory.getDataStore();
+        dataStore2 = jdbcDataStoreFactory.getDataStore();
 
         assertThat(dataStore1).isNotNull();
         assertThat(dataStore2).isNotNull();
@@ -61,8 +81,8 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(false);
         jdbcDataStoreFactory.init(config);
 
-        DataSource dataStore1 = jdbcDataStoreFactory.getDataStore();
-        DataSource dataStore2 = jdbcDataStoreFactory.getDataStore();
+        dataStore1 = jdbcDataStoreFactory.getDataStore();
+        dataStore2 = jdbcDataStoreFactory.getDataStore();
 
         assertThat(dataStore1).isNotNull();
         assertThat(dataStore2).isNotNull();


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/21991

**Issue**
https://jenkins.hazelcast.com/view/Official%20Builds/job/Hazelcast-master-ZuluJDK8/206/testReport/classloading/ThreadLeakTest/testThreadLeakUtils/

```
15:28:25,794 ERROR |testThreadLeakUtils| - [ThreadLeakTestUtils] testThreadLeakUtils - There should be one thread running!
-> leaking-thread (id: 1107543) (group: main) (daemon: true) (alive: true) (interrupted: false) (state: WAITING)
[classloading.ThreadLeakTest$1.run(ThreadLeakTest.java:65)]

15:28:25,797 ERROR |testThreadLeakUtils| - [ThreadLeakTestUtils] testThreadLeakUtils - There should be no threads running!
-> HikariPool-3 connection adder (id: 1107544) (group: main) (daemon: true) (alive: true) (interrupted: false) (state: TIMED_WAITING)
[org.h2.engine.ConnectionInfo.getKeys(ConnectionInfo.java:514), org.h2.engine.Engine.openSession(Engine.java:241), org.h2.engine.Engine.createSession(Engine.java:201), org.h2.engine.SessionRemote.connectEmbeddedOrServer(SessionRemote.java:338), org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:122), org.h2.Driver.connect(Driver.java:59), com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:121), com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:364), com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:206), com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:476), com.zaxxer.hikari.pool.HikariPool.access$100(HikariPool.java:71), com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:726), com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:712), java.util.concurrent.FutureTask.run(FutureTask.java:266), java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149), java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624), java.lang.Thread.run(Thread.java:748)]
```