### PR TITLE
Fix race condition in cancelAllExecutions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -240,14 +240,13 @@ public class JobExecutionService implements DynamicMetricsProvider {
      */
     @SuppressWarnings("rawtypes")
     public void cancelAllExecutions(String reason) {
-        Collection<ExecutionContext> contexts = executionContexts.values();
-        CompletableFuture[] futures = new CompletableFuture[contexts.size()];
-        int index = 0;
-        for (ExecutionContext exeCtx : contexts) {
-            LoggingUtil.logFine(logger, "Completing %s locally. Reason: %s",
-                    exeCtx.jobNameAndExecutionId(), reason);
-            futures[index++] = terminateExecution0(exeCtx, null, new CancellationException());
-        }
+        CompletableFuture[] futures = executionContexts.values().stream()
+                .map(exeCtx -> {
+                    LoggingUtil.logFine(logger, "Completing %s locally. Reason: %s",
+                            exeCtx.jobNameAndExecutionId(), reason);
+                    return terminateExecution0(exeCtx, null, new CancellationException());
+                })
+                .toArray(CompletableFuture[]::new);
 
         CompletableFuture.allOf(futures).join();
     }


### PR DESCRIPTION
Fixes: 
- https://github.com/hazelcast/hazelcast/issues/22253
- https://github.com/hazelcast/hazelcast/issues/22492
- the one failure of https://github.com/hazelcast/hazelcast/issues/21992

The race condition can be replicated with easy code:

```java
    public static void main(String[] args) throws InterruptedException {
        Map<Integer, Integer> map = new ConcurrentHashMap<>();

        Thread producer = new Thread(() -> {
            int i = 0;
            while (true) {
                if (map.size() == 0) {
                    map.put(i, i);
                    i++;
                }
            }
        });

        Thread consumer = new Thread(() -> {
            while (true) {
                Collection<Integer> values = map.values();
                Integer[] valuesArr = new Integer[values.size()];
                int i = 0;
                for (Integer value : values) {
                    valuesArr[i++] = value;
                }
                map.clear();
            }
        });

        producer.start();
        consumer.start();
        producer.join();
        consumer.join();
    }
```

The rest of the explanation is in the comment in our code.

I believe we should backport it to ```5.2.z```.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
