### PR TITLE
Handle null in creation of KubernetesDiscoveryStrategy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -83,8 +83,11 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
 
     public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
                                                   Map<String, Comparable> properties) {
-        ClusterTopologyIntentTracker tracker = (ClusterTopologyIntentTracker) discoveryNode.getProperties()
-                .get(DISCOVERY_PROPERTY_CLUSTER_TOPOLOGY_INTENT_TRACKER);
+        ClusterTopologyIntentTracker tracker = null;
+        if (discoveryNode != null) {
+            tracker = (ClusterTopologyIntentTracker) discoveryNode.getProperties()
+                    .get(DISCOVERY_PROPERTY_CLUSTER_TOPOLOGY_INTENT_TRACKER);
+        }
         return new HazelcastKubernetesDiscoveryStrategy(logger, properties, tracker);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactoryTest.java
@@ -66,16 +66,12 @@ public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
 
     @Test
     public void createDiscoveryStrategy() {
-        HashMap<String, Comparable> properties = new HashMap<>();
-        properties.put(KubernetesProperties.KUBERNETES_API_TOKEN.key(), API_TOKEN);
-        properties.put(KubernetesProperties.KUBERNETES_CA_CERTIFICATE.key(), CA_CERTIFICATE);
-        properties.put(String.valueOf(KubernetesProperties.SERVICE_PORT), 333);
-        properties.put(KubernetesProperties.NAMESPACE.key(), "default");
-        HazelcastKubernetesDiscoveryStrategyFactory factory = new HazelcastKubernetesDiscoveryStrategyFactory();
-        DiscoveryStrategy strategy = factory.newDiscoveryStrategy(mock(DiscoveryNode.class), LOGGER, properties);
-        assertTrue(strategy instanceof HazelcastKubernetesDiscoveryStrategy);
-        strategy.start();
-        strategy.destroy();
+        testCreateDiscoveryStrategy(mock(DiscoveryNode.class));
+    }
+
+    @Test
+    public void createDiscoveryStrategy_whenDiscoveryNodeIsNull() {
+        testCreateDiscoveryStrategy(null);
     }
 
     @Test
@@ -87,5 +83,18 @@ public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
         // when & then
         assertTrue(factory.tokenFileExists());
         assertEquals(DiscoveryStrategyLevel.PLATFORM, factory.discoveryStrategyLevel());
+    }
+
+    private void testCreateDiscoveryStrategy(DiscoveryNode node) {
+        HashMap<String, Comparable> properties = new HashMap<>();
+        properties.put(KubernetesProperties.KUBERNETES_API_TOKEN.key(), API_TOKEN);
+        properties.put(KubernetesProperties.KUBERNETES_CA_CERTIFICATE.key(), CA_CERTIFICATE);
+        properties.put(String.valueOf(KubernetesProperties.SERVICE_PORT), 333);
+        properties.put(KubernetesProperties.NAMESPACE.key(), "default");
+        HazelcastKubernetesDiscoveryStrategyFactory factory = new HazelcastKubernetesDiscoveryStrategyFactory();
+        DiscoveryStrategy strategy = factory.newDiscoveryStrategy(node, LOGGER, properties);
+        assertTrue(strategy instanceof HazelcastKubernetesDiscoveryStrategy);
+        strategy.start();
+        strategy.destroy();
     }
 }


### PR DESCRIPTION
When creating new `HazelcastKubernetesDiscoveryStrategy`, `DiscoveryNode`
argument can be `null`.
Fixes NPE when Kubernetes discovery strategy is instantiated from client side.

Backport of https://github.com/hazelcast/hazelcast/pull/22568 to 5.2.z branch
Fixes https://github.com/hazelcast/hazelcast/issues/22569 on 5.2.z