### PR TITLE
Backport5.0.z/clearbackup operation [BACKPORT] [HZ-1210]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -33,7 +33,7 @@ public class ClearBackupOperation extends MapOperation implements BackupOperatio
     @Override
     protected void runInternal() {
         if (recordStore != null) {
-            recordStore.clear();
+            recordStore.clear(true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -46,7 +46,7 @@ public class ClearOperation extends MapOperation
             return;
         }
 
-        numberOfClearedEntries = recordStore.clear();
+        numberOfClearedEntries = recordStore.clear(false);
         shouldBackup = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeMutationObserver.java
@@ -136,7 +136,7 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
     }
 
     @Override
-    public void onRemoveRecord(Data key, R record) {
+    public void onRemoveRecord(Data key, R record, boolean backup) {
         if (isEmpty(mutationObservers)) {
             return;
         }
@@ -145,7 +145,7 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
 
         for (MutationObserver<R> mutationObserver : mutationObservers) {
             try {
-                mutationObserver.onRemoveRecord(key, record);
+                mutationObserver.onRemoveRecord(key, record, backup);
             } catch (Throwable t) {
                 if (exception == null) {
                     exception = t;
@@ -159,7 +159,7 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
     }
 
     @Override
-    public void onEvictRecord(Data key, R record) {
+    public void onEvictRecord(Data key, R record, boolean backup) {
         if (isEmpty(mutationObservers)) {
             return;
         }
@@ -168,7 +168,7 @@ class CompositeMutationObserver<R extends Record> implements MutationObserver<R>
 
         for (MutationObserver<R> mutationObserver : mutationObservers) {
             try {
-                mutationObserver.onEvictRecord(key, record);
+                mutationObserver.onEvictRecord(key, record, backup);
             } catch (Throwable t) {
                 if (exception == null) {
                     exception = t;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterMutationObserver.java
@@ -56,13 +56,13 @@ public class EventJournalWriterMutationObserver implements MutationObserver {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         eventJournal.writeRemoveEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace,
                 partitionId, key, record.getValue());
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
@@ -69,13 +69,17 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
     }
 
     @Override
-    public void onRemoveRecord(@Nonnull Data key, R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onRemoveRecord(@Nonnull Data key, R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override
-    public void onEvictRecord(@Nonnull Data key, @Nonnull R record) {
-        removeIndex(key, record, Index.OperationSource.USER);
+    public void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup) {
+        if (!backup) {
+            removeIndex(key, record, Index.OperationSource.USER);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataMutationObserver.java
@@ -72,12 +72,12 @@ public class JsonMetadataMutationObserver implements MutationObserver<Record> {
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Data key, Record record, boolean backup) {
         metadataStore.remove(key);
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Data key, Record record, boolean backup) {
         metadataStore.remove(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/MutationObserver.java
@@ -70,16 +70,18 @@ public interface MutationObserver<R extends Record> {
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      */
-    void onRemoveRecord(@Nonnull Data key, R record);
+    void onRemoveRecord(@Nonnull Data key, R record, boolean backup);
 
     /**
      * Called when a record is evicted from the observed {@link RecordStore}
      *
      * @param key    The key of the record
      * @param record The record
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.*
      */
-    void onEvictRecord(@Nonnull Data key, @Nonnull R record);
+    void onEvictRecord(@Nonnull Data key, @Nonnull R record, boolean backup);
 
     /**
      * Called when a record is loaded into the observed {@link RecordStore}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -321,8 +321,9 @@ public interface RecordStore<R extends Record> {
      * Remove record for given key. Does not load from MapLoader,
      * does not intercept.
      * @param dataKey   key to remove
+     * @param backup {@code true} if a backup partition, otherwise {@code false}.
      */
-    void removeReplicatedRecord(Data dataKey);
+    void removeReplicatedRecord(Data dataKey, boolean backup);
 
     void forEach(BiConsumer<Data, R> consumer, boolean backup);
 
@@ -646,9 +647,10 @@ public interface RecordStore<R extends Record> {
      * <p>
      * Clears data in this record store.
      *
+     * @param backup  {@code true} if a backup partition, otherwise {@code false}.
      * @return number of cleared entries.
      */
-    int clear();
+    int clear(boolean backup);
 
     /**
      * Resets the record store to it's initial state.


### PR DESCRIPTION
Propagate backup flag into removeRecord method to disable removeIndex calls on the replicas.

EE https://github.com/hazelcast/hazelcast-enterprise/pull/5359