### PR TITLE
Adding checks on invalidation if entry processor is read only

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/map/impl/nearcache/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/map/impl/nearcache/NearCachedClientMapProxy.java
@@ -503,7 +503,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         try {
             response = super.executeOnKeyInternal(key, entryProcessor);
         } finally {
-            if (!(entryProcessor instanceof ReadOnly)){
+            if (!(entryProcessor instanceof ReadOnly)) {
                 invalidateNearCache(key);
             }
         }
@@ -518,7 +518,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         try {
             future = super.submitToKeyInternal(key, entryProcessor);
         } finally {
-            if (!(entryProcessor instanceof ReadOnly)){
+            if (!(entryProcessor instanceof ReadOnly)) {
                 invalidateNearCache(key);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/map/impl/nearcache/NearCachedClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/map/impl/nearcache/NearCachedClientMapProxy.java
@@ -41,7 +41,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
-
+import com.hazelcast.core.ReadOnly;
 import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Iterator;
@@ -503,7 +503,9 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         try {
             response = super.executeOnKeyInternal(key, entryProcessor);
         } finally {
-            invalidateNearCache(key);
+            if (!(entryProcessor instanceof ReadOnly)){
+                invalidateNearCache(key);
+            }
         }
         return response;
     }
@@ -516,7 +518,9 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         try {
             future = super.submitToKeyInternal(key, entryProcessor);
         } finally {
-            invalidateNearCache(key);
+            if (!(entryProcessor instanceof ReadOnly)){
+                invalidateNearCache(key);
+            }
         }
         return future;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -521,7 +521,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         try {
             return super.executeOnKeyInternal(nearCacheKey, entryProcessor);
         } finally {
-            if (!(entryProcessor instanceof ReadOnly)){
+            if (!(entryProcessor instanceof ReadOnly)) {
                 invalidateNearCache(nearCacheKey);
             }
         }
@@ -539,7 +539,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         } finally {
             Set<?> ncKeys = serializeKeys ? dataKeys : keys;
             for (Object key : ncKeys) {
-                if (!(entryProcessor instanceof ReadOnly)){
+                if (!(entryProcessor instanceof ReadOnly)) {
                     invalidateNearCache(key);
                 }
             }
@@ -553,7 +553,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         } finally {
             for (int i = 0; i < resultingKeyValuePairs.size(); i += 2) {
                 Data key = resultingKeyValuePairs.get(i);
-                if (!(entryProcessor instanceof ReadOnly)){
+                if (!(entryProcessor instanceof ReadOnly)) {
                     invalidateNearCache(serializeKeys ? key : toObject(key));
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -538,8 +538,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
             return super.submitToKeysInternal(keys, dataKeys, entryProcessor);
         } finally {
             Set<?> ncKeys = serializeKeys ? dataKeys : keys;
-            for (Object key : ncKeys) {
-                if (!(entryProcessor instanceof ReadOnly)) {
+            if (!(entryProcessor instanceof ReadOnly)) {
+                for (Object key : ncKeys) {
                     invalidateNearCache(key);
                 }
             }
@@ -551,9 +551,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         try {
             super.executeOnEntriesInternal(entryProcessor, predicate, resultingKeyValuePairs);
         } finally {
-            for (int i = 0; i < resultingKeyValuePairs.size(); i += 2) {
-                Data key = resultingKeyValuePairs.get(i);
-                if (!(entryProcessor instanceof ReadOnly)) {
+            if (!(entryProcessor instanceof ReadOnly)) {
+                for (int i = 0; i < resultingKeyValuePairs.size(); i += 2) {
+                    Data key = resultingKeyValuePairs.get(i);
                     invalidateNearCache(serializeKeys ? key : toObject(key));
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.proxy;
 
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.impl.invalidation.BatchNearCacheInvalidation;
@@ -520,7 +521,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         try {
             return super.executeOnKeyInternal(nearCacheKey, entryProcessor);
         } finally {
-            invalidateNearCache(nearCacheKey);
+            if (!(entryProcessor instanceof ReadOnly)){
+                invalidateNearCache(nearCacheKey);
+            }
         }
     }
 
@@ -536,7 +539,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         } finally {
             Set<?> ncKeys = serializeKeys ? dataKeys : keys;
             for (Object key : ncKeys) {
-                invalidateNearCache(key);
+                if (!(entryProcessor instanceof ReadOnly)){
+                    invalidateNearCache(key);
+                }
             }
         }
     }
@@ -548,7 +553,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         } finally {
             for (int i = 0; i < resultingKeyValuePairs.size(); i += 2) {
                 Data key = resultingKeyValuePairs.get(i);
-                invalidateNearCache(serializeKeys ? key : toObject(key));
+                if (!(entryProcessor instanceof ReadOnly)){
+                    invalidateNearCache(serializeKeys ? key : toObject(key));
+                }
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -230,6 +230,41 @@ public class NearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
+    public void testNearCacheStatsWithReadOnlyProcessor() {
+        int mapSize = 1000;
+        String mapName = randomMapName();
+
+        Config config = getConfig();
+        config.getMapConfig(mapName).setNearCacheConfig(newNearCacheConfig().setInvalidateOnChange(false));
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances(config);
+
+        // populate map
+        IMap<Integer, Integer> map = instances[0].getMap(mapName);
+        populateMap(map, mapSize);
+
+        // populate Near Cache
+        populateNearCache(map, mapSize);
+
+        NearCacheStats stats = getNearCacheStats(map);
+        long ownedEntryCount = stats.getOwnedEntryCount();
+        long misses = stats.getMisses();
+        assertTrue(format("Near Cache entry count should be > %d but were %d", 400, ownedEntryCount), ownedEntryCount > 400);
+        assertEquals(format("Near Cache misses should be %d but were %d", mapSize, misses), mapSize, misses);
+
+        // make some hits
+        populateNearCache(map, mapSize);
+
+        long hitsBefore = stats.getHits();
+        for (int i = 0; i< mapSize; i++){
+            map.executeOnKey(i,new TestReadOnlyProcessor());
+        }
+        long hitsAfter = stats.getHits();
+        assertEquals("No Invalidation after getting keys from read only entry processor", hitsBefore, hitsAfter);
+    }
+
+    @Test
     public void testNearCacheStats() {
         int mapSize = 1000;
         String mapName = randomMapName();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -257,8 +257,8 @@ public class NearCacheTest extends NearCacheTestSupport {
         populateNearCache(map, mapSize);
 
         long hitsBefore = stats.getHits();
-        for (int i = 0; i< mapSize; i++){
-            map.executeOnKey(i,new TestReadOnlyProcessor());
+        for (int i = 0; i < mapSize; i++) {
+            map.executeOnKey(i, new TestReadOnlyProcessor());
         }
         long hitsAfter = stats.getHits();
         assertEquals("No Invalidation after getting keys from read only entry processor", hitsBefore, hitsAfter);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -261,7 +261,7 @@ public class NearCacheTest extends NearCacheTestSupport {
             map.executeOnKey(i, new TestReadOnlyProcessor());
         }
         long hitsAfter = stats.getHits();
-        assertEquals("No Invalidation after getting keys from read only entry processor", hitsBefore, hitsAfter);
+        assertEquals("No Invalidation after getting keys from read only entry processor ", hitsBefore, hitsAfter);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/TestReadOnlyProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/TestReadOnlyProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.core.ReadOnly;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/TestReadOnlyProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/TestReadOnlyProcessor.java
@@ -18,8 +18,7 @@ package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.map.EntryProcessor;
-import org.jetbrains.annotations.Nullable;
-
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public class TestReadOnlyProcessor implements EntryProcessor<Integer, Integer, Boolean>, ReadOnly {
@@ -29,8 +28,9 @@ public class TestReadOnlyProcessor implements EntryProcessor<Integer, Integer, B
         return true;
     }
 
-    @Nullable
+
     @Override
+    @Nullable
     public EntryProcessor<Integer, Integer, Boolean> getBackupProcessor() {
         return null;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/TestReadOnlyProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/TestReadOnlyProcessor.java
@@ -1,0 +1,21 @@
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.core.ReadOnly;
+import com.hazelcast.map.EntryProcessor;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public class TestReadOnlyProcessor implements EntryProcessor<Integer, Integer, Boolean>, ReadOnly {
+
+    @Override
+    public Boolean process(Map.Entry<Integer, Integer> entry) {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public EntryProcessor<Integer, Integer, Boolean> getBackupProcessor() {
+        return null;
+    }
+}


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Currently when an entryProcessor is invoked, it will invalidate the particular key from near cache regardless if it is readOnly or not. This PR contains checks around the same issue wherein we will check first what type of entry processor is being invoked and then invalidate basis of that for particular events.

Fixes
https://github.com/hazelcast/hazelcast/issues/22233


Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
