### PR TITLE
Start k8s sts monitor only when tracker enabled [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -98,7 +98,7 @@ class KubernetesClient {
         }
         this.apiProvider =  buildKubernetesApiUrlProvider();
         this.stsName = extractStsName();
-        this.stsMonitorThread = clusterTopologyIntentTracker != null
+        this.stsMonitorThread = (clusterTopologyIntentTracker != null && clusterTopologyIntentTracker.isEnabled())
                 ? new Thread(new StsMonitor(), "hz-k8s-sts-monitor") : null;
     }
 

--- a/kubernetes-rbac.yaml
+++ b/kubernetes-rbac.yaml
@@ -5,14 +5,23 @@ metadata:
 rules:
   - apiGroups:
       - ""
+      # Access to apps API is only required to support automatic cluster state management
+      # when persistence (hot-restart) is enabled.
+      - apps
     resources:
       - endpoints
       - pods
       - nodes
       - services
+      # Access to statefulsets resource is only required to support automatic cluster state management
+      # when persistence (hot-restart) is enabled.
+      - statefulsets
     verbs:
       - get
       - list
+      # Watching resources is only required to support automatic cluster state management
+      # when persistence (hot-restart) is enabled.
+      - watch
   - apiGroups:
       - "discovery.k8s.io"
     resources:


### PR DESCRIPTION
The kubernetes statefulset monitor thread should be only started when clusterTopologyIntentTracker is not null and is enabled. Fixes #22538

Also update kubernetes-rbac.yaml, adding rules to allow access for watching statefulsets which is required when using Hazelcast EE with persistence enabled for automatic cluster state management.

(cherry picked from commit f84956f636957131e0d86a98535669a78bc1bdf8)
1:1 clean backport of https://github.com/hazelcast/hazelcast/pull/22539
