### PR TITLE
Fix non-finalized items in wan queue [HZ-1502] [5.1.z] (#22437)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapAddOrUpdateEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapAddOrUpdateEvent.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.wan.WanEventCounters;
 import com.hazelcast.wan.WanEventType;
@@ -37,7 +36,7 @@ import java.util.Set;
 /**
  * WAN replication object for map update operations.
  */
-public class WanMapAddOrUpdateEvent implements InternalWanEvent<EntryView<Object, Object>>, IdentifiedDataSerializable {
+public class WanMapAddOrUpdateEvent implements InternalWanEvent<EntryView<Object, Object>> {
     private String mapName;
     /**
      * The policy how to merge the entry on the receiving cluster

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapRemoveEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapRemoveEvent.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.serialization.SerializationServiceAware;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.wan.WanEventCounters;
 import com.hazelcast.wan.WanEventType;
 import com.hazelcast.wan.impl.InternalWanEvent;
@@ -35,7 +34,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
-public class WanMapRemoveEvent implements InternalWanEvent<Object>, IdentifiedDataSerializable, SerializationServiceAware {
+public class WanMapRemoveEvent implements InternalWanEvent<Object>, SerializationServiceAware {
     private SerializationService serializationService;
     private String mapName;
     private Data dataKey;

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanEvent.java
@@ -18,6 +18,7 @@ package com.hazelcast.wan.impl;
 
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.wan.WanEvent;
 import com.hazelcast.wan.WanEventCounters;
 
@@ -30,7 +31,7 @@ import java.util.Set;
  *
  * @param <T> type of object on which the event occurred
  */
-public interface InternalWanEvent<T> extends WanEvent<T> {
+public interface InternalWanEvent<T> extends WanEvent<T>, IdentifiedDataSerializable {
     /**
      * Returns the key for the entry on which the event occurred.
      */


### PR DESCRIPTION
Previously, there is only one `Finalizer` per event. Since one event  can be published from multiple publishers, only one of those was  finalized when the event is acknowledged. This caused OOME in  multi-published replication setups. This PR aims to fix this issue.

Now `FinalizableEnterpriseWanEvent` isn't an interface but a wrapper   class. So each `FinalizableEnterpriseWanEvent` is unique per queue now, and it's `Finalizer` isn't a shared field between queues like before.

Backport of: https://github.com/hazelcast/hazelcast/pull/22437