### PR TITLE
URL Decode strings before using in REST API API-1389

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -159,6 +159,10 @@ public abstract class HttpCommandProcessor<T extends HttpCommand> extends Abstra
         }
     }
 
+    protected static String urlDecode(String value) throws UnsupportedEncodingException {
+        return URLDecoder.decode(value, "UTF-8");
+    }
+
     /**
      * Decodes HTTP post params contained in {@link HttpPostCommand#getData()}. The data
      * should be encoded in UTF-8 and joined together with an ampersand (&).
@@ -189,7 +193,7 @@ public abstract class HttpCommandProcessor<T extends HttpCommand> extends Abstra
         }
 
         for (int i = 0; i < expectedParamCount; i++) {
-            decoded[i] = URLDecoder.decode(encoded[i], "UTF-8");
+            decoded[i] = urlDecode(encoded[i]);
         }
         return decoded;
     }
@@ -220,7 +224,7 @@ public abstract class HttpCommandProcessor<T extends HttpCommand> extends Abstra
                                  @Nullable String userName,
                                  @Nullable String pass)
             throws UnsupportedEncodingException {
-        String decodedName = userName != null ? URLDecoder.decode(userName, "UTF-8") : null;
+        String decodedName = userName != null ? urlDecode(userName) : null;
         SecurityContext securityContext = getNode().getNodeExtension().getSecurityContext();
         String clusterName = getNode().getConfig().getClusterName();
         if (securityContext == null) {
@@ -229,7 +233,7 @@ public abstract class HttpCommandProcessor<T extends HttpCommand> extends Abstra
             }
             return clusterName.equals(decodedName);
         }
-        String decodedPass = pass != null ? URLDecoder.decode(pass, "UTF-8") : null;
+        String decodedPass = pass != null ? urlDecode(pass) : null;
         UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(decodedName, decodedPass);
         Boolean passed = Boolean.FALSE;
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
@@ -19,6 +19,8 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.util.StringUtil;
 
+import java.io.UnsupportedEncodingException;
+
 import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.MAP;
 import static com.hazelcast.internal.ascii.rest.RestCallExecution.ObjectType.QUEUE;
 
@@ -48,32 +50,32 @@ public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteC
         textCommandService.sendResponse(command);
     }
 
-    private void handleMap(HttpDeleteCommand command, String uri) {
+    private void handleMap(HttpDeleteCommand command, String uri) throws UnsupportedEncodingException {
         command.getExecutionDetails().setObjectType(MAP);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         if (indexEnd == -1) {
-            String mapName = uri.substring(URI_MAPS.length());
+            String mapName = urlDecode(uri.substring(URI_MAPS.length()));
             textCommandService.deleteAll(mapName);
             command.getExecutionDetails().setObjectName(mapName);
             command.send200();
         } else {
-            String mapName = uri.substring(URI_MAPS.length(), indexEnd);
+            String mapName = urlDecode(uri.substring(URI_MAPS.length(), indexEnd));
             command.getExecutionDetails().setObjectName(mapName);
-            String key = uri.substring(indexEnd + 1);
+            String key = urlDecode(uri.substring(indexEnd + 1));
             key = StringUtil.stripTrailingSlash(key);
             textCommandService.delete(mapName, key);
             command.send200();
         }
     }
 
-    private void handleQueue(HttpDeleteCommand command, String uri) {
+    private void handleQueue(HttpDeleteCommand command, String uri) throws UnsupportedEncodingException {
         // Poll an item from the default queue in 3 seconds
         // http://127.0.0.1:5701/hazelcast/rest/queues/default/3
         int indexEnd = uri.indexOf('/', URI_QUEUES.length());
         command.getExecutionDetails().setObjectType(QUEUE);
-        String queueName = uri.substring(URI_QUEUES.length(), indexEnd);
+        String queueName = urlDecode(uri.substring(URI_QUEUES.length(), indexEnd));
         command.getExecutionDetails().setObjectName(queueName);
-        String secondStr = (uri.length() > (indexEnd + 1)) ? uri.substring(indexEnd + 1) : null;
+        String secondStr = (uri.length() > (indexEnd + 1)) ? urlDecode(uri.substring(indexEnd + 1)) : null;
         int seconds = (secondStr == null) ? 0 : Integer.parseInt(secondStr);
         Object value = textCommandService.poll(queueName, seconds);
         if (value == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -41,6 +41,7 @@ import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.logging.impl.LoggingServiceImpl;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -375,12 +376,12 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         prepareResponse(command, new JsonObject().add("name", textCommandService.getInstanceName()));
     }
 
-    private void handleQueue(HttpGetCommand command, String uri) {
+    private void handleQueue(HttpGetCommand command, String uri) throws UnsupportedEncodingException {
         command.getExecutionDetails().setObjectType(QUEUE);
         int indexEnd = uri.indexOf('/', URI_QUEUES.length());
-        String queueName = uri.substring(URI_QUEUES.length(), indexEnd);
+        String queueName = urlDecode(uri.substring(URI_QUEUES.length(), indexEnd));
         command.getExecutionDetails().setObjectName(queueName);
-        String secondStr = (uri.length() > (indexEnd + 1)) ? uri.substring(indexEnd + 1) : null;
+        String secondStr = (uri.length() > (indexEnd + 1)) ? urlDecode(uri.substring(indexEnd + 1)) : null;
 
         if (equalsIgnoreCase(QUEUE_SIZE_COMMAND, secondStr)) {
             int size = textCommandService.size(queueName);
@@ -392,13 +393,13 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         }
     }
 
-    private void handleMap(HttpGetCommand command, String uri) {
+    private void handleMap(HttpGetCommand command, String uri) throws UnsupportedEncodingException {
         command.getExecutionDetails().setObjectType(MAP);
         uri = StringUtil.stripTrailingSlash(uri);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
-        String mapName = uri.substring(URI_MAPS.length(), indexEnd);
+        String mapName = urlDecode(uri.substring(URI_MAPS.length(), indexEnd));
         command.getExecutionDetails().setObjectName(mapName);
-        String key = uri.substring(indexEnd + 1);
+        String key = urlDecode(uri.substring(indexEnd + 1));
         Object value = textCommandService.get(mapName, key);
         prepareResponse(command, value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -253,7 +253,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         getNode().hazelcastInstance.shutdown();
     }
 
-    private void handleQueue(HttpPostCommand command, String uri) {
+    private void handleQueue(HttpPostCommand command, String uri) throws UnsupportedEncodingException {
         String simpleValue = null;
         String suffix;
         int baseUriLength = URI_QUEUES.length();
@@ -273,8 +273,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         if (indexSlash == -1) {
             queueName = suffix;
         } else {
-            queueName = suffix.substring(0, indexSlash);
-            simpleValue = suffix.substring(indexSlash + 1);
+            queueName = urlDecode(suffix.substring(0, indexSlash));
+            simpleValue = urlDecode(suffix.substring(indexSlash + 1));
         }
         command.getExecutionDetails().setObjectName(queueName);
         byte[] data;
@@ -294,16 +294,16 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         }
     }
 
-    private void handleMap(HttpPostCommand command, String uri) {
+    private void handleMap(HttpPostCommand command, String uri) throws UnsupportedEncodingException {
         command.getExecutionDetails().setObjectType(MAP);
         uri = StringUtil.stripTrailingSlash(uri);
         int indexEnd = uri.indexOf('/', URI_MAPS.length());
         if (indexEnd == -1) {
             throw new HttpBadRequestException("Missing map name");
         }
-        String mapName = uri.substring(URI_MAPS.length(), indexEnd);
+        String mapName = urlDecode(uri.substring(URI_MAPS.length(), indexEnd));
         command.getExecutionDetails().setObjectName(mapName);
-        String key = uri.substring(indexEnd + 1);
+        String key = urlDecode(uri.substring(indexEnd + 1));
         byte[] data = command.getData();
         textCommandService.put(mapName, key, new RestValue(data, command.getContentType()), -1);
         command.send200();


### PR DESCRIPTION
Fixes #21284

Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
