### PR TITLE
Fix errors when schema change enabled [5.2.z]

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
@@ -34,6 +34,7 @@ import io.debezium.relational.history.AbstractDatabaseHistory;
 import io.debezium.relational.history.DatabaseHistoryException;
 import io.debezium.relational.history.HistoryRecord;
 import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -78,6 +79,7 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
 
     private static final BroadcastKey<String> SNAPSHOT_KEY = broadcastKey("snap");
     private static final ThreadLocal<List<byte[]>> THREAD_LOCAL_HISTORY = new ThreadLocal<>();
+    private static final String TIMESTAMP_MS_FIELD_NAME = "ts_ms";
 
     @Nonnull
     private final Properties properties;
@@ -412,11 +414,20 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
         }
     }
 
-    private static long extractTimestamp(SourceRecord record) {
-        if (record.valueSchema().field("ts_ms") == null) {
+    private static long extractTimestamp(SourceRecord sourceRecord) {
+        Schema valueSchema = sourceRecord.valueSchema();
+        boolean noValueTsMs = valueSchema.field(TIMESTAMP_MS_FIELD_NAME) == null;
+        boolean noSourceTsMs = valueSchema.field("source").schema().field(TIMESTAMP_MS_FIELD_NAME) == null;
+        if (noValueTsMs && noSourceTsMs) {
             return NO_NATIVE_TIME;
         }
-        Long timestamp = ((Struct) record.value()).getInt64("ts_ms");
+        Long timestamp;
+        Struct valueStruct = (Struct) sourceRecord.value();
+        if (noValueTsMs) {
+            timestamp = valueStruct.getStruct("source").getInt64("ts_ms");
+        } else {
+            timestamp = valueStruct.getInt64("ts_ms");
+        }
         return timestamp == null ? NO_NATIVE_TIME : timestamp;
     }
 

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordCdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordCdcSourceP.java
@@ -62,21 +62,35 @@ public class ChangeRecordCdcSourceP extends CdcSourceP<ChangeRecord> {
         long sequenceValue = sequenceExtractor.sequence(record.sourceOffset());
         String keyJson = Values.convertToString(record.keySchema(), record.key());
         Struct value = (Struct) record.value();
+        Schema valueSchema = record.valueSchema();
         Struct source = (Struct) value.get("source");
 
-        Operation operation = Operation.get(value.getString("op"));
-        Schema valueSchema = record.valueSchema();
+        Operation operation = value.schema().field("op") != null
+                ?   Operation.get(value.getString("op"))
+                : Operation.UNSPECIFIED;
 
-        Object before = value.get("before");
-        Object after = value.get("after");
-        Supplier<String> oldValueJson = before == null
-                ? null
-                : () -> Values.convertToString(valueSchema.field("before").schema(), before);
-        Supplier<String> newValueJson = after == null
-                ? null
-                : () -> Values.convertToString(valueSchema.field("after").schema(), after);
+        long timestamp;
+        Supplier<String> oldValueJson;
+        Supplier<String> newValueJson;
+        if (operation == Operation.UNSPECIFIED) {
+            timestamp = ((Struct) value.get("source")).getInt64("ts_ms");
+            oldValueJson = () -> Values.convertToString(valueSchema, value);
+            newValueJson = () -> Values.convertToString(valueSchema, value);
+        } else {
+            Object before = value.get("before");
+            Object after = value.get("after");
+
+            timestamp = value.getInt64("ts_ms");
+            oldValueJson = before == null
+                    ? null
+                    : () -> Values.convertToString(valueSchema.field("before").schema(), before);
+            newValueJson = after == null
+                    ? null
+                    : () -> Values.convertToString(valueSchema.field("after").schema(), after);
+        }
+
         return new ChangeRecordImpl(
-                value.getInt64("ts_ms"),
+                timestamp,
                 sequenceSource,
                 sequenceValue,
                 operation,

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -132,6 +132,7 @@ public class ChangeRecordImpl implements ChangeRecord {
     @Nonnull
     public RecordPart value() {
         switch (operation) {
+            case UNSPECIFIED:
             case SYNC:
             case INSERT:
             case UPDATE: return requireNonNull(newValue(), "newValue missing for operation " + operation);

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.cdc.Operation.UNSPECIFIED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
@@ -69,13 +69,13 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
             // given
             List<String> expectedRecords = Arrays.asList(
-                    "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                    "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                    "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                    "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
-                    "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
+                    "SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
+                    "SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
+                    "SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
+                    "SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
+                    "DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
             );
 
             StreamSource<ChangeRecord> source = mySqlSource(container);
@@ -84,26 +84,22 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             pipeline.readFrom(source)
                     .withNativeTimestamps(0)
                     .<ChangeRecord>customTransform("filter_timestamps", filterTimestampsProcessorSupplier())
-                    .groupingKey(record -> (Integer) record.key().toMap().get("id"))
-                    .mapStateful(
-                            LongAccumulator::new,
-                            (accumulator, customerId, record) -> {
-                                long count = accumulator.get();
-                                accumulator.add(1);
-                                Operation operation = record.operation();
-                                RecordPart value = record.value();
-                                Customer customer = value.toObject(Customer.class);
-                                return entry(customerId + "/" + count, operation + ":" + customer);
-                            })
-                    .setLocalParallelism(1)
-                    .writeTo(Sinks.map("results"));
+                    .filter(record -> record.operation() != UNSPECIFIED)
+                    .map(record -> {
+                        Operation operation = record.operation();
+                        RecordPart value = record.value();
+                        Customer customer = value.toObject(Customer.class);
+                        return operation + ":" + customer;
+                    })
+                    .writeTo(Sinks.list("results"));
+            pipeline.setPreserveOrder(true);
 
             // when
             HazelcastInstance hz = createHazelcastInstances(2)[0];
             Job job = hz.getJet().newJob(pipeline);
 
             //then
-            assertEqualsEventually(() -> hz.getMap("results").size(), 4);
+            assertEqualsEventually(() -> hz.getList("results").size(), 4);
 
             //when
             try (Connection connection = getMySqlConnection(container.withDatabaseName("inventory").getJdbcUrl(),
@@ -116,8 +112,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             }
 
             //then
+            String expected = String.join("\n", expectedRecords);
             try {
-                assertEqualsEventually(() -> mapResultsToSortedList(hz.getMap("results")), expectedRecords);
+                assertEqualsEventually(() -> String.join("\n", hz.getList("results")), expected);
             } finally {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);
@@ -129,7 +126,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     private StreamSource<ChangeRecord> mySqlSource(MySQLContainer<?> container) {
         return DebeziumCdcSources.debezium("mysql",
                         MySqlConnector.class)
-                        .setProperty("include.schema.changes", "false")
+                        .setProperty("include.schema.changes", "true")
                         .setProperty("database.hostname", container.getContainerIpAddress())
                         .setProperty("database.port", Integer.toString(container.getMappedPort(MYSQL_PORT)))
                         .setProperty("database.user", "debezium")
@@ -238,13 +235,13 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
             // given
             List<String> expectedRecords = Arrays.asList(
-                    "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                    "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                    "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                    "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
-                    "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
-                    "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
+                    "SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
+                    "SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
+                    "SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
+                    "SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
+                    "INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
+                    "DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
             );
 
             StreamSource<ChangeRecord> source = DebeziumCdcSources.debezium("postgres",
@@ -261,27 +258,24 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             Pipeline pipeline = Pipeline.create();
             pipeline.readFrom(source)
                     .withNativeTimestamps(0)
+                    .filter(record -> record.operation() != UNSPECIFIED)
                     .<ChangeRecord>customTransform("filter_timestamps", filterTimestampsProcessorSupplier())
-                    .groupingKey(record -> (Integer) record.key().toMap().get("id"))
-                    .mapStateful(
-                            LongAccumulator::new,
-                            (accumulator, customerId, record) -> {
-                                long count = accumulator.get();
-                                accumulator.add(1);
-                                Operation operation = record.operation();
-                                RecordPart value = record.value();
-                                Customer customer = value.toObject(Customer.class);
-                                return entry(customerId + "/" + count, operation + ":" + customer);
-                            })
+                    .map(record -> {
+                        Operation operation = record.operation();
+                        RecordPart value = record.value();
+                        Customer customer = value.toObject(Customer.class);
+                        return operation + ":" + customer;
+                    })
                     .setLocalParallelism(1)
-                    .writeTo(Sinks.map("results"));
+                    .writeTo(Sinks.list("results"));
 
+            pipeline.setPreserveOrder(true);
             // when
             HazelcastInstance hz = createHazelcastInstances(2)[0];
             Job job = hz.getJet().newJob(pipeline);
 
             //then
-            assertEqualsEventually(() -> hz.getMap("results").size(), 4);
+            assertEqualsEventually(() -> hz.getList("results").size(), 4);
 
             //when
             try (Connection connection = getPostgreSqlConnection(container.getJdbcUrl(), container.getUsername(),
@@ -295,8 +289,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             }
 
             //then
+            String expected = String.join("\n", expectedRecords);
             try {
-                assertEqualsEventually(() -> mapResultsToSortedList(hz.getMap("results")), expectedRecords);
+                assertEqualsEventually(() -> String.join("\n", hz.getList("results")), expected);
             } finally {
                 job.cancel();
                 assertJobStatusEventually(job, JobStatus.FAILED);


### PR DESCRIPTION
By default, we disable this option in MySQL/PostgreSQL connector, but user still may use generic connector or other connector class. In that cases, our code was producing errors, because change schema connect records don't have before and after.

Backport of #22444
Fixes #22438

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
