### PR TITLE
Call tryBeginSnapshot when status set RUNNING

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -501,6 +501,7 @@ public class MasterJobContext {
                         responses);
 
         mc.setJobStatus(RUNNING);
+        // There can be a snapshot enqueued while the job is starting, start it now if that's the case
         mc.snapshotContext().tryBeginSnapshot();
         mc.invokeOnParticipants(operationCtor, completionCallback, executionFailureCallback, false);
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -501,6 +501,7 @@ public class MasterJobContext {
                         responses);
 
         mc.setJobStatus(RUNNING);
+        mc.snapshotContext().tryBeginSnapshot();
         mc.invokeOnParticipants(operationCtor, completionCallback, executionFailureCallback, false);
 
         if (mc.jobConfig().getProcessingGuarantee() != NONE) {


### PR DESCRIPTION
This PR solves the issue that a job will ignore an execution termination
with a terminal snapshot, if the termination is requested early while 
the job is starting. A termination can be requested by the user, or by 
a member being shut down. A terminal snapshot will be enqueued to 
`MasterSnapshotContext.snapshotQueue`. After enqueuing, 
`tryBeginSnapshot()` is called, but it does nothing because the job 
status is not in the RUNNING state. Couple moments later the job will 
switch to RUNNING state, but the terminal snapshot request remains in 
the queue until the next regular snapshot, which starts the snapshot 
from the snapshot queue. If the snapshot interval is very long, the job
will block the member shutdown for that time.

The fix is to call `tryBeginSnapshot` after setting the RUNNING job 
status - it checks the queue and starts a snapshot in it, if any.
