### PR TITLE
Fix NPE in ChangeRecordImpl when old or new value is null  [5.2.z]

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -177,12 +177,8 @@ public class ChangeRecordImpl implements ChangeRecord {
 
     @Override
     public int hashCode() {
-        int hash = (int) sequenceSource;
-        hash = 31 * hash + (int) sequenceValue;
-        hash = 31 * hash + keyJson.hashCode();
-        hash = 31 * hash + oldValue.toJson().hashCode();
-        hash = 31 * hash + newValue.toJson().hashCode();
-        return hash;
+        return Objects.hash(sequenceSource, sequenceValue, keyJson, timestamp,
+                operation, database, schema, table, oldValue, newValue);
     }
 
     @Override
@@ -194,10 +190,15 @@ public class ChangeRecordImpl implements ChangeRecord {
             return false;
         }
         ChangeRecordImpl that = (ChangeRecordImpl) obj;
-        return this.sequenceSource == that.sequenceSource &&
-                this.sequenceValue == that.sequenceValue &&
-                this.keyJson.equals(that.keyJson) &&
-                Objects.equals(this.oldValue, that.oldValue) &&
-                Objects.equals(this.newValue, that.newValue);
+        return this.sequenceSource == that.sequenceSource
+                && this.sequenceValue == that.sequenceValue
+                && Objects.equals(this.keyJson, that.keyJson)
+                && Objects.equals(this.timestamp, that.timestamp)
+                && this.operation == that.operation
+                && Objects.equals(this.database, that.database)
+                && Objects.equals(this.schema, that.schema)
+                && Objects.equals(this.table, that.table)
+                && Objects.equals(this.oldValue, that.oldValue)
+                && Objects.equals(this.newValue, that.newValue);
     }
 }

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -45,6 +45,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import static com.hazelcast.jet.Util.entry;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
@@ -402,6 +403,35 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
         assertThatThrownBy(job::join)
                 .hasRootCauseInstanceOf(JetException.class)
                 .hasStackTraceContaining("connector class io.debezium.connector.xxx.BlaBlaBla not found");
+    }
+
+    @Test
+    public void notFailWhenOldValueNotPresent() {
+        try (MySQLContainer<?> container = mySqlContainer()) {
+            container.start();
+            Pipeline pipeline = Pipeline.create();
+
+            // stateful transform causes hashCode to be used
+            StreamSource<ChangeRecord> source = mySqlSource(container);
+            pipeline.readFrom(source)
+                    .withNativeTimestamps(1)
+                    .setLocalParallelism(1)
+                    .groupingKey(r -> r)
+                    .mapStateful(
+                            LongAccumulator::new,
+                            (acc, key, record) -> {
+                                acc.add(1);
+                                return acc.get();
+                            }
+                    )
+                    .peek()
+                    .writeTo(Sinks.list("notFailWhenOldValueNotPresent"));
+
+            HazelcastInstance hz = createHazelcastInstances(1)[0];
+            hz.getJet().newJob(pipeline);
+
+            assertTrueEventually(() -> assertThat(hz.getList("notFailWhenOldValueNotPresent")).isNotEmpty());
+        }
     }
 
     private static class Customer {


### PR DESCRIPTION
Fix NPE in ChangeRecordImpl when old or new value is null.
Use NPE-proof Objects.hashCode.

Fixes #https://github.com/hazelcast/hazelcast/issues/22446

Backport of: #22447

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
