### PR TITLE
Fix NPE in ClientReconnectTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientReconnectTest extends ClientTestSupport {
 


### PR DESCRIPTION
The client proxy is set to ```null``` in method ```HazelcastClient#shutdown```:
```java
    public static void shutdown(String instanceName) {
        InstanceFuture<HazelcastClientProxy> future = CLIENTS.remove(instanceName);
        if (future == null || !future.isSet()) {
            return;
        }

        HazelcastClientProxy proxy = future.get();
        HazelcastClientInstanceImpl client = proxy.client;
        if (client == null) {
            return;
        }
        proxy.client = null;
        try {
            client.shutdown();
        } catch (Throwable ignored) {
            EmptyStatement.ignore(ignored);
        } finally {
            OutOfMemoryErrorDispatcher.deregisterClient(client);
        }
    }
```

That method is static, so if we have multiple tests running at the same time we have a race. One instance of JUnit test can clear proxy field, second one may still use it. 

Fixes: https://github.com/hazelcast/hazelcast/issues/22516

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible