### PR TITLE
Add index only on local during MapProxy init [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -260,7 +260,11 @@ abstract class MapProxySupport<K, V>
     @Override
     public void initialize() {
         initializeListeners();
-        initializeIndexes();
+        if (getNodeEngine().isStartCompleted()) {
+            initializeIndexes();
+        } else {
+            initializeLocalIndexes();
+        }
         initializeMapStoreLoad();
     }
 
@@ -318,6 +322,12 @@ abstract class MapProxySupport<K, V>
     private void initializeIndexes() {
         for (IndexConfig index : mapConfig.getIndexConfigs()) {
             addIndex(index);
+        }
+    }
+
+    private void initializeLocalIndexes() {
+        for (IndexConfig index : mapConfig.getIndexConfigs()) {
+            addIndexInternal(index, true);
         }
     }
 
@@ -1334,6 +1344,10 @@ abstract class MapProxySupport<K, V>
 
     @Override
     public void addIndex(IndexConfig indexConfig) {
+        addIndexInternal(indexConfig, false);
+    }
+
+    private void addIndexInternal(IndexConfig indexConfig, boolean localOnly) {
         checkNotNull(indexConfig, "Index config cannot be null.");
         checkFalse(isNativeMemoryAndBitmapIndexingEnabled(indexConfig.getType()),
                 "BITMAP indexes are not supported by NATIVE storage");
@@ -1342,9 +1356,14 @@ abstract class MapProxySupport<K, V>
 
         try {
             AddIndexOperation addIndexOperation = new AddIndexOperation(name, indexConfig0);
-
-            operationService.invokeOnAllPartitions(SERVICE_NAME,
-                    new BinaryOperationFactory(addIndexOperation, getNodeEngine()));
+            if (localOnly) {
+                PartitionIdSet ownedPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
+                operationService.invokeOnPartitions(SERVICE_NAME,
+                        new BinaryOperationFactory(addIndexOperation, getNodeEngine()), ownedPartitions);
+            } else {
+                operationService.invokeOnAllPartitions(SERVICE_NAME,
+                        new BinaryOperationFactory(addIndexOperation, getNodeEngine()));
+            }
         } catch (Throwable t) {
             throw rethrow(t);
         }


### PR DESCRIPTION
if recovery from persistence is still in progress
(that's the case when proxy can be created and start is not yet completed). If we attempt
to initialize indexes cluster-wide, since operations are not allowed during recovery, the local member recovery will fail.

(cherry picked from commit 285517dcd7b6c95a2d751f97140a1f046230adca)
1:1 clean backport of #22485 