### PR TITLE
#22438 Error when schema change capture is enabled

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -132,6 +132,7 @@ public class ChangeRecordImpl implements ChangeRecord {
     @Nonnull
     public RecordPart value() {
         switch (operation) {
+            case UNSPECIFIED:
             case SYNC:
             case INSERT:
             case UPDATE: return requireNonNull(newValue(), "newValue missing for operation " + operation);

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
-import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
@@ -44,7 +43,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.cdc.Operation.UNSPECIFIED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
@@ -68,13 +67,13 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
             // given
             List<String> expectedRecords = Arrays.asList(
-                    "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                    "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                    "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                    "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
-                    "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
+                    "SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
+                    "SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
+                    "SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
+                    "SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
+                    "DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
             );
 
             StreamSource<ChangeRecord> source = mySqlSource(container);
@@ -83,26 +82,22 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             pipeline.readFrom(source)
                     .withNativeTimestamps(0)
                     .<ChangeRecord>customTransform("filter_timestamps", filterTimestampsProcessorSupplier())
-                    .groupingKey(record -> (Integer) record.key().toMap().get("id"))
-                    .mapStateful(
-                            LongAccumulator::new,
-                            (accumulator, customerId, record) -> {
-                                long count = accumulator.get();
-                                accumulator.add(1);
-                                Operation operation = record.operation();
-                                RecordPart value = record.value();
-                                Customer customer = value.toObject(Customer.class);
-                                return entry(customerId + "/" + count, operation + ":" + customer);
-                            })
-                    .setLocalParallelism(1)
-                    .writeTo(Sinks.map("results"));
+                    .filter(record -> record.operation() != UNSPECIFIED)
+                    .map(record -> {
+                        Operation operation = record.operation();
+                        RecordPart value = record.value();
+                        Customer customer = value.toObject(Customer.class);
+                        return operation + ":" + customer;
+                    })
+                    .writeTo(Sinks.list("results"));
+            pipeline.setPreserveOrder(true);
 
             // when
             HazelcastInstance hz = createHazelcastInstances(2)[0];
             Job job = hz.getJet().newJob(pipeline);
 
             //then
-            assertEqualsEventually(() -> hz.getMap("results").size(), 4);
+            assertEqualsEventually(() -> hz.getList("results").size(), 4);
 
             //when
             try (Connection connection = getMySqlConnection(container.withDatabaseName("inventory").getJdbcUrl(),
@@ -115,8 +110,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             }
 
             //then
+            String expected = String.join("\n", expectedRecords);
             try {
-                assertEqualsEventually(() -> mapResultsToSortedList(hz.getMap("results")), expectedRecords);
+                assertEqualsEventually(() -> String.join("\n", hz.getList("results")), expected);
             } finally {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);
@@ -128,7 +124,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     private StreamSource<ChangeRecord> mySqlSource(MySQLContainer<?> container) {
         return DebeziumCdcSources.debezium("mysql",
                         MySqlConnector.class)
-                        .setProperty("include.schema.changes", "false")
+                        .setProperty("include.schema.changes", "true")
                         .setProperty("database.hostname", container.getContainerIpAddress())
                         .setProperty("database.port", Integer.toString(container.getMappedPort(MYSQL_PORT)))
                         .setProperty("database.user", "debezium")
@@ -237,13 +233,13 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
             // given
             List<String> expectedRecords = Arrays.asList(
-                    "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                    "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                    "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                    "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
-                    "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
+                    "SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
+                    "SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
+                    "SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
+                    "SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
+                    "DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
             );
 
             StreamSource<ChangeRecord> source = DebeziumCdcSources.debezium("postgres",
@@ -260,27 +256,24 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             Pipeline pipeline = Pipeline.create();
             pipeline.readFrom(source)
                     .withNativeTimestamps(0)
+                    .filter(record -> record.operation() != UNSPECIFIED)
                     .<ChangeRecord>customTransform("filter_timestamps", filterTimestampsProcessorSupplier())
-                    .groupingKey(record -> (Integer) record.key().toMap().get("id"))
-                    .mapStateful(
-                            LongAccumulator::new,
-                            (accumulator, customerId, record) -> {
-                                long count = accumulator.get();
-                                accumulator.add(1);
-                                Operation operation = record.operation();
-                                RecordPart value = record.value();
-                                Customer customer = value.toObject(Customer.class);
-                                return entry(customerId + "/" + count, operation + ":" + customer);
-                            })
+                    .map(record -> {
+                        Operation operation = record.operation();
+                        RecordPart value = record.value();
+                        Customer customer = value.toObject(Customer.class);
+                        return operation + ":" + customer;
+                    })
                     .setLocalParallelism(1)
-                    .writeTo(Sinks.map("results"));
+                    .writeTo(Sinks.list("results"));
 
+            pipeline.setPreserveOrder(true);
             // when
             HazelcastInstance hz = createHazelcastInstances(2)[0];
             Job job = hz.getJet().newJob(pipeline);
 
             //then
-            assertEqualsEventually(() -> hz.getMap("results").size(), 4);
+            assertEqualsEventually(() -> hz.getList("results").size(), 4);
 
             //when
             try (Connection connection = getPostgreSqlConnection(container.getJdbcUrl(), container.getUsername(),
@@ -294,8 +287,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             }
 
             //then
+            String expected = String.join("\n", expectedRecords);
             try {
-                assertEqualsEventually(() -> mapResultsToSortedList(hz.getMap("results")), expectedRecords);
+                assertEqualsEventually(() -> String.join("\n", hz.getList("results")), expected);
             } finally {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);


### PR DESCRIPTION
By default, we disable this option in MySQL/PostgreSQL connector, but user still may use generic connector or other connector class. In that cases, our code was producing errors, because change schema connect records don't have before and after.


Fixes #22438

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
