### PR TITLE
Add destroy permission to DestroyRaftObjectMessageTask [API-1639]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/DestroyRaftObjectMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/DestroyRaftObjectMessageTask.java
@@ -22,8 +22,11 @@ import com.hazelcast.cp.internal.client.AbstractCPMessageTask;
 import com.hazelcast.cp.internal.datastructures.spi.operation.DestroyRaftObjectOp;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
 
 import java.security.Permission;
+
+import static com.hazelcast.security.permission.ActionConstants.getPermission;
 
 /**
  * Client message task for destroying Raft objects
@@ -61,7 +64,7 @@ public class DestroyRaftObjectMessageTask extends AbstractCPMessageTask<CPGroupD
 
     @Override
     public Permission getRequiredPermission() {
-        return null;
+        return getPermission(parameters.objectName, parameters.serviceName, ActionConstants.ACTION_DESTROY);
     }
 
     @Override


### PR DESCRIPTION
Formerly, the message task was returning null for the required permissions, signaling that destroying the CP objects requires no permission.

However, it is possible to configure DESTROY permission for such objects as well. And, it is definitely an unexpected thing to be able to destroy a CP object without this permission, when the security and permission config is enabled for such objects.

This PR adds the correct permissions to the required message task.

The tests will be added to the enterprise PR.
