### PR TITLE
Add index only on local during MapProxy init [HZ-1192]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -260,7 +260,11 @@ abstract class MapProxySupport<K, V>
     @Override
     public void initialize() {
         initializeListeners();
-        initializeIndexes();
+        if (getNodeEngine().isStartCompleted()) {
+            initializeIndexes();
+        } else {
+            initializeLocalIndexes();
+        }
         initializeMapStoreLoad();
     }
 
@@ -318,6 +322,12 @@ abstract class MapProxySupport<K, V>
     private void initializeIndexes() {
         for (IndexConfig index : mapConfig.getIndexConfigs()) {
             addIndex(index);
+        }
+    }
+
+    private void initializeLocalIndexes() {
+        for (IndexConfig index : mapConfig.getIndexConfigs()) {
+            addIndexInternal(index, true);
         }
     }
 
@@ -1334,6 +1344,10 @@ abstract class MapProxySupport<K, V>
 
     @Override
     public void addIndex(IndexConfig indexConfig) {
+        addIndexInternal(indexConfig, false);
+    }
+
+    private void addIndexInternal(IndexConfig indexConfig, boolean localOnly) {
         checkNotNull(indexConfig, "Index config cannot be null.");
         checkFalse(isNativeMemoryAndBitmapIndexingEnabled(indexConfig.getType()),
                 "BITMAP indexes are not supported by NATIVE storage");
@@ -1342,9 +1356,15 @@ abstract class MapProxySupport<K, V>
 
         try {
             AddIndexOperation addIndexOperation = new AddIndexOperation(name, indexConfig0);
-
-            operationService.invokeOnAllPartitions(SERVICE_NAME,
-                    new BinaryOperationFactory(addIndexOperation, getNodeEngine()));
+            if (localOnly) {
+                List<Integer> ownedPartitions = getNodeEngine().getPartitionService()
+                        .getMemberPartitions(getNodeEngine().getThisAddress());
+                operationService.invokeOnPartitions(SERVICE_NAME,
+                        new BinaryOperationFactory(addIndexOperation, getNodeEngine()), ownedPartitions);
+            } else {
+                operationService.invokeOnAllPartitions(SERVICE_NAME,
+                        new BinaryOperationFactory(addIndexOperation, getNodeEngine()));
+            }
         } catch (Throwable t) {
             throw rethrow(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1357,8 +1357,7 @@ abstract class MapProxySupport<K, V>
         try {
             AddIndexOperation addIndexOperation = new AddIndexOperation(name, indexConfig0);
             if (localOnly) {
-                List<Integer> ownedPartitions = getNodeEngine().getPartitionService()
-                        .getMemberPartitions(getNodeEngine().getThisAddress());
+                PartitionIdSet ownedPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
                 operationService.invokeOnPartitions(SERVICE_NAME,
                         new BinaryOperationFactory(addIndexOperation, getNodeEngine()), ownedPartitions);
             } else {


### PR DESCRIPTION
if recovery from persistence is still in progress
(that's the case when proxy can be created and start is not yet completed), then only initialize the local proxy indexes. If we attempt to initialize indexes cluster-wide, since operations are not allowed during recovery, the local member recovery will fail.

Note: originally part of #21844 

To be backported to 5.2.0 and 5.2.z branches after merge.