### PR TITLE
Set default value changeExpiryOnUpdate to true

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
@@ -77,7 +77,7 @@ public class State {
     private volatile boolean disableWanReplicationEvent;
     private volatile boolean triggerMapLoader;
     private volatile boolean shouldLoad;
-    private volatile boolean changeExpiryOnUpdate;
+    private volatile boolean changeExpiryOnUpdate = true;
     private volatile Object oldValue;
     private volatile Object newValue;
     private volatile Object result;

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -1311,7 +1311,9 @@ public class EvictionTest extends HazelcastTestSupport {
     }
 
     protected MapConfig newMapConfig(String mapName) {
-        return new MapConfig(mapName).setStatisticsEnabled(statisticsEnabled);
+        return new MapConfig(mapName)
+                .setStatisticsEnabled(statisticsEnabled)
+                .setPerEntryStatsEnabled(perEntryStatsEnabled);
     }
 
     private Config newConfig(String mapName, int maxSize, MaxSizePolicy maxSizePolicy) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/steps/engine/StateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/steps/engine/StateTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation.steps.engine;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class StateTest extends HazelcastTestSupport {
+
+    @Test
+    public void changeExpiryOnUpdate_is_true_when_default() {
+        State state = new State(null, null);
+
+        assertTrue(state.isChangeExpiryOnUpdate());
+    }
+
+
+    @Test
+    public void changeExpiryOnUpdate_is_false_when_set() {
+        State state = new State(null, null);
+        state.setChangeExpiryOnUpdate(false);
+
+        assertFalse(state.isChangeExpiryOnUpdate());
+    }
+}


### PR DESCRIPTION
EE counterpart which fixes a test config: https://github.com/hazelcast/hazelcast-enterprise/pull/5347

**Description:**
Fixes an issue which shows itself in the failed run here: https://jenkins.hazelcast.com/view/force-offload-map/job/force-offload-Hazelcast-EE-master-OracleJDK8-nightly-clone/lastCompletedBuild/testReport/

2 issues related with map-store-offloading in separate commits

**Issue-1:**
Expiration is not working correctly since default value of `changeExpiryOnUpdate` must be `true` but as a left-over it remained `false` in `State` object. (follow-up of https://github.com/hazelcast/hazelcast/pull/22199) 

**Issue-2:**
Default value of `maxRunNanos` is set to `zero`, previously it was `5nanos`, reasoning is explained here:
https://github.com/hazelcast/hazelcast/pull/22381/files#diff-e686bb76a8b259dd2eeb983e0ff285c8bfab40001b08a9dbb4b996df37d85998R158. Zero seems a better default value.