### PR TITLE
Make dynamic external data store configs thread safe

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -63,19 +63,10 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
 
     @Override
     public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
-        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories
-                .computeIfAbsent(name, this::createFactoryIfConfigPresent);
-        if (externalDataStoreFactory == null) {
+        ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
+        if (externalDataStoreConfig == null) {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }
-        return externalDataStoreFactory;
-    }
-
-    private ExternalDataStoreFactory<?> createFactoryIfConfigPresent(String name) {
-        ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
-        if (externalDataStoreConfig != null) {
-            return createFactory(externalDataStoreConfig);
-        }
-        return null;
+        return dataStoreFactories.computeIfAbsent(name, n -> createFactory(externalDataStoreConfig));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -37,7 +37,7 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
         this.classLoader = classLoader;
         this.node = node;
         for (Map.Entry<String, ExternalDataStoreConfig> entry : node.getConfig().getExternalDataStoreConfigs().entrySet()) {
-            createFactory(entry.getValue());
+            dataStoreFactories.put(entry.getKey(), createFactory(entry.getValue()));
         }
     }
 
@@ -46,7 +46,6 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
         try {
             ExternalDataStoreFactory<?> externalDataStoreFactory = ClassLoaderUtil.newInstance(classLoader, className);
             externalDataStoreFactory.init(config);
-            dataStoreFactories.put(config.getName(), externalDataStoreFactory);
             return externalDataStoreFactory;
         } catch (ClassCastException e) {
             throw new HazelcastException("External data store '" + config.getName() + "' misconfigured: "

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -63,16 +63,19 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
 
     @Override
     public ExternalDataStoreFactory<?> getExternalDataStoreFactory(String name) {
-        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories.get(name);
-        if (externalDataStoreFactory == null) {
-            ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
-            if (externalDataStoreConfig != null) {
-                return createFactory(externalDataStoreConfig);
-            }
-        }
+        ExternalDataStoreFactory<?> externalDataStoreFactory = dataStoreFactories
+                .computeIfAbsent(name, this::createFactoryIfConfigPresent);
         if (externalDataStoreFactory == null) {
             throw new HazelcastException("External data store factory '" + name + "' not found");
         }
         return externalDataStoreFactory;
+    }
+
+    private ExternalDataStoreFactory<?> createFactoryIfConfigPresent(String name) {
+        ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
+        if (externalDataStoreConfig != null) {
+            return createFactory(externalDataStoreConfig);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Makes dynamic external datastore factory creation thread-safe

Related PR: https://github.com/hazelcast/hazelcast/pull/22450 