### PR TITLE
Improve local hostname resolution by trying different methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.function.SupplierEx;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * HostnameUtil contains hostname helper methods
+ */
+public final class HostnameUtil {
+
+    public static final int PROCESS_TIMEOUT_IN_SECONDS = 5;
+
+    private HostnameUtil() {
+    }
+
+    /**
+     * Resolves local hostname
+     *
+     * @return local hostname or null if it can't be resolved
+     */
+    public static String getLocalHostname() {
+        String hostname = System.getenv("HOSTNAME");
+        if (hostname == null) {
+            hostname = getOrNull(HostnameUtil::execHostnameCmd);
+        }
+        if (hostname == null) {
+            hostname = getOrNull(() -> InetAddress.getLocalHost().getHostName());
+        }
+        return shortHostname(hostname);
+    }
+
+    @Nonnull
+    private static String execHostnameCmd() throws Exception {
+        Process exec = Runtime.getRuntime().exec("hostname");
+        exec.waitFor(PROCESS_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+        InputStream stream = exec.getInputStream();
+        return new BufferedReader(new InputStreamReader(stream)).lines().collect(Collectors.joining("\n"));
+    }
+
+    private static String shortHostname(String hostname) {
+        if (hostname == null) {
+            return null;
+        }
+        return hostname.substring(0, hostname.indexOf("."));
+    }
+
+    private static String getOrNull(SupplierEx<String> supplierEx) {
+        try {
+            return supplierEx.getEx();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/HostnameUtil.java
@@ -64,7 +64,10 @@ public final class HostnameUtil {
         if (hostname == null) {
             return null;
         }
-        return hostname.substring(0, hostname.indexOf("."));
+        if (hostname.contains(".")) {
+            hostname = hostname.substring(0, hostname.indexOf("."));
+        }
+        return hostname;
     }
 
     private static String getOrNull(SupplierEx<String> supplierEx) {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.internal.util.HostnameUtil.getLocalHostname;
+
 final class HazelcastKubernetesDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
     private final KubernetesClient client;
@@ -125,13 +127,10 @@ final class HazelcastKubernetesDiscoveryStrategy
         return "unknown";
     }
 
-    private String podName() throws UnknownHostException {
+    private String podName() {
         String podName = System.getenv("POD_NAME");
         if (podName == null) {
-            podName = System.getenv("HOSTNAME");
-        }
-        if (podName == null) {
-            podName = InetAddress.getLocalHost().getHostName();
+            podName = getLocalHostname();
         }
         return podName;
     }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.util.HostnameUtil;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.kubernetes.KubernetesConfig.ExposeExternallyMode;
 import com.hazelcast.logging.ILogger;
@@ -264,7 +265,7 @@ class KubernetesClient {
     }
 
     private String extractStsName() {
-        String stsName = System.getenv("HOSTNAME");
+        String stsName = HostnameUtil.getLocalHostname();
         int dashIndex = stsName.lastIndexOf('-');
         if (dashIndex > 0) {
             stsName = stsName.substring(0, dashIndex);

--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
@@ -89,7 +89,7 @@ public class AuthenticationInformationLeakTest {
     @Test
     public void testAuthenticationExceptionDoesNotLeakInfo() throws IOException {
         SerializationService ss = new DefaultSerializationServiceBuilder().build();
-        InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
+        InetSocketAddress endpoint = instance.getCluster().getLocalMember().getSocketAddress();
         try (Socket socket = new Socket()) {
             socket.setReuseAddress(true);
             socket.connect(endpoint);
@@ -130,7 +130,7 @@ public class AuthenticationInformationLeakTest {
     }
 
     private void authenticateAndAssert(AuthenticationStatus status, byte serVersion, boolean useWrongClusterName, String clusterName) throws IOException {
-        InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
+        InetSocketAddress endpoint = instance.getCluster().getLocalMember().getSocketAddress();
         try (Socket socket = new Socket()) {
             socket.setReuseAddress(true);
             socket.connect(endpoint);


### PR DESCRIPTION
Getting hostname from HOSTNAME env variables doesn't work on vanilla non-containerised Ubuntu systems. 

Here's the failures on non-dockerized env: https://jenkins.hazelcast.com/job/Hazelcast-master-OracleJDK8-Esxi7/4/#showFailuresLink

Example on clean AWS ubuntu:

ubuntu version
```
root@ip-10-0-189-252:/home/ubuntu# cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.1 LTS"
```
java version
```
root@ip-10-0-189-252:/home/ubuntu# java -version
openjdk version "11.0.16" 2022-07-19
OpenJDK Runtime Environment (build 11.0.16+8-post-Ubuntu-0ubuntu122.04)
OpenJDK 64-Bit Server VM (build 11.0.16+8-post-Ubuntu-0ubuntu122.04, mixed mode, sharing)
```
Getting hostname with different methods
```
root@ip-10-0-189-252:/home/ubuntu# jshell
|  Welcome to JShell -- Version 11.0.16
|  For an introduction type: /help intro

jshell> System.getenv("HOSTNAME")
$1 ==> null

jshell> java.net.InetAddress.getLocalHost().getHostName();
$2 ==> "ip-10-0-189-252"

root@ip-10-0-189-252:/home/ubuntu# hostname
ip-10-0-189-252
```

This PR tries to improve hostname resolution by trying different methods:
- get HOSTNAME env variable
- get output from `hostname` system command
- get hostname `InetAddress.getLocalHost().getHostName()` (broken DNS setup can break it)

Reference:
- https://stackoverflow.com/a/28043326
- https://stackoverflow.com/a/7800008
