### PR TITLE
Fix stress test - faster result compare

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_slow/MapScanMigrationStressTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_slow/MapScanMigrationStressTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.sql_slow;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
@@ -35,12 +36,14 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -50,7 +53,6 @@ import static org.junit.Assert.fail;
 @Category(SlowTest.class)
 public class MapScanMigrationStressTest extends JetTestSupport {
     private static final int ITEM_COUNT = 500_000;
-    private static final int MIN_PROGRESS_BETWEEN_MUTATIONS = 10_000;
     private static final String MAP_NAME = "map";
 
     private AtomicInteger progress;
@@ -66,12 +68,21 @@ public class MapScanMigrationStressTest extends JetTestSupport {
         factory = new TestHazelcastFactory();
         instances = new HazelcastInstance[4];
         for (int i = 0; i < instances.length - 1; i++) {
-            instances[i] = factory.newHazelcastInstance(smallInstanceConfig());
+            instances[i] = factory.newHazelcastInstance(createFastRetryConfig());
         }
         SqlTestSupport.createMapping(instances[0], MAP_NAME, Integer.class, Integer.class);
         map = instances[0].getMap(MAP_NAME);
         mutatorException = new AtomicReference<>(null);
         progress = new AtomicInteger();
+    }
+
+    private static Config createFastRetryConfig() {
+        // The stress test should end in 10 minutes, if the execution of a query is done also on the member that will die soon,
+        // then the operation is retried. The default retry mechanism retries the operation 250 times with progressive delay
+        // from 0 up to 500ms. Such a retry may take up to 2 minutes. We change the maximum retry delay to 180ms, so it takes
+        // up to 45 seconds in total.
+        return smallInstanceConfig()
+                .setProperty("hazelcast.invocation.retry.pause.millis", "180");
     }
 
     @After
@@ -93,15 +104,16 @@ public class MapScanMigrationStressTest extends JetTestSupport {
     public void stressTest_noIndex() throws InterruptedException {
         List<Row> expected = new ArrayList<>();
         Map<Integer, Integer> temp = new HashMap<>();
-        for (int i = 0; i <= ITEM_COUNT / 7; i++) {
+        for (int i = 0; i <= ITEM_COUNT; i++) {
             temp.put(i, 1);
             expected.add(new Row(i, i + "-" + 1));
         }
         map.putAll(temp);
 
-        mutator = new MutatorThread();
+        mutator = new MutatorThread(1_000);
 
-        assertRowsAnyOrder("SELECT __key, Concat_WS('-', __key, this) FROM " + MAP_NAME , expected, mutator);
+        assertRowsAnyOrder("SELECT __key, Concat_WS('-', __key, this) FROM " + MAP_NAME , expected, mutator,
+                o -> ((Integer) o.getValues()[0]));
 
         mutator.terminate();
         mutator.join();
@@ -112,7 +124,7 @@ public class MapScanMigrationStressTest extends JetTestSupport {
     public void stressTest_hashIndex() throws InterruptedException {
         List<Row> expected = new ArrayList<>();
         Map<Integer, Integer> temp = new HashMap<>();
-        for (int i = 0; i <= ITEM_COUNT / 5; i++) {
+        for (int i = 0; i <= ITEM_COUNT; i++) {
             temp.put(i, 1);
             expected.add(new Row(i, 1));
         }
@@ -121,10 +133,11 @@ public class MapScanMigrationStressTest extends JetTestSupport {
         IndexConfig indexConfig = new IndexConfig(IndexType.HASH, "this").setName(randomName());
         map.addIndex(indexConfig);
 
-        mutator = new MutatorThread();
+        mutator = new MutatorThread(1_000);
 
         // Awful performance of such a query, but still a good load for test.
-        assertRowsAnyOrder("SELECT * FROM " + MAP_NAME + " WHERE this = 1", expected, mutator);
+        assertRowsAnyOrder("SELECT * FROM " + MAP_NAME + " WHERE this = 1", expected, mutator,
+                o -> ((Integer) o.getValues()[0]));
 
         mutator.terminate();
         mutator.join();
@@ -144,7 +157,7 @@ public class MapScanMigrationStressTest extends JetTestSupport {
         IndexConfig indexConfig = new IndexConfig(IndexType.SORTED, "this").setName(randomName());
         map.addIndex(indexConfig);
 
-        mutator = new MutatorThread();
+        mutator = new MutatorThread(100_000);
         assertRowsOrdered("SELECT * FROM " + MAP_NAME + " ORDER BY this DESC", expected, mutator);
 
         mutator.terminate();
@@ -153,10 +166,12 @@ public class MapScanMigrationStressTest extends JetTestSupport {
     }
 
     private class MutatorThread extends Thread {
+        private final int minProgressBetweenMutations;
         private boolean firstLaunch = true;
         private volatile boolean active = true;
 
-        private MutatorThread() {
+        private MutatorThread(int minProgressBetweenMutations) {
+            this.minProgressBetweenMutations = minProgressBetweenMutations;
         }
 
         private synchronized void terminate() {
@@ -175,12 +190,13 @@ public class MapScanMigrationStressTest extends JetTestSupport {
                     } else {
                         firstLaunch = false;
                     }
-                    instances[3] = factory.newHazelcastInstance(smallInstanceConfig());
+                    instances[3] = factory.newHazelcastInstance(createFastRetryConfig());
 
-                    while (active && (currentProgress = progress.get()) < lastProgressSeen + MIN_PROGRESS_BETWEEN_MUTATIONS) {
+                    while (active && (currentProgress = progress.get()) < lastProgressSeen + minProgressBetweenMutations) {
                         // Waiting for proper progress
-                        Thread.sleep(1);
+                        Thread.yield();
                     }
+                    logger.info("Mutating");
                     lastProgressSeen = currentProgress;
                 } catch (Exception e) {
                     mutatorException.set(e);
@@ -190,9 +206,14 @@ public class MapScanMigrationStressTest extends JetTestSupport {
         }
     }
 
-    private void assertRowsAnyOrder(String sql, Collection<Row> expectedRows, Thread mutator) {
+    private void assertRowsAnyOrder(String sql, List<Row> expectedRows, Thread mutator,
+                                    Function<Row, Integer> sortedColumnFunction) {
         List<Row> actualRows = executeAndGetResult(sql, mutator);
-        assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectedRows);
+
+        // We know that expectedRows is sorted by sortedColumnFunction, so we sort the actualRows the same way.
+        // This way we compare two lists in O(n log n), the containsExactlyInAnyOrderElementsOf complexity is O(n^2).
+        actualRows.sort(Comparator.comparing(sortedColumnFunction));
+        assertEquals(expectedRows, actualRows);
     }
 
     private void assertRowsOrdered(String sql, Collection<Row> expectedRows, Thread mutator) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_slow/MapScanMigrationStressTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_slow/MapScanMigrationStressTest.java
@@ -178,7 +178,8 @@ public class MapScanMigrationStressTest extends JetTestSupport {
                     instances[3] = factory.newHazelcastInstance(smallInstanceConfig());
 
                     while (active && (currentProgress = progress.get()) < lastProgressSeen + MIN_PROGRESS_BETWEEN_MUTATIONS) {
-                        // spinning and waiting for proper progress
+                        // Waiting for proper progress
+                        Thread.sleep(1);
                     }
                     lastProgressSeen = currentProgress;
                 } catch (Exception e) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_slow/MapScanMigrationStressTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql_slow/MapScanMigrationStressTest.java
@@ -207,12 +207,12 @@ public class MapScanMigrationStressTest extends JetTestSupport {
     }
 
     private void assertRowsAnyOrder(String sql, List<Row> expectedRows, Thread mutator,
-                                    Function<Row, Integer> sortedColumnFunction) {
+                                    Function<Row, Integer> extractSortKeyFn) {
         List<Row> actualRows = executeAndGetResult(sql, mutator);
 
-        // We know that expectedRows is sorted by sortedColumnFunction, so we sort the actualRows the same way.
+        // We know that expectedRows is sorted by extractSortKeyFn, so we sort the actualRows the same way.
         // This way we compare two lists in O(n log n), the containsExactlyInAnyOrderElementsOf complexity is O(n^2).
-        actualRows.sort(Comparator.comparing(sortedColumnFunction));
+        actualRows.sort(Comparator.comparing(extractSortKeyFn));
         assertEquals(expectedRows, actualRows);
     }
 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/22433 and may fix https://github.com/hazelcast/hazelcast/issues/21866 as this happens after the ```MapScanMigrationStressTest``` fails.
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
