### PR TITLE
Fixed ClearBackupOperation [HZ-1210] [BACKPORT] (#22082)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -33,7 +33,7 @@ public class ClearBackupOperation extends MapOperation implements BackupOperatio
     @Override
     protected void runInternal() {
         if (recordStore != null) {
-            recordStore.clear();
+            recordStore.clear(true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -46,7 +46,7 @@ public class ClearOperation extends MapOperation
             return;
         }
 
-        numberOfClearedEntries = recordStore.clear();
+        numberOfClearedEntries = recordStore.clear(false);
         shouldBackup = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
@@ -100,24 +100,24 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
     }
 
     @Override
-    public void onRemoveRecord(Data key, R record) {
+    public void onRemoveRecord(Data key, R record, boolean backup) {
         if (isEmpty(mutationObservers)) {
             return;
         }
 
         for (MutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onRemoveRecord(key, record);
+            mutationObserver.onRemoveRecord(key, record, backup);
         }
     }
 
     @Override
-    public void onEvictRecord(Data key, R record) {
+    public void onEvictRecord(Data key, R record, boolean backup) {
         if (isEmpty(mutationObservers)) {
             return;
         }
 
         for (MutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onEvictRecord(key, record);
+            mutationObserver.onEvictRecord(key, record, backup);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
@@ -56,13 +56,13 @@ public class EventJournalWriterMutationObserver implements MutationObserver {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         eventJournal.writeRemoveEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
@@ -69,13 +69,17 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
     }
 
     @Override
-    public void onRemoveRecord(@Nonnull Data key, R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onRemoveRecord(@Nonnull Data key, R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override
-    public void onEvictRecord(@Nonnull Data key, @Nonnull R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
@@ -72,12 +72,12 @@ public class JsonMetadataMutationObserver implements MutationObserver<Record> {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         metadataStore.remove(key);
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         metadataStore.remove(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
@@ -70,16 +70,18 @@ public interface MutationObserver<R extends Record> {
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      */
-    void onRemoveRecord(@Nonnull Data key, R record);
+    void onRemoveRecord(@Nonnull Data key, R record, boolean backup);
 
     /**
      * Called when a record is evicted from the observed {@link RecordStore}
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.*
      */
-    void onEvictRecord(@Nonnull Data key, @Nonnull R record);
+    void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup);
 
     /**
      * Called when a record is loaded into the observed {@link RecordStore}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -616,9 +616,10 @@ public interface RecordStore<R extends Record> {
      * <p>
      * Clears data in this record store.
      *
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      * @return number of cleared entries.
      */
-    int clear();
+    int clear(boolean backup);
 
     /**
      * Resets the record store to it's initial state.


### PR DESCRIPTION
Propagate backup flag into removeRecord method to disable removeIndex calls on the replicas.

EE https://github.com/hazelcast/hazelcast-enterprise/pull/5353