### PR TITLE
Fix adding external data store config dynamically [HZ-1563]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -151,10 +151,12 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
         MapConfig mapConfig = new MapConfig(randomTableName).setMapStoreConfig(mapStoreConfig);
         client.getConfig().addMapConfig(mapConfig);
 
-        IMap<Integer, String> someTestMap = client.getMap(randomTableName);
-        someTestMap.put(1, "val-1");
+        IMap<Integer, Person> someTestMap = client.getMap(randomTableName);
+        someTestMap.put(42, new Person(42, "some-name-42"));
 
-        assertThat(jdbcRowsTable(randomTableName)).hasSize(1);
+        assertJdbcRowsAnyOrder(randomTableName,
+                new Row(42, "some-name-42")
+        );
 
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -65,7 +65,7 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
     public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
         ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories.get(name);
         if (externalDataStoreFactory == null) {
-            ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfig(name);
+            ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
             if (externalDataStoreConfig != null) {
                 return createFactory(externalDataStoreConfig);
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -159,7 +159,7 @@ public class NodeEngineImpl implements NodeEngine {
             this.transactionManagerService = new TransactionManagerServiceImpl(this);
             this.wanReplicationService = node.getNodeExtension().createService(WanReplicationService.class);
             this.sqlService = new SqlServiceImpl(this);
-            this.externalDataStoreService = new ExternalDataStoreServiceImpl(node.config, configClassLoader);
+            this.externalDataStoreService = new ExternalDataStoreServiceImpl(node, configClassLoader);
             this.packetDispatcher = new PacketDispatcher(
                     logger,
                     operationService.getOperationExecutor(),


### PR DESCRIPTION
Fixes https://hazelcast.atlassian.net/browse/HZ-1563

Adding a new external data store config dynamically didn't result with `ExternalDataStoreFactory` being available for users. 

Now if we don't find `ExternalDataStoreFactory` for a given name we check if there's a new external data store config with the same name and if found we create the factory on-demand