### PR TITLE
Update protobuf to 3.19.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <picocli.version>4.6.3</picocli.version>
         <postgresql.version>42.4.2</postgresql.version>
         <prometheus.version>0.17.1</prometheus.version>
-        <protobuf.version>3.19.4</protobuf.version>
+        <protobuf.version>3.19.6</protobuf.version>
         <scala.version>2.13</scala.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>4.3.0.RELEASE</spring.version>


### PR DESCRIPTION
Partially fixes #22541 for 5.2.0

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

Stable branches should to receive an update to latest protobuf, not only latest patch, so no direct backports for this PR.