### PR TITLE
Fix assumption for skipping Hadoop tests on some IBM Java versions

### DIFF
--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
@@ -33,10 +33,10 @@ public abstract class HadoopTestSupport extends SimpleTestInClusterSupport {
             // line and follow instructions here: https://stackoverflow.com/a/35652866/952135
             assumeThatNoWindowsOS();
 
-            // Tests will fail on IBM JDK17 with error:
+            // Tests might fail on some IBM JDKs with error:
             // No LoginModule found for com.ibm.security.auth.module.JAASLoginModule
             // see https://github.com/hazelcast/hazelcast/issues/20754
-            assumeThatNotIBMJDK17();
+            assumeHadoopSupportsIbmPlatform();
         }
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlHadoopTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlHadoopTest.java
@@ -57,10 +57,10 @@ public class SqlHadoopTest extends SqlTestSupport {
     public static void setUpClass() throws Exception {
         assumeThatNoWindowsOS();
 
-        // Tests will fail on IBM JDK17 with error:
+        // Tests might fail on some IBM JDKs with error:
         // No LoginModule found for com.ibm.security.auth.module.JAASLoginModule
         // see https://github.com/hazelcast/hazelcast/issues/20754
-        assumeThatNotIBMJDK17();
+        assumeHadoopSupportsIbmPlatform();
 
         initialize(1, null);
         sqlService = instance().getSql();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1619,8 +1619,15 @@ public abstract class HazelcastTestSupport {
         assumeFalse("Zing JDK6 used", JAVA_VERSION.startsWith("1.6.") && JVM_NAME.startsWith("Zing"));
     }
 
-    public static void assumeThatNotIBMJDK17() {
-        assumeFalse("Skipping on IBM JDK 17", JAVA_VERSION.startsWith("17.") && JAVA_VENDOR.contains("IBM"));
+    public static void assumeHadoopSupportsIbmPlatform() {
+        boolean missingIbmLoginModule = true;
+        try {
+            Class.forName("com.ibm.security.auth.module.JAASLoginModule");
+            missingIbmLoginModule = false;
+        } catch (ClassNotFoundException ignored) {
+        }
+        assumeFalse("Skipping due Hadoop authentication issues. See https://github.com/apache/hadoop/pull/4537",
+                JAVA_VENDOR.contains("IBM") && missingIbmLoginModule);
     }
 
     public static void assumeThatNoWindowsOS() {


### PR DESCRIPTION
Fixes #20754

Hadoop in the current version wrongly checks which login module should be used on some IBM Java versions. We should skip problematic configurations until Hadoop has the fix released.

See also apache/hadoop#4537