### PR TITLE
Fix KeyedWatermarkCoalescer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/KeyedWatermarkCoalescer.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/KeyedWatermarkCoalescer.java
@@ -85,6 +85,7 @@ public class KeyedWatermarkCoalescer {
         for (WatermarkCoalescer c : coalescers.values()) {
             c.observeEvent(queueIndex);
         }
+        idleQueues[queueIndex] = false;
     }
 
     public List<Watermark> observeWm(int queueIndex, Watermark watermark) {
@@ -92,8 +93,10 @@ public class KeyedWatermarkCoalescer {
             idleQueues[queueIndex] = true;
             boolean allIdle = true;
             // we need to track idle queues for the case when there's no coalescer yet
-            for (boolean idleQueue : idleQueues) {
-                allIdle &= idleQueue;
+            for (int i = 0; i < idleQueues.length; i++) {
+                if (!doneQueues.contains(i)) {
+                    allIdle &= idleQueues[i];
+                }
             }
 
             List<Watermark> watermarks = new ArrayList<>();

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/KeyedWatermarkCoalescerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/KeyedWatermarkCoalescerTest.java
@@ -88,4 +88,17 @@ public class KeyedWatermarkCoalescerTest extends JetTestSupport {
         assertEquals(emptyList(), kwc.observeWm(0, IDLE_MESSAGE));
         assertEquals(asList(wm(42), IDLE_MESSAGE), kwc.observeWm(1, IDLE_MESSAGE));
     }
+
+    @Test
+    public void test_oneQueueDoneOtherIdle_then_allIdle() {
+        assertEquals(emptyList(), kwc.queueDone(0));
+        assertEquals(singletonList(IDLE_MESSAGE), kwc.observeWm(1, IDLE_MESSAGE));
+    }
+
+    @Test
+    public void test_q1IdleThenActiveThenQ2Idle_then_notAllIdle() {
+        assertEquals(emptyList(), kwc.observeWm(0, IDLE_MESSAGE));
+        kwc.observeEvent(0);
+        assertEquals(emptyList(), kwc.observeWm(1, IDLE_MESSAGE));
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescerTest.java
@@ -186,6 +186,7 @@ public class WatermarkCoalescerTest {
     public void when_allDone_then_noMaxValueEmitted() {
         assertEquals(Long.MIN_VALUE, wc.queueDone(0));
         assertEquals(Long.MIN_VALUE, wc.queueDone(1));
+        assertFalse(wc.idleMessagePending());
     }
 
     @Test


### PR DESCRIPTION
The PR fixes two instances of incorrect idle message handling:

1. idle status for a queue wasn't reset when an event was observed

2. a queue that was done was included in allIdle calculation

This caused discrepancy between the idle-handling logic in WatermarkCoalescer and in KeyedWatermarkCoalescer, which the assert was (correctly) supposed to surface.

The two added tests failed before.

Fixes #22156, supersedes #22425.