### PR TITLE
Use BIG_ENDIAN byte order for the serializer id in toDataWithSchema

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -174,7 +174,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             // (like array list of Compact serialized objects).
             obj = toObject(data);
         }
-        byte[] bytes = toBytes(obj, 0, true, globalPartitioningStrategy, getByteOrder(), true);
+        byte[] bytes = toBytes(obj, 0, true, globalPartitioningStrategy, BIG_ENDIAN, true);
         return (B) new HeapData(bytes);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactWithSchemaStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactWithSchemaStreamSerializerTest.java
@@ -16,10 +16,11 @@
 
 package com.hazelcast.internal.serialization.impl.compact;
 
+import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import example.serialization.EmployeeDTO;
@@ -27,16 +28,25 @@ import example.serialization.NodeDTO;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
-import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createSerializationService;
 import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder.compact;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastParametrizedRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class CompactWithSchemaStreamSerializerTest {
+
+    @Parameterized.Parameter
+    public ByteOrder byteOrder;
+
+    @Parameterized.Parameters(name = "byteOrder:{0}")
+    public static Object[] parameters() {
+        return new Object[]{ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN};
+    }
 
     @Test
     public void testReadAsGenericRecord() throws IOException {
@@ -123,5 +133,11 @@ public class CompactWithSchemaStreamSerializerTest {
         SerializationService serializationService2 = createSerializationService();
         NodeDTO actual = serializationService2.toObject(data);
         assertEquals(expected, actual);
+    }
+
+    private SerializationService createSerializationService() {
+        SerializationConfig config = new SerializationConfig();
+        config.setByteOrder(byteOrder);
+        return CompactTestUtil.createSerializationService(config);
     }
 }


### PR DESCRIPTION
In Hazelcast, the top level serializer id is always encoded in BIG_ENDIAN byte order, and for nested fields, the configured byte order is used.

toDataWithSchema was not following this behaviour, and was using the configured byte order for the top level class.

Note that, for nested compacts, we don't recursively call toDataWithSchema. The logic to serialize nested fields are handled within the serializer.