### PR TITLE
Upgrade jackson to 2.14.0 [4.1.z]

### DIFF
--- a/hazelcast-sql-core/pom.xml
+++ b/hazelcast-sql-core/pom.xml
@@ -115,6 +115,14 @@
             </exclusions>
         </dependency>
 
+        <!-- This dependency overrides the vulnerable 2.10.0 as a transitive dependency
+         of avatica-core-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <log4j2.version>2.17.0</log4j2.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
-        <jackson.version>2.11.4</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
         <junit.version>4.13.1</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <log4j2.version>2.17.0</log4j2.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
-        <jackson.version>2.11.2</jackson.version>
+        <jackson.version>2.11.4</jackson.version>
         <junit.version>4.13.1</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>


### PR DESCRIPTION
Fixes CVE-2020-25649 in 4.1 in jackson-databind 2.10.0 as a transitive dependency of `avatica-core` in `hazelcast-sql` module.

Fixes #22392