### PR TITLE
Upgrade jackson-databind to 2.14.0 [4.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <log4j2.version>2.17.0</log4j2.version>
         <slf4j.version>1.7.30</slf4j.version>
 
-        <jackson.version>2.12.7</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.6.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <log4j2.version>2.17.0</log4j2.version>
         <slf4j.version>1.7.30</slf4j.version>
 
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.12.7</jackson.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.6.0</mockito.version>


### PR DESCRIPTION
Fixes #22385

The version in EE remains 2.13.3, this version is unaffected by the vulnerability. The comment in `hazelcast-enterprise/pom.xml` says that the version in EE should be the same as in OS, but these versions don't match currently, so I've left it that way.