### PR TITLE
Fix spelling error in HazelcastCacheMananger Javadoc

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.springframework.util.Assert.isTrue;
 
 /**
- * Sprint related {@link HazelcastCacheManager} implementation for Hazelcast.
+ * Spring related {@link HazelcastCacheManager} implementation for Hazelcast.
  */
 @SuppressWarnings("WeakerAccess")
 public class HazelcastCacheManager implements CacheManager {


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Fix spelling error in the class Javadoc for `HazelcastCacheManager`, changing "Sprint" to "Spring".

I did not file an issue ticket.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
