### PR TITLE
Fix race condition in cancelAllExecutions [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -110,6 +110,7 @@ public class JobExecutionService implements DynamicMetricsProvider {
     private static final long UNINITIALIZED_CONTEXT_MAX_AGE_NS = MINUTES.toNanos(5);
 
     private static final long FAILED_EXECUTION_EXPIRY_NS = SECONDS.toNanos(5);
+    private static final CompletableFuture<?>[] EMPTY_COMPLETABLE_FUTURE_ARRAY = new CompletableFuture[0];
 
     private final Object mutex = new Object();
 
@@ -240,16 +241,18 @@ public class JobExecutionService implements DynamicMetricsProvider {
      */
     @SuppressWarnings("rawtypes")
     public void cancelAllExecutions(String reason) {
+        // The ConcurrentHashMap.values() is a projection of underlying data in the map. If other thread mutates the map the
+        // collection returned by values() mutates as well. That's the reason why we use ArrayList here instead of an array, the
+        // count of items may change.
         Collection<ExecutionContext> contexts = executionContexts.values();
-        CompletableFuture[] futures = new CompletableFuture[contexts.size()];
-        int index = 0;
+        List<CompletableFuture> futures = new ArrayList<>(contexts.size());
+
         for (ExecutionContext exeCtx : contexts) {
-            LoggingUtil.logFine(logger, "Completing %s locally. Reason: %s",
-                    exeCtx.jobNameAndExecutionId(), reason);
-            futures[index++] = terminateExecution0(exeCtx, null, new CancellationException());
+            LoggingUtil.logFine(logger, "Completing %s locally. Reason: %s", exeCtx.jobNameAndExecutionId(), reason);
+            futures.add(terminateExecution0(exeCtx, null, new CancellationException()));
         }
 
-        CompletableFuture.allOf(futures).join();
+        CompletableFuture.allOf(futures.toArray(EMPTY_COMPLETABLE_FUTURE_ARRAY)).join();
     }
 
     /**
@@ -640,7 +643,7 @@ public class JobExecutionService implements DynamicMetricsProvider {
             }
 
             if (!terminateFutures.isEmpty()) {
-                CompletableFuture.allOf(terminateFutures.toArray(new CompletableFuture[0])).join();
+                CompletableFuture.allOf(terminateFutures.toArray(EMPTY_COMPLETABLE_FUTURE_ARRAY)).join();
             }
 
             // submit the query to the coordinator


### PR DESCRIPTION
Backport of #22493.

Fixes:
- https://github.com/hazelcast/hazelcast/issues/22253
- https://github.com/hazelcast/hazelcast/issues/22492
- the one failure of https://github.com/hazelcast/hazelcast/issues/21992

The race condition can be replicated with easy code:

```java
    public static void main(String[] args) throws InterruptedException {
        Map<Integer, Integer> map = new ConcurrentHashMap<>();

        Thread producer = new Thread(() -> {
            int i = 0;
            while (true) {
                if (map.size() == 0) {
                    map.put(i, i);
                    i++;
                }
            }
        });

        Thread consumer = new Thread(() -> {
            while (true) {
                Collection<Integer> values = map.values();
                Integer[] valuesArr = new Integer[values.size()];
                int i = 0;
                for (Integer value : values) {
                    valuesArr[i++] = value;
                }
                map.clear();
            }
        });

        producer.start();
        consumer.start();
        producer.join();
        consumer.join();
    }
```

The rest of the explanation is in the comment in our code.

I believe we should backport it to ```5.2.z```.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
