### PR TITLE
[CN-360] [BACKPORT] [5.1.z] Add multiple label support for Kubernetes Plugin service and pod labels

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -269,6 +269,20 @@ final class KubernetesConfig {
                     String.format("Properties '%s' and '%s' cannot be defined at the same time",
                             SERVICE_LABEL_NAME.key(), POD_LABEL_NAME.key()));
         }
+        if (!StringUtil.isNullOrEmptyAfterTrim(serviceLabelName) && !StringUtil.isNullOrEmptyAfterTrim(serviceLabelValue)
+                && (serviceLabelName.chars().filter(ch -> ch == ',').count()
+                != serviceLabelValue.chars().filter(ch -> ch == ',').count())) {
+            throw new InvalidConfigurationException(
+                    String.format("Properties '%s' and '%s' must have the same number of comma separated elements",
+                            SERVICE_LABEL_NAME.key(), SERVICE_LABEL_VALUE.key()));
+        }
+        if (!StringUtil.isNullOrEmptyAfterTrim(podLabelName) && !StringUtil.isNullOrEmptyAfterTrim(podLabelValue)
+                && (podLabelName.chars().filter(ch -> ch == ',').count()
+                != podLabelValue.chars().filter(ch -> ch == ',').count())) {
+            throw new InvalidConfigurationException(
+                    String.format("Properties '%s' and '%s' must have the same number of comma separated elements",
+                            POD_LABEL_NAME.key(), POD_LABEL_VALUE.key()));
+        }
         if (serviceDnsTimeout < 0) {
             throw new InvalidConfigurationException(
                     String.format("Property '%s' cannot be a negative number", SERVICE_DNS_TIMEOUT.key()));

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -70,12 +70,12 @@ public final class KubernetesProperties {
     public static final PropertyDefinition SERVICE_NAME = property("service-name", STRING);
     /**
      * <p>Configuration key: <code>service-label-name</code></p>
-     * Defines the service label to lookup through the Service Discovery REST API of Kubernetes.
+     * Defines the comma separated service labels to lookup through the Service Discovery REST API of Kubernetes.
      */
     public static final PropertyDefinition SERVICE_LABEL_NAME = property("service-label-name", STRING);
     /**
      * <p>Configuration key: <code>service-label-value</code></p>
-     * Defines the service label value to lookup through the Service Discovery REST API of Kubernetes.
+     * Defines the comma separated service label values to lookup through the Service Discovery REST API of Kubernetes.
      */
     public static final PropertyDefinition SERVICE_LABEL_VALUE = property("service-label-value", STRING);
 
@@ -87,12 +87,12 @@ public final class KubernetesProperties {
 
     /**
      * <p>Configuration key: <code>pod-label-name</code></p>
-     * Defines the pod label to lookup through the Service Discovery REST API of Kubernetes.
+     * Defines the comma separated pod labels to lookup through the Service Discovery REST API of Kubernetes.
      */
     public static final PropertyDefinition POD_LABEL_NAME = property("pod-label-name", STRING);
     /**
      * <p>Configuration key: <code>pod-label-value</code></p>
-     * Defines the pod label value to lookup through the Service Discovery REST API of Kubernetes.
+     * Defines the comma separated pod label values to lookup through the Service Discovery REST API of Kubernetes.
      */
     public static final PropertyDefinition POD_LABEL_VALUE = property("pod-label-value", STRING);
 

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -275,6 +275,78 @@ public class KubernetesClientTest {
     }
 
     @Test
+    public void endpointsByNamespaceAndMultipleServiceLabels() {
+        // given
+        //language=JSON
+        String endpointsListResponse = "{\n"
+                + "  \"kind\": \"EndpointsList\",\n"
+                + "  \"items\": [\n"
+                + "    {\n"
+                + "      \"subsets\": [\n"
+                + "        {\n"
+                + "          \"addresses\": [\n"
+                + "            {\n"
+                + "              \"ip\": \"192.168.0.25\",\n"
+                + "              \"targetRef\": {\n"
+                + "                \"name\": \"hazelcast-1\""
+                + "              }\n"
+                + "            }\n"
+                + "          ],\n"
+                + "          \"ports\": [\n"
+                + "            {\n"
+                + "              \"port\": 5701\n"
+                + "            },\n"
+                + "            {\n"
+                + "              \"name\": \"hazelcast-service-port\",\n"
+                + "              \"protocol\": \"TCP\",\n"
+                + "              \"port\": 5702\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"subsets\": [\n"
+                + "        {\n"
+                + "          \"addresses\": [\n"
+                + "            {\n"
+                + "              \"ip\": \"172.17.0.5\",\n"
+                + "              \"targetRef\": {\n"
+                + "                \"name\": \"hazelcast-1\""
+                + "              }\n"
+                + "            }\n"
+                + "          ],\n"
+                + "          \"notReadyAddresses\": [\n"
+                + "            {\n"
+                + "              \"ip\": \"172.17.0.6\",\n"
+                + "              \"targetRef\": {\n"
+                + "                \"name\": \"hazelcast-1\""
+                + "              }\n"
+                + "            }\n"
+                + "          ],\n"
+                + "          \"ports\": [\n"
+                + "            {\n"
+                + "              \"port\": 5701\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+        String serviceLabels = "service-label-1,service-label-2";
+        String serviceLabelValues = "service-label-value-1,service-label-value-2";
+        Map<String, String> queryParams = singletonMap("labelSelector", String.format("service-label-1=service-label-value-1,service-label-2=service-label-value-2"));
+        stub(String.format("/api/v1/namespaces/%s/endpoints", NAMESPACE), queryParams, endpointsListResponse);
+
+        // when
+        List<Endpoint> result = kubernetesClient.endpointsByServiceLabel(serviceLabels, serviceLabelValues);
+
+        // then
+        assertThat(format(result),
+                containsInAnyOrder(ready("192.168.0.25", 5702), ready("172.17.0.5", 5701), notReady("172.17.0.6", 5701)));
+    }
+    @Test
     public void endpointsByNamespaceAndServiceName() {
         // given
         //language=JSON
@@ -366,6 +438,79 @@ public class KubernetesClientTest {
         String podLabelValue = "sample-pod-label-value";
         Map<String, String> queryParams = singletonMap("labelSelector", String.format("%s=%s", podLabel, podLabelValue));
         stub(String.format("/api/v1/namespaces/%s/pods", NAMESPACE, podLabel), queryParams, podsListResponse);
+
+        // when
+        List<Endpoint> result = kubernetesClient.endpointsByPodLabel(podLabel, podLabelValue);
+
+        // then
+        assertThat(format(result),
+                containsInAnyOrder(ready("192.168.0.25", 5701), ready("172.17.0.5", 5702)));
+    }
+
+
+    @Test
+    public void endpointsByNamespaceAndMultiplePodLabels() {
+        // given
+        //language=JSON
+        String podsListResponse = "{\n"
+                + "  \"kind\": \"PodList\",\n"
+                + "  \"items\": [\n"
+                + "    {\n"
+                + "      \"metadata\": {\n"
+                + "        \"name\": \"hazelcast-0\"\n"
+                + "      },\n"
+                + "      \"spec\": {\n"
+                + "        \"containers\": [\n"
+                + "          {\n"
+                + "            \"ports\": [\n"
+                + "              {\n"
+                + "                \"containerPort\": 5701\n"
+                + "              }\n"
+                + "            ]\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      },\n"
+                + "      \"status\": {\n"
+                + "        \"podIP\": \"192.168.0.25\",\n"
+                + "        \"containerStatuses\": [\n"
+                + "          {\n"
+                + "            \"ready\": true\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      }\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"metadata\": {\n"
+                + "        \"name\": \"hazelcast-1\"\n"
+                + "      },\n"
+                + "      \"spec\": {\n"
+                + "        \"containers\": [\n"
+                + "          {\n"
+                + "            \"ports\": [\n"
+                + "              {\n"
+                + "                \"containerPort\": 5702\n"
+                + "              }\n"
+                + "            ]\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      },\n"
+                + "      \"status\": {\n"
+                + "        \"podIP\": \"172.17.0.5\",\n"
+                + "        \"containerStatuses\": [\n"
+                + "          {\n"
+                + "            \"ready\": true\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+
+        String podLabel = "pod-label-1,pod-label-2";
+        String podLabelValue = "pod-label-value-1,pod-label-value-2";
+        Map<String, String> queryParams = singletonMap("labelSelector", String.format("pod-label-1=pod-label-value-1,pod-label-2=pod-label-value-2"));
+        stub(String.format("/api/v1/namespaces/%s/pods", NAMESPACE), queryParams, podsListResponse);
 
         // when
         List<Endpoint> result = kubernetesClient.endpointsByPodLabel(podLabel, podLabelValue);

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -40,6 +40,8 @@ import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_RETIR
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_TOKEN;
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_CA_CERTIFICATE;
 import static com.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
+import static com.hazelcast.kubernetes.KubernetesProperties.POD_LABEL_NAME;
+import static com.hazelcast.kubernetes.KubernetesProperties.POD_LABEL_VALUE;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS_TIMEOUT;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
@@ -242,6 +244,34 @@ public class KubernetesConfigTest {
         properties.put(SERVICE_NAME.key(), "service-name");
         properties.put(SERVICE_LABEL_NAME.key(), "service-label-name");
         properties.put(SERVICE_LABEL_VALUE.key(), "service-label-value");
+
+        // when
+        new KubernetesConfig(properties);
+
+        // then
+        // throws exception
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void invalidConfigurationMismatchingServiceLabelNameAndValues() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(SERVICE_LABEL_NAME.key(), "service-label-1,service-label-2");
+        properties.put(SERVICE_LABEL_VALUE.key(), "service-val-1");
+
+        // when
+        new KubernetesConfig(properties);
+
+        // then
+        // throws exception
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void invalidConfigurationMismatchingPodLabelNameAndValues() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(POD_LABEL_NAME.key(), "pod-label-1,pod-label-2");
+        properties.put(POD_LABEL_VALUE.key(), "pod-val-1");
 
         // when
         new KubernetesConfig(properties);


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

User API for the Kubernetes Discovery Plugin stays the same. Now the users will be able to give comma separated lists for giving multiple labels for Kubernetes Plugin configs "service-label-name", "service-label-value" and "pod-label-name" and "pod-label-value"


Fixes  #21005

Backport of #22277

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
