### PR TITLE
Close dataStores after the usage

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
@@ -45,8 +45,7 @@ abstract class AbstractJdbcSqlConnectorProcessorSupplier implements ProcessorSup
         ExternalDataStoreService externalDataStoreService = ((HazelcastInstanceImpl) context.hazelcastInstance())
                 .node.getNodeEngine().getExternalDataStoreService();
 
-        ExternalDataStoreFactory<DataSource> factory = (ExternalDataStoreFactory<DataSource>)
-                externalDataStoreService.getExternalDataStoreFactory(externalDataStoreRef);
+        ExternalDataStoreFactory<DataSource> factory = externalDataStoreService.getExternalDataStoreFactory(externalDataStoreRef);
 
         dataSource = factory.createDataStore();
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
@@ -16,21 +16,23 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.ExternalDataStoreService;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
-import com.hazelcast.jet.core.ProcessorSupplier.Context;
+import com.hazelcast.jet.core.ProcessorSupplier;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 import static java.util.Objects.requireNonNull;
 
-class AbstractJdbcSqlConnectorProcessorSupplier {
+abstract class AbstractJdbcSqlConnectorProcessorSupplier implements ProcessorSupplier {
 
     protected String externalDataStoreRef;
 
-    protected transient DataSource dataSource;
+    protected transient DataStoreSupplier<DataSource> dataSource;
 
     AbstractJdbcSqlConnectorProcessorSupplier() {
     }
@@ -49,4 +51,8 @@ class AbstractJdbcSqlConnectorProcessorSupplier {
         dataSource = factory.getDataStore();
     }
 
+    @Override
+    public void close(@Nullable Throwable error) throws Exception {
+        dataSource.close();
+    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
@@ -48,7 +48,7 @@ abstract class AbstractJdbcSqlConnectorProcessorSupplier implements ProcessorSup
         ExternalDataStoreFactory<DataSource> factory = (ExternalDataStoreFactory<DataSource>)
                 externalDataStoreService.getExternalDataStoreFactory(externalDataStoreRef);
 
-        dataSource = factory.getDataStore();
+        dataSource = factory.createDataStore();
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/AbstractJdbcSqlConnectorProcessorSupplier.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.ExternalDataStoreService;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
@@ -32,7 +32,7 @@ abstract class AbstractJdbcSqlConnectorProcessorSupplier implements ProcessorSup
 
     protected String externalDataStoreRef;
 
-    protected transient DataStoreSupplier<DataSource> dataSource;
+    protected transient DataStoreHolder<DataSource> dataSource;
 
     AbstractJdbcSqlConnectorProcessorSupplier() {
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteProcessorSupplier.java
@@ -64,7 +64,7 @@ public class DeleteProcessorSupplier
         for (int i = 0; i < count; i++) {
             Processor processor = new WriteJdbcP<>(
                     query,
-                    dataSource,
+                    dataSource.get(),
                     (PreparedStatement ps, JetSqlRow row) -> {
                         for (int j = 0; j < row.getFieldCount(); j++) {
                             ps.setObject(j + 1, row.get(j));

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertProcessorSupplier.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.connector.WriteJdbcP;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -42,7 +41,7 @@ import static java.util.Collections.singletonList;
 
 public class InsertProcessorSupplier
         extends AbstractJdbcSqlConnectorProcessorSupplier
-        implements ProcessorSupplier, DataSerializable, SecuredFunction {
+        implements DataSerializable, SecuredFunction {
 
     private String query;
     private int batchLimit;
@@ -64,7 +63,7 @@ public class InsertProcessorSupplier
         for (int i = 0; i < count; i++) {
             Processor processor = new WriteJdbcP<>(
                     query,
-                    dataSource,
+                    dataSource.get(),
                     (PreparedStatement ps, JetSqlRow row) -> {
                         for (int j = 0; j < row.getFieldCount(); j++) {
                             // JDBC parameterIndex is 1-based, so j + 1

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.datastore.DataStoreHolder;
+import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
@@ -169,9 +170,9 @@ public class JdbcSqlConnector implements SqlConnector {
     }
 
     private static DataStoreHolder<DataSource> createDataStore(NodeEngine nodeEngine, String externalDataStoreRef) {
-        return (DataStoreHolder<DataSource>) nodeEngine.getExternalDataStoreService()
-                .getExternalDataStoreFactory(externalDataStoreRef)
-                .createDataStore();
+        final ExternalDataStoreFactory<DataSource> externalDataStoreFactory = nodeEngine.getExternalDataStoreService()
+                .getExternalDataStoreFactory(externalDataStoreRef);
+        return externalDataStoreFactory.createDataStore();
     }
 
     private Set<String> readPrimaryKeyColumns(@Nonnull String externalName, Connection connection) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -142,7 +142,7 @@ public class JdbcSqlConnector implements SqlConnector {
         );
         try (DataStoreSupplier<DataSource> dataSource = (DataStoreSupplier<DataSource>) nodeEngine.getExternalDataStoreService()
                 .getExternalDataStoreFactory(externalDataStoreRef)
-                .getDataStore();
+                .createDataStore();
              Connection connection = dataSource.get().getConnection();
              Statement statement = connection.createStatement()) {
             Set<String> pkColumns = readPrimaryKeyColumns(externalTableName, connection);
@@ -234,7 +234,7 @@ public class JdbcSqlConnector implements SqlConnector {
 
         try (DataStoreSupplier<DataSource> dataSource = (DataStoreSupplier<DataSource>) nodeEngine.getExternalDataStoreService()
                 .getExternalDataStoreFactory(externalDataStoreRef)
-                .getDataStore(); Connection connection = dataSource.get().getConnection()) {
+                .createDataStore(); Connection connection = dataSource.get().getConnection()) {
 
             SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(connection.getMetaData());
             String databaseProductName = connection.getMetaData().getDatabaseProductName();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
@@ -140,7 +140,7 @@ public class JdbcSqlConnector implements SqlConnector {
                 options.get(OPTION_EXTERNAL_DATASTORE_REF),
                 OPTION_EXTERNAL_DATASTORE_REF + " must be set"
         );
-        try (DataStoreSupplier<DataSource> dataSource = (DataStoreSupplier<DataSource>) nodeEngine.getExternalDataStoreService()
+        try (DataStoreHolder<DataSource> dataSource = (DataStoreHolder<DataSource>) nodeEngine.getExternalDataStoreService()
                 .getExternalDataStoreFactory(externalDataStoreRef)
                 .createDataStore();
              Connection connection = dataSource.get().getConnection();
@@ -232,7 +232,7 @@ public class JdbcSqlConnector implements SqlConnector {
 
     private SqlDialect resolveDialect(NodeEngine nodeEngine, String externalDataStoreRef) {
 
-        try (DataStoreSupplier<DataSource> dataSource = (DataStoreSupplier<DataSource>) nodeEngine.getExternalDataStoreService()
+        try (DataStoreHolder<DataSource> dataSource = (DataStoreHolder<DataSource>) nodeEngine.getExternalDataStoreService()
                 .getExternalDataStoreFactory(externalDataStoreRef)
                 .createDataStore(); Connection connection = dataSource.get().getConnection()) {
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
@@ -139,33 +140,30 @@ public class JdbcSqlConnector implements SqlConnector {
                 options.get(OPTION_EXTERNAL_DATASTORE_REF),
                 OPTION_EXTERNAL_DATASTORE_REF + " must be set"
         );
-        try {
-            DataSource dataSource = (DataSource) nodeEngine.getExternalDataStoreService()
-                                                           .getExternalDataStoreFactory(externalDataStoreRef)
-                                                           .getDataStore();
+        try (DataStoreSupplier<DataSource> dataSource = (DataStoreSupplier<DataSource>) nodeEngine.getExternalDataStoreService()
+                .getExternalDataStoreFactory(externalDataStoreRef)
+                .getDataStore();
+             Connection connection = dataSource.get().getConnection();
+             Statement statement = connection.createStatement()) {
+            Set<String> pkColumns = readPrimaryKeyColumns(externalTableName, connection);
 
-            try (Connection connection = dataSource.getConnection();
-                 Statement statement = connection.createStatement()) {
-                Set<String> pkColumns = readPrimaryKeyColumns(externalTableName, connection);
-
-                boolean hasResultSet = statement.execute("SELECT * FROM " + externalTableName + " LIMIT 0");
-                if (!hasResultSet) {
-                    throw new IllegalStateException("Could not resolve fields for table " + externalTableName);
-                }
-                ResultSet rs = statement.getResultSet();
-                ResultSetMetaData metaData = rs.getMetaData();
-
-                Map<String, DbField> fields = new HashMap<>();
-                for (int i = 1; i <= metaData.getColumnCount(); i++) {
-                    String columnName = metaData.getColumnName(i);
-                    fields.put(columnName,
-                            new DbField(metaData.getColumnTypeName(i),
-                                    columnName,
-                                    pkColumns.contains(columnName)
-                            ));
-                }
-                return fields;
+            boolean hasResultSet = statement.execute("SELECT * FROM " + externalTableName + " LIMIT 0");
+            if (!hasResultSet) {
+                throw new IllegalStateException("Could not resolve fields for table " + externalTableName);
             }
+            ResultSet rs = statement.getResultSet();
+            ResultSetMetaData metaData = rs.getMetaData();
+
+            Map<String, DbField> fields = new HashMap<>();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                String columnName = metaData.getColumnName(i);
+                fields.put(columnName,
+                        new DbField(metaData.getColumnTypeName(i),
+                                columnName,
+                                pkColumns.contains(columnName)
+                        ));
+            }
+            return fields;
         } catch (Exception e) {
             throw new HazelcastException("Could not read column metadata for table " + externalDataStoreRef, e);
         }
@@ -233,28 +231,25 @@ public class JdbcSqlConnector implements SqlConnector {
     }
 
     private SqlDialect resolveDialect(NodeEngine nodeEngine, String externalDataStoreRef) {
-        try {
-            DataSource dataSource = (DataSource) nodeEngine.getExternalDataStoreService()
-                                                           .getExternalDataStoreFactory(externalDataStoreRef)
-                                                           .getDataStore();
 
-            try (Connection connection = dataSource.getConnection()) {
+        try (DataStoreSupplier<DataSource> dataSource = (DataStoreSupplier<DataSource>) nodeEngine.getExternalDataStoreService()
+                .getExternalDataStoreFactory(externalDataStoreRef)
+                .getDataStore(); Connection connection = dataSource.get().getConnection()) {
 
-                SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(connection.getMetaData());
-                String databaseProductName = connection.getMetaData().getDatabaseProductName();
-                switch (databaseProductName) {
-                    case "MySQL":
-                    case "PostgreSQL":
-                    case "H2":
-                        return dialect;
+            SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(connection.getMetaData());
+            String databaseProductName = connection.getMetaData().getDatabaseProductName();
+            switch (databaseProductName) {
+                case "MySQL":
+                case "PostgreSQL":
+                case "H2":
+                    return dialect;
 
-                    default:
-                        LOG.warning("Database " + databaseProductName + " is not officially supported");
-                        return dialect;
-                }
-
+                default:
+                    LOG.warning("Database " + databaseProductName + " is not officially supported");
+                    return dialect;
             }
-        } catch (SQLException e) {
+
+        } catch (Exception e) {
             throw new HazelcastException("Could not determine dialect for externalDataStoreRef: "
                     + externalDataStoreRef, e);
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -238,7 +238,10 @@ public class JdbcSqlConnector implements SqlConnector {
 
     private SqlDialect resolveDialect(NodeEngine nodeEngine, String externalDataStoreRef) {
 
-        try (DataStoreHolder<DataSource> dataSource = createDataStore(nodeEngine, externalDataStoreRef); Connection connection = dataSource.get().getConnection()) {
+        try (
+                DataStoreHolder<DataSource> dataSource = createDataStore(nodeEngine, externalDataStoreRef);
+                Connection connection = dataSource.get().getConnection()
+        ) {
 
             SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(connection.getMetaData());
             String databaseProductName = connection.getMetaData().getDatabaseProductName();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectProcessorSupplier.java
@@ -77,7 +77,7 @@ public class SelectProcessorSupplier
         List<Processor> processors = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
             Processor processor = new ReadJdbcP<>(
-                    () -> dataSource.getConnection(),
+                    () -> dataSource.get().getConnection(),
                     (connection, parallelism, index) -> {
                         PreparedStatement statement = connection.prepareStatement(query);
                         List<Object> arguments = evalContext.getArguments();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateProcessorSupplier.java
@@ -79,7 +79,7 @@ public class UpdateProcessorSupplier
         for (int i = 0; i < count; i++) {
             Processor processor = new WriteJdbcP<>(
                     query,
-                    dataSource,
+                    dataSource.get(),
                     (PreparedStatement ps, JetSqlRow row) -> {
                         List<Object> arguments = evalContext.getArguments();
 

--- a/hazelcast/src/main/java/com/hazelcast/datastore/AbstractDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/AbstractDataStoreFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.datastore;
 
 import com.hazelcast.config.ExternalDataStoreConfig;
@@ -17,11 +33,11 @@ public abstract class AbstractDataStoreFactory<DS> implements ExternalDataStoreF
     protected ExternalDataStoreConfig config;
 
     /**
-     * Create a new data store
+     * Creates a new data store
      *
-     * @return
+     * @return a new data store instance
      */
-    abstract protected DS createDataSource();
+    protected abstract DS createDataSource();
 
     @Override
     public void init(ExternalDataStoreConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/datastore/AbstractDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/AbstractDataStoreFactory.java
@@ -32,8 +32,8 @@ public abstract class AbstractDataStoreFactory<DS> implements ExternalDataStoreF
     }
 
     @Override
-    public DataStoreSupplier<DS> createDataStore() {
-        return config.isShared() ? DataStoreSupplier.nonClosing(sharedDataStore) : DataStoreSupplier.closing(createDataSource());
+    public DataStoreHolder<DS> createDataStore() {
+        return config.isShared() ? DataStoreHolder.nonClosing(sharedDataStore) : DataStoreHolder.closing(createDataSource());
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/AbstractDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/AbstractDataStoreFactory.java
@@ -1,0 +1,39 @@
+package com.hazelcast.datastore;
+
+import com.hazelcast.config.ExternalDataStoreConfig;
+import com.hazelcast.spi.annotation.Beta;
+
+/**
+ * Basic implementation of the {@link ExternalDataStoreFactory}.
+ * Requires implementing only how to create a datastore and how to close the factory
+ *
+ * @param <DS> - type of the data store
+ * @since 5.2
+ */
+@Beta
+public abstract class AbstractDataStoreFactory<DS> implements ExternalDataStoreFactory<DS> {
+
+    protected DS sharedDataStore;
+    protected ExternalDataStoreConfig config;
+
+    /**
+     * Create a new data store
+     *
+     * @return
+     */
+    abstract protected DS createDataSource();
+
+    @Override
+    public void init(ExternalDataStoreConfig config) {
+        this.config = config;
+        if (config.isShared()) {
+            sharedDataStore = createDataSource();
+        }
+    }
+
+    @Override
+    public DataStoreSupplier<DS> createDataStore() {
+        return config.isShared() ? DataStoreSupplier.nonClosing(sharedDataStore) : DataStoreSupplier.closing(createDataSource());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/datastore/DataStoreHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/DataStoreHolder.java
@@ -21,16 +21,16 @@ import com.hazelcast.spi.annotation.Beta;
 import java.util.function.Supplier;
 
 /**
- * Wrapper for supplying a data store and handling the close of the wrapped datastore
+ * Holder of a data store and which handles the close of the wrapped datastore
  *
- * @param <DS> - Data store type supplied by the object of this class
+ * @param <DS> - Data store type hold by the object of this class
  * @since 5.2
  */
 @Beta
-public interface DataStoreSupplier<DS> extends Supplier<DS>, AutoCloseable {
+public interface DataStoreHolder<DS> extends Supplier<DS>, AutoCloseable {
 
-    static <DS> DataStoreSupplier<DS> closing(DS datastore) {
-        return new DataStoreSupplier<DS>() {
+    static <DS> DataStoreHolder<DS> closing(DS datastore) {
+        return new DataStoreHolder<DS>() {
             @Override
             public DS get() {
                 return datastore;
@@ -45,8 +45,8 @@ public interface DataStoreSupplier<DS> extends Supplier<DS>, AutoCloseable {
         };
     }
 
-    static <DS> DataStoreSupplier<DS> nonClosing(DS datastore) {
-        return new DataStoreSupplier<DS>() {
+    static <DS> DataStoreHolder<DS> nonClosing(DS datastore) {
+        return new DataStoreHolder<DS>() {
             @Override
             public DS get() {
                 return datastore;

--- a/hazelcast/src/main/java/com/hazelcast/datastore/DataStoreSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/DataStoreSupplier.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.datastore;
+
+import java.util.function.Supplier;
+
+public interface DataStoreSupplier<DS> extends Supplier<DS>, AutoCloseable {
+
+    static <DS> DataStoreSupplier<DS> closing(DS datastore) {
+        return new DataStoreSupplier<DS>() {
+            @Override
+            public DS get() {
+                return datastore;
+            }
+
+            @Override
+            public void close() throws Exception {
+                if (datastore instanceof AutoCloseable) {
+                    ((AutoCloseable) datastore).close();
+                }
+            }
+        };
+    }
+
+    static <DS> DataStoreSupplier<DS> nonClosing(DS datastore) {
+        return new DataStoreSupplier<DS>() {
+            @Override
+            public DS get() {
+                return datastore;
+            }
+
+            @Override
+            public void close() {
+                //no closing
+            }
+        };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/datastore/DataStoreSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/DataStoreSupplier.java
@@ -16,8 +16,17 @@
 
 package com.hazelcast.datastore;
 
+import com.hazelcast.spi.annotation.Beta;
+
 import java.util.function.Supplier;
 
+/**
+ * Wrapper for supplying a data store and handling the close of the wrapped datastore
+ *
+ * @param <DS> - Data store type supplied by the object of this class
+ * @since 5.2
+ */
+@Beta
 public interface DataStoreSupplier<DS> extends Supplier<DS>, AutoCloseable {
 
     static <DS> DataStoreSupplier<DS> closing(DS datastore) {

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
@@ -31,7 +31,7 @@ public interface ExternalDataStoreFactory<DS> extends AutoCloseable {
      * Returns configured data store. Depending on configuration and implementation it can create new data store
      * or reuse existing one.
      */
-    DataStoreSupplier<DS> getDataStore();
+    DataStoreSupplier<DS> createDataStore();
 
     /**
      * Initialize factory with the config

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
@@ -31,7 +31,7 @@ public interface ExternalDataStoreFactory<DS> extends AutoCloseable {
      * Returns configured data store. Depending on configuration and implementation it can create new data store
      * or reuse existing one.
      */
-    DS getDataStore();
+    DataStoreSupplier<DS> getDataStore();
 
     /**
      * Initialize factory with the config

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
@@ -31,7 +31,7 @@ public interface ExternalDataStoreFactory<DS> extends AutoCloseable {
      * Returns configured data store. Depending on configuration and implementation it can create new data store
      * or reuse existing one.
      */
-    DataStoreSupplier<DS> createDataStore();
+    DataStoreHolder<DS> createDataStore();
 
     /**
      * Initialize factory with the config

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.annotation.Beta;
  * @since 5.2
  */
 @Beta
-public interface ExternalDataStoreFactory<DS> {
+public interface ExternalDataStoreFactory<DS> extends AutoCloseable {
     /**
      * Returns configured data store. Depending on configuration and implementation it can create new data store
      * or reuse existing one.
@@ -39,4 +39,14 @@ public interface ExternalDataStoreFactory<DS> {
      * @param config configuration of the given datastore
      */
     void init(ExternalDataStoreConfig config);
+
+    /**
+     * Closes underlying resources
+     *
+     * @throws Exception
+     */
+    @Override
+    default void close() throws Exception {
+        //no op
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
@@ -30,8 +30,9 @@ public interface ExternalDataStoreService extends AutoCloseable {
      * Returns external data store factory with given name.
      *
      * @param name name of the data store factory
+     * @param <DS> type of the data store
      * @return instance of the factory
-     * @throws HazelcastException if the factory with given name is not found or misconfigured
+     * @throws HazelcastException if the factory with given name is not found or misconfigured*
      */
-    ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name);
+    <DS> ExternalDataStoreFactory<DS> getExternalDataStoreFactory(String name);
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
@@ -25,7 +25,7 @@ import com.hazelcast.spi.annotation.Beta;
  * @since 5.2
  */
 @Beta
-public interface ExternalDataStoreService {
+public interface ExternalDataStoreService extends AutoCloseable {
     /**
      * Returns external data store factory with given name.
      *

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -47,7 +47,7 @@ public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource
     }
 
     @Override
-    public DataStoreSupplier<DataSource> getDataStore() {
+    public DataStoreSupplier<DataSource> createDataStore() {
         return config.isShared() ? DataStoreSupplier.nonClosing(sharedDataSource) : DataStoreSupplier.closing(createDataSource());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -38,6 +38,7 @@ public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource
     private ExternalDataStoreConfig config;
     private DataSource shareDataSource;
 
+    @Override
     public void init(ExternalDataStoreConfig config) {
         this.config = config;
         if (config.isShared()) {

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -34,32 +34,17 @@ import javax.sql.DataSource;
  * @since 5.2
  */
 @Beta
-public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource> {
-    private ExternalDataStoreConfig config;
-    private HikariDataSource sharedDataSource;
+public class JdbcDataStoreFactory extends AbstractDataStoreFactory<DataSource> {
 
-    @Override
-    public void init(ExternalDataStoreConfig config) {
-        this.config = config;
-        if (config.isShared()) {
-            sharedDataSource = createDataSource();
-        }
-    }
-
-    @Override
-    public DataStoreSupplier<DataSource> createDataStore() {
-        return config.isShared() ? DataStoreSupplier.nonClosing(sharedDataSource) : DataStoreSupplier.closing(createDataSource());
-    }
-
-    private HikariDataSource createDataSource() {
+    protected HikariDataSource createDataSource() {
         HikariConfig dataSourceConfig = new HikariConfig(config.getProperties());
         return new HikariDataSource(dataSourceConfig);
     }
 
     @Override
     public void close() throws Exception {
-        if (sharedDataSource != null) {
-            sharedDataSource.close();
+        if (sharedDataStore != null) {
+            ((HikariDataSource) sharedDataStore).close();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -47,8 +47,8 @@ public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource
     }
 
     @Override
-    public DataSource getDataStore() {
-        return config.isShared() ? sharedDataSource : createDataSource();
+    public DataStoreSupplier<DataSource> getDataStore() {
+        return config.isShared() ? DataStoreSupplier.nonClosing(sharedDataSource) : DataStoreSupplier.closing(createDataSource());
     }
 
     private HikariDataSource createDataSource() {
@@ -58,6 +58,8 @@ public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource
 
     @Override
     public void close() throws Exception {
-        sharedDataSource.close();
+        if (sharedDataSource != null) {
+            sharedDataSource.close();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -36,23 +36,28 @@ import javax.sql.DataSource;
 @Beta
 public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource> {
     private ExternalDataStoreConfig config;
-    private DataSource shareDataSource;
+    private HikariDataSource sharedDataSource;
 
     @Override
     public void init(ExternalDataStoreConfig config) {
         this.config = config;
         if (config.isShared()) {
-            shareDataSource = createDataSource();
+            sharedDataSource = createDataSource();
         }
     }
 
     @Override
     public DataSource getDataStore() {
-        return config.isShared() ? shareDataSource : createDataSource();
+        return config.isShared() ? sharedDataSource : createDataSource();
     }
 
-    private DataSource createDataSource() {
+    private HikariDataSource createDataSource() {
         HikariConfig dataSourceConfig = new HikariConfig(config.getProperties());
         return new HikariDataSource(dataSourceConfig);
+    }
+
+    @Override
+    public void close() throws Exception {
+        sharedDataSource.close();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -22,7 +22,9 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.ExternalDataStoreService;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.internal.nio.IOUtil;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -63,5 +65,18 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }
         return externalDataStoreFactory;
+    }
+
+    public void shutDown(boolean terminate) {
+        if (terminate) {
+            return;
+        }
+
+        for (ExternalDataStoreFactory<?> dataStoreFactory : dataStoreFactories.values()) {
+            Object dataStore = dataStoreFactory.getDataStore();
+            if (dataStore instanceof Closeable) {
+                IOUtil.closeResource(((Closeable) dataStore));
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -57,8 +57,8 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
     }
 
     @Override
-    public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
-        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories.get(name);
+    public <DS> ExternalDataStoreFactory<DS> getExternalDataStoreFactory(String name) {
+        ExternalDataStoreFactory<DS> externalDataStoreFactory = (ExternalDataStoreFactory<DS>) dataStoreFactories.get(name);
         if (externalDataStoreFactory == null) {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -22,9 +22,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.ExternalDataStoreService;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.nio.IOUtil;
 
-import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -67,16 +65,10 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
         return externalDataStoreFactory;
     }
 
-    public void shutDown(boolean terminate) {
-        if (terminate) {
-            return;
-        }
-
+    @Override
+    public void close() throws Exception {
         for (ExternalDataStoreFactory<?> dataStoreFactory : dataStoreFactories.values()) {
-            Object dataStore = dataStoreFactory.getDataStore();
-            if (dataStore instanceof Closeable) {
-                IOUtil.closeResource(((Closeable) dataStore));
-            }
+            dataStoreFactory.close();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.core.processor;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 import com.hazelcast.function.BiConsumerEx;
@@ -49,6 +50,7 @@ import javax.jms.Connection;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.sql.CommonDataSource;
+import javax.sql.DataSource;
 import java.io.BufferedWriter;
 import java.nio.charset.Charset;
 import java.sql.PreparedStatement;
@@ -388,7 +390,7 @@ public final class SinkProcessors {
     public static <T> ProcessorMetaSupplier writeJdbcP(
             @Nullable String jdbcUrl,
             @Nonnull String updateQuery,
-            @Nonnull SupplierEx<? extends CommonDataSource> dataSourceSupplier,
+            @Nonnull SupplierEx<DataStoreSupplier<CommonDataSource>> dataSourceSupplier,
             @Nonnull BiConsumerEx<? super PreparedStatement, ? super T> bindFn,
             boolean exactlyOnce,
             int batchLimit
@@ -422,7 +424,8 @@ public final class SinkProcessors {
                 bindFn, exactlyOnce, batchLimit);
     }
 
-    private static FunctionEx<ProcessorMetaSupplier.Context, CommonDataSource> dataSourceSupplier(String externalDataStoreName) {
+    private static FunctionEx<ProcessorMetaSupplier.Context,
+            DataStoreSupplier<DataSource>> dataSourceSupplier(String externalDataStoreName) {
         return context -> getDataStoreFactory(context, externalDataStoreName).getDataStore();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -399,7 +399,7 @@ public final class SinkProcessors {
         checkNotNull(dataSourceSupplier, "dataSourceSupplier");
         checkNotNull(bindFn, "bindFn");
         checkPositive(batchLimit, "batchLimit");
-        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreHolder.closing(dataSourceSupplier.get()),
+        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreHolder.nonClosing(dataSourceSupplier.get()),
                 bindFn, exactlyOnce, batchLimit);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.core.processor;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 import com.hazelcast.function.BiConsumerEx;
@@ -399,7 +399,7 @@ public final class SinkProcessors {
         checkNotNull(dataSourceSupplier, "dataSourceSupplier");
         checkNotNull(bindFn, "bindFn");
         checkPositive(batchLimit, "batchLimit");
-        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreSupplier.closing(dataSourceSupplier.get()), bindFn, exactlyOnce, batchLimit);
+        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreHolder.closing(dataSourceSupplier.get()), bindFn, exactlyOnce, batchLimit);
     }
 
     /**
@@ -425,7 +425,7 @@ public final class SinkProcessors {
     }
 
     private static FunctionEx<ProcessorMetaSupplier.Context,
-            DataStoreSupplier<DataSource>> dataSourceSupplier(String externalDataStoreName) {
+            DataStoreHolder<DataSource>> dataSourceSupplier(String externalDataStoreName) {
         return context -> getDataStoreFactory(context, externalDataStoreName).createDataStore();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -102,7 +102,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeRemoteMapP(
-        @Nonnull String mapName, @Nonnull ClientConfig clientConfig
+            @Nonnull String mapName, @Nonnull ClientConfig clientConfig
     ) {
         return writeRemoteMapP(mapName, clientConfig, identity(), identity());
     }
@@ -168,7 +168,7 @@ public final class SinkProcessors {
     /**
      * Returns a supplier of processors for
      * {@link Sinks#remoteMapWithUpdating(String, ClientConfig, FunctionEx
-     * , BiFunctionEx)}.
+     *, BiFunctionEx)}.
      */
     @Nonnull
     public static <T, K, V> ProcessorMetaSupplier updateRemoteMapP(
@@ -333,8 +333,8 @@ public final class SinkProcessors {
      * The returned processor will have preferred local parallelism of 1. It
      * will not participate in state saving for fault tolerance.
      *
-     * @param createFn     supplies the writer. The argument to this function
-     *                     is the context for the given processor.
+     * @param createFn    supplies the writer. The argument to this function
+     *                    is the context for the given processor.
      * @param onReceiveFn function that Jet calls upon receiving each item for the sink
      * @param flushFn     function that flushes the writer
      * @param destroyFn   function that destroys the writer
@@ -390,7 +390,7 @@ public final class SinkProcessors {
     public static <T> ProcessorMetaSupplier writeJdbcP(
             @Nullable String jdbcUrl,
             @Nonnull String updateQuery,
-            @Nonnull SupplierEx<DataStoreSupplier<CommonDataSource>> dataSourceSupplier,
+            @Nonnull SupplierEx<? extends CommonDataSource> dataSourceSupplier,
             @Nonnull BiConsumerEx<? super PreparedStatement, ? super T> bindFn,
             boolean exactlyOnce,
             int batchLimit
@@ -399,7 +399,7 @@ public final class SinkProcessors {
         checkNotNull(dataSourceSupplier, "dataSourceSupplier");
         checkNotNull(bindFn, "bindFn");
         checkPositive(batchLimit, "batchLimit");
-        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> dataSourceSupplier.get(), bindFn, exactlyOnce, batchLimit);
+        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreSupplier.closing(dataSourceSupplier.get()), bindFn, exactlyOnce, batchLimit);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -426,7 +426,7 @@ public final class SinkProcessors {
 
     private static FunctionEx<ProcessorMetaSupplier.Context,
             DataStoreSupplier<DataSource>> dataSourceSupplier(String externalDataStoreName) {
-        return context -> getDataStoreFactory(context, externalDataStoreName).getDataStore();
+        return context -> getDataStoreFactory(context, externalDataStoreName).createDataStore();
     }
 
     private static JdbcDataStoreFactory getDataStoreFactory(ProcessorMetaSupplier.Context context, String name) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -399,7 +399,8 @@ public final class SinkProcessors {
         checkNotNull(dataSourceSupplier, "dataSourceSupplier");
         checkNotNull(bindFn, "bindFn");
         checkPositive(batchLimit, "batchLimit");
-        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreHolder.closing(dataSourceSupplier.get()), bindFn, exactlyOnce, batchLimit);
+        return WriteJdbcP.metaSupplier(jdbcUrl, updateQuery, ctx -> DataStoreHolder.closing(dataSourceSupplier.get()),
+                bindFn, exactlyOnce, batchLimit);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -459,7 +459,7 @@ public final class SourceProcessors {
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
-        return ReadJdbcP.supplier(context -> getDataStoreFactory(context, externalDataStoreRef.getName()).getDataStore(),
+        return ReadJdbcP.supplier(context -> getDataStoreFactory(context, externalDataStoreRef.getName()).createDataStore(),
                 resultSetFn,
                 mapOutputFn);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.core.processor;
 import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 import com.hazelcast.function.BiConsumerEx;
@@ -443,7 +444,8 @@ public final class SourceProcessors {
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
-        return ReadJdbcP.supplier(context -> new DataSourceFromConnectionSupplier(newConnectionFn), resultSetFn, mapOutputFn);
+        return ReadJdbcP.supplier(context -> DataStoreSupplier.closing(new DataSourceFromConnectionSupplier(newConnectionFn)),
+                resultSetFn, mapOutputFn);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.core.processor;
 import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 import com.hazelcast.function.BiConsumerEx;
@@ -444,7 +443,7 @@ public final class SourceProcessors {
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
-        return ReadJdbcP.supplier(context -> DataStoreHolder.closing(new DataSourceFromConnectionSupplier(newConnectionFn)),
+        return ReadJdbcP.supplierWithoutHolder(context -> new DataSourceFromConnectionSupplier(newConnectionFn),
                 resultSetFn, mapOutputFn);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -19,7 +19,7 @@ package com.hazelcast.jet.core.processor;
 import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 import com.hazelcast.function.BiConsumerEx;
@@ -444,7 +444,7 @@ public final class SourceProcessors {
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
-        return ReadJdbcP.supplier(context -> DataStoreSupplier.closing(new DataSourceFromConnectionSupplier(newConnectionFn)),
+        return ReadJdbcP.supplier(context -> DataStoreHolder.closing(new DataSourceFromConnectionSupplier(newConnectionFn)),
                 resultSetFn, mapOutputFn);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Traverser;
@@ -73,7 +73,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
      * Use {@link SourceProcessors#readJdbcP}.
      */
     public static <T> ProcessorMetaSupplier supplier(
-            @Nonnull SupplierEx<? extends DataStoreSupplier<DataSource>> newDataSourceFn,
+            @Nonnull SupplierEx<? extends DataStoreHolder<DataSource>> newDataSourceFn,
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
@@ -84,7 +84,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
      * Use {@link SourceProcessors#readJdbcP}.
      */
     public static <T> ProcessorMetaSupplier supplier(
-            @Nonnull FunctionEx<ProcessorSupplier.Context, ? extends DataStoreSupplier<DataSource>> newDataSourceFn,
+            @Nonnull FunctionEx<ProcessorSupplier.Context, ? extends DataStoreHolder<DataSource>> newDataSourceFn,
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
@@ -105,7 +105,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
 
         return ProcessorMetaSupplier.forceTotalParallelismOne(
                 SecuredFunctions.readJdbcProcessorFn(connectionURL,
-                        (ctx) -> DataStoreSupplier.closing(new DataSourceFromJdbcUrl(connectionURL)),
+                        (ctx) -> DataStoreHolder.closing(new DataSourceFromJdbcUrl(connectionURL)),
                         (connection, parallelism, index) -> {
                             PreparedStatement statement = connection.prepareStatement(query);
                             try {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.connector;
 
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Traverser;
@@ -72,7 +73,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
      * Use {@link SourceProcessors#readJdbcP}.
      */
     public static <T> ProcessorMetaSupplier supplier(
-            @Nonnull SupplierEx<? extends DataSource> newDataSourceFn,
+            @Nonnull SupplierEx<? extends DataStoreSupplier<DataSource>> newDataSourceFn,
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
@@ -83,7 +84,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
      * Use {@link SourceProcessors#readJdbcP}.
      */
     public static <T> ProcessorMetaSupplier supplier(
-            @Nonnull FunctionEx<ProcessorSupplier.Context, ? extends DataSource> newDataSourceFn,
+            @Nonnull FunctionEx<ProcessorSupplier.Context, ? extends DataStoreSupplier<DataSource>> newDataSourceFn,
             @Nonnull ToResultSetFunction resultSetFn,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
@@ -104,7 +105,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
 
         return ProcessorMetaSupplier.forceTotalParallelismOne(
                 SecuredFunctions.readJdbcProcessorFn(connectionURL,
-                        (ctx) -> new DataSourceFromJdbcUrl(connectionURL),
+                        (ctx) -> DataStoreSupplier.closing(new DataSourceFromJdbcUrl(connectionURL)),
                         (connection, parallelism, index) -> {
                             PreparedStatement statement = connection.prepareStatement(query);
                             try {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.connector;
 
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
@@ -118,7 +119,8 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
     public static <T> ProcessorMetaSupplier metaSupplier(
             @Nullable String jdbcUrl,
             @Nonnull String updateQuery,
-            @Nonnull FunctionEx<ProcessorMetaSupplier.Context, ? extends CommonDataSource> dataSourceSupplier,
+            @Nonnull FunctionEx<ProcessorMetaSupplier.Context,
+                    ? extends DataStoreSupplier<? extends CommonDataSource>> dataSourceSupplier,
             @Nonnull BiConsumerEx<? super PreparedStatement, ? super T> bindFn,
             boolean exactlyOnce,
             int batchLimit
@@ -130,19 +132,25 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
         return ProcessorMetaSupplier.preferLocalParallelismOne(
                 ConnectorPermission.jdbc(jdbcUrl, ACTION_WRITE),
                 new ProcessorSupplier() {
-                    private transient CommonDataSource dataSource;
+                    private transient DataStoreSupplier<? extends CommonDataSource> dataSource;
 
                     @Override
                     public void init(@Nonnull Context context) {
                         dataSource = dataSourceSupplier.apply(context);
                     }
 
-                    @Nonnull @Override
+                    @Override
+                    public void close(Throwable error) throws Exception {
+                        dataSource.close();
+                    }
+
+                    @Nonnull
+                    @Override
                     public Collection<? extends Processor> get(int count) {
                         return IntStream.range(0, count)
-                                        .mapToObj(i -> new WriteJdbcP<>(updateQuery, dataSource, bindFn,
-                                                               exactlyOnce, batchLimit))
-                                        .collect(Collectors.toList());
+                                .mapToObj(i -> new WriteJdbcP<>(updateQuery, dataSource.get(), bindFn,
+                                        exactlyOnce, batchLimit))
+                                .collect(Collectors.toList());
                     }
 
                     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
@@ -120,7 +120,7 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
             @Nullable String jdbcUrl,
             @Nonnull String updateQuery,
             @Nonnull FunctionEx<ProcessorMetaSupplier.Context,
-                    ? extends DataStoreSupplier<? extends CommonDataSource>> dataSourceSupplier,
+                    ? extends DataStoreHolder<? extends CommonDataSource>> dataSourceSupplier,
             @Nonnull BiConsumerEx<? super PreparedStatement, ? super T> bindFn,
             boolean exactlyOnce,
             int batchLimit
@@ -132,7 +132,7 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
         return ProcessorMetaSupplier.preferLocalParallelismOne(
                 ConnectorPermission.jdbc(jdbcUrl, ACTION_WRITE),
                 new ProcessorSupplier() {
-                    private transient DataStoreSupplier<? extends CommonDataSource> dataSource;
+                    private transient DataStoreHolder<? extends CommonDataSource> dataSource;
 
                     @Override
                     public void init(@Nonnull Context context) {

--- a/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
@@ -18,7 +18,7 @@ package com.hazelcast.security.impl.function;
 
 import com.hazelcast.cache.EventJournalCacheEvent;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
@@ -275,13 +275,13 @@ public final class SecuredFunctions {
 
     public static <T> ProcessorSupplier readJdbcProcessorFn(
             String connectionUrl,
-            FunctionEx<ProcessorSupplier.Context, ? extends DataStoreSupplier<DataSource>> newDataSourceFn,
+            FunctionEx<ProcessorSupplier.Context, ? extends DataStoreHolder<DataSource>> newDataSourceFn,
             ToResultSetFunction resultSetFn,
             FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
         return new ProcessorSupplier() {
 
-            private DataStoreSupplier<DataSource> dataSource;
+            private DataStoreHolder<DataSource> dataSource;
 
             @Override
             public void init(@Nonnull ProcessorSupplier.Context context) {

--- a/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
@@ -308,6 +308,16 @@ public final class SecuredFunctions {
         };
     }
 
+    public static <T> ProcessorSupplier readJdbcProcessorFnWithoutHolder(
+            String connectionUrl,
+            FunctionEx<ProcessorSupplier.Context, ? extends DataSource> newDataSourceFn,
+            ToResultSetFunction resultSetFn,
+            FunctionEx<? super ResultSet, ? extends T> mapOutputFn
+    ) {
+        return readJdbcProcessorFn(connectionUrl, ctx -> DataStoreHolder.nonClosing(newDataSourceFn.apply(ctx)),
+                resultSetFn, mapOutputFn);
+    }
+
     public static FunctionEx<? super Processor.Context, ? extends BufferedWriter> createBufferedWriterFn(
             String host, int port, String charsetName
     ) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -132,7 +132,7 @@ public class NodeEngineImpl implements NodeEngine {
     private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
     private final ConcurrencyDetection concurrencyDetection;
     private final TenantControlServiceImpl tenantControlService;
-    private final ExternalDataStoreService externalDataStoreService;
+    private final ExternalDataStoreServiceImpl externalDataStoreService;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     public NodeEngineImpl(Node node) {
@@ -576,6 +576,8 @@ public class NodeEngineImpl implements NodeEngine {
         if (diagnostics != null) {
             diagnostics.shutdown();
         }
+
+        externalDataStoreService.shutDown(terminate);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -577,6 +577,10 @@ public class NodeEngineImpl implements NodeEngine {
             diagnostics.shutdown();
         }
 
+        closeExternalDataStoreService();
+    }
+
+    private void closeExternalDataStoreService() {
         try {
             externalDataStoreService.close();
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -132,7 +132,7 @@ public class NodeEngineImpl implements NodeEngine {
     private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
     private final ConcurrencyDetection concurrencyDetection;
     private final TenantControlServiceImpl tenantControlService;
-    private final ExternalDataStoreServiceImpl externalDataStoreService;
+    private final ExternalDataStoreService externalDataStoreService;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     public NodeEngineImpl(Node node) {
@@ -577,7 +577,11 @@ public class NodeEngineImpl implements NodeEngine {
             diagnostics.shutdown();
         }
 
-        externalDataStoreService.shutDown(terminate);
+        try {
+            externalDataStoreService.close();
+        } catch (Exception e) {
+            logger.warning("Closing data stores failed", e);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
@@ -36,8 +36,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JdbcDataStoreFactoryTest {
 
-    DataStoreSupplier<DataSource> dataStore1;
-    DataStoreSupplier<DataSource> dataStore2;
+    DataStoreHolder<DataSource> dataStore1;
+    DataStoreHolder<DataSource> dataStore2;
     JdbcDataStoreFactory jdbcDataStoreFactory = new JdbcDataStoreFactory();
 
     @After
@@ -47,7 +47,7 @@ public class JdbcDataStoreFactoryTest {
         jdbcDataStoreFactory.close();
     }
 
-    private static void close(DataStoreSupplier<DataSource> dataStore) throws Exception {
+    private static void close(DataStoreHolder<DataSource> dataStore) throws Exception {
         if (dataStore != null) {
             dataStore.close();
         }
@@ -77,10 +77,10 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(true);
         jdbcDataStoreFactory.init(config);
 
-        DataStoreSupplier<DataSource> dataStoreSupplier = jdbcDataStoreFactory.createDataStore();
-        dataStoreSupplier.close();
+        DataStoreHolder<DataSource> dataStoreHolder = jdbcDataStoreFactory.createDataStore();
+        dataStoreHolder.close();
 
-        ResultSet resultSet = executeQuery(dataStoreSupplier, "select 'some-name' as name");
+        ResultSet resultSet = executeQuery(dataStoreHolder, "select 'some-name' as name");
         resultSet.next();
         String actualName = resultSet.getString(1);
 
@@ -96,15 +96,15 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(false);
         jdbcDataStoreFactory.init(config);
 
-        DataStoreSupplier<DataSource> dataStoreSupplier = jdbcDataStoreFactory.createDataStore();
-        dataStoreSupplier.close();
+        DataStoreHolder<DataSource> dataStoreHolder = jdbcDataStoreFactory.createDataStore();
+        dataStoreHolder.close();
 
-        assertThatThrownBy(() -> executeQuery(dataStoreSupplier, "select 'some-name' as name"))
+        assertThatThrownBy(() -> executeQuery(dataStoreHolder, "select 'some-name' as name"))
                 .isInstanceOf(SQLException.class).hasMessage("HikariDataSource HikariDataSource (HikariPool-1) has been closed.");
     }
 
-    private ResultSet executeQuery(DataStoreSupplier<DataSource> dataStoreSupplier, String sql) throws SQLException {
-        return dataStoreSupplier.get().getConnection().prepareStatement(sql).executeQuery();
+    private ResultSet executeQuery(DataStoreHolder<DataSource> dataStoreHolder, String sql) throws SQLException {
+        return dataStoreHolder.get().getConnection().prepareStatement(sql).executeQuery();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
@@ -54,7 +54,7 @@ public class JdbcDataStoreFactoryTest {
     }
 
     @Test
-    public void should_return_same_DataStore_when_shared() {
+    public void should_return_same_datastore_when_shared() {
         JdbcDataStoreFactory jdbcDataStoreFactory = new JdbcDataStoreFactory();
         ExternalDataStoreConfig config = new ExternalDataStoreConfig()
                 .setProperty("jdbcUrl", "jdbc:h2:mem:" + JdbcDataStoreFactoryTest.class.getSimpleName() + "_shared")
@@ -108,7 +108,7 @@ public class JdbcDataStoreFactoryTest {
     }
 
     @Test
-    public void should_return_different_DataStore_when_NOT_shared() {
+    public void should_return_different_datastore_when_NOT_shared() {
         JdbcDataStoreFactory jdbcDataStoreFactory = new JdbcDataStoreFactory();
         ExternalDataStoreConfig config = new ExternalDataStoreConfig()
                 .setProperty("jdbcUrl", "jdbc:h2:mem:" + JdbcDataStoreFactoryTest.class.getSimpleName() + "_not_shared")

--- a/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
@@ -61,8 +61,8 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(true);
         jdbcDataStoreFactory.init(config);
 
-        dataStore1 = jdbcDataStoreFactory.getDataStore();
-        dataStore2 = jdbcDataStoreFactory.getDataStore();
+        dataStore1 = jdbcDataStoreFactory.createDataStore();
+        dataStore2 = jdbcDataStoreFactory.createDataStore();
 
         assertThat(dataStore1.get()).isNotNull();
         assertThat(dataStore2.get()).isNotNull();
@@ -77,7 +77,7 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(true);
         jdbcDataStoreFactory.init(config);
 
-        DataStoreSupplier<DataSource> dataStoreSupplier = jdbcDataStoreFactory.getDataStore();
+        DataStoreSupplier<DataSource> dataStoreSupplier = jdbcDataStoreFactory.createDataStore();
         dataStoreSupplier.close();
 
         ResultSet resultSet = executeQuery(dataStoreSupplier, "select 'some-name' as name");
@@ -96,7 +96,7 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(false);
         jdbcDataStoreFactory.init(config);
 
-        DataStoreSupplier<DataSource> dataStoreSupplier = jdbcDataStoreFactory.getDataStore();
+        DataStoreSupplier<DataSource> dataStoreSupplier = jdbcDataStoreFactory.createDataStore();
         dataStoreSupplier.close();
 
         assertThatThrownBy(() -> executeQuery(dataStoreSupplier, "select 'some-name' as name"))
@@ -115,8 +115,8 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(false);
         jdbcDataStoreFactory.init(config);
 
-        dataStore1 = jdbcDataStoreFactory.getDataStore();
-        dataStore2 = jdbcDataStoreFactory.getDataStore();
+        dataStore1 = jdbcDataStoreFactory.createDataStore();
+        dataStore2 = jdbcDataStoreFactory.createDataStore();
 
         assertThat(dataStore1.get()).isNotNull();
         assertThat(dataStore2.get()).isNotNull();
@@ -131,7 +131,7 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(true);
         jdbcDataStoreFactory.init(config);
 
-        DataSource dataSource = jdbcDataStoreFactory.getDataStore().get();
+        DataSource dataSource = jdbcDataStoreFactory.createDataStore().get();
         jdbcDataStoreFactory.close();
 
         assertThatThrownBy(() -> executeQuery(dataSource, "select 'some-name' as name"))

--- a/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/JdbcDataStoreFactoryTest.java
@@ -17,14 +17,17 @@
 package com.hazelcast.datastore;
 
 import com.hazelcast.config.ExternalDataStoreConfig;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.sql.DataSource;
+import java.io.Closeable;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +35,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JdbcDataStoreFactoryTest {
+
+    DataSource dataStore1;
+    DataSource dataStore2;
+
+    @After
+    public void tearDown() throws Exception {
+        closeDataStore(dataStore1);
+        closeDataStore(dataStore2);
+    }
+
+    private static void closeDataStore(DataSource dataSource) {
+        if (!(dataSource instanceof Closeable)) {
+            return;
+        }
+
+        IOUtil.closeResource(((Closeable) dataSource));
+    }
 
     @Test
     public void should_return_same_DataStore_when_shared() {
@@ -43,8 +63,8 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(true);
         jdbcDataStoreFactory.init(config);
 
-        DataSource dataStore1 = jdbcDataStoreFactory.getDataStore();
-        DataSource dataStore2 = jdbcDataStoreFactory.getDataStore();
+        dataStore1 = jdbcDataStoreFactory.getDataStore();
+        dataStore2 = jdbcDataStoreFactory.getDataStore();
 
         assertThat(dataStore1).isNotNull();
         assertThat(dataStore2).isNotNull();
@@ -61,8 +81,8 @@ public class JdbcDataStoreFactoryTest {
                 .setShared(false);
         jdbcDataStoreFactory.init(config);
 
-        DataSource dataStore1 = jdbcDataStoreFactory.getDataStore();
-        DataSource dataStore2 = jdbcDataStoreFactory.getDataStore();
+        dataStore1 = jdbcDataStoreFactory.getDataStore();
+        dataStore2 = jdbcDataStoreFactory.getDataStore();
 
         assertThat(dataStore1).isNotNull();
         assertThat(dataStore2).isNotNull();

--- a/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
@@ -64,7 +64,7 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
         ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
         assertInstanceOf(JdbcDataStoreFactory.class, dataStoreFactory);
 
-        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore().get();
+        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).createDataStore().get();
 
         ResultSet resultSet = executeQuery(dataSource, "select 'some-name' as name");
         resultSet.next();
@@ -86,7 +86,7 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
         ExternalDataStoreService externalDataStoreService = getExternalDataStoreService();
         ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
 
-        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore().get();
+        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).createDataStore().get();
         externalDataStoreService.close();
 
         assertThatThrownBy(() -> executeQuery(dataSource, "select 'some-name' as name"))

--- a/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
@@ -64,7 +64,7 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
         ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
         assertInstanceOf(JdbcDataStoreFactory.class, dataStoreFactory);
 
-        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore();
+        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore().get();
 
         ResultSet resultSet = executeQuery(dataSource, "select 'some-name' as name");
         resultSet.next();
@@ -86,7 +86,7 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
         ExternalDataStoreService externalDataStoreService = getExternalDataStoreService();
         ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
 
-        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore();
+        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore().get();
         externalDataStoreService.close();
 
         assertThatThrownBy(() -> executeQuery(dataSource, "select 'some-name' as name"))

--- a/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 
 import javax.sql.DataSource;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,14 +60,13 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
 
     @Test
     public void should_return_working_datastore() throws Exception {
-        HazelcastInstance instance = createHazelcastInstance(config);
-        ExternalDataStoreService externalDataStoreService = Util.getNodeEngine(instance).getExternalDataStoreService();
+        ExternalDataStoreService externalDataStoreService = getExternalDataStoreService();
         ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
         assertInstanceOf(JdbcDataStoreFactory.class, dataStoreFactory);
 
         DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore();
 
-        ResultSet resultSet = dataSource.getConnection().prepareStatement("select 'some-name' as name").executeQuery();
+        ResultSet resultSet = executeQuery(dataSource, "select 'some-name' as name");
         resultSet.next();
         String actualName = resultSet.getString(1);
 
@@ -75,11 +75,31 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
 
     @Test
     public void should_fail_when_non_existing_datastore() throws Exception {
-        HazelcastInstance instance = createHazelcastInstance(config);
-        ExternalDataStoreService externalDataStoreService = Util.getNodeEngine(instance).getExternalDataStoreService();
+        ExternalDataStoreService externalDataStoreService = getExternalDataStoreService();
         assertThatThrownBy(() -> externalDataStoreService.getExternalDataStoreFactory("non-existing-data-store"))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessage("External data store factory 'non-existing-data-store' not found");
+    }
+
+    @Test
+    public void should_close_factories() throws Exception {
+        ExternalDataStoreService externalDataStoreService = getExternalDataStoreService();
+        ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
+
+        DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore();
+        externalDataStoreService.close();
+
+        assertThatThrownBy(() -> executeQuery(dataSource, "select 'some-name' as name"))
+                .isInstanceOf(SQLException.class).hasMessage("HikariDataSource HikariDataSource (HikariPool-1) has been closed.");
+    }
+
+    private ExternalDataStoreService getExternalDataStoreService() {
+        HazelcastInstance instance = createHazelcastInstance(config);
+        return Util.getNodeEngine(instance).getExternalDataStoreService();
+    }
+
+    private ResultSet executeQuery(DataSource dataSource, String sql) throws SQLException {
+        return dataSource.getConnection().prepareStatement(sql).executeQuery();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ExternalDataStoreConfig;
-import com.hazelcast.datastore.DataStoreSupplier;
+import com.hazelcast.datastore.DataStoreHolder;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 
@@ -62,8 +62,8 @@ final class ExternalDataStoreTestUtil {
     private static class DummyDataStoreFactory implements ExternalDataStoreFactory<Object> {
 
         @Override
-        public DataStoreSupplier<Object> createDataStore() {
-            return DataStoreSupplier.closing(new Object());
+        public DataStoreHolder<Object> createDataStore() {
+            return DataStoreHolder.closing(new Object());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ExternalDataStoreConfig;
+import com.hazelcast.datastore.DataStoreSupplier;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.JdbcDataStoreFactory;
 
@@ -61,8 +62,8 @@ final class ExternalDataStoreTestUtil {
     private static class DummyDataStoreFactory implements ExternalDataStoreFactory<Object> {
 
         @Override
-        public Object getDataStore() {
-            return new Object();
+        public DataStoreSupplier<Object> getDataStore() {
+            return DataStoreSupplier.closing(new Object());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
@@ -62,7 +62,7 @@ final class ExternalDataStoreTestUtil {
     private static class DummyDataStoreFactory implements ExternalDataStoreFactory<Object> {
 
         @Override
-        public DataStoreSupplier<Object> getDataStore() {
+        public DataStoreSupplier<Object> createDataStore() {
             return DataStoreSupplier.closing(new Object());
         }
 


### PR DESCRIPTION
Datastores need to be closed to release underlying resources (e.g. TCP connections).

- Shared datastores will be closed on the node shutdown
- Non-shared datastores will be closed right after the usage (e.g. within `ProcessorSupplier#close` method). Since we don't know if a datastore used in the job is shared or not, we wrap all datastores with `DataStoreHolder` on which we always call `close` method. 
- Shared datastores will be wrapped with non-closing `DataStoreHolder` which will be suppressing closing of the wrapped datastore
- Non-shared datastores will be wrapped with closing `DataStoreHolder` which will close the wrapped datastore

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
