### PR TITLE
Improvements for running Hazelcast persistence on kubernetes [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -61,7 +61,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.properties.ClusterProperty;
@@ -98,7 +97,7 @@ import static java.util.Collections.singleton;
 
 @SuppressWarnings("checkstyle:classdataabstractioncoupling")
 public abstract class AbstractCacheService implements ICacheService,
-        PreJoinAwareService, PartitionAwareService,
+        PreJoinAwareService<OnJoinCacheOperation>, PartitionAwareService,
         SplitBrainProtectionAwareService, SplitBrainHandlerService,
         ClusterStateListener, TenantContextAwareService {
     /**
@@ -734,7 +733,7 @@ public abstract class AbstractCacheService implements ICacheService,
     }
 
     @Override
-    public Operation getPreJoinOperation() {
+    public OnJoinCacheOperation getPreJoinOperation() {
         OnJoinCacheOperation preJoinCacheOperation;
         preJoinCacheOperation = new OnJoinCacheOperation();
         for (Map.Entry<String, CompletableFuture<CacheConfig>> cacheConfigEntry : configs.entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.exception.ServiceNotFoundException;
 
@@ -41,7 +42,7 @@ import static com.hazelcast.cache.impl.JCacheDetector.isJCacheAvailable;
  * resolve a race between the {@link CacheConfig} becoming available in the joining member and creation of a
  * {@link com.hazelcast.cache.ICache} proxy.
  */
-public class OnJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
+public class OnJoinCacheOperation extends Operation implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private List<CacheConfig> configs = new ArrayList<CacheConfig>();
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -158,8 +158,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity", "checkstyle:classdataabstractioncoupling"})
 public class RaftService implements ManagedService, SnapshotAwareService<MetadataRaftGroupSnapshot>, GracefulShutdownAwareService,
-                                    MembershipAwareService, PreJoinAwareService, RaftNodeLifecycleAwareService,
-                                    MigrationAwareService, DynamicMetricsProvider,
+                                    MembershipAwareService, PreJoinAwareService<RaftServicePreJoinOp>,
+                                    RaftNodeLifecycleAwareService, MigrationAwareService, DynamicMetricsProvider,
                                     EventPublishingService<Object, EventListener> {
 
     public static final String SERVICE_NAME = "hz:core:raft";
@@ -569,7 +569,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
     }
 
     @Override
-    public Operation getPreJoinOperation() {
+    public RaftServicePreJoinOp getPreJoinOperation() {
         if (!cpSubsystemEnabled) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/RaftServicePreJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raftop/metadata/RaftServicePreJoinOp.java
@@ -24,6 +24,7 @@ import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.io.IOException;
@@ -35,7 +36,7 @@ import java.io.IOException;
  * Please note that this operation is not a {@link RaftOp},
  * so it is not handled via the Raft layer.
  */
-public class RaftServicePreJoinOp extends Operation implements IdentifiedDataSerializable {
+public class RaftServicePreJoinOp extends Operation implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private boolean discoveryCompleted;
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/ClusterTopologyIntent.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/ClusterTopologyIntent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+/**
+ * This class represents the estimated intent of topology changes
+ * performed in a managed runtime context (kubernetes) that may affect the cluster.
+ * {@link #NOT_IN_MANAGED_CONTEXT} indicates Hazelcast is not executed within a
+ * managed runtime context; all other values represent different detected intents
+ * within a managed runtime context.
+ *
+ * @see ClusterTopologyIntentTracker
+ */
+public enum ClusterTopologyIntent {
+    /**
+     * Hazelcast is not deployed in a managed context
+     */
+    NOT_IN_MANAGED_CONTEXT(0),
+    /**
+     * Unknown state, but in managed context (Kubernetes)
+     */
+    IN_MANAGED_CONTEXT_UNKNOWN(1),
+    /**
+     * No change to the number of Hazelcast members in the cluster is intended
+     */
+    CLUSTER_STABLE(2),
+    /**
+     * No change to the number of Hazelcast members in the cluster is intended,
+     * but some members are missing from the cluster.
+     * For example this might happen when kubernetes reschedules a pod, so it is first shutdown, then restarted.
+     * Even though the requested number of members in the cluster stays the same
+     * all the time, a member will be missing for some time and the detected intent during
+     * that time will be {@code MISSING_MEMBERS}.
+     */
+    CLUSTER_STABLE_WITH_MISSING_MEMBERS(3),
+    /**
+     * Full cluster shutdown is intended
+     */
+    CLUSTER_SHUTDOWN(4),
+    /**
+     * Cluster is starting up
+     */
+    CLUSTER_START(5),
+    /**
+     * Cluster is shutting down, but had some missing members before
+     * cluster-wide shutdown.
+     */
+    CLUSTER_SHUTDOWN_WITH_MISSING_MEMBERS(6),
+    /**
+     * Hazelcast cluster is being scaled up or down
+     */
+    SCALING(7);
+
+    private final int id;
+
+    ClusterTopologyIntent(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public static ClusterTopologyIntent of(int id) {
+        for (ClusterTopologyIntent intent : ClusterTopologyIntent.values()) {
+            if (intent.id == id) {
+                return intent;
+            }
+        }
+        throw new IllegalArgumentException("No ClusterTopologyIntent exists with id " + id);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/ClusterTopologyIntentTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/ClusterTopologyIntentTracker.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+/**
+ * Receives updates about the context in which Hazelcast is executed
+ * in order to detect what is the intent of topology changes from the
+ * managed runtime context that may affect how the Hazelcast cluster should react.
+ * <p/>
+ * Terminology:
+ * <ul>
+ *     <li><b>Managed runtime context</b>: a runtime orchestration environment within which Hazelcast is
+ *     being executed (e.g. Kubernetes).</li>
+ *     <li><b>Replica</b>: a Hazelcast member that is executed in a managed runtime context. For example,
+ *     when running a 3-member Hazelcast cluster, there are 3 replicas.</li>
+ *     <li><b>Specification / specified replicas</b>: the desired runtime state of the Hazelcast member, as declared by the user
+ *     to the managed runtime context. For example, when user executes {@code kubectl scale sts hz --replicas 5},
+ *     the <b>specified replicas</b> are 5.</li>
+ *     <li><b>Current replicas</b>: number of replicas that are running by the managed runtime. Notice that current replicas
+ *     does not necessarily reflect the current number of members in the Hazelcast cluster. Examples:
+ *     <br/>- When a kubernetes pod is terminated, "current replicas" is immediately
+ *     decreased by 1, even though the Hazelcast member is still live and just started performing its graceful shutdown. So
+ *     there will be some time during which current replicas may be lower than actual number of members in the Hazelcast cluster
+ *     (until graceful shutdown completes).
+ *     <br/>- When a kubernetes pod is scheduled, "current replicas" immediately increases by 1 even though Hazelcast is just
+ *     started and not joined to any cluster.</li>
+ *     <li><b>Ready replicas</b>: replicas which are observed as "ready" by the managed runtime. "Ready" implies that the
+ *     managed runtime has queried the configured readiness probe and found the Hazelcast member to be ready (i.e. up & running
+ *     and ready to accept and serve requests). Notice that since "ready" state is based on a periodic check by the managed
+ *     runtime, its updates can lag for some time, depending on configuration (e.g. what is the period of readiness probe checks
+ *     etc). Example:
+ *     <br/>Kubernetes deletes a pod of a running cluster with specified replicas 3. Immediately
+ *     "current replicas" drops to 2, however "ready replicas" is still 3 until the readiness probe monitoring period passes
+ *     and the readiness check figures out the Hazelcast member is no longer ready.
+ *     <br/>
+ *     Also related to "readiness" definition: {@code NodeExtension#isReady}.</li>
+ * </ul>
+ */
+public interface ClusterTopologyIntentTracker {
+
+    int UNKNOWN = -1;
+
+    /**
+     * Process an update of the cluster topology. Each update carries information about
+     * the previous & current specified replicas count, the current number of replicas and ready replicas in the cluster.
+     * <br/>
+     * <b>Examples</b> (numbers in parentheses indicate (previous specified replica count, current specified replica count,
+     * current replicas, current ready replicas))
+     * <p>
+     *     A cluster with specified replica count 3 is starting up. This is expected to result in a series
+     *     of updates similar to the following:
+     *     <pre>{@code
+     *     (-1, 3, 0, 0)
+     *     (3, 3, 1, 0)
+     *     (3, 3, 1, 1)
+     *     (3, 3, 2, 1)
+     *     (3, 3, 2, 2)
+     *     (3, 3, 3, 2)
+     *     (3, 3, 3, 3)
+     *     }</pre>
+     * </p>
+     * <p>
+     *     Assuming user requests scaling up a running cluster of 3 members to 5, the following
+     *     updates are expected:
+     *     <pre>{@code
+     *     (3, 3, 3, 3)
+     *     (3, 5, 4, 3)
+     *     (5, 5, 4, 4)
+     *     (5, 5, 5, 4)
+     *     (5, 5, 5, 5)
+     *     }</pre>
+     * </p>
+     * Notice that actual updates may differ (eg duplicate notifications of intermediate states may be received).
+     *
+     * @param previousSpecifiedReplicas   previous specified replicas count
+     * @param updatedSpecifiedReplicas    updated specified replicas count
+     * @param previousReadyReplicas       number of previously ready replicas
+     * @param updatedReadyReplicas        number of updated ready replicas
+     * @param previousCurrentReplicas     number of previous current replicas
+     * @param updatedCurrentReplicas      number of updated current replicas
+     *
+     * @see NodeExtension#isReady()
+     */
+    void update(int previousSpecifiedReplicas, int updatedSpecifiedReplicas,
+                int previousReadyReplicas, int updatedReadyReplicas,
+                int previousCurrentReplicas, int updatedCurrentReplicas);
+
+    ClusterTopologyIntent getClusterTopologyIntent();
+
+    /**
+     * Initialize this tracker, if the tracker supports it. This method must be called first, before the tracker
+     * can receive any updates.
+     */
+    void initialize();
+
+    /**
+     * Prepare this tracker for shutdown.
+     */
+    void destroy();
+
+    /**
+     * Initialize explicitly the cluster topology intent.
+     * @param clusterTopologyIntent
+     */
+    void initializeClusterTopologyIntent(ClusterTopologyIntent clusterTopologyIntent);
+
+    /**
+     * Handle Hazelcast node shutdown with the given cluster topology intent.
+     * @param clusterTopologyIntent
+     */
+    void shutdownWithIntent(ClusterTopologyIntent clusterTopologyIntent);
+
+    /**
+     * @return {@code true} if this instance of {@code ClusterTopologyIntentTracker} is active and tracking
+     *         cluster topology changes in a managed context, otherwise {@code false}.
+     */
+    boolean isEnabled();
+
+    /**
+     * @return  the number of requested Hazelcast members in the cluster, as determined by the specification
+     *          that is managed by the runtime context. When running Hazelcast in a Kubernetes StatefulSet,
+     *          this corresponds to the value in {@code StatefulSetSpec.size}.
+     */
+    int getCurrentSpecifiedReplicaCount();
+
+    /**
+     * Notifies the {@link ClusterTopologyIntentTracker} that Hazelcast members list has changed.
+     */
+    void onMembershipChange();
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -322,6 +322,11 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public boolean isReady() {
+        return node.getClusterService().isJoined();
+    }
+
+    @Override
     public SecurityContext getSecurityContext() {
         logger.warning("Security features are only available on Hazelcast Enterprise!");
         return null;
@@ -533,6 +538,7 @@ public class DefaultNodeExtension implements NodeExtension {
         if (service != null) {
             service.onMemberListChange();
         }
+        node.clusterTopologyIntentTracker.onMembershipChange();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/KubernetesTopologyIntentTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/KubernetesTopologyIntentTracker.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.util.BiTuple;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.utils.RetryUtils;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.spi.properties.ClusterProperty.CLUSTER_SHUTDOWN_TIMEOUT_SECONDS;
+import static com.hazelcast.spi.properties.ClusterProperty.PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY;
+import static java.lang.Thread.sleep;
+
+/**
+ * Implementation of {@link ClusterTopologyIntentTracker} that automates cluster state management
+ * according to intent of topology changes detected in kubernetes environment.
+ * <br/>
+ * Example flow of change in detected intent and associated {@code currentClusterSpecSize} on a cluster's master member:
+ * (User action on left, detected intent with cluster spec size in parenthese on the right side).
+ * <pre>
+ * {@code
+ * +-----------------------------------------------------------------+---------------------------------+
+ * | $ helm install hz --set cluster.memberCount=3 \                 | NOT_IN_MANAGED_CONTEXT(-1) ->   |
+ * |             hazelcast-enterprise-5.3.1-gcs.tgz                  | CLUSTER_START(3) ->             |
+ * |                                                                 | (after pods are started)        |
+ * |                                                                 | STABLE(3)                       |
+ * +-----------------------------------------------------------------+---------------------------------+
+ * | $ kubectl scale sts hz-hazelcast-enterprise --replicas 5        | SCALING(5) ->                   |
+ * |                                                                 | (after new pods are started)    |
+ * |                                                                 | STABLE(5)                       |
+ * +-----------------------------------------------------------------+---------------------------------+
+ * | $ kubectl delete pod hz-hazelcast-enterprise-2                  | MISSING_MEMBERS(5) ->           |
+ * |   (simulating kubernetes deleted a pod)                         | (after pod is restarted)        |
+ * |                                                                 | STABLE(5)                       |
+ * +-----------------------------------------------------------------+---------------------------------+
+ * | $ kubectl scale sts hz-hazelcast-enterprise --replicas 0        | CLUSTER_SHUTDOWN(0)             |
+ * +-----------------------------------------------------------------+---------------------------------+
+ * }
+ * </pre>
+ */
+public class KubernetesTopologyIntentTracker implements ClusterTopologyIntentTracker {
+
+    /**
+     * Currently detected cluster topology intent.
+     */
+    private final AtomicReference<ClusterTopologyIntent> clusterTopologyIntent =
+            new AtomicReference<>(ClusterTopologyIntent.NOT_IN_MANAGED_CONTEXT);
+    // single-threaded executor for actions in response to cluster topology intent changes
+    private final ExecutorService clusterTopologyExecutor;
+    // applies when automatic cluster state management is enabled (with persistence in kubernetes)
+    private final ClusterState clusterStateForMissingMembers;
+    private final ILogger logger;
+    private final Node node;
+    /**
+     * The desired number of members, as specified in the runtime environment. eg in kubernetes
+     * {@code kubectl scale sts hz --replicas 5} means {@code currentClusterSpecSize} is 5.
+     */
+    private volatile int currentClusterSpecSize = UNKNOWN;
+    /**
+     * The last known cluster spec size while cluster was detected in {@link ClusterTopologyIntent#CLUSTER_STABLE} intent.
+     * Used during cluster-wide shutdown, while {@link #currentClusterSpecSize} is {@code 0}.
+     */
+    private volatile int lastKnownStableClusterSpecSize = UNKNOWN;
+    /**
+     * Current Hazelcast cluster size, as observed by {@link com.hazelcast.internal.cluster.ClusterService}.
+     */
+    private volatile int currentClusterSize;
+
+    private volatile boolean enabled;
+
+    public KubernetesTopologyIntentTracker(Node node) {
+        this.clusterStateForMissingMembers = node.getProperties()
+                .getEnum(PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY, ClusterState.class);
+        if (clusterStateForMissingMembers != ClusterState.FROZEN
+                && clusterStateForMissingMembers != ClusterState.NO_MIGRATION) {
+            throw new InvalidConfigurationException("Value of property " + PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY.getName()
+                    + " was " + clusterStateForMissingMembers + " but should be one of FROZEN, NO_MIGRATION.");
+        }
+        this.clusterTopologyExecutor = Executors.newSingleThreadExecutor();
+        this.logger = node.getLogger(ClusterTopologyIntentTracker.class);
+        this.node = node;
+    }
+
+    @Override
+    public void initialize() {
+        enabled = true;
+    }
+
+    @Override
+    public void destroy() {
+        clusterTopologyExecutor.shutdown();
+    }
+
+    @Override
+    public void update(int previousSpecifiedReplicas, int updatedSpecifiedReplicas,
+                       int previousReadyReplicas, int updatedReadyReplicas,
+                       int previousCurrentReplicas, int updatedCurrentReplicas) {
+        final int previousClusterSpecSizeValue = this.currentClusterSpecSize;
+        this.currentClusterSpecSize = updatedSpecifiedReplicas;
+        if (previousSpecifiedReplicas == UNKNOWN) {
+            handleInitialUpdate(updatedSpecifiedReplicas, updatedReadyReplicas);
+            return;
+        }
+        final ClusterTopologyIntent previous = clusterTopologyIntent.get();
+        ClusterTopologyIntent newTopologyIntent;
+        Runnable postUpdateActionOnMaster = null;
+        if (updatedSpecifiedReplicas == 0) {
+            newTopologyIntent = handleShutdownUpdate(previousClusterSpecSizeValue, previous);
+        } else if (previousSpecifiedReplicas == updatedSpecifiedReplicas) {
+            if (ignoreUpdateWhenClusterSpecEqual(previous, updatedReadyReplicas)) {
+                return;
+            }
+            BiTuple<ClusterTopologyIntent, Runnable> t =
+                    nextIntentWhenClusterSpecEqual(previous,
+                            previousReadyReplicas, updatedReadyReplicas,
+                            previousCurrentReplicas, updatedCurrentReplicas);
+            newTopologyIntent = t.element1;
+            postUpdateActionOnMaster = t.element2;
+        } else {
+            newTopologyIntent = ClusterTopologyIntent.SCALING;
+            postUpdateActionOnMaster = () -> changeClusterState(ClusterState.ACTIVE);
+        }
+        if (clusterTopologyIntent.compareAndSet(previous, newTopologyIntent)) {
+            onClusterTopologyIntentUpdate(previous, newTopologyIntent, postUpdateActionOnMaster);
+        }
+    }
+
+    private void handleInitialUpdate(int currentSpecifiedReplicaCount, int readyReplicasCount) {
+        if (currentSpecifiedReplicaCount > 0
+                && (readyReplicasCount == UNKNOWN || readyReplicasCount == 0)) {
+            // startup of first member of new cluster
+            logger.info("Cluster starting in managed context");
+            clusterTopologyIntent.set(ClusterTopologyIntent.CLUSTER_START);
+        } else {
+            logger.info("Member starting in managed context");
+            clusterTopologyIntent.set(ClusterTopologyIntent.IN_MANAGED_CONTEXT_UNKNOWN);
+        }
+    }
+
+    private ClusterTopologyIntent handleShutdownUpdate(int previousClusterSpecSizeValue, ClusterTopologyIntent previous) {
+        ClusterTopologyIntent newTopologyIntent;
+        if (previousClusterSpecSizeValue > 0) {
+            this.lastKnownStableClusterSpecSize = previousClusterSpecSizeValue;
+        }
+        newTopologyIntent = nextIntentWhenShuttingDown(previous);
+        return newTopologyIntent;
+    }
+
+    private void onClusterTopologyIntentUpdate(ClusterTopologyIntent previous, ClusterTopologyIntent newTopologyIntent,
+                                               @Nullable Runnable actionOnMaster) {
+        logger.info("Cluster topology intent: " + previous + " -> " + newTopologyIntent);
+        clusterTopologyExecutor.submit(() -> {
+            node.getNodeExtension().getInternalHotRestartService().onClusterTopologyIntentChange();
+            if (!node.isMaster()) {
+                return;
+            }
+            if (actionOnMaster != null) {
+                actionOnMaster.run();
+            }
+        });
+    }
+
+    private ClusterTopologyIntent nextIntentWhenShuttingDown(ClusterTopologyIntent previous) {
+        // if members were previously missing, next intent is CLUSTER_SHUTDOWN_WITH_MISSING_MEMBERS
+        // otherwise plain CLUSTER_SHUTDOWN
+        return previous == ClusterTopologyIntent.CLUSTER_STABLE_WITH_MISSING_MEMBERS
+                || previous == ClusterTopologyIntent.CLUSTER_SHUTDOWN_WITH_MISSING_MEMBERS
+                ? ClusterTopologyIntent.CLUSTER_SHUTDOWN_WITH_MISSING_MEMBERS
+                : ClusterTopologyIntent.CLUSTER_SHUTDOWN;
+    }
+
+    /**
+     * Decide whether an update from managed context should be ignored when cluster spec size stays the same.
+     * @return {@code true} if update should be ignored, otherwise {@code false}.
+     */
+    private boolean ignoreUpdateWhenClusterSpecEqual(ClusterTopologyIntent previous,
+                                                     int readyNodesCount) {
+        if (readyNodesCount != currentClusterSpecSize
+            && (previous == ClusterTopologyIntent.SCALING
+                || previous == ClusterTopologyIntent.IN_MANAGED_CONTEXT_UNKNOWN
+                || previous == ClusterTopologyIntent.CLUSTER_START)) {
+            logger.info("Ignoring update because readyNodesCount is "
+                    + readyNodesCount + ", while spec requires " + currentClusterSpecSize
+                    + " and previous cluster topology intent is " + previous);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return next {@code ClusterTopologyIntent} according to rules applicable while there is no change
+     * in cluster size specification in managed context. (ie StatefulSetSpec.size remains the same, so
+     * user does not intend a change in cluster size).
+     */
+    private BiTuple<ClusterTopologyIntent, Runnable> nextIntentWhenClusterSpecEqual(ClusterTopologyIntent previous,
+                                                         int previousReadyReplicas, int updatedReadyReplicas,
+                                                         int previousCurrentReplicas, int updatedCurrentReplicas) {
+        ClusterTopologyIntent next = previous;
+        Runnable action = null;
+        if (updatedReadyReplicas == currentClusterSpecSize) {
+            if (updatedCurrentReplicas < previousCurrentReplicas) {
+                if (updatedReadyReplicas == previousReadyReplicas) {
+                    // If updatedReady == previousReady and updatedCurrent < previousCurrent, then this is the beginning of a
+                    // rollout restart and readiness probe hasn't yet noticed.
+                    next = ClusterTopologyIntent.CLUSTER_STABLE_WITH_MISSING_MEMBERS;
+                } else if (updatedReadyReplicas > previousReadyReplicas) {
+                    // If updatedReady > previousReady and updatedCurrent < previousCurrent, then this is a coalesced Kubernetes
+                    // event in the middle of rollout restart. It marks at the same time a previously restarted member
+                    // is now ready and the next pod is going down for restart.
+                    next = ClusterTopologyIntent.CLUSTER_STABLE_WITH_MISSING_MEMBERS;
+                    // need to fix partition table before allowing next pod to restart
+                    action = clusterStateForMissingMembers == ClusterState.NO_MIGRATION
+                            ? () -> changeClusterState(ClusterState.ACTIVE)
+                            : null;
+                }
+            } else if (previous != ClusterTopologyIntent.CLUSTER_STABLE) {
+                next = ClusterTopologyIntent.CLUSTER_STABLE;
+                action = () -> {
+                    if (getClusterService().getClusterState() != ClusterState.ACTIVE) {
+                        tryExecuteOrSetDeferredClusterStateChange(ClusterState.ACTIVE);
+                    } else if (!getPartitionService().isPartitionTableSafe()) {
+                        getPartitionService().getMigrationManager().triggerControlTask();
+                    }
+                };
+            }
+        } else if (previous == ClusterTopologyIntent.CLUSTER_STABLE && updatedCurrentReplicas < currentClusterSpecSize) {
+            next = ClusterTopologyIntent.CLUSTER_STABLE_WITH_MISSING_MEMBERS;
+        }
+        return BiTuple.of(next, action);
+    }
+
+    @Override
+    public ClusterTopologyIntent getClusterTopologyIntent() {
+        return clusterTopologyIntent.get();
+    }
+
+    @Override
+    public void initializeClusterTopologyIntent(ClusterTopologyIntent clusterTopologyIntent) {
+        ClusterTopologyIntent current = this.clusterTopologyIntent.get();
+        logger.info("Current node cluster topology intent is " + current);
+        // if not UNKNOWN, then it was already initialized
+        if (current == ClusterTopologyIntent.IN_MANAGED_CONTEXT_UNKNOWN) {
+            logger.info("Initializing this node's cluster topology to " + clusterTopologyIntent);
+            this.clusterTopologyIntent.set(clusterTopologyIntent);
+        }
+    }
+
+    @Override
+    public void shutdownWithIntent(ClusterTopologyIntent shutdownIntent) {
+        // consider the detected shutdown intent before triggering node shutdown
+        if (shutdownIntent == ClusterTopologyIntent.CLUSTER_STABLE
+                || shutdownIntent == ClusterTopologyIntent.CLUSTER_STABLE_WITH_MISSING_MEMBERS) {
+            try {
+                // wait for partition table to be healthy before switching to NO_MIGRATION
+                // eg in "rollout restart" case, node is shutdown in NO_MIGRATION state
+                waitCallableWithShutdownTimeout(() -> getPartitionService().isPartitionTableSafe());
+                changeClusterState(clusterStateForMissingMembers);
+            } catch (Throwable t) {
+                // let shutdown proceed even though we failed to switch to desired state
+                logger.warning("Could not switch to transient " + clusterStateForMissingMembers + " state while cluster"
+                        + "shutdown intent was " + shutdownIntent, t);
+            }
+        } else if (shutdownIntent == ClusterTopologyIntent.CLUSTER_SHUTDOWN) {
+            clusterWideShutdown();
+        } else if (shutdownIntent == ClusterTopologyIntent.CLUSTER_SHUTDOWN_WITH_MISSING_MEMBERS) {
+            // If cluster is shutting down with missing members, it is possible that a member might
+            // rejoin while attempting the graceful shutdown. In this case, races may occur, which may
+            // lead to lack of progress on the shutting-down member, so we orchestrate shutdown:
+            // - shutting down member waits for the missing member to rejoin
+            // - we ensure partition table is healthy (required for next step) and switch to ACTIVE cluster state to
+            //   allow for partition rebalancing to fix potentially missing partition replica assignments
+            // - finally switch to PASSIVE cluster state and wait for partition replica sync (similar to normal
+            //   CLUSTER_SHUTDOWN case)
+            long remainingNanosForShutdown = waitForMissingMember();
+            clusterWideShutdownWithMissingMember(shutdownIntent, remainingNanosForShutdown);
+        }
+    }
+
+    private void clusterWideShutdownWithMissingMember(ClusterTopologyIntent shutdownIntent,
+                                                      long remainingNanosForShutdown) {
+        try {
+            // The do-while loop ensures that we wait for partition table to be healthy after successfully
+            // switching to PASSIVE cluster state (during which attempts of missing members to rejoin will
+            // be denied), otherwise we retry by switching to ACTIVE cluster state.
+            do {
+                logger.info("Waiting for partition table to be healthy");
+                if (!getPartitionService().isPartitionTableSafe()) {
+                    logger.warning("Switching to ACTIVE state in order to allow for partition table to be healthy");
+                    changeClusterState(ClusterState.ACTIVE);
+                    waitCallableWithShutdownTimeout(() -> getPartitionService().isPartitionTableSafe());
+                }
+                changeClusterState(ClusterState.PASSIVE);
+            } while (!getPartitionService().isPartitionTableSafe());
+        } catch (Throwable t) {
+            // let shutdown proceed even though we failed to switch to PASSIVE state
+            // and wait for replica sync
+            logger.warning("Could not switch to transient PASSIVE state while cluster"
+                    + "shutdown intent was " + shutdownIntent, t);
+        }
+        try {
+            getNodeExtension().getInternalHotRestartService()
+                    .waitPartitionReplicaSyncOnCluster(remainingNanosForShutdown, TimeUnit.NANOSECONDS);
+        } catch (IllegalStateException e) {
+            logger.severe("Failure while waiting for partition replica sync before shutdown", e);
+        }
+    }
+
+    private void clusterWideShutdown() {
+        try {
+            changeClusterState(ClusterState.PASSIVE);
+        } catch (Throwable t) {
+            // let shutdown proceed even though we failed to switch to PASSIVE state
+            logger.warning("Could not switch to transient PASSIVE state while cluster "
+                    + "shutdown intent was CLUSTER_SHUTDOWN.", t);
+        }
+        long timeoutNanos = node.getProperties().getNanos(CLUSTER_SHUTDOWN_TIMEOUT_SECONDS);
+        try {
+            // wait for replica sync
+            getNodeExtension().getInternalHotRestartService()
+                    .waitPartitionReplicaSyncOnCluster(timeoutNanos, TimeUnit.NANOSECONDS);
+        } catch (IllegalStateException e) {
+            logger.severe("Failure while waiting for partition replica sync before shutdown.", e);
+        }
+    }
+
+    /**
+     * Wait for cluster size (as observed by Hazelcast's ClusterService) to become equal to the
+     * last known cluster size as specified in Kubernetes {@code StatefulsetSpec.size), before cluster-wide shutdown
+     * was requested.
+     * @return nanos remaining until cluster shutdown timeout
+     */
+    long waitForMissingMember() {
+        long nanosRemaining = node.getProperties().getNanos(CLUSTER_SHUTDOWN_TIMEOUT_SECONDS);
+        if (getClusterService().getClusterState() == ClusterState.PASSIVE) {
+            // cluster is already in PASSIVE state and shutting down, so don't wait
+            return nanosRemaining;
+        }
+        if (lastKnownStableClusterSpecSize == currentClusterSize) {
+            return nanosRemaining;
+        }
+        logger.info("Waiting for missing members: lastKnownStableClusterSpecSize: " + lastKnownStableClusterSpecSize + ", "
+                + "currentClusterSize " + currentClusterSize);
+        return waitCallableWithTimeout(() -> lastKnownStableClusterSpecSize == currentClusterSize, nanosRemaining);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public int getCurrentSpecifiedReplicaCount() {
+        return currentClusterSpecSize;
+    }
+
+    @Override
+    public void onMembershipChange() {
+        currentClusterSize = getClusterService().getSize();
+    }
+
+    /**
+     * If recovery from persistence is completed, then immediately changes cluster state to given {@code newClusterState}.
+     * Otherwise, the given {@code newClusterState} is passed on to hot-restart service and may be applied as final cluster
+     * state after recovery is done.
+     *
+     * @param newClusterState the new cluster state
+     * @see com.hazelcast.internal.hotrestart.InternalHotRestartService#trySetDeferredClusterState(ClusterState)
+     */
+    private void tryExecuteOrSetDeferredClusterStateChange(ClusterState newClusterState) {
+        if (!getNodeExtension().getInternalHotRestartService().trySetDeferredClusterState(newClusterState)) {
+            // hot restart recovery is completed, just apply the new cluster state here
+            changeClusterState(newClusterState);
+        }
+    }
+
+    /**
+     *
+     * @param callable  {@link Callable<Boolean>} that returns {@code true} when its condition is completed and
+     *                  control should return to caller.
+     * @return {@code true} if completed because callable completed normally or {@code false} if timeout passed or
+     *         thread was interrupted.
+     */
+    private long waitCallableWithShutdownTimeout(Callable<Boolean> callable) {
+        return waitCallableWithTimeout(callable, node.getProperties().getNanos(CLUSTER_SHUTDOWN_TIMEOUT_SECONDS));
+    }
+
+    long waitCallableWithTimeout(Callable<Boolean> callable, long timeoutNanos) {
+        boolean callableCompleted;
+        long start = System.nanoTime();
+        do {
+            try {
+                callableCompleted = callable.call();
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+            try {
+                sleep(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            timeoutNanos -= (System.nanoTime() - start);
+        } while (!callableCompleted && timeoutNanos > 0);
+        return timeoutNanos;
+    }
+
+    /**
+     * Change cluster state, if current state is not already the desired one.
+     * Retries up to 3 times. The cluster state change is transient, so if persistence
+     * is enabled, the new cluster state is not persisted to disk.
+     *
+     * @param newClusterState
+     */
+    private void changeClusterState(ClusterState newClusterState) {
+        RetryUtils.retry(
+                () -> {
+                    getClusterService().changeClusterState(newClusterState, true);
+                    return null;
+                }, 3);
+    }
+
+    private NodeExtension getNodeExtension() {
+        return node.getNodeExtension();
+    }
+
+    private InternalPartitionServiceImpl getPartitionService() {
+        return node.partitionService;
+    }
+
+    private ClusterServiceImpl getClusterService() {
+        return node.getClusterService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NoOpClusterTopologyIntentTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NoOpClusterTopologyIntentTracker.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+public class NoOpClusterTopologyIntentTracker implements ClusterTopologyIntentTracker {
+
+    @Override
+    public void update(int previousSpecifiedReplicas, int updatedSpecifiedReplicas,
+                       int previousReadyReplicas, int updatedReadyReplicas,
+                       int previousCurrentReplicas, int updatedCurrentReplicas) {
+    }
+
+    @Override
+    public ClusterTopologyIntent getClusterTopologyIntent() {
+        return ClusterTopologyIntent.NOT_IN_MANAGED_CONTEXT;
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void initializeClusterTopologyIntent(ClusterTopologyIntent clusterTopologyIntent) {
+    }
+
+    @Override
+    public void shutdownWithIntent(ClusterTopologyIntent clusterTopologyIntent) {
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public int getCurrentSpecifiedReplicaCount() {
+        return 0;
+    }
+
+    @Override
+    public void onMembershipChange() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -88,6 +88,7 @@ import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.security.SecurityService;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
@@ -97,6 +98,7 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
@@ -142,6 +144,10 @@ import static java.security.AccessController.doPrivileged;
         "checkstyle:classfanoutcomplexity"})
 public class Node {
 
+    // name of property used to inject ClusterTopologyIntentTracker in Discovery Service
+    public static final String DISCOVERY_PROPERTY_CLUSTER_TOPOLOGY_INTENT_TRACKER =
+            "hazelcast.internal.discovery.cluster.topology.intent.tracker";
+
     private static final int THREAD_SLEEP_DURATION_MS = 500;
     private static final String GRACEFUL_SHUTDOWN_EXECUTOR_NAME = "hz:graceful-shutdown";
 
@@ -164,6 +170,7 @@ public class Node {
      */
     public final Address address;
     public final SecurityContext securityContext;
+    final ClusterTopologyIntentTracker clusterTopologyIntentTracker;
 
     private final ILogger logger;
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
@@ -261,6 +268,12 @@ public class Node {
             healthMonitor = new HealthMonitor(this);
             clientEngine = hasClientServerSocket() ? new ClientEngineImpl(this) : new NoOpClientEngine();
             JoinConfig joinConfig = getActiveMemberNetworkConfig(this.config).getJoin();
+            if (properties.getBoolean(ClusterProperty.PERSISTENCE_AUTO_CLUSTER_STATE)
+                    && config.getPersistenceConfig().isEnabled()) {
+                clusterTopologyIntentTracker = new KubernetesTopologyIntentTracker(this);
+            } else {
+                clusterTopologyIntentTracker = new NoOpClusterTopologyIntentTracker();
+            }
             DiscoveryConfig discoveryConfig = new DiscoveryConfigReadOnly(joinConfig.getDiscoveryConfig());
             List<DiscoveryStrategyConfig> aliasedDiscoveryConfigs =
                     AliasedDiscoveryConfigUtils.createDiscoveryStrategyConfigs(joinConfig);
@@ -331,6 +344,10 @@ public class Node {
         }
         ILogger logger = getLogger(DiscoveryService.class);
 
+        final Map attributes = new HashMap<>(localMember.getAttributes());
+        attributes.put(DISCOVERY_PROPERTY_CLUSTER_TOPOLOGY_INTENT_TRACKER, clusterTopologyIntentTracker);
+        DiscoveryNode thisDiscoveryNode = new SimpleDiscoveryNode(localMember.getAddress(), attributes);
+
         DiscoveryServiceSettings settings = new DiscoveryServiceSettings()
                 .setConfigClassLoader(configClassLoader)
                 .setLogger(logger)
@@ -338,8 +355,7 @@ public class Node {
                 .setDiscoveryConfig(discoveryConfig)
                 .setAliasedDiscoveryConfigs(aliasedDiscoveryConfigs)
                 .setAutoDetectionEnabled(isAutoDetectionEnabled)
-                .setDiscoveryNode(
-                        new SimpleDiscoveryNode(localMember.getAddress(), localMember.getAttributes()));
+                .setDiscoveryNode(thisDiscoveryNode);
 
         return factory.newDiscoveryService(settings);
     }
@@ -688,6 +704,10 @@ public class Node {
         state = NodeState.PASSIVE;
     }
 
+    public void forceNodeStateToPassive() {
+        state = NodeState.PASSIVE;
+    }
+
     /**
      * Resets the internal cluster-state of the Node to be able to make it ready to join a new cluster.
      * After this method is called,
@@ -765,23 +785,70 @@ public class Node {
         @Override
         public void run() {
             try {
-                if (isRunning()) {
-                    logger.info("Running shutdown hook... Current state: " + state);
-                    switch (policy) {
-                        case TERMINATE:
-                            hazelcastInstance.getLifecycleService().terminate();
-                            break;
-                        case GRACEFUL:
-                            hazelcastInstance.getLifecycleService().shutdown();
-                            break;
-                        default:
-                            throw new IllegalArgumentException("Unimplemented shutdown hook policy: " + policy);
-                    }
+                if (!isRunning()) {
+                    return;
+                }
+                final ClusterTopologyIntent shutdownIntent = clusterTopologyIntentTracker.getClusterTopologyIntent();
+                if (clusterTopologyIntentTracker.isEnabled()
+                        && getNodeExtension().getInternalHotRestartService().isEnabled()
+                        && shutdownIntent != ClusterTopologyIntent.IN_MANAGED_CONTEXT_UNKNOWN
+                        && shutdownIntent != ClusterTopologyIntent.NOT_IN_MANAGED_CONTEXT) {
+                    final ClusterState clusterState = clusterService.getClusterState();
+                    logger.info("Running shutdown hook... Current node state: " + state
+                                + ", detected shutdown intent: " + shutdownIntent
+                                + ", cluster state: " + clusterState);
+                    clusterTopologyIntentTracker.shutdownWithIntent(shutdownIntent);
+                } else {
+                    logger.info("Running shutdown hook... Current node state: " + state);
+                }
+                switch (policy) {
+                    case TERMINATE:
+                        hazelcastInstance.getLifecycleService().terminate();
+                        break;
+                    case GRACEFUL:
+                        hazelcastInstance.getLifecycleService().shutdown();
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unimplemented shutdown hook policy: " + policy);
                 }
             } catch (Exception e) {
                 logger.warning(e);
             }
         }
+    }
+
+    public ClusterTopologyIntent getClusterTopologyIntent() {
+        return clusterTopologyIntentTracker.getClusterTopologyIntent();
+    }
+
+    public void initializeClusterTopologyIntent(ClusterTopologyIntent clusterTopologyIntent) {
+        clusterTopologyIntentTracker.initializeClusterTopologyIntent(clusterTopologyIntent);
+    }
+
+    // true when Hazelcast is running in managed context with a tracker enabled
+    public boolean isClusterStateManagementAutomatic() {
+        return clusterTopologyIntentTracker.isEnabled();
+    }
+
+    /**
+     * When running in managed context with automatic cluster state management,
+     * return true if the current cluster size (as observed by Hazelcast's cluster service)
+     * is same as the cluster specification size (as provided by the runtime environment ie Kubernetes).
+     * @return  {@code true} if running with auto cluster state management and current cluster size is same as
+     *          specified one, otherwise {@code false}.
+     */
+    public boolean isClusterComplete() {
+        return clusterTopologyIntentTracker.isEnabled()
+                && clusterTopologyIntentTracker.getCurrentSpecifiedReplicaCount() == clusterService.getSize();
+    }
+
+    public boolean isManagedClusterStable() {
+        return isClusterComplete()
+                && clusterTopologyIntentTracker.getClusterTopologyIntent() == ClusterTopologyIntent.CLUSTER_STABLE;
+    }
+
+    public int currentSpecifiedReplicaCount() {
+        return clusterTopologyIntentTracker.getCurrentSpecifiedReplicaCount();
     }
 
     public SplitBrainJoinMessage createSplitBrainJoinMessage() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeExtension.java
@@ -177,6 +177,13 @@ public interface NodeExtension {
     boolean isStartCompleted();
 
     /**
+     * Check whether this instance is ready to start accepting requests. Use this
+     * method as a readiness probe.
+     * @return {@code true} when this instance is ready to accept requests, {@code false} otherwise.
+     */
+    boolean isReady();
+
+    /**
      * Called before <tt>Node.shutdown()</tt>
      */
     void beforeShutdown(boolean terminate);

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/NodeState.java
@@ -52,6 +52,11 @@ public enum NodeState {
      * When the cluster state moves to {@link ClusterState#PASSIVE} via
      * {@link Cluster#changeClusterState(ClusterState)}
      * </li>
+     * <li>
+     * During recovery from persistence while running under a managed context (e.g. Hazelcast member
+     * is running in Kubernetes) and not doing a cluster-wide start. For example, when a single pod
+     * is deleted, the rescheduled member will perform recovery in {@code PASSIVE} node state.
+     * </li>
      * </ul>
      */
     PASSIVE,

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -123,7 +123,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         Node node = textCommandService.getNode();
 
         if (node.isRunning()
-                && node.getNodeExtension().isStartCompleted()) {
+                && node.getNodeExtension().isReady()) {
             command.send200();
         } else {
             command.send503();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -691,7 +691,8 @@ public class ClusterJoinManager {
                         clusterService.getMembershipManager().getMembersView(), preJoinOp, postJoinOp,
                         clusterClock.getClusterTime(), clusterService.getClusterId(),
                         clusterClock.getClusterStartTime(), clusterStateManager.getState(),
-                        clusterService.getClusterVersion(), partitionRuntimeState, deferPartitionProcessing);
+                        clusterService.getClusterVersion(), partitionRuntimeState, deferPartitionProcessing,
+                        node.getClusterTopologyIntent());
                 op.setCallerUuid(clusterService.getThisUuid());
                 invokeClusterOp(op, targetAddress);
             }
@@ -805,7 +806,8 @@ public class ClusterJoinManager {
                     long startTime = clusterClock.getClusterStartTime();
                     Operation op = new FinalizeJoinOp(member.getUuid(), newMembersView, preJoinOp, postJoinOp, time,
                             clusterService.getClusterId(), startTime, clusterStateManager.getState(),
-                            clusterService.getClusterVersion(), partitionRuntimeState, !shouldTriggerRepartition);
+                            clusterService.getClusterVersion(), partitionRuntimeState, !shouldTriggerRepartition,
+                            node.getClusterTopologyIntent());
                     op.setCallerUuid(thisUuid);
                     invokeClusterOp(op, member.getAddress());
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -813,7 +813,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         changeClusterState(newState, false);
     }
 
-    private void changeClusterState(ClusterState newState, boolean isTransient) {
+    public void changeClusterState(ClusterState newState, boolean isTransient) {
         long partitionStateStamp = getPartitionStateStamp();
         clusterStateManager.changeClusterState(ClusterStateChange.from(newState), membershipManager.getMemberMap(),
                 partitionStateStamp, isTransient);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -23,6 +23,7 @@ import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOp;
+import com.hazelcast.internal.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.FutureUtil;
@@ -113,16 +114,23 @@ public class ClusterStateManager {
         clusterServiceLock.lock();
         try {
             node.getNodeExtension().onInitialClusterState(initialState);
+            validateNodeCompatibleWith(version);
 
             final ClusterState currentState = getState();
+            InternalHotRestartService hotRestartService = node.getNodeExtension().getInternalHotRestartService();
+            boolean startingFromPersistence = hotRestartService.isEnabled() && hotRestartService.isClusterMetadataFoundOnDisk();
+            if (startingFromPersistence) {
+                // When starting from persistence, ClusterMetadataManager initializes the cluster state
+                logger.fine("Skipping setting initial cluster state to "
+                        + initialState + ", as instructed by master, because persistence is enabled");
+                return;
+            }
             if (currentState != ClusterState.ACTIVE && currentState != initialState) {
                 logger.warning("Initial state is already set! " + "Current state: " + currentState + ", Given state: "
                         + initialState);
                 return;
             }
-            // no need to validate again
             logger.fine("Setting initial cluster state: " + initialState + " and version: " + version);
-            validateNodeCompatibleWith(version);
             setClusterStateAndVersion(initialState, version, true);
         } finally {
             clusterServiceLock.unlock();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.impl.ClusterTopologyIntent;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
 
+import static com.hazelcast.internal.cluster.Versions.V5_2;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createEmptyResponseHandler;
 
 /**
@@ -59,6 +61,8 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
     private ClusterState clusterState;
     private Version clusterVersion;
     private boolean deferPartitionProcessing;
+    // The detected cluster topology intent as observed by master member
+    private ClusterTopologyIntent clusterTopologyIntent;
 
     private transient boolean finalized;
     private transient Exception deserializationFailure;
@@ -70,7 +74,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
     public FinalizeJoinOp(UUID targetUuid, MembersView members, OnJoinOp preJoinOp, OnJoinOp postJoinOp,
                           long masterTime, UUID clusterId, long clusterStartTime, ClusterState clusterState,
                           Version clusterVersion, PartitionRuntimeState partitionRuntimeState,
-                          boolean deferPartitionProcessing) {
+                          boolean deferPartitionProcessing, ClusterTopologyIntent clusterTopologyIntent) {
         super(targetUuid, members, masterTime, partitionRuntimeState, true);
         this.preJoinOp = preJoinOp;
         this.postJoinOp = postJoinOp;
@@ -79,6 +83,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         this.clusterState = clusterState;
         this.clusterVersion = clusterVersion;
         this.deferPartitionProcessing = deferPartitionProcessing;
+        this.clusterTopologyIntent = clusterTopologyIntent;
     }
 
     @Override
@@ -96,6 +101,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         if (hrServiceEnabled) {
             // notify hot restart before setting initial cluster state
             hrService.setRejoiningActiveCluster(deferPartitionProcessing);
+            hrService.setClusterTopologyIntentOnMaster(clusterTopologyIntent);
         }
         finalized = clusterService.finalizeJoin(getMembersView(), callerAddress, callerUuid, targetUuid, clusterId, clusterState,
                 clusterVersion, clusterStartTime, masterTime, preJoinOp);
@@ -134,9 +140,16 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         }
 
         final boolean shouldExecutePostJoinOp = preparePostOp(postJoinOp);
-        if (deferPartitionProcessing && getInternalHotRestartService() != null && getInternalHotRestartService().isEnabled()) {
-            getInternalHotRestartService().deferPostJoinOps(postJoinOp);
-            return;
+        if (getInternalHotRestartService() != null && getInternalHotRestartService().isEnabled()) {
+            // Do not execute now the post-join ops either because master requested that (deferPartitionProcessing)
+            // or because recovery is not yet complete.
+            // For other operations, OperationRunnerImpl#checkNodeState enforces not allowing execution during
+            // recovery. However, post-join ops are executed without any node state checks by OnJoinOp, so we
+            // need to explicitly defer execution after recovery from persistence is done.
+            if (deferPartitionProcessing || !getInternalHotRestartService().isStartCompleted()) {
+                getInternalHotRestartService().deferPostJoinOps(postJoinOp);
+                return;
+            }
         }
 
         sendPostJoinOperationsBackToMaster();
@@ -188,6 +201,10 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         out.writeObject(preJoinOp);
         out.writeObject(postJoinOp);
         out.writeBoolean(deferPartitionProcessing);
+        // RU_COMPAT 5.1
+        if (clusterVersion.isGreaterOrEqual(V5_2)) {
+            out.writeByte(clusterTopologyIntent.getId());
+        }
     }
 
     @Override
@@ -200,7 +217,17 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         clusterVersion = in.readObject();
         preJoinOp = readOnJoinOp(in);
         postJoinOp = readOnJoinOp(in);
+        if (deserializationFailure != null) {
+            // failure occurred while deserializing pre- or post-join ops
+            // stop deserializing now because outcome is undefined and run() will anyway fail
+            return;
+        }
         deferPartitionProcessing = in.readBoolean();
+        // RU_COMPAT 5.1
+        if (clusterVersion.isGreaterOrEqual(V5_2)) {
+            byte topologyIntentId = in.readByte();
+            clusterTopologyIntent = ClusterTopologyIntent.of(topologyIntentId);
+        }
     }
 
     private OnJoinOp readOnJoinOp(ObjectDataInput in) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -53,7 +53,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -81,7 +80,7 @@ import static java.util.Collections.singleton;
 
 @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class ClusterWideConfigurationService implements
-        PreJoinAwareService,
+        PreJoinAwareService<DynamicConfigPreJoinOperation>,
         CoreService,
         ClusterVersionListener,
         ManagedService,
@@ -160,7 +159,7 @@ public class ClusterWideConfigurationService implements
     }
 
     @Override
-    public Operation getPreJoinOperation() {
+    public DynamicConfigPreJoinOperation getPreJoinOperation() {
         IdentifiedDataSerializable[] allConfigurations = collectAllDynamicConfigs();
         if (noConfigurationExist(allConfigurations)) {
             // there is no dynamic configuration -> no need to send an empty operation

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
@@ -20,12 +20,13 @@ import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
 public class DynamicConfigPreJoinOperation
-        extends AbstractDynamicConfigOperation {
+        extends AbstractDynamicConfigOperation implements AllowedDuringPassiveState {
 
     private IdentifiedDataSerializable[] configs;
     private ConfigCheckMode configCheckMode;

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/InternalHotRestartService.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.internal.hotrestart;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.instance.impl.ClusterTopologyIntent;
 import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.cluster.Address;
@@ -47,6 +49,23 @@ public interface InternalHotRestartService {
      * Returns whether hot-restart is enabled or not.
      */
     boolean isEnabled();
+
+    /**
+     * If recovery is in progress and no other deferred cluster state was already set
+     * (with a previous call to {@code trySetDeferredClusterState}),
+     * stores the given {@code newClusterState} and applies it after recovery is complete,
+     * returning {@code true}. Otherwise does nothing and returns {@code false}.
+     *
+     * @param newClusterState
+     * @return {@code true} if recovery is in progress, indicating that the new cluster
+     * state will be applied once recovery is complete, otherwise {@code false}.
+     */
+    boolean trySetDeferredClusterState(ClusterState newClusterState);
+
+    /**
+     * @return {@code true} when recovery process is completed and all members reached final state, otherwise {@code false}.
+     */
+    boolean isStartCompleted();
 
     /**
      * Forces node to start by skipping hot-restart completely and removing all hot-restart data
@@ -141,4 +160,23 @@ public interface InternalHotRestartService {
      * @param postJoinOp
      */
     void deferPostJoinOps(OnJoinOp postJoinOp);
+
+    /**
+     * @return {@code true} if cluster metadata were found on disk
+     *         so recovery will proceed from disk, otherwise {@code false}.
+     */
+    boolean isClusterMetadataFoundOnDisk();
+
+    /**
+     * Invoked each time an enabled {@link com.hazelcast.instance.impl.ClusterTopologyIntentTracker}
+     * detects a change of cluster topology in the runtime environment. Only used when running in a
+     * managed context (Kubernetes).
+     */
+    void onClusterTopologyIntentChange();
+
+    /**
+     * Conveys information about the detected cluster topology intent on master member.
+     * @param clusterTopologyIntent the cluster topology intent, as detected by master member.
+     */
+    void setClusterTopologyIntentOnMaster(ClusterTopologyIntent clusterTopologyIntent);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/NoopInternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/hotrestart/NoopInternalHotRestartService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.hotrestart;
 
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.impl.ClusterTopologyIntent;
 import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.cluster.Address;
@@ -35,6 +37,11 @@ public class NoopInternalHotRestartService implements InternalHotRestartService 
     @Override
     public boolean isEnabled() {
         return false;
+    }
+
+    @Override
+    public boolean isStartCompleted() {
+        return true;
     }
 
     @Override
@@ -92,5 +99,23 @@ public class NoopInternalHotRestartService implements InternalHotRestartService 
 
     @Override
     public void deferPostJoinOps(OnJoinOp postJoinOp) {
+    }
+
+    @Override
+    public void setClusterTopologyIntentOnMaster(ClusterTopologyIntent clusterTopologyIntent) {
+    }
+
+    @Override
+    public boolean isClusterMetadataFoundOnDisk() {
+        return false;
+    }
+
+    @Override
+    public void onClusterTopologyIntentChange() {
+    }
+
+    @Override
+    public boolean trySetDeferredClusterState(ClusterState newClusterState) {
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdatePermissionConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdatePermissionConfigOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.util.Set;
 /**
  * Propagates {@link PermissionConfig} changes to members.
  */
-public class UpdatePermissionConfigOperation extends AbstractManagementOperation {
+public class UpdatePermissionConfigOperation extends AbstractManagementOperation implements AllowedDuringPassiveState {
 
     private Set<PermissionConfig> permissionConfigs;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
@@ -158,10 +158,21 @@ public interface IPartitionService extends CoreService {
      * Queries and returns if this member in a safe state or not.
      * <p>
      * This method just checks for a safe state, it doesn't force this member to be in a safe state.
+     * <p>
+     * This method performs the same checks as {@link #isPartitionTableSafe()}, and in addition also
+     * checks whether replica sync is required.
      *
      * @return {@code true} if this member in a safe state, otherwise {@code false}
      */
     boolean isMemberStateSafe();
+
+    /**
+     * Queries and returns if the partition table is safe, meaning partition replicas are assigned to owners,
+     * no migrations are ongoing and there is no need to fetch partition table from other members.
+     *
+     * @return {@code] true} is partition table is safe, otherwise {@code false}
+     */
+    boolean isPartitionTableSafe();
 
     /**
      * Returns maximum allowed backup count according to current

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplicaVersionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplicaVersionManager.java
@@ -57,6 +57,19 @@ public interface PartitionReplicaVersionManager {
     long[] getPartitionReplicaVersions(int partitionId, ServiceNamespace namespace);
 
     /**
+     * Returns replica versions for syncing to backup replicas, ensuring any replica versions
+     * that are marked explicitly for sync ({@code REQUIRES_SYNC}) are reset. This is necessary
+     * when syncing primary to backup replicas (anti-entropy, migration etc), otherwise there is
+     * risk of perpetual attempts to sync partition data which may be already in sync.
+     *
+     * @param partitionId
+     * @param namespace
+     * @return
+     * @see     com.hazelcast.internal.partition.impl.PartitionReplicaManager#REQUIRES_SYNC
+     */
+    long[] getPartitionReplicaVersionsForSync(int partitionId, ServiceNamespace namespace);
+
+    /**
      * Updates the partition replica version and triggers replica sync if the replica is dirty (e.g. the
      * received version is not expected and this node might have missed an update)
      *
@@ -87,4 +100,6 @@ public interface PartitionReplicaVersionManager {
      * @return service namespace for operation
      */
     ServiceNamespace getServiceNamespace(Operation operation);
+
+    void markPartitionReplicaAsSyncRequired(int partitionId, ServiceNamespace namespace, int replicaIndex);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -396,6 +396,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                     // no partitions were assigned to it (member left with graceful shutdown)
                     if (!partitionStateManager.isAbsentInPartitionTable(member)) {
                         partitionStateManager.storeSnapshot(member.getUuid());
+                    } else {
+                        // member is removed due to graceful shutdown
+                        // cleanup any leftover snapshots
+                        partitionStateManager.removeSnapshot(member.getUuid());
                     }
                 }
             }
@@ -964,6 +968,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
     @Override
     public boolean isMemberStateSafe() {
         return partitionReplicaStateChecker.getPartitionServiceState() == PartitionServiceState.SAFE;
+    }
+
+    @Override
+    public boolean isPartitionTableSafe() {
+        return partitionReplicaStateChecker.getPartitionTableState() == PartitionServiceState.SAFE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -588,7 +588,7 @@ public class MigrationManager {
     /**
      * Clears the migration queue and triggers the control task. Called on the master node.
      */
-    void triggerControlTask() {
+    public void triggerControlTask() {
         migrationQueue.clear();
         migrationThread.abortMigrationTask();
         if (stats.getRemainingMigrations() > 0) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaFragmentVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaFragmentVersions.java
@@ -16,18 +16,19 @@
 
 package com.hazelcast.internal.partition.impl;
 
-import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.services.ServiceNamespace;
 
 import java.util.Arrays;
 
+import static com.hazelcast.internal.partition.IPartition.MAX_BACKUP_COUNT;
+import static com.hazelcast.internal.partition.impl.PartitionReplicaManager.REQUIRES_SYNC;
 import static java.lang.System.arraycopy;
 
 // read and updated only by partition threads
 final class PartitionReplicaFragmentVersions {
     private final int partitionId;
     private final ServiceNamespace namespace;
-    private final long[] versions = new long[InternalPartition.MAX_BACKUP_COUNT];
+    private final long[] versions = new long[MAX_BACKUP_COUNT];
     /**
      * Shows whether partition has missing backups somewhere between the last applied backup
      * and the last incremental backup received.
@@ -39,9 +40,21 @@ final class PartitionReplicaFragmentVersions {
         this.namespace = namespace;
     }
 
+    /**
+     * Increments partition replica versions on partition owner
+     * when backup operation is prepared and sent to replica.
+     *
+     * If a replica is designated as requiring sync,
+     * do not increment because a sync has not occurred yet.
+     * It will be reset to 0 when
+     * {@link PartitionReplicaManager#getPartitionReplicaVersionsForSync}
+     * is executed.
+     */
     long[] incrementAndGet(int backupCount) {
         for (int i = 0; i < backupCount; i++) {
-            versions[i]++;
+            if (versions[i] != REQUIRES_SYNC) {
+                versions[i]++;
+            }
         }
         return versions;
     }
@@ -60,12 +73,13 @@ final class PartitionReplicaFragmentVersions {
         int index = replicaIndex - 1;
         long currentVersion = versions[index];
         long newVersion = newVersions[index];
-        return currentVersion > newVersion;
+        return currentVersion > newVersion || currentVersion == REQUIRES_SYNC;
     }
 
     /**
-     * Updates replica version if it is newer than current version. Otherwise has no effect.
+     * Updates replica version if it is newer than current version. Otherwise, has no effect.
      * Marks versions as dirty if version increase is not incremental.
+     * Executed on backup replica owner.
      *
      * @param newVersions new replica versions
      * @param replicaIndex replica index
@@ -75,6 +89,13 @@ final class PartitionReplicaFragmentVersions {
         int index = replicaIndex - 1;
         long currentVersion = versions[index];
         long nextVersion = newVersions[index];
+
+        if (currentVersion == REQUIRES_SYNC) {
+            // the replica is marked explicitly for partition sync,
+            // so maintain it as is and mark versions as dirty.
+            dirty = true;
+            return true;
+        }
 
         if (currentVersion < nextVersion) {
             setVersions(newVersions, replicaIndex);
@@ -97,6 +118,10 @@ final class PartitionReplicaFragmentVersions {
 
     boolean isDirty() {
         return dirty;
+    }
+
+    void markAsSyncRequired(int replicaIndex) {
+        versions[replicaIndex - 1] = REQUIRES_SYNC;
     }
 
     void clear() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -69,6 +69,11 @@ import static java.util.Collections.newSetFromMap;
 public class PartitionReplicaManager implements PartitionReplicaVersionManager {
 
     /**
+     * Marker that indicates a particular backup replica index requires a sync with the primary replica.
+     */
+    public static final long REQUIRES_SYNC = -1;
+
+    /**
      * Allow running partition replica sync on generic operation threads? Default is true.
      * System property supplied as a workaround in case of unexpected issues.
      *
@@ -323,9 +328,27 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
     }
 
     @Override
+    public void markPartitionReplicaAsSyncRequired(int partitionId, ServiceNamespace namespace, int replicaIndex) {
+        replicaVersions[partitionId].markAsSyncRequired(namespace, replicaIndex);
+    }
+
+    @Override
     // Caution: Returning version array without copying for performance reasons. Callers must not modify this array!
     public long[] getPartitionReplicaVersions(int partitionId, ServiceNamespace namespace) {
         return replicaVersions[partitionId].get(namespace);
+    }
+
+    @Override
+    // Caution: Returning version array without copying for performance reasons. Callers must not modify this array!
+    // Mutates the replica version array, so that any replica indexes which require sync are reset to 0
+    public long[] getPartitionReplicaVersionsForSync(int partitionId, ServiceNamespace namespace) {
+        long[] replicas = replicaVersions[partitionId].get(namespace);
+        for (int i = 0; i < replicas.length; i++) {
+            if (replicas[i] == REQUIRES_SYNC) {
+                replicas[i] = 0;
+            }
+        }
+        return replicas;
     }
 
     // called in operation threads

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
@@ -73,6 +73,10 @@ final class PartitionReplicaVersions {
         return getFragmentVersions(namespace).isDirty();
     }
 
+    void markAsSyncRequired(ServiceNamespace namespace, int replicaIndex) {
+        getFragmentVersions(namespace).markAsSyncRequired(replicaIndex);
+    }
+
     void clear(ServiceNamespace namespace) {
         getFragmentVersions(namespace).clear();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -467,4 +467,8 @@ public class PartitionStateManager {
     PartitionTableView getSnapshot(UUID crashedMemberUuid) {
         return snapshotOnRemove.get(crashedMemberUuid);
     }
+
+    void removeSnapshot(UUID memberUuid) {
+        snapshotOnRemove.remove(memberUuid);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -353,7 +353,7 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
         PartitionReplicaVersionManager versionManager = partitionService.getPartitionReplicaVersionManager();
         Map<ServiceNamespace, long[]> versions = new HashMap<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
-            long[] v = versionManager.getPartitionReplicaVersions(getPartitionId(), namespace);
+            long[] v = versionManager.getPartitionReplicaVersionsForSync(getPartitionId(), namespace);
             versions.put(namespace, v);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.PARTITION_BACKUP_REPLICA_ANTI_ENTROPY;
+import static com.hazelcast.internal.partition.impl.PartitionReplicaManager.REQUIRES_SYNC;
 
 // should not be an urgent operation. required to be in order with backup operations on target node
 public final class PartitionBackupReplicaAntiEntropyOperation
@@ -105,7 +106,8 @@ public final class PartitionBackupReplicaAntiEntropyOperation
             long[] currentVersions = replicaManager.getPartitionReplicaVersions(partitionId, ns);
             long currentVersion = currentVersions[replicaIndex - 1];
 
-            if (replicaManager.isPartitionReplicaVersionDirty(partitionId, ns) || currentVersion != primaryVersion) {
+            if (replicaManager.isPartitionReplicaVersionDirty(partitionId, ns) || currentVersion != primaryVersion
+                || currentVersion == REQUIRES_SYNC) {
                 logBackupVersionMismatch(ns, currentVersion, primaryVersion);
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -276,7 +276,7 @@ public class PartitionReplicaSyncRequest extends AbstractPartitionOperation
         InternalPartitionServiceImpl partitionService = getService();
         PartitionReplicaVersionManager versionManager = partitionService.getPartitionReplicaVersionManager();
 
-        long[] versions = versionManager.getPartitionReplicaVersions(partitionId, ns);
+        long[] versions = versionManager.getPartitionReplicaVersionsForSync(partitionId, ns);
         PartitionReplicaSyncResponse syncResponse = new PartitionReplicaSyncResponse(operations,
                 chunkSuppliers, ns, versions,
                 isChunkedMigrationEnabled(),

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
@@ -152,7 +152,7 @@ public final class PartitionReplicaSyncRequestOffloadable
                         // returns references to the internal
                         // replica versions data structures
                         // that may change under our feet
-                        long[] versions = Arrays.copyOf(versionManager.getPartitionReplicaVersions(partitionId(), ns),
+                        long[] versions = Arrays.copyOf(versionManager.getPartitionReplicaVersionsForSync(partitionId(), ns),
                                 IPartition.MAX_BACKUP_COUNT);
                         replicaVersions.put(BiTuple.of(partitionId(), ns), versions);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/MemberSchemaService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/MemberSchemaService.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.services.SplitBrainHandlerService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.operationservice.Operation;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -42,7 +41,7 @@ import java.util.stream.Collectors;
  */
 public class MemberSchemaService implements
         ManagedService,
-        PreJoinAwareService,
+        PreJoinAwareService<SendSchemaReplicationsOperation>,
         SchemaService,
         SplitBrainHandlerService,
         CoreService {
@@ -138,7 +137,7 @@ public class MemberSchemaService implements
     }
 
     @Override
-    public Operation getPreJoinOperation() {
+    public SendSchemaReplicationsOperation getPreJoinOperation() {
         // Called in the master node to retrieve an operation that will be
         // executed on the joining member.
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SendSchemaReplicationsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SendSchemaReplicationsOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.impl.compact.SchemaService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ import java.util.Collection;
  * will make sure that the coordinator members will retry the acknowledgment
  * operation until the new member becomes one of the participants.
  */
-public class SendSchemaReplicationsOperation extends Operation implements IdentifiedDataSerializable {
+public class SendSchemaReplicationsOperation extends Operation implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private Collection<SchemaReplication> replications;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/PreJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/PreJoinAwareService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.services;
 
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
@@ -25,10 +26,12 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
  * {@link PostJoinAwareService#getPostJoinOperation()}s which are executed on the joining member after it is set as joined.
  * The practical outcome is that pre-join operations are already executed before the {@link com.hazelcast.core.HazelcastInstance}
  * is returned to the caller, while post-join operations may be still executing.
+ * Additionally, pre-join operations must implement {@link AllowedDuringPassiveState}, since they have to be executed
+ * during recovery from persistence.
  *
  * @since 3.9
  */
-public interface PreJoinAwareService {
+public interface PreJoinAwareService<T extends Operation & AllowedDuringPassiveState> {
 
     /**
      * An operation to be executed on the joining member before it is set as joined. As is the case with
@@ -44,5 +47,5 @@ public interface PreJoinAwareService {
      *
      * @return an operation to be executed on joining member before it is set as joined. Can be {@code null}.
      */
-    Operation getPreJoinOperation();
+     T getPreJoinOperation();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.function.SupplierEx;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * HostnameUtil contains hostname helper methods
+ */
+public final class HostnameUtil {
+
+    public static final int PROCESS_TIMEOUT_IN_SECONDS = 5;
+
+    private HostnameUtil() {
+    }
+
+    /**
+     * Resolves local hostname
+     *
+     * @return local hostname or null if it can't be resolved
+     */
+    public static String getLocalHostname() {
+        String hostname = System.getenv("HOSTNAME");
+        if (hostname == null) {
+            hostname = getOrNull(HostnameUtil::execHostnameCmd);
+        }
+        if (hostname == null) {
+            hostname = getOrNull(() -> InetAddress.getLocalHost().getHostName());
+        }
+        return shortHostname(hostname);
+    }
+
+    @Nonnull
+    private static String execHostnameCmd() throws Exception {
+        Process exec = Runtime.getRuntime().exec("hostname");
+        exec.waitFor(PROCESS_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+        InputStream stream = exec.getInputStream();
+        return new BufferedReader(new InputStreamReader(stream)).lines().collect(Collectors.joining("\n"));
+    }
+
+    private static String shortHostname(String hostname) {
+        if (hostname == null) {
+            return null;
+        }
+        return hostname.substring(0, hostname.indexOf("."));
+    }
+
+    private static String getOrNull(SupplierEx<String> supplierEx) {
+        try {
+            return supplierEx.getEx();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
@@ -64,7 +64,10 @@ public final class HostnameUtil {
         if (hostname == null) {
             return null;
         }
-        return hostname.substring(0, hostname.indexOf("."));
+        if (hostname.contains(".")) {
+            hostname = hostname.substring(0, hostname.indexOf("."));
+        }
+        return hostname;
     }
 
     private static String getOrNull(SupplierEx<String> supplierEx) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -833,6 +833,15 @@ public class JobCoordinationService {
             logger.fine("Not starting jobs because partitions are not yet initialized.");
             return false;
         }
+        if (nodeEngine.getNode().isClusterStateManagementAutomatic()
+            && !nodeEngine.getNode().isManagedClusterStable()) {
+            LoggingUtil.logFine(logger, "Not starting jobs because cluster is running in managed context "
+                            + "and is not yet stable. Current cluster topology intentL %s, "
+                            + "expected cluster size: %d, current: %d.",
+                    nodeEngine.getNode().getClusterTopologyIntent(),
+                    nodeEngine.getNode().currentSpecifiedReplicaCount(), nodeEngine.getClusterService().getSize());
+            return false;
+        }
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.HostnameUtil.getLocalHostname;
+
 final class HazelcastKubernetesDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
     private final KubernetesClient client;
@@ -125,13 +127,10 @@ final class HazelcastKubernetesDiscoveryStrategy
         return "unknown";
     }
 
-    private String podName() throws UnknownHostException {
+    private String podName() {
         String podName = System.getenv("POD_NAME");
         if (podName == null) {
-            podName = System.getenv("HOSTNAME");
-        }
-        if (podName == null) {
-            podName = InetAddress.getLocalHost().getHostName();
+            podName = getLocalHostname();
         }
         return podName;
     }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.kubernetes;
 
 import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.instance.impl.ClusterTopologyIntentTracker;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.discovery.DiscoveryNode;
@@ -31,6 +32,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+
+import static com.hazelcast.instance.impl.Node.DISCOVERY_PROPERTY_CLUSTER_TOPOLOGY_INTENT_TRACKER;
 
 /**
  * Just the factory to create the Kubernetes Discovery Strategy
@@ -80,8 +83,9 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
 
     public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
                                                   Map<String, Comparable> properties) {
-
-        return new HazelcastKubernetesDiscoveryStrategy(logger, properties);
+        ClusterTopologyIntentTracker tracker = (ClusterTopologyIntentTracker) discoveryNode.getProperties()
+                .get(DISCOVERY_PROPERTY_CLUSTER_TOPOLOGY_INTENT_TRACKER);
+        return new HazelcastKubernetesDiscoveryStrategy(logger, properties, tracker);
     }
 
     public Collection<PropertyDefinition> getConfigurationProperties() {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.kubernetes;
 
+import com.hazelcast.instance.impl.ClusterTopologyIntentTracker;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
@@ -29,6 +30,7 @@ import com.hazelcast.spi.utils.RestClient;
 import com.hazelcast.spi.utils.RetryUtils;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.hazelcast.instance.impl.ClusterTopologyIntentTracker.UNKNOWN;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
@@ -54,6 +57,7 @@ class KubernetesClient {
             "\"reason\":\"NotFound\"",
             "Failure in generating SSLSocketFactory");
 
+    private final String stsName;
     private final String namespace;
     private final String kubernetesMaster;
     private final String caCertificate;
@@ -63,8 +67,13 @@ class KubernetesClient {
     private final boolean useNodeNameAsExternalAddress;
     private final String servicePerPodLabelName;
     private final String servicePerPodLabelValue;
+    @Nullable
+    private final Thread stsMonitorThread;
 
     private final KubernetesTokenProvider tokenProvider;
+
+    @Nullable
+    private final ClusterTopologyIntentTracker clusterTopologyIntentTracker;
 
     private boolean isNoPublicIpAlreadyLogged;
     private boolean isKnownExceptionAlreadyLogged;
@@ -72,7 +81,7 @@ class KubernetesClient {
     KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
                      String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
                      boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
-                     String servicePerPodLabelValue) {
+                     String servicePerPodLabelValue, @Nullable ClusterTopologyIntentTracker clusterTopologyIntentTracker) {
         this.namespace = namespace;
         this.kubernetesMaster = kubernetesMaster;
         this.tokenProvider = tokenProvider;
@@ -82,9 +91,17 @@ class KubernetesClient {
         this.useNodeNameAsExternalAddress = useNodeNameAsExternalAddress;
         this.servicePerPodLabelName = servicePerPodLabelName;
         this.servicePerPodLabelValue = servicePerPodLabelValue;
-        this.apiProvider = buildKubernetesApiUrlProvider();
+        this.clusterTopologyIntentTracker = clusterTopologyIntentTracker;
+        if (clusterTopologyIntentTracker != null) {
+            clusterTopologyIntentTracker.initialize();
+        }
+        this.apiProvider =  buildKubernetesApiUrlProvider();
+        this.stsName = extractStsName();
+        this.stsMonitorThread = clusterTopologyIntentTracker != null
+                ? new Thread(new StsMonitor(), "hz-k8s-sts-monitor") : null;
     }
 
+    // test usage only
     KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
                      String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
                      boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
@@ -99,6 +116,25 @@ class KubernetesClient {
         this.servicePerPodLabelName = servicePerPodLabelName;
         this.servicePerPodLabelValue = servicePerPodLabelValue;
         this.apiProvider = apiProvider;
+        this.stsMonitorThread = null;
+        this.stsName = extractStsName();
+        this.clusterTopologyIntentTracker = null;
+    }
+
+    public void start() {
+        if (stsMonitorThread != null) {
+            stsMonitorThread.start();
+        }
+    }
+
+    public void destroy() {
+        if (clusterTopologyIntentTracker != null) {
+            clusterTopologyIntentTracker.destroy();
+        }
+        if (stsMonitorThread != null) {
+            LOGGER.info("Interrupting StatefulSet monitor thread");
+            stsMonitorThread.interrupt();
+        }
     }
 
     KubernetesApiProvider buildKubernetesApiUrlProvider() {
@@ -225,6 +261,41 @@ class KubernetesClient {
     // For test purpose
     boolean isKnownExceptionAlreadyLogged() {
         return isKnownExceptionAlreadyLogged;
+    }
+
+    private String extractStsName() {
+        String stsName = System.getenv("HOSTNAME");
+        int dashIndex = stsName.lastIndexOf('-');
+        if (dashIndex > 0) {
+            stsName = stsName.substring(0, dashIndex);
+        }
+        return stsName;
+    }
+
+    @Nullable
+    private RuntimeContext extractStsList(JsonObject jsonObject) {
+        String resourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion",
+                null);
+        // identify stateful set this pod belongs to
+        for (JsonValue item : toJsonArray(jsonObject.get("items"))) {
+            String itemName = item.asObject().get("metadata").asObject().getString("name", null);
+            if (stsName.equals(itemName)) {
+                // identified the stateful set
+                int specReplicas = item.asObject().get("spec").asObject().getInt("replicas", UNKNOWN);
+                int readyReplicas = item.asObject().get("status").asObject().getInt("readyReplicas", UNKNOWN);
+                int replicas = item.asObject().get("status").asObject().getInt("currentReplicas", UNKNOWN);
+                return new RuntimeContext(specReplicas, readyReplicas, replicas, resourceVersion);
+            }
+        }
+        return null;
+    }
+
+    private RuntimeContext extractSts(JsonObject jsonObject) {
+        int specReplicas = jsonObject.get("spec").asObject().getInt("replicas", UNKNOWN);
+        int readyReplicas = jsonObject.get("status").asObject().getInt("readyReplicas", UNKNOWN);
+        String resourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion", null);
+        int replicas = jsonObject.get("status").asObject().getInt("currentReplicas", UNKNOWN);
+        return new RuntimeContext(specReplicas, readyReplicas, replicas, resourceVersion);
     }
 
     private static List<Endpoint> parsePodsList(JsonObject podsListJson) {
@@ -617,6 +688,97 @@ class KubernetesClient {
         @Override
         public String toString() {
             return String.format("%s:%s", ip, port);
+        }
+    }
+
+    final class StsMonitor implements Runnable {
+        private String latestResourceVersion;
+        private RuntimeContext latestRuntimeContext;
+
+        /**
+         * Initializes and watches information about the StatefulSet in which Hazelcast is being executed.
+         * See <a href="https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes">
+         * Efficient detection of changes on Kubernetes API reference</a>.
+         * <p>
+         * Important: If this thread starves, then timely updates may be stalled and shutdown hook
+         * may not act on the latest cluster information.
+         */
+        @Override
+        public void run() {
+            String stsUrlString = String.format("%s/apis/apps/v1/namespaces/%s/statefulsets", kubernetesMaster,
+                    namespace);
+            JsonObject jsonObject = callGet(stsUrlString);
+            latestResourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion",
+                    null);
+            latestRuntimeContext = extractStsList(jsonObject);
+            LOGGER.info("Initializing cluster topology tracker with initial context: "
+                    + latestRuntimeContext);
+            clusterTopologyIntentTracker.update(UNKNOWN,
+                    latestRuntimeContext.getSpecifiedReplicaCount(),
+                    UNKNOWN, latestRuntimeContext.getReadyReplicas(),
+                    UNKNOWN, latestRuntimeContext.getCurrentReplicas());
+            while (true) {
+                if (Thread.interrupted()) {
+                    break;
+                }
+                RestClient restClient = RestClient.create(stsUrlString)
+                        .withHeader("Authorization", String.format("Bearer %s", tokenProvider.getToken()))
+                        .withCaCertificates(caCertificate);
+                RestClient.WatchResponse watchResponse = restClient.watch(latestResourceVersion);
+                String message;
+                try {
+                    while ((message = watchResponse.nextLine()) != null) {
+                        onMessage(message);
+                    }
+                } catch (IOException e) {
+                    LOGGER.info("Exception while watching for StatefulSet changes", e);
+                    try {
+                        watchResponse.disconnect();
+                    } catch (Throwable t) {
+                        LOGGER.fine("Exception while closing connection after an IOException", t);
+                    }
+                }
+            }
+        }
+
+        @SuppressWarnings("checkstyle:cyclomaticcomplexity")
+        private void onMessage(String message) {
+            if (LOGGER.isFinestEnabled()) {
+                LOGGER.finest("Complete message from kubernetes API: " + message);
+            }
+            JsonObject jsonObject = Json.parse(message).asObject();
+            JsonObject sts = jsonObject.get("object").asObject();
+            String itemName = sts.asObject().get("metadata").asObject().getString("name", null);
+            if (!stsName.equals(itemName)) {
+                return;
+            }
+            String watchType = jsonObject.getString("type", null);
+            RuntimeContext ctx = null;
+            switch (watchType) {
+                case "MODIFIED":
+                    ctx = extractSts(sts);
+                    latestResourceVersion = ctx.getResourceVersion();
+                    break;
+                case "DELETED":
+                    ctx = extractSts(sts);
+                    latestResourceVersion = ctx.getResourceVersion();
+                    ctx = new RuntimeContext(0, ctx.getReadyReplicas(),
+                            ctx.getCurrentReplicas(), ctx.getResourceVersion());
+                    break;
+                case "ADDED":
+                    throw new IllegalStateException("A new sts with same name as this cannot be added");
+                default:
+                    LOGGER.info("Unknown watch type " + watchType + ", complete message:\n" + message);
+            }
+            if (latestRuntimeContext != null && ctx != null) {
+                LOGGER.info("Updating cluster topology tracker with previous: "
+                    + latestRuntimeContext + ", updated: " + ctx);
+                clusterTopologyIntentTracker.update(latestRuntimeContext.getSpecifiedReplicaCount(),
+                        ctx.getSpecifiedReplicaCount(),
+                        latestRuntimeContext.getReadyReplicas(), ctx.getReadyReplicas(),
+                        latestRuntimeContext.getCurrentReplicas(), ctx.getCurrentReplicas());
+            }
+            latestRuntimeContext = ctx;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.util.HostnameUtil;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.kubernetes.KubernetesConfig.ExposeExternallyMode;
 import com.hazelcast.logging.ILogger;
@@ -264,7 +265,7 @@ class KubernetesClient {
     }
 
     private String extractStsName() {
-        String stsName = System.getenv("HOSTNAME");
+        String stsName = HostnameUtil.getLocalHostname();
         int dashIndex = stsName.lastIndexOf('-');
         if (dashIndex > 0) {
             stsName = stsName.substring(0, dashIndex);

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/RuntimeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/RuntimeContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import javax.annotation.Nullable;
+
+public class RuntimeContext {
+
+    /**
+     * Unknown value
+     */
+    public static final long UNKNOWN = -1;
+
+    // specified number of replicas. Corresponds to StatefulSetSpec.replicas
+    private final int specifiedReplicaCount;
+
+    // number of ready replicas. Corresponds to StatefulSetStatus.readyReplicas
+    private final int readyReplicas;
+
+    // number of replicas created by the current revision of the StatefulSet.
+    // Populated from StatefulSetStatus.currentReplicas
+    private final int currentReplicas;
+
+    @Nullable
+    private final String resourceVersion;
+
+    public RuntimeContext(int specifiedReplicaCount, int readyReplicas, int currentReplicas,
+                          @Nullable String resourceVersion) {
+        this.specifiedReplicaCount = specifiedReplicaCount;
+        this.readyReplicas = readyReplicas;
+        this.currentReplicas = currentReplicas;
+        this.resourceVersion = resourceVersion;
+    }
+
+    public int getSpecifiedReplicaCount() {
+        return specifiedReplicaCount;
+    }
+
+    public int getReadyReplicas() {
+        return readyReplicas;
+    }
+
+    public String getResourceVersion() {
+        return resourceVersion;
+    }
+
+    public int getCurrentReplicas() {
+        return currentReplicas;
+    }
+
+    @Override
+    public String toString() {
+        return "RuntimeContext{"
+                + "specifiedReplicaCount=" + specifiedReplicaCount
+                + ", readyReplicas=" + readyReplicas
+                + ", currentReplicas=" + currentReplicas
+                + ", resourceVersion='" + resourceVersion + '\''
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
@@ -22,6 +22,7 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.datastore.ExternalDataStoreService;
+import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
@@ -230,6 +231,12 @@ public interface NodeEngine {
      * @return {@code true} if node is not shutting down or it has not already shut down, {@code false} otherwise
      */
     boolean isRunning();
+
+    /**
+     * @return      {@code true} if this {@code Node} has completed startup, {@code false} otherwise.
+     * @see         NodeExtension#isStartCompleted()
+     */
+    boolean isStartCompleted();
 
     /**
      * Returns the HazelcastInstance that this {@link NodeEngine} belongs to.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -406,6 +406,11 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
+    public boolean isStartCompleted() {
+        return node.getNodeExtension().isStartCompleted();
+    }
+
+    @Override
     public HazelcastInstance getHazelcastInstance() {
         return node.hazelcastInstance;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/EventService.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.eventservice;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.services.PostJoinAwareService;
 import com.hazelcast.internal.services.PreJoinAwareService;
+import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
 import com.hazelcast.spi.properties.ClusterProperty;
 
 import javax.annotation.Nonnull;
@@ -29,7 +30,7 @@ import java.util.function.Consumer;
 /**
  * Component responsible for handling events like topic events or map.listener events. The events are divided into topics.
  */
-public interface EventService extends Consumer<Packet>, PreJoinAwareService, PostJoinAwareService {
+public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJoinRegistrationOperation>, PostJoinAwareService {
 
     /**
      * Returns the event thread count.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -676,7 +676,7 @@ public class EventServiceImpl implements EventService, StaticMetricsProvider {
     }
 
     @Override
-    public Operation getPreJoinOperation() {
+    public OnJoinRegistrationOperation getPreJoinOperation() {
         // pre-join operations are only sent by master member
         return getOnJoinRegistrationOperation();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/OnJoinRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/OnJoinRegistrationOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.eventservice.impl.operations;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
@@ -29,7 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class OnJoinRegistrationOperation extends Operation implements IdentifiedDataSerializable {
+public class OnJoinRegistrationOperation extends Operation implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private Collection<Registration> registrations;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.operationservice;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.cluster.ClusterClock;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.server.ServerConnection;
@@ -637,6 +638,7 @@ public abstract class Operation implements DataSerializable, Tenantable {
      *
      * @param e Exception/Error thrown during operation execution
      */
+    @SuppressWarnings("checkstyle:cyclomaticcomplexity")
     public void logError(Throwable e) {
         final ILogger logger = getLogger();
         if (e instanceof SilentException) {
@@ -651,6 +653,18 @@ public abstract class Operation implements DataSerializable, Tenantable {
                 logger.severe(e.getMessage(), e);
             } catch (Throwable ignored) {
                 ignore(ignored);
+            }
+        } else if (e instanceof IllegalStateException) {
+            // if start is not yet completed, do not warn about IllegalStateExceptions
+            // due to cluster state being PASSIVE
+            Level level = Level.WARNING;
+            if (nodeEngine != null
+                    && nodeEngine.getClusterService().getClusterState() == ClusterState.PASSIVE
+                    && !nodeEngine.isStartCompleted()) {
+                level = Level.FINE;
+            }
+            if (logger.isLoggable(level)) {
+                logger.log(level, e.getMessage(), e);
             }
         } else {
             final Level level = nodeEngine != null && nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeState;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.metrics.ExcludedMetricTargets;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -46,6 +47,7 @@ import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -330,6 +332,11 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
         // Cluster is in passive state. There is no need to retry.
         if (nodeEngine.getClusterService().getClusterState() == ClusterState.PASSIVE) {
             throw new IllegalStateException("Cluster is in " + ClusterState.PASSIVE + " state! Operation: " + op);
+        }
+
+        InternalHotRestartService hotRestartService = node.getNodeExtension().getInternalHotRestartService();
+        if (hotRestartService.isEnabled() && !hotRestartService.isStartCompleted()) {
+            throw new RetryableHazelcastException("Recovery from persistence is still in progress. Operation: " + op);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlReplicationOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.tenantcontrol.TenantControl;
@@ -36,7 +37,8 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @since 4.2
  */
-public class TenantControlReplicationOperation extends Operation implements IdentifiedDataSerializable {
+public class TenantControlReplicationOperation extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private ConcurrentMap<String, ConcurrentMap<String, TenantControl>> tenantControlMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlServiceImpl.java
@@ -26,7 +26,6 @@ import com.hazelcast.internal.util.ServiceLoader;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.tenantcontrol.TenantControl;
 import com.hazelcast.spi.tenantcontrol.TenantControlFactory;
 import com.hazelcast.version.Version;
@@ -46,7 +45,7 @@ import static com.hazelcast.spi.tenantcontrol.TenantControlFactory.NOOP_TENANT_C
  * Each tenant control instance is bound to a single distributed object.
  */
 public class TenantControlServiceImpl
-        implements ClusterVersionListener, DistributedObjectListener, PreJoinAwareService {
+        implements ClusterVersionListener, DistributedObjectListener, PreJoinAwareService<TenantControlReplicationOperation> {
     public static final String SERVICE_NAME = "hz:impl:tenantControlService";
     /**
      * The number of retries for invocations replicating {@link TenantControl}
@@ -208,7 +207,7 @@ public class TenantControlServiceImpl
     }
 
     @Override
-    public Operation getPreJoinOperation() {
+    public TenantControlReplicationOperation getPreJoinOperation() {
         return isTenantControlEnabled()
                 ? new TenantControlReplicationOperation(tenantControlMap)
                 : null;

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.properties;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EndpointConfig;
@@ -1790,6 +1791,29 @@ public final class ClusterProperty {
     @Beta
     public static final HazelcastProperty SQL_CUSTOM_TYPES_ENABLED = new HazelcastProperty(
             "hazelcast.sql.experimental.custom.types.enabled", false);
+
+    /**
+     * When {@code true}, enables monitoring of the runtime environment to detect the intent of shutdown
+     * and automate cluster state management decisions.
+     * Supported when persistence is enabled and Hazelcast is executed in a Kubernetes
+     * <a href="https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/">StatefulSet</a>.
+     * <p/>
+     * The default value is {@code true}.
+     *
+     * @since 5.2
+     */
+    public static final HazelcastProperty PERSISTENCE_AUTO_CLUSTER_STATE = new HazelcastProperty(
+            "hazelcast.persistence.auto.cluster.state", true);
+
+    /**
+     * Select which cluster state to use when dealing with missing members in a managed runtime environment.
+     * Used when {@link #PERSISTENCE_AUTO_CLUSTER_STATE} and persistence are both enabled.
+     * Valid values are {@code FROZEN} or {@code NO_MIGRATION}.
+     *
+     * @since 5.2
+     */
+    public static final HazelcastProperty PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY = new HazelcastProperty(
+            "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
 
     private ClusterProperty() {
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -443,15 +443,15 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     public void testAfterLoadAllNearCacheIsInvalidated() {
         int mapSize = 1000;
         String mapName = randomMapName();
-        HazelcastInstance server = hazelcastFactory.newHazelcastInstance(newConfig());
-        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
 
         SimpleMapStore store = new SimpleMapStore();
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setImplementation(store);
-        Config config = server.getConfig();
+        Config config = newConfig();
         config.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig);
+        hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
 
         final IMap<Integer, Integer> clientMap = client.getMap(mapName);
 
@@ -471,15 +471,15 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     public void testMemberLoadAll_invalidates_clientNearCache() {
         int mapSize = 1000;
         String mapName = randomMapName();
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(newConfig());
-        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
-
         SimpleMapStore store = new SimpleMapStore();
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setImplementation(store);
-        Config config = member.getConfig();
+        Config config = newConfig();
         config.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
 
         final IMap<Integer, Integer> clientMap = client.getMap(mapName);
 
@@ -500,15 +500,15 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     public void testAfterLoadAllWithDefinedKeysNearCacheIsInvalidated() {
         int mapSize = 1000;
         String mapName = randomMapName();
-        HazelcastInstance server = hazelcastFactory.newHazelcastInstance(newConfig());
-        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
 
         SimpleMapStore store = new SimpleMapStore();
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setImplementation(store);
-        Config config = server.getConfig();
+        Config config = newConfig();
         config.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig);
+        hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
 
         final IMap<Integer, Integer> clientMap = client.getMap(mapName);
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/KubernetesTopologyIntentTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/KubernetesTopologyIntentTrackerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.instance.impl.ClusterTopologyIntentTracker.UNKNOWN;
+import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+import static com.hazelcast.test.HazelcastTestSupport.spawn;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class KubernetesTopologyIntentTrackerTest {
+
+    private final Properties properties = new Properties();
+    private final ClusterServiceImpl clusterService = mock(ClusterServiceImpl.class);
+    private KubernetesTopologyIntentTracker clusterTopologyIntentTracker;
+
+    private Node setupMockNode() {
+        Node node = mock(Node.class);
+        properties.put(ClusterProperty.CLUSTER_SHUTDOWN_TIMEOUT_SECONDS.getName(), "2");
+        HazelcastProperties hazelcastProperties = new HazelcastProperties(properties);
+        when(node.getProperties()).thenReturn(hazelcastProperties);
+        when(node.getLogger(ArgumentMatchers.any(Class.class)))
+                .thenReturn(Logger.getLogger(KubernetesTopologyIntentTracker.class));
+        when(node.getClusterService()).thenReturn(clusterService);
+        return node;
+    }
+
+    @Test
+    public void testConstructor_whenClusterAutoStateStrategyActive() {
+        properties.put(ClusterProperty.PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY.getName(), "ACTIVE");
+        assertThrows(InvalidConfigurationException.class,
+                () -> new KubernetesTopologyIntentTracker(setupMockNode()));
+    }
+
+    @Test
+    public void testConstructor_whenInvalidClusterAutoStateStrategy() {
+        properties.put(ClusterProperty.PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY.getName(), "NOT_A_CLUSTER_STATE");
+        assertThrows(IllegalArgumentException.class,
+                () -> new KubernetesTopologyIntentTracker(setupMockNode()));
+    }
+
+    @Test
+    public void test_waitCallableWithTimeout_whenImmediatelyTrue() {
+        clusterTopologyIntentTracker = new KubernetesTopologyIntentTracker(setupMockNode());
+        // wait 100 seconds for condition to be true
+        long timeRemaining = clusterTopologyIntentTracker.waitCallableWithTimeout(() -> true,
+                TimeUnit.SECONDS.toNanos(100));
+        System.out.println(">> timeRemaining " + timeRemaining);
+        // assert at least 95 seconds remain from given timeout (to avoid spurious failures on busy CI machine)
+        assertTrue(timeRemaining > TimeUnit.SECONDS.toNanos(95));
+    }
+
+    @Test
+    public void test_waitCallableWithTimeout_whenAlwaysFalse() {
+        clusterTopologyIntentTracker = new KubernetesTopologyIntentTracker(setupMockNode());
+        long timeRemaining = clusterTopologyIntentTracker.waitCallableWithTimeout(() -> true,
+                TimeUnit.SECONDS.toNanos(100));
+        assertTrue(timeRemaining > TimeUnit.SECONDS.toNanos(95));
+    }
+
+    @Test
+    public void test_waitForMissingMembers() throws InterruptedException, ExecutionException, TimeoutException {
+        when(clusterService.getSize()).thenReturn(3);
+        clusterTopologyIntentTracker = new KubernetesTopologyIntentTracker(setupMockNode());
+        // cluster is running with 3 members
+        clusterTopologyIntentTracker.update(UNKNOWN, 3,
+                UNKNOWN, 3, UNKNOWN, 3);
+        // cluster is missing a member
+        clusterTopologyIntentTracker.update(3, 3,
+                3, 2,
+                3, 2);
+        // cluster shutdown starts
+        clusterTopologyIntentTracker.update(3, 0,
+                2, 3,
+                2, 2);
+        Future future = spawn(() -> {
+            clusterTopologyIntentTracker.waitForMissingMember();
+        });
+        sleepSeconds(1);
+        // trigger membership change event to update size of cluster from clusterService
+        clusterTopologyIntentTracker.onMembershipChange();
+        // ensure wait thread completed
+        future.get(15, TimeUnit.SECONDS);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.internal.hotrestart.NoopInternalHotRestartService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.LockGuard;
@@ -82,6 +83,7 @@ public class ClusterStateManagerTest {
         when(nodeExtension.isStartCompleted()).thenReturn(true);
         when(nodeExtension.getAuditlogService()).thenReturn(NoOpAuditlogService.INSTANCE);
         when(nodeExtension.isNodeVersionCompatibleWith(ArgumentMatchers.any(Version.class))).thenReturn(true);
+        when(nodeExtension.getInternalHotRestartService()).thenReturn(new NoopInternalHotRestartService());
 
         when(node.getPartitionService()).thenReturn(partitionService);
         when(node.getClusterService()).thenReturn(clusterService);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.services.PostJoinAwareService;
 import com.hazelcast.internal.services.PreJoinAwareService;
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
@@ -864,7 +865,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         }
     }
 
-    private static class PreJoinAwareServiceImpl implements PreJoinAwareService {
+    private static class PreJoinAwareServiceImpl implements PreJoinAwareService<TimeConsumingPreJoinOperation> {
         static final String SERVICE_NAME = "pre-join-service";
 
         final CountDownLatch latch;
@@ -876,12 +877,12 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Operation getPreJoinOperation() {
+        public TimeConsumingPreJoinOperation getPreJoinOperation() {
             return new TimeConsumingPreJoinOperation();
         }
     }
 
-    private static class TimeConsumingPreJoinOperation extends Operation {
+    private static class TimeConsumingPreJoinOperation extends Operation implements AllowedDuringPassiveState {
         @Override
         public void run() throws Exception {
             PreJoinAwareServiceImpl service = getService();
@@ -917,11 +918,11 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         }
     }
 
-    private static class FailingPreJoinOpService implements PreJoinAwareService {
+    private static class FailingPreJoinOpService implements PreJoinAwareService<FailsDeserializationOperation> {
         static final String SERVICE_NAME = "failing-pre-join-service";
 
         @Override
-        public Operation getPreJoinOperation() {
+        public FailsDeserializationOperation getPreJoinOperation() {
             return new FailsDeserializationOperation();
         }
     }
@@ -935,7 +936,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         }
     }
 
-    public static class FailsDeserializationOperation extends Operation {
+    public static class FailsDeserializationOperation extends Operation implements AllowedDuringPassiveState {
 
         @Override
         public void run() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -40,6 +40,7 @@ import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
+import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
@@ -338,7 +339,7 @@ public class MockServerContext implements ServerContext {
             }
 
             @Override
-            public Operation getPreJoinOperation() {
+            public OnJoinRegistrationOperation getPreJoinOperation() {
                 return null;
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.kubernetes;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hazelcast.instance.impl.ClusterTopologyIntentTracker;
 import com.hazelcast.kubernetes.KubernetesClient.Endpoint;
 import com.hazelcast.kubernetes.KubernetesConfig.ExposeExternallyMode;
 import com.hazelcast.spi.exception.RestClientException;
@@ -1501,7 +1502,8 @@ public class KubernetesClientTest {
 
     private KubernetesClient newKubernetesClient(KubernetesTokenProvider tokenProvider) {
         String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
-        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, tokenProvider, CA_CERTIFICATE, RETRIES, ExposeExternallyMode.AUTO, true, null, null);
+        return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, tokenProvider, CA_CERTIFICATE, RETRIES,
+                ExposeExternallyMode.AUTO, true, null, null, (ClusterTopologyIntentTracker) null);
     }
 
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress) {

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -118,6 +118,11 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
+    public boolean isReady() {
+        return nodeExtension.isReady();
+    }
+
+    @Override
     public void beforeShutdown(boolean terminate) {
         nodeExtension.beforeShutdown(terminate);
     }


### PR DESCRIPTION
- Adds automated cluster state management for persistence on kubernetes
- Supports cluster-wide shutdown, rolling restart and partial member recovery from failure on kubernetes [HZ-1190] [HZ-1191] [HZ-1193]
- Fixes behaviour of readiness probe with persistence enabled [HZ-1349]
- Allows tuning either for speedy crash recovery with FROZEN state or availability of in-memory data structures with NO_MIGRATION state for missing members [HZ-1311]
- Fixes backup sync after single member crash recovery [HZ-1349]

Design document in EE side:
https://github.com/vbekiaris/hazelcast-enterprise/blob/enhancements/5.2/k8s-persistence/docs/design/persistence/04-persistence-kubernetes-improvements.md

(cherry picked from commit 1ddc16ece50e35aa0deb00592460bfad87968858)
1:1 clean backport from #21844 

[HZ-1190]: https://hazelcast.atlassian.net/browse/HZ-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-1191]: https://hazelcast.atlassian.net/browse/HZ-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-1193]: https://hazelcast.atlassian.net/browse/HZ-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-1349]: https://hazelcast.atlassian.net/browse/HZ-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-1311]: https://hazelcast.atlassian.net/browse/HZ-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-1349]: https://hazelcast.atlassian.net/browse/HZ-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ