### PR TITLE
[CN-399] [BACKPORT] Change Kubernetes client behavior for token refresh

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/FileReaderTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/FileReaderTokenProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+class FileReaderTokenProvider implements KubernetesTokenProvider {
+    private final String tokenPath;
+    private final KubernetesConfig.FileContentsReader fileContentsReader;
+
+    FileReaderTokenProvider(String tokenPath) {
+        this.tokenPath = tokenPath;
+        this.fileContentsReader = new KubernetesConfig.DefaultFileContentsReader();
+    }
+
+    @Override
+    public String getToken() {
+        return fileContentsReader.readFileContents(tokenPath);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -58,7 +58,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     }
 
     private static KubernetesClient buildKubernetesClient(KubernetesConfig config) {
-        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getKubernetesApiToken(),
+        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getTokenProvider(),
                 config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.getExposeExternallyMode(),
                 config.isUseNodeNameAsExternalAddress(), config.getServicePerPodLabelName(), config.getServicePerPodLabelValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -50,13 +50,11 @@ class KubernetesClient {
 
     private static final List<String> NON_RETRYABLE_KEYWORDS = asList(
             "\"reason\":\"Forbidden\"",
-            "\"reason\":\"Unauthorized\"",
             "\"reason\":\"NotFound\"",
             "Failure in generating SSLSocketFactory");
 
     private final String namespace;
     private final String kubernetesMaster;
-    private final String apiToken;
     private final String caCertificate;
     private final int retries;
     private final KubernetesApiProvider apiProvider;
@@ -65,15 +63,18 @@ class KubernetesClient {
     private final String servicePerPodLabelName;
     private final String servicePerPodLabelValue;
 
+    private final KubernetesTokenProvider tokenProvider;
+
     private boolean isNoPublicIpAlreadyLogged;
     private boolean isKnownExceptionAlreadyLogged;
 
-    KubernetesClient(String namespace, String kubernetesMaster, String apiToken, String caCertificate, int retries,
-                     ExposeExternallyMode exposeExternallyMode, boolean useNodeNameAsExternalAddress,
-                     String servicePerPodLabelName, String servicePerPodLabelValue) {
+    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
+                     String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
+                     boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
+                     String servicePerPodLabelValue) {
         this.namespace = namespace;
         this.kubernetesMaster = kubernetesMaster;
-        this.apiToken = apiToken;
+        this.tokenProvider = tokenProvider;
         this.caCertificate = caCertificate;
         this.retries = retries;
         this.exposeExternallyMode = exposeExternallyMode;
@@ -83,13 +84,13 @@ class KubernetesClient {
         this.apiProvider = buildKubernetesApiUrlProvider();
     }
 
-    KubernetesClient(String namespace, String kubernetesMaster, String apiToken, String caCertificate, int retries,
-                     ExposeExternallyMode exposeExternallyMode, boolean useNodeNameAsExternalAddress,
-                     String servicePerPodLabelName, String servicePerPodLabelValue,
-                     KubernetesApiProvider apiProvider) {
+    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
+                     String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
+                     boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
+                     String servicePerPodLabelValue, KubernetesApiProvider apiProvider) {
         this.namespace = namespace;
         this.kubernetesMaster = kubernetesMaster;
-        this.apiToken = apiToken;
+        this.tokenProvider = tokenProvider;
         this.caCertificate = caCertificate;
         this.retries = retries;
         this.exposeExternallyMode = exposeExternallyMode;
@@ -208,6 +209,11 @@ class KubernetesClient {
     String nodeName(String podName) {
         String podUrlString = String.format("%s/api/v1/namespaces/%s/pods/%s", kubernetesMaster, namespace, podName);
         return extractNodeName(callGet(podUrlString));
+    }
+
+    // For test purpose
+    boolean isKnownExceptionAlreadyLogged() {
+        return isKnownExceptionAlreadyLogged;
     }
 
     private static List<Endpoint> parsePodsList(JsonObject podsListJson) {
@@ -450,7 +456,8 @@ class KubernetesClient {
      */
     private JsonObject callGet(final String urlString) {
         return RetryUtils.retry(() -> Json
-                .parse(RestClient.create(urlString).withHeader("Authorization", String.format("Bearer %s", apiToken))
+                .parse(RestClient.create(urlString)
+                        .withHeader("Authorization", String.format("Bearer %s", tokenProvider.getToken()))
                         .withCaCertificates(caCertificate)
                         .get()
                         .getBody())

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesTokenProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+interface KubernetesTokenProvider {
+    String getToken();
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/StaticTokenProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/StaticTokenProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+class StaticTokenProvider implements KubernetesTokenProvider {
+    private final String token;
+
+    StaticTokenProvider(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String getToken() {
+        return token;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -24,8 +24,13 @@ import com.hazelcast.spi.exception.RestClientException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -45,11 +50,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class KubernetesClientTest {
     private static final String KUBERNETES_MASTER_IP = "localhost";
-
     private static final String TOKEN = "sample-token";
     private static final String CA_CERTIFICATE = "sample-ca-certificate";
     private static final String NAMESPACE = "sample-namespace";
@@ -57,6 +62,9 @@ public class KubernetesClientTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
 
     private KubernetesClient kubernetesClient;
 
@@ -865,6 +873,50 @@ public class KubernetesClientTest {
         assertThat(formatPublic(result), containsInAnyOrder(ready("35.232.226.200", 32124), ready("35.232.226.201", 32124)));
     }
 
+    @Test
+    public void apiAccessWithTokenRefresh() throws IOException {
+        // Token is read from the file, first token value is value-1
+        File file = testFolder.newFile("token");
+        Files.write(file.toPath(), "value-1".getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
+
+        stubFor(get(urlMatching("/apis/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-1"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        stubFor(get(urlMatching("/api/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-1"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        stubFor(get(urlMatching("/api/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-2"))
+                .willReturn(aResponse().withStatus(402).withBody("{}")));
+        stubFor(get(urlMatching("/apis/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-2"))
+                .willReturn(aResponse().withStatus(402).withBody("{}")));
+
+        KubernetesClient client = newKubernetesClient(new FileReaderTokenProvider(file.toString()));
+        client.endpoints();
+        assertFalse(client.isKnownExceptionAlreadyLogged());
+
+        // Token is rotated
+        Files.write(file.toPath(), "value-2".getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
+
+        // Api server will not accept token with old value
+        stubFor(get(urlMatching("/apis/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-1"))
+                .willReturn(aResponse().withStatus(402).withBody("{}")));
+        stubFor(get(urlMatching("/api/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-1"))
+                .willReturn(aResponse().withStatus(402).withBody("{}")));
+        stubFor(get(urlMatching("/api/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-2"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        stubFor(get(urlMatching("/apis/.*")).atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer value-2"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        client.endpoints();
+        assertFalse(client.isKnownExceptionAlreadyLogged());
+    }
+
     private static String serviceResponse(String ip) {
         //language=JSON
         return "{\n"
@@ -1298,12 +1350,16 @@ public class KubernetesClientTest {
         return newKubernetesClient(false);
     }
 
+    private KubernetesClient newKubernetesClient(KubernetesTokenProvider tokenProvider) {
+        String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
+        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, tokenProvider, CA_CERTIFICATE, RETRIES, ExposeExternallyMode.AUTO, true, null, null);
+    }
+
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress) {
         return newKubernetesClient(useNodeNameAsExternalAddress, null, null);
     }
 
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress, String servicePerPodLabelName, String servicePerPodLabelValue) {
-        String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
         return newKubernetesClient(ExposeExternallyMode.AUTO, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue);
     }
 
@@ -1313,7 +1369,7 @@ public class KubernetesClientTest {
 
     private KubernetesClient newKubernetesClient(ExposeExternallyMode exposeExternally, boolean useNodeNameAsExternalAddress, String servicePerPodLabelName, String servicePerPodLabelValue, KubernetesApiProvider urlProvider) {
         String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
-        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, TOKEN, CA_CERTIFICATE, RETRIES, exposeExternally, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue, urlProvider);
+        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, new StaticTokenProvider(TOKEN), CA_CERTIFICATE, RETRIES, exposeExternally, useNodeNameAsExternalAddress, servicePerPodLabelName, servicePerPodLabelValue, urlProvider);
     }
 
     private static List<String> format(List<Endpoint> addresses) {

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -101,7 +101,6 @@ public class KubernetesConfigTest {
         assertEquals(serviceDns, config.getServiceDns());
         assertEquals(serviceDnsTimeout, config.getServiceDnsTimeout());
         assertEquals(servicePort, config.getServicePort());
-        assertNull(config.getKubernetesApiToken());
         assertNull(config.getKubernetesCaCertificate());
     }
 
@@ -118,7 +117,7 @@ public class KubernetesConfigTest {
         assertEquals("test", config.getNamespace());
         assertEquals(true, config.isResolveNotReadyAddresses());
         assertEquals(false, config.isUseNodeNameAsExternalAddress());
-        assertEquals(TEST_API_TOKEN, config.getKubernetesApiToken());
+        assertEquals(TEST_API_TOKEN, config.getTokenProvider().getToken());
         assertEquals(TEST_CA_CERTIFICATE, config.getKubernetesCaCertificate());
         assertEquals(ExposeExternallyMode.AUTO, config.getExposeExternallyMode());
     }
@@ -187,8 +186,6 @@ public class KubernetesConfigTest {
         // given
         KubernetesConfig.FileContentsReader dummyFileContentsReader = fileName -> {
             switch (fileName) {
-                case "/var/run/secrets/kubernetes.io/serviceaccount/token":
-                    return "token-xyz";
                 case "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt":
                     return "certificate-xyz";
                 case "/var/run/secrets/kubernetes.io/serviceaccount/namespace":
@@ -202,7 +199,6 @@ public class KubernetesConfigTest {
 
         // then
         assertEquals("certificate-xyz", config.getKubernetesCaCertificate());
-        assertEquals("token-xyz", config.getKubernetesApiToken());
         assertEquals("namespace-xyz", config.getNamespace());
     }
 


### PR DESCRIPTION
Kubernetes token which is read from the file was static in the beginning. With the recent changes, it is time-bound, and its content is periodically refreshed.

To incorporate new behavior:
* Introduced a new token reader which gets the value by reading the file every time.
* Introduced a second token reader which imitates the original behavior.

Fixes https://github.com/hazelcast/hazelcast/issues/21461

Backport of: https://github.com/hazelcast/hazelcast/pull/21544

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
