### PR TITLE
Exclude the ZipSlip CodeQL query

### DIFF
--- a/.github/codeql/java-custom-queries.qls
+++ b/.github/codeql/java-custom-queries.qls
@@ -6,5 +6,5 @@
     - java/polynomial-redos
     - java/path-injection
     - java/ssrf
-
+    - java/zipslip
 


### PR DESCRIPTION
The CodeQL GH workflow started to freeze again. The ZipSlip is a suspected query.