### PR TITLE
Fix NPE [HZ-1640] 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideOpSteps.java
@@ -133,13 +133,12 @@ public enum PartitionWideOpSteps implements Step<State> {
             // state from main State object
             List<State> toStore = state.getToStore();
             List<State> toRemove = state.getToRemove();
-            MapEntries responses = state.getMapEntries();
 
             EntryEventType eventType = singleKeyState.getOperator().getEventType();
             if (eventType == null) {
                 Data result = singleKeyState.getOperator().getResult();
                 if (result != null) {
-                    responses.add(singleKeyState.getKey(), result);
+                    ((MapEntries) state.getResult()).add(singleKeyState.getKey(), result);
                 }
             } else {
                 switch (eventType) {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/22570 

**Fix:**
((MapEntries) state.getResult()) must be the correct object to collect responses. Response object collection was done over responses object mistakenly.