### PR TITLE
Fix adding external data store config dynamically [HZ-1563] [5.2.z]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -128,4 +128,36 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
 
         assertThat(jdbcRowsTable(tableName)).isEmpty();
     }
+
+    @Test
+    public void testDynamicExternalDataStoreConfig() throws Exception {
+        String randomTableName = randomTableName();
+
+        createTable(randomTableName);
+        assertThat(jdbcRowsTable(randomTableName)).isEmpty();
+
+        HazelcastInstance client = client();
+
+        client.getConfig().addExternalDataStoreConfig(
+                new ExternalDataStoreConfig("dynamically-added-datastore")
+                        .setClassName(JdbcDataStoreFactory.class.getName())
+                        .setProperty("jdbcUrl", dbConnectionUrl)
+        );
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setClassName(GenericMapStore.class.getName())
+                .setProperty(EXTERNAL_REF_ID_PROPERTY, "dynamically-added-datastore")
+                .setProperty("table-name", randomTableName);
+        MapConfig mapConfig = new MapConfig(randomTableName).setMapStoreConfig(mapStoreConfig);
+        client.getConfig().addMapConfig(mapConfig);
+
+        IMap<Integer, Person> someTestMap = client.getMap(randomTableName);
+        someTestMap.put(42, new Person(42, "some-name-42"));
+
+        assertJdbcRowsAnyOrder(randomTableName,
+                new Row(42, "some-name-42")
+        );
+
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -63,19 +63,10 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
 
     @Override
     public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
-        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories
-                .computeIfAbsent(name, this::createFactoryIfConfigPresent);
-        if (externalDataStoreFactory == null) {
+        ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
+        if (externalDataStoreConfig == null) {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }
-        return externalDataStoreFactory;
-    }
-
-    private ExternalDataStoreFactory<?> createFactoryIfConfigPresent(String name) {
-        ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
-        if (externalDataStoreConfig != null) {
-            return createFactory(externalDataStoreConfig);
-        }
-        return null;
+        return dataStoreFactories.computeIfAbsent(name, n -> createFactory(externalDataStoreConfig));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.datastore.impl;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.config.ExternalDataStoreConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.datastore.ExternalDataStoreFactory;
 import com.hazelcast.datastore.ExternalDataStoreService;
+import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 
 import java.util.Map;
@@ -30,18 +30,23 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 
 public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
     private final Map<String, ExternalDataStoreFactory<?>> dataStoreFactories = new ConcurrentHashMap<>();
+    private final ClassLoader classLoader;
+    private final Node node;
 
-    public ExternalDataStoreServiceImpl(Config config, ClassLoader classLoader) {
-        for (Map.Entry<String, ExternalDataStoreConfig> entry : config.getExternalDataStoreConfigs().entrySet()) {
-            dataStoreFactories.put(entry.getKey(), createFactory(entry.getValue(), classLoader));
+    public ExternalDataStoreServiceImpl(Node node, ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        this.node = node;
+        for (Map.Entry<String, ExternalDataStoreConfig> entry : node.getConfig().getExternalDataStoreConfigs().entrySet()) {
+            createFactory(entry.getValue());
         }
     }
 
-    private ExternalDataStoreFactory<?> createFactory(ExternalDataStoreConfig config, ClassLoader classLoader) {
+    private ExternalDataStoreFactory<?> createFactory(ExternalDataStoreConfig config) {
         String className = config.getClassName();
         try {
             ExternalDataStoreFactory<?> externalDataStoreFactory = ClassLoaderUtil.newInstance(classLoader, className);
             externalDataStoreFactory.init(config);
+            dataStoreFactories.put(config.getName(), externalDataStoreFactory);
             return externalDataStoreFactory;
         } catch (ClassCastException e) {
             throw new HazelcastException("External data store '" + config.getName() + "' misconfigured: "
@@ -59,6 +64,12 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
     @Override
     public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
         ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories.get(name);
+        if (externalDataStoreFactory == null) {
+            ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
+            if (externalDataStoreConfig != null) {
+                return createFactory(externalDataStoreConfig);
+            }
+        }
         if (externalDataStoreFactory == null) {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -37,7 +37,7 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
         this.classLoader = classLoader;
         this.node = node;
         for (Map.Entry<String, ExternalDataStoreConfig> entry : node.getConfig().getExternalDataStoreConfigs().entrySet()) {
-            createFactory(entry.getValue());
+            dataStoreFactories.put(entry.getKey(), createFactory(entry.getValue()));
         }
     }
 
@@ -46,7 +46,6 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
         try {
             ExternalDataStoreFactory<?> externalDataStoreFactory = ClassLoaderUtil.newInstance(classLoader, className);
             externalDataStoreFactory.init(config);
-            dataStoreFactories.put(config.getName(), externalDataStoreFactory);
             return externalDataStoreFactory;
         } catch (ClassCastException e) {
             throw new HazelcastException("External data store '" + config.getName() + "' misconfigured: "

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -63,16 +63,19 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
 
     @Override
     public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
-        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories.get(name);
-        if (externalDataStoreFactory == null) {
-            ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
-            if (externalDataStoreConfig != null) {
-                return createFactory(externalDataStoreConfig);
-            }
-        }
+        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories
+                .computeIfAbsent(name, this::createFactoryIfConfigPresent);
         if (externalDataStoreFactory == null) {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }
         return externalDataStoreFactory;
+    }
+
+    private ExternalDataStoreFactory<?> createFactoryIfConfigPresent(String name) {
+        ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
+        if (externalDataStoreConfig != null) {
+            return createFactory(externalDataStoreConfig);
+        }
+        return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -159,7 +159,7 @@ public class NodeEngineImpl implements NodeEngine {
             this.transactionManagerService = new TransactionManagerServiceImpl(this);
             this.wanReplicationService = node.getNodeExtension().createService(WanReplicationService.class);
             this.sqlService = new SqlServiceImpl(this);
-            this.externalDataStoreService = new ExternalDataStoreServiceImpl(node.config, configClassLoader);
+            this.externalDataStoreService = new ExternalDataStoreServiceImpl(node, configClassLoader);
             this.packetDispatcher = new PacketDispatcher(
                     logger,
                     operationService.getOperationExecutor(),


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/22450
Fixes https://hazelcast.atlassian.net/browse/HZ-1563

Adding a new external data store config dynamically didn't result with `ExternalDataStoreFactory` being available for users.

Now if we don't find `ExternalDataStoreFactory` for a given name we check if there's a new external data store config with the same name and if found we create the factory on-demand

(cherry picked from commit 60b3cf9c98fa56140bad5e2209d9d3f00b12cb17)