### PR TITLE
Fix NPE in ChangeRecordImpl when old or new value is null

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -177,7 +177,8 @@ public class ChangeRecordImpl implements ChangeRecord {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sequenceSource, sequenceValue, keyJson, oldValue, newValue);
+        return Objects.hash(sequenceSource, sequenceValue, keyJson, timestamp,
+                operation, database, schema, table, oldValue, newValue);
     }
 
     @Override
@@ -192,6 +193,11 @@ public class ChangeRecordImpl implements ChangeRecord {
         return this.sequenceSource == that.sequenceSource
                 && this.sequenceValue == that.sequenceValue
                 && Objects.equals(this.keyJson, that.keyJson)
+                && Objects.equals(this.timestamp, that.timestamp)
+                && this.operation == that.operation
+                && Objects.equals(this.database, that.database)
+                && Objects.equals(this.schema, that.schema)
+                && Objects.equals(this.table, that.table)
                 && Objects.equals(this.oldValue, that.oldValue)
                 && Objects.equals(this.newValue, that.newValue);
     }

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -177,12 +177,7 @@ public class ChangeRecordImpl implements ChangeRecord {
 
     @Override
     public int hashCode() {
-        int hash = (int) sequenceSource;
-        hash = 31 * hash + (int) sequenceValue;
-        hash = 31 * hash + keyJson.hashCode();
-        hash = 31 * hash + oldValue.toJson().hashCode();
-        hash = 31 * hash + newValue.toJson().hashCode();
-        return hash;
+        return Objects.hash(sequenceSource, sequenceValue, keyJson, oldValue, newValue);
     }
 
     @Override

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -189,10 +189,10 @@ public class ChangeRecordImpl implements ChangeRecord {
             return false;
         }
         ChangeRecordImpl that = (ChangeRecordImpl) obj;
-        return this.sequenceSource == that.sequenceSource &&
-                this.sequenceValue == that.sequenceValue &&
-                this.keyJson.equals(that.keyJson) &&
-                Objects.equals(this.oldValue, that.oldValue) &&
-                Objects.equals(this.newValue, that.newValue);
+        return this.sequenceSource == that.sequenceSource
+                && this.sequenceValue == that.sequenceValue
+                && this.keyJson.equals(that.keyJson)
+                && Objects.equals(this.oldValue, that.oldValue)
+                && Objects.equals(this.newValue, that.newValue);
     }
 }

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -191,7 +191,7 @@ public class ChangeRecordImpl implements ChangeRecord {
         ChangeRecordImpl that = (ChangeRecordImpl) obj;
         return this.sequenceSource == that.sequenceSource
                 && this.sequenceValue == that.sequenceValue
-                && this.keyJson.equals(that.keyJson)
+                && Objects.equals(this.keyJson, that.keyJson)
                 && Objects.equals(this.oldValue, that.oldValue)
                 && Objects.equals(this.newValue, that.newValue);
     }

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -421,6 +421,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                     .window(sliding(SECONDS.toMillis(2), SECONDS.toMillis(1)))
                     .distinct()
                     .writeTo(Sinks.logger(WindowResult::toString));
+
+            HazelcastInstance hz = createHazelcastInstances(1)[0];
+            hz.getJet().newJob(pipeline);
         }
     }
 


### PR DESCRIPTION
Use NPE-proof Objects.hashCode

Fixes #22446

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
