### PR TITLE
[CN-62] Add AWS ECS/EC2 client discovery for ECS/EC2

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
@@ -66,7 +66,7 @@ final class AwsClientConfigurator {
         // ECS Discovery
         String cluster = resolveCluster(awsConfig, metadataApi, environment);
         logEcsEnvironment(awsConfig, region, cluster);
-        return new AwsEcsClient(cluster, ecsApi, ec2Api, metadataApi, credentialsProvider);
+        return new AwsEcsClient(cluster, awsConfig, ecsApi, ec2Api, metadataApi, credentialsProvider);
     }
 
     static String resolveRegion(AwsConfig awsConfig, AwsMetadataApi metadataApi, Environment environment) {

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
@@ -55,16 +55,16 @@ final class AwsClientConfigurator {
 
         AwsCredentialsProvider credentialsProvider = new AwsCredentialsProvider(awsConfig, metadataApi, environment);
         AwsEc2Api ec2Api = createEc2Api(awsConfig, region);
+        AwsEcsApi ecsApi = createEcsApi(awsConfig, region);
 
         // EC2 Discovery
         if (explicitlyEc2Configured(awsConfig) || (!explicitlyEcsConfigured(awsConfig) && !environment.isRunningOnEcs())) {
             logEc2Environment(awsConfig, region);
-            return new AwsEc2Client(ec2Api, metadataApi, credentialsProvider);
+            return new AwsEc2Client(ec2Api, ecsApi, metadataApi, credentialsProvider, awsConfig);
         }
 
         // ECS Discovery
         String cluster = resolveCluster(awsConfig, metadataApi, environment);
-        AwsEcsApi ecsApi = createEcsApi(awsConfig, region);
         logEcsEnvironment(awsConfig, region, cluster);
         return new AwsEcsClient(cluster, ecsApi, ec2Api, metadataApi, credentialsProvider);
     }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -19,7 +19,6 @@ package com.hazelcast.aws;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.spi.utils.PortRange;
 
-import javax.management.relation.Role;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.aws;
 
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.utils.PortRange;
 
 import java.util.ArrayList;
@@ -48,13 +49,14 @@ final class AwsConfig {
     private final String cluster;
     private final String family;
     private final String serviceName;
+    private final DiscoveryMode discoveryMode;
 
     @SuppressWarnings("checkstyle:parameternumber")
     // Constructor has a lot of parameters, but it's private.
     private AwsConfig(String accessKey, String secretKey, String region, String iamRole, String hostHeader,
                       String securityGroupName, String tagKey, String tagValue, int connectionTimeoutSeconds,
                       int connectionRetries, int readTimeoutSeconds, PortRange hzPort, String cluster, String family,
-                      String serviceName) {
+                      String serviceName, DiscoveryMode discoveryMode) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.region = region;
@@ -69,6 +71,7 @@ final class AwsConfig {
         this.cluster = cluster;
         this.family = family;
         this.serviceName = serviceName;
+        this.discoveryMode = discoveryMode;
 
         validateConfig();
     }
@@ -105,26 +108,26 @@ final class AwsConfig {
     private void validateConfig() {
         if (anyOfEc2PropertiesConfigured() && anyOfEcsPropertiesConfigured()) {
             throw new InvalidConfigurationException(
-                "You have to configure either EC2 properties ('iam-role', 'security-group-name')"
-                    + " or ECS properties ('cluster', 'family', 'service-name'). You cannot define both of them"
+                    "You have to configure either EC2 properties ('iam-role', 'security-group-name')"
+                            + " or ECS properties ('cluster', 'family', 'service-name'). You cannot define both of them"
             );
         }
         if (!isNullOrEmptyAfterTrim(family) && !isNullOrEmptyAfterTrim(serviceName)) {
             throw new InvalidConfigurationException(
-                "You cannot configure ECS discovery with both 'family' and 'service-name', these filters are mutually"
-                    + " exclusive"
+                    "You cannot configure ECS discovery with both 'family' and 'service-name', these filters are mutually"
+                            + " exclusive"
             );
         }
         if (!isNullOrEmptyAfterTrim(iamRole)
                 && (!isNullOrEmptyAfterTrim(accessKey) || !isNullOrEmptyAfterTrim(secretKey))) {
             throw new InvalidConfigurationException(
-                "You cannot define both 'iam-role' and 'access-key'/'secret-key'. Choose how you want to authenticate"
-                    + " with AWS API, either with IAM Role or with hardcoded AWS Credentials");
+                    "You cannot define both 'iam-role' and 'access-key'/'secret-key'. Choose how you want to authenticate"
+                            + " with AWS API, either with IAM Role or with hardcoded AWS Credentials");
         }
         if ((isNullOrEmptyAfterTrim(accessKey) && !isNullOrEmptyAfterTrim(secretKey))
                 || (!isNullOrEmptyAfterTrim(accessKey) && isNullOrEmptyAfterTrim(secretKey))) {
             throw new InvalidConfigurationException(
-                "You have to either define both ('access-key', 'secret-key') or none of them");
+                    "You have to either define both ('access-key', 'secret-key') or none of them");
         }
     }
 
@@ -196,24 +199,28 @@ final class AwsConfig {
         return serviceName;
     }
 
+    public DiscoveryMode getDiscoveryMode() {
+        return discoveryMode;
+    }
+
     @Override
     public String toString() {
         return "AwsConfig{"
-            + "accessKey='***'"
-            + ", secretKey='***'"
-            + ", iamRole='" + iamRole + '\''
-            + ", region='" + region + '\''
-            + ", hostHeader='" + hostHeader + '\''
-            + ", securityGroupName='" + securityGroupName + '\''
-            + ", tags='" + tags + '\''
-            + ", hzPort=" + hzPort
-            + ", cluster='" + cluster + '\''
-            + ", family='" + family + '\''
-            + ", serviceName='" + serviceName + '\''
-            + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds
-            + ", connectionRetries=" + connectionRetries
-            + ", readTimeoutSeconds=" + readTimeoutSeconds
-            + '}';
+                + "accessKey='***'"
+                + ", secretKey='***'"
+                + ", iamRole='" + iamRole + '\''
+                + ", region='" + region + '\''
+                + ", hostHeader='" + hostHeader + '\''
+                + ", securityGroupName='" + securityGroupName + '\''
+                + ", tags='" + tags + '\''
+                + ", hzPort=" + hzPort
+                + ", cluster='" + cluster + '\''
+                + ", family='" + family + '\''
+                + ", serviceName='" + serviceName + '\''
+                + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds
+                + ", connectionRetries=" + connectionRetries
+                + ", readTimeoutSeconds=" + readTimeoutSeconds
+                + '}';
     }
 
     static class Builder {
@@ -233,6 +240,7 @@ final class AwsConfig {
         private String cluster;
         private String family;
         private String serviceName;
+        private DiscoveryMode discoveryMode;
 
         Builder setAccessKey(String accessKey) {
             this.accessKey = accessKey;
@@ -309,9 +317,15 @@ final class AwsConfig {
             return this;
         }
 
+        Builder setDiscoveryMode(DiscoveryMode discoveryMode) {
+            this.discoveryMode = discoveryMode;
+            return this;
+        }
+
         AwsConfig build() {
             return new AwsConfig(accessKey, secretKey, region, iamRole, hostHeader, securityGroupName, tagKey, tagValue,
-                connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, cluster, family, serviceName);
+                    connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, cluster, family, serviceName,
+                    discoveryMode);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -106,7 +106,7 @@ final class AwsConfig {
     private void validateConfig() {
         if (anyOfEc2PropertiesConfigured() && anyOfEcsPropertiesConfigured()) {
             throw new InvalidConfigurationException(
-                "You have to configure either EC2 properties ('iam-role', 'security-group-name', 'tag-key', 'tag-value')"
+                "You have to configure either EC2 properties ('iam-role', 'security-group-name')"
                     + " or ECS properties ('cluster', 'family', 'service-name'). You cannot define both of them"
             );
         }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -131,11 +131,11 @@ final class AwsConfig {
         }
     }
 
-    private boolean anyOfEc2PropertiesConfigured() {
+    boolean anyOfEc2PropertiesConfigured() {
         return !isNullOrEmptyAfterTrim(iamRole) || !isNullOrEmptyAfterTrim(securityGroupName);
     }
 
-    private boolean anyOfEcsPropertiesConfigured() {
+    boolean anyOfEcsPropertiesConfigured() {
         return !isNullOrEmptyAfterTrim(cluster) || !isNullOrEmptyAfterTrim(family) || !isNullOrEmptyAfterTrim(serviceName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -220,6 +220,7 @@ final class AwsConfig {
                 + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds
                 + ", connectionRetries=" + connectionRetries
                 + ", readTimeoutSeconds=" + readTimeoutSeconds
+                + ", discoveryMode=" + discoveryMode
                 + '}';
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -19,6 +19,7 @@ package com.hazelcast.aws;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.spi.utils.PortRange;
 
+import javax.management.relation.Role;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -129,11 +130,7 @@ final class AwsConfig {
     }
 
     private boolean anyOfEc2PropertiesConfigured() {
-        return !isNullOrEmptyAfterTrim(iamRole) || !isNullOrEmptyAfterTrim(securityGroupName) || hasTags(tags);
-    }
-
-    private boolean hasTags(List<Tag> tags) {
-        return tags != null && !tags.isEmpty();
+        return !isNullOrEmptyAfterTrim(iamRole) || !isNullOrEmptyAfterTrim(securityGroupName);
     }
 
     private boolean anyOfEcsPropertiesConfigured() {

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.exception.NoCredentialsException;
 import com.hazelcast.spi.exception.RestClientException;
 import com.hazelcast.spi.partitiongroup.PartitionGroupMetaData;
@@ -78,11 +79,15 @@ public class AwsDiscoveryStrategy
     private boolean isEmptyAddressListAlreadyLogged;
 
     AwsDiscoveryStrategy(Map<String, Comparable> properties) {
+        this(null, properties);
+    }
+
+    AwsDiscoveryStrategy(DiscoveryNode discoveryNode, Map<String, Comparable> properties) {
         super(LOGGER, properties);
-
-        AwsConfig awsConfig = createAwsConfig();
+        AwsConfig awsConfig = createAwsConfig()
+                .setDiscoveryMode(discoveryNode == null ? DiscoveryMode.Client : DiscoveryMode.Member)
+                .build();
         LOGGER.info("Using AWS discovery plugin with configuration: " + awsConfig);
-
         this.awsClient = AwsClientConfigurator.createAwsClient(awsConfig);
         this.portRange = awsConfig.getHzPort();
     }
@@ -93,27 +98,26 @@ public class AwsDiscoveryStrategy
     AwsDiscoveryStrategy(Map<String, Comparable> properties, AwsClient client) {
         super(LOGGER, properties);
         this.awsClient = client;
-        this.portRange = createAwsConfig().getHzPort();
+        this.portRange = new PortRange(getPortRange());
     }
 
-    private AwsConfig createAwsConfig() {
+    private AwsConfig.Builder createAwsConfig() {
         try {
             return AwsConfig.builder()
-                .setAccessKey(getOrNull(ACCESS_KEY)).setSecretKey(getOrNull(SECRET_KEY))
-                .setRegion(getOrDefault(REGION.getDefinition(), null))
-                .setIamRole(getOrNull(IAM_ROLE))
-                .setHostHeader(getOrNull(HOST_HEADER.getDefinition()))
-                .setSecurityGroupName(getOrNull(SECURITY_GROUP_NAME)).setTagKey(getOrNull(TAG_KEY))
-                .setTagValue(getOrNull(TAG_VALUE))
-                .setConnectionTimeoutSeconds(getOrDefault(CONNECTION_TIMEOUT_SECONDS.getDefinition(),
-                    DEFAULT_CONNECTION_TIMEOUT_SECONDS))
-                .setConnectionRetries(getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES))
-                .setReadTimeoutSeconds(getOrDefault(READ_TIMEOUT_SECONDS.getDefinition(), DEFAULT_READ_TIMEOUT_SECONDS))
-                .setHzPort(new PortRange(getPortRange()))
-                .setCluster(getOrNull(CLUSTER))
-                .setFamily(getOrNull(FAMILY))
-                .setServiceName(getOrNull(SERVICE_NAME))
-                .build();
+                    .setAccessKey(getOrNull(ACCESS_KEY)).setSecretKey(getOrNull(SECRET_KEY))
+                    .setRegion(getOrDefault(REGION.getDefinition(), null))
+                    .setIamRole(getOrNull(IAM_ROLE))
+                    .setHostHeader(getOrNull(HOST_HEADER.getDefinition()))
+                    .setSecurityGroupName(getOrNull(SECURITY_GROUP_NAME)).setTagKey(getOrNull(TAG_KEY))
+                    .setTagValue(getOrNull(TAG_VALUE))
+                    .setConnectionTimeoutSeconds(getOrDefault(CONNECTION_TIMEOUT_SECONDS.getDefinition(),
+                            DEFAULT_CONNECTION_TIMEOUT_SECONDS))
+                    .setConnectionRetries(getOrDefault(CONNECTION_RETRIES.getDefinition(), DEFAULT_CONNECTION_RETRIES))
+                    .setReadTimeoutSeconds(getOrDefault(READ_TIMEOUT_SECONDS.getDefinition(), DEFAULT_READ_TIMEOUT_SECONDS))
+                    .setHzPort(new PortRange(getPortRange()))
+                    .setCluster(getOrNull(CLUSTER))
+                    .setFamily(getOrNull(FAMILY))
+                    .setServiceName(getOrNull(SERVICE_NAME));
         } catch (IllegalArgumentException e) {
             throw new InvalidConfigurationException("AWS configuration is not valid", e);
         }
@@ -157,9 +161,9 @@ public class AwsDiscoveryStrategy
      * two resources in different zones but in the same placement group will be assumed as
      * a single group.
      *
+     * @return Placement group name if exists, empty otherwise.
      * @see AwsClient#getPlacementGroup()
      * @see AwsClient#getPlacementPartitionNumber()
-     * @return  Placement group name if exists, empty otherwise.
      */
     private Optional<String> getPlacementGroup() {
         Optional<String> placementGroup = awsClient.getPlacementGroup();

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategyFactory.java
@@ -49,7 +49,7 @@ public class AwsDiscoveryStrategyFactory
     @Override
     public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
                                                   Map<String, Comparable> properties) {
-        return new AwsDiscoveryStrategy(properties);
+        return new AwsDiscoveryStrategy(discoveryNode, properties);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
@@ -49,7 +49,9 @@ class AwsEc2Client implements AwsClient {
         AwsCredentials credentials = awsCredentialsProvider.credentials();
         Map<String, String> instances = awsEc2Api.describeInstances(credentials);
         if (instances.isEmpty()) {
-            if (!isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
+            System.out.println("~~~~~~~~~~~~~~~~~~");
+            System.out.println(awsConfig);
+            if (isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
                 throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
             }
             List<String> taskAddresses = awsEcsApi.listTaskPrivateAddresses(awsConfig.getCluster(), credentials);

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
@@ -21,6 +21,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,16 +49,26 @@ class AwsEc2Client implements AwsClient {
     @Override
     public Map<String, String> getAddresses() {
         AwsCredentials credentials = awsCredentialsProvider.credentials();
-        Map<String, String> instances = awsEc2Api.describeInstances(credentials);
+        Map<String, String> instances = Collections.emptyMap();
+        if (!awsConfig.anyOfEcsPropertiesConfigured()) {
+            instances = awsEc2Api.describeInstances(credentials);
+        }
+        if (awsConfig.anyOfEc2PropertiesConfigured()) {
+            return instances;
+        }
         if (instances.isEmpty() && DiscoveryMode.Client == awsConfig.getDiscoveryMode()) {
-            if (isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
-                throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
-            }
-            List<String> taskAddresses = awsEcsApi.listTaskPrivateAddresses(awsConfig.getCluster(), credentials);
-            LOGGER.fine(String.format("AWS ECS DescribeTasks found the following addresses: %s", taskAddresses));
-            return awsEc2Api.describeNetworkInterfaces(taskAddresses, credentials);
+            return getEcsAddresses(credentials);
         }
         return instances;
+    }
+
+    private Map<String, String> getEcsAddresses(AwsCredentials credentials) {
+        if (isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
+            throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
+        }
+        List<String> taskAddresses = awsEcsApi.listTaskPrivateAddresses(awsConfig.getCluster(), credentials);
+        LOGGER.fine(String.format("AWS ECS DescribeTasks found the following addresses: %s", taskAddresses));
+        return awsEc2Api.describeNetworkInterfaces(taskAddresses, credentials);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
@@ -16,23 +16,47 @@
 
 package com.hazelcast.aws;
 
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmptyAfterTrim;
+
 class AwsEc2Client implements AwsClient {
+
+    private static final ILogger LOGGER = Logger.getLogger(AwsEc2Client.class);
     private final AwsEc2Api awsEc2Api;
+    private final AwsEcsApi awsEcsApi;
     private final AwsMetadataApi awsMetadataApi;
     private final AwsCredentialsProvider awsCredentialsProvider;
+    private final AwsConfig awsConfig;
 
-    AwsEc2Client(AwsEc2Api awsEc2Api, AwsMetadataApi awsMetadataApi, AwsCredentialsProvider awsCredentialsProvider) {
+    AwsEc2Client(AwsEc2Api awsEc2Api, AwsEcsApi awsEcsApi, AwsMetadataApi awsMetadataApi,
+                 AwsCredentialsProvider awsCredentialsProvider, AwsConfig awsConfig) {
         this.awsEc2Api = awsEc2Api;
+        this.awsEcsApi = awsEcsApi;
         this.awsMetadataApi = awsMetadataApi;
         this.awsCredentialsProvider = awsCredentialsProvider;
+        this.awsConfig = awsConfig;
     }
 
     @Override
     public Map<String, String> getAddresses() {
-        return awsEc2Api.describeInstances(awsCredentialsProvider.credentials());
+        AwsCredentials credentials = awsCredentialsProvider.credentials();
+        Map<String, String> instances = awsEc2Api.describeInstances(credentials);
+        if (instances.isEmpty()) {
+            if (!isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
+                throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
+            }
+            List<String> taskAddresses = awsEcsApi.listTaskPrivateAddresses(awsConfig.getCluster(), credentials);
+            LOGGER.fine(String.format("AWS ECS DescribeTasks found the following addresses: %s", taskAddresses));
+            return awsEc2Api.describeNetworkInterfaces(taskAddresses, credentials);
+        }
+        return instances;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
@@ -19,6 +19,7 @@ package com.hazelcast.aws;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,7 @@ class AwsEc2Client implements AwsClient {
     public Map<String, String> getAddresses() {
         AwsCredentials credentials = awsCredentialsProvider.credentials();
         Map<String, String> instances = awsEc2Api.describeInstances(credentials);
-        if (instances.isEmpty()) {
+        if (instances.isEmpty() && DiscoveryMode.Client == awsConfig.getDiscoveryMode()) {
             if (isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
                 throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
             }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Client.java
@@ -49,8 +49,6 @@ class AwsEc2Client implements AwsClient {
         AwsCredentials credentials = awsCredentialsProvider.credentials();
         Map<String, String> instances = awsEc2Api.describeInstances(credentials);
         if (instances.isEmpty()) {
-            System.out.println("~~~~~~~~~~~~~~~~~~");
-            System.out.println(awsConfig);
             if (isNullOrEmptyAfterTrim(awsConfig.getCluster())) {
                 throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
             }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsApi.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsApi.java
@@ -73,7 +73,7 @@ class AwsEcsApi {
         return emptyList();
     }
 
-    List<String> listTasks(String cluster, AwsCredentials credentials) {
+    private List<String> listTasks(String cluster, AwsCredentials credentials) {
         String body = createBodyListTasks(cluster);
         Map<String, String> headers = createHeadersListTasks(body, credentials);
         String response = callAwsService(body, headers);

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsApi.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsApi.java
@@ -21,11 +21,14 @@ import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,6 +37,7 @@ import java.util.stream.StreamSupport;
 import static com.hazelcast.aws.AwsRequestUtils.createRestClient;
 import static com.hazelcast.aws.AwsRequestUtils.currentTimestamp;
 import static com.hazelcast.aws.AwsRequestUtils.urlFor;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -42,6 +46,8 @@ import static java.util.Collections.emptyMap;
  * @see <a href="https://docs.aws.amazon.com/AmazonECS/latest/APIReference/Welcome.html">AWS ECS API</a>
  */
 class AwsEcsApi {
+
+    private static final ILogger LOGGER = Logger.getLogger(AwsEcsApi.class);
     private final String endpoint;
     private final AwsConfig awsConfig;
     private final AwsRequestSigner requestSigner;
@@ -52,6 +58,19 @@ class AwsEcsApi {
         this.awsConfig = awsConfig;
         this.requestSigner = requestSigner;
         this.clock = clock;
+    }
+
+    List<String> listTaskPrivateAddresses(String cluster, AwsCredentials credentials) {
+        LOGGER.fine(String.format("Listing tasks from cluster: '%s'", cluster));
+        List<String> taskArns = listTasks(cluster, credentials);
+        LOGGER.fine(String.format("AWS ECS ListTasks found the following tasks: %s", taskArns));
+        if (!taskArns.isEmpty()) {
+            List<Task> tasks = describeTasks(cluster, taskArns, credentials);
+            if (!tasks.isEmpty()) {
+                return tasks.stream().map(Task::getPrivateAddress).collect(Collectors.toList());
+            }
+        }
+        return emptyList();
     }
 
     List<String> listTasks(String cluster, AwsCredentials credentials) {
@@ -79,8 +98,8 @@ class AwsEcsApi {
 
     private List<String> parseListTasks(String response) {
         return toStream(toJson(response).get("taskArns"))
-            .map(JsonValue::asString)
-            .collect(Collectors.toList());
+                .map(JsonValue::asString)
+                .collect(Collectors.toList());
     }
 
     List<Task> describeTasks(String clusterArn, List<String> taskArns, AwsCredentials credentials) {
@@ -94,9 +113,10 @@ class AwsEcsApi {
         JsonArray jsonArray = new JsonArray();
         taskArns.stream().map(Json::value).forEach(jsonArray::add);
         return new JsonObject()
-            .add("tasks", jsonArray)
-            .add("cluster", cluster)
-            .toString();
+                .add("tasks", jsonArray)
+                .add("include", new JsonArray().add("TAGS"))
+                .add("cluster", cluster)
+                .toString();
     }
 
     private Map<String, String> createHeadersDescribeTasks(String body, AwsCredentials credentials) {
@@ -105,17 +125,27 @@ class AwsEcsApi {
 
     private List<Task> parseDescribeTasks(String response) {
         return toStream(toJson(response).get("tasks"))
-            .flatMap(e -> toTask(e).map(Stream::of).orElseGet(Stream::empty))
-            .collect(Collectors.toList());
+                .filter(this::filterByTags)
+                .flatMap(e -> toTask(e).map(Stream::of).orElseGet(Stream::empty))
+                .collect(Collectors.toList());
     }
 
     private Optional<Task> toTask(JsonValue taskJson) {
         String availabilityZone = taskJson.asObject().get("availabilityZone").asString();
         return toStream(taskJson.asObject().get("containers"))
-            .flatMap(e -> toStream(e.asObject().get("networkInterfaces")))
-            .map(e -> e.asObject().get("privateIpv4Address").asString())
-            .map(e -> new Task(e, availabilityZone))
-            .findFirst();
+                .flatMap(e -> toStream(e.asObject().get("networkInterfaces")))
+                .map(e -> e.asObject().get("privateIpv4Address").asString())
+                .map(e -> new Task(e, availabilityZone))
+                .findFirst();
+    }
+
+    private static Map<String, String> parseTaskTags(JsonValue taskJson) {
+        Map<String, String> tags = new HashMap<>();
+        for (JsonValue tag : taskJson.asObject().get("tags").asArray()) {
+            JsonObject object = tag.asObject();
+            tags.put(object.getString("key", ""), object.getString("value", ""));
+        }
+        return tags;
     }
 
     private Map<String, String> createHeaders(String body, AwsCredentials credentials, String awsTargetAction) {
@@ -137,10 +167,10 @@ class AwsEcsApi {
 
     private String callAwsService(String body, Map<String, String> headers) {
         return createRestClient(urlFor(endpoint), awsConfig)
-            .withHeaders(headers)
-            .withBody(body)
-            .post()
-            .getBody();
+                .withHeaders(headers)
+                .withBody(body)
+                .post()
+                .getBody();
     }
 
     private static JsonObject toJson(String jsonString) {
@@ -149,6 +179,14 @@ class AwsEcsApi {
 
     private static Stream<JsonValue> toStream(JsonValue json) {
         return StreamSupport.stream(json.asArray().spliterator(), false);
+    }
+
+    private boolean filterByTags(JsonValue taskJson) {
+        if (!awsConfig.getTags().isEmpty()) {
+            Map<String, String> tags = parseTaskTags(taskJson);
+            return awsConfig.getTags().stream().allMatch(t -> Objects.equals(tags.get(t.getKey()), t.getValue()));
+        }
+        return true;
     }
 
     static class Task {

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
@@ -21,7 +21,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
@@ -55,7 +55,7 @@ class AwsEcsClient implements AwsClient {
         LOGGER.fine(String.format("AWS ECS DescribeTasks found the following addresses: %s", taskAddresses));
         if (!taskAddresses.isEmpty()) {
             return awsEc2Api.describeNetworkInterfaces(taskAddresses, credentials);
-        } else if (DiscoveryMode.Member != awsConfig.getDiscoveryMode()) {
+        } else if (DiscoveryMode.Client == awsConfig.getDiscoveryMode()) {
             LOGGER.fine(String.format("No tasks found in ECS cluster: '%s'. Trying AWS EC2 Discovery.", cluster));
             return awsEc2Api.describeInstances(credentials);
         }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
@@ -23,9 +23,7 @@ import com.hazelcast.logging.Logger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 
 class AwsEcsClient implements AwsClient {
@@ -36,8 +34,6 @@ class AwsEcsClient implements AwsClient {
     private final AwsMetadataApi awsMetadataApi;
     private final AwsCredentialsProvider awsCredentialsProvider;
     private final String cluster;
-
-    private boolean isNoPublicIpAlreadyLogged;
 
     AwsEcsClient(String cluster, AwsEcsApi awsEcsApi, AwsEc2Api awsEc2Api, AwsMetadataApi awsMetadataApi,
                  AwsCredentialsProvider awsCredentialsProvider) {
@@ -51,48 +47,13 @@ class AwsEcsClient implements AwsClient {
     @Override
     public Map<String, String> getAddresses() {
         AwsCredentials credentials = awsCredentialsProvider.credentials();
-
-        LOGGER.fine(String.format("Listing tasks from cluster: '%s'", cluster));
-        List<String> taskArns = awsEcsApi.listTasks(cluster, credentials);
-        LOGGER.fine(String.format("AWS ECS ListTasks found the following tasks: %s", taskArns));
-
-        if (!taskArns.isEmpty()) {
-            List<Task> tasks = awsEcsApi.describeTasks(cluster, taskArns, credentials);
-            List<String> taskAddresses = tasks.stream().map(Task::getPrivateAddress).collect(Collectors.toList());
-            LOGGER.fine(String.format("AWS ECS DescribeTasks found the following addresses: %s", taskAddresses));
-
-            return fetchPublicAddresses(taskAddresses, credentials);
-        }
-        return emptyMap();
-    }
-
-    /**
-     * Fetches private addresses for the tasks.
-     * <p>
-     * Note that this is done as best-effort and does not fail if no public addresses are found, because:
-     * <ul>
-     * <li>Task may not have public IP addresses</li>
-     * <li>Task may not have access rights to query for public addresses</li>
-     * </ul>
-     * <p>
-     * Also note that this is performed regardless of the configured use-public-ip value
-     * to make external smart clients able to work properly when possible.
-     */
-    private Map<String, String> fetchPublicAddresses(List<String> privateAddresses, AwsCredentials credentials) {
-        try {
-            return awsEc2Api.describeNetworkInterfaces(privateAddresses, credentials);
-        } catch (Exception e) {
-            LOGGER.finest(e);
-            // Log warning only once.
-            if (!isNoPublicIpAlreadyLogged) {
-                LOGGER.warning("Cannot fetch the public IPs of ECS Tasks. You won't be able to use "
-                        + "Hazelcast Smart Client from outside of this VPC.");
-                isNoPublicIpAlreadyLogged = true;
-            }
-
-            Map<String, String> map = new HashMap<>();
-            privateAddresses.forEach(k -> map.put(k, null));
-            return map;
+        List<String> taskAddresses = awsEcsApi.listTaskPrivateAddresses(cluster, credentials);
+        LOGGER.fine(String.format("AWS ECS DescribeTasks found the following addresses: %s", taskAddresses));
+        if (!taskAddresses.isEmpty()) {
+            return awsEc2Api.describeNetworkInterfaces(taskAddresses, credentials);
+        } else {
+            LOGGER.fine(String.format("No tasks found in ECS cluster: '%s'. Trying AWS EC2 Discovery.", cluster));
+            return awsEc2Api.describeInstances(credentials);
         }
     }
 
@@ -102,8 +63,8 @@ class AwsEcsClient implements AwsClient {
         AwsCredentials credentials = awsCredentialsProvider.credentials();
         List<Task> tasks = awsEcsApi.describeTasks(cluster, singletonList(taskArn), credentials);
         return tasks.stream()
-            .map(Task::getAvailabilityZone)
-            .findFirst()
-            .orElse("unknown");
+                .map(Task::getAvailabilityZone)
+                .findFirst()
+                .orElse("unknown");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.spi.discovery;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 
 import java.util.Collection;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.discovery;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 
 import java.util.Collection;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -20,15 +20,14 @@ import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.properties.ValidationException;
+import com.hazelcast.internal.util.ServiceLoader;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 import com.hazelcast.spi.discovery.NodeFilter;
-import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
-import com.hazelcast.internal.util.ServiceLoader;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,14 +50,12 @@ public class DefaultDiscoveryService
     private final DiscoveryNode discoveryNode;
     private final NodeFilter nodeFilter;
     private final Iterable<DiscoveryStrategy> discoveryStrategies;
-    private final DiscoveryMode discoveryMode;
 
     public DefaultDiscoveryService(DiscoveryServiceSettings settings) {
         this.logger = settings.getLogger();
         this.discoveryNode = settings.getDiscoveryNode();
         this.nodeFilter = getNodeFilter(settings);
         this.discoveryStrategies = loadDiscoveryStrategies(settings);
-        this.discoveryMode = settings.getDiscoveryMode();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.internal.util.ServiceLoader;
@@ -50,12 +51,14 @@ public class DefaultDiscoveryService
     private final DiscoveryNode discoveryNode;
     private final NodeFilter nodeFilter;
     private final Iterable<DiscoveryStrategy> discoveryStrategies;
+    private final DiscoveryMode discoveryMode;
 
     public DefaultDiscoveryService(DiscoveryServiceSettings settings) {
         this.logger = settings.getLogger();
         this.discoveryNode = settings.getDiscoveryNode();
         this.nodeFilter = getNodeFilter(settings);
         this.discoveryStrategies = loadDiscoveryStrategies(settings);
+        this.discoveryMode = settings.getDiscoveryMode();
     }
 
     @Override
@@ -67,7 +70,7 @@ public class DefaultDiscoveryService
 
     @Override
     public Iterable<DiscoveryNode> discoverNodes() {
-        Set<DiscoveryNode> discoveryNodes = new HashSet<DiscoveryNode>();
+        Set<DiscoveryNode> discoveryNodes = new HashSet<>();
         for (DiscoveryStrategy discoveryStrategy : discoveryStrategies) {
             Iterable<DiscoveryNode> candidates = discoveryStrategy.discoverNodes();
 
@@ -132,11 +135,11 @@ public class DefaultDiscoveryService
         ClassLoader configClassLoader = settings.getConfigClassLoader();
 
         try {
-            Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = new ArrayList<DiscoveryStrategyConfig>(
+            Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = new ArrayList<>(
                     settings.getAllDiscoveryConfigs());
             List<DiscoveryStrategyFactory> factories = collectFactories(discoveryStrategyConfigs, configClassLoader);
 
-            List<DiscoveryStrategy> discoveryStrategies = new ArrayList<DiscoveryStrategy>();
+            List<DiscoveryStrategy> discoveryStrategies = new ArrayList<>();
             for (DiscoveryStrategyConfig config : discoveryStrategyConfigs) {
                 DiscoveryStrategy discoveryStrategy = buildDiscoveryStrategy(config, factories);
                 discoveryStrategies.add(discoveryStrategy);

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceSettings.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceSettings.java
@@ -35,7 +35,7 @@ public final class DiscoveryServiceSettings {
     private ILogger logger;
     private ClassLoader configClassLoader;
     private DiscoveryConfig discoveryConfig;
-    private List<DiscoveryStrategyConfig> aliasedDiscoveryConfigs = new ArrayList<DiscoveryStrategyConfig>();
+    private List<DiscoveryStrategyConfig> aliasedDiscoveryConfigs = new ArrayList<>();
     private boolean autoDetectionEnabled;
     private DiscoveryMode discoveryMode;
 

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -247,6 +247,54 @@ public class AwsEc2ApiTest {
     }
 
     @Test
+    public void describeNetworkInterfacesException() {
+        // given
+        List<String> privateAddresses = asList("10.0.1.207", "10.0.1.82");
+
+        String requestUrl = "/?Action=DescribeNetworkInterfaces"
+                + "&Filter.1.Name=addresses.private-ip-address"
+                + "&Filter.1.Value.1=10.0.1.207"
+                + "&Filter.1.Value.2=10.0.1.82"
+                + "&Version=2016-11-15";
+
+        //language=XML
+        String response = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<DescribeNetworkInterfacesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">\n"
+                + "    <requestId>21bc9f93-2196-4107-87a3-9e5b2b3f29d9</requestId>\n"
+                + "    <networkInterfaceSet>\n"
+                + "        <item>\n"
+                + "            <availabilityZone>eu-central-1a</availabilityZone>\n"
+                + "            <privateIpAddress>10.0.1.207</privateIpAddress>\n"
+                + "            <association>\n"
+                + "                <publicIp>54.93.217.194</publicIp>\n"
+                + "            </association>\n"
+                + "        </item>\n"
+                + "        <item>\n"
+                + "            <availabilityZone>eu-central-1a</availabilityZone>\n"
+                + "            <privateIpAddress>10.0.1.82</privateIpAddress>\n"
+                + "            <association>\n"
+                + "                <publicIp>35.156.192.128</publicIp>\n"
+                + "            </association>\n"
+                + "        </item>\n"
+                + "    </networkInterfaceSet>\n"
+                + "</DescribeNetworkInterfacesResponse>";
+
+        stubFor(get(urlEqualTo(requestUrl))
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .willReturn(aResponse().withStatus(500)));
+
+        // when
+        Map<String, String> result = awsEc2Api.describeNetworkInterfaces(privateAddresses, CREDENTIALS);
+
+        // then
+        assertEquals(2, result.size());
+        assertNull(result.get("10.0.1.207"));
+        assertNull(result.get("10.0.1.82"));
+    }
+
+    @Test
     public void describeNetworkInterfacesNoPublicIp() {
         // given
         List<String> privateAddresses = asList("10.0.1.207", "10.0.1.82");

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
@@ -47,8 +47,6 @@ public class AwsEc2ClientTest {
     public void setUp() throws Exception {
         closeable = MockitoAnnotations.openMocks(this);
         AwsConfig awsConfig = AwsConfig.builder().setCluster("CLUSTER").build();
-        System.out.println("~~~~~~~~~~~~~~~~~~");
-        System.out.println(awsConfig);
         awsEc2Client = new AwsEc2Client(awsEc2Api, awsEcsApi, awsMetadataApi, awsCredentialsProvider, awsConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
@@ -17,20 +17,25 @@
 package com.hazelcast.aws;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableMap;
 import com.hazelcast.aws.AwsEcsApi.Task;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.util.StringUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -39,7 +44,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
@@ -82,39 +86,17 @@ public class AwsEcsApiTest {
     public void listTasks() {
         // given
         String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
-
-        //language=JSON
-        String requestBody = "{\n"
-                + "  \"cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\"\n"
-                + "}";
-
-        //language=JSON
-        String response = "{\n"
-                + "  \"taskArns\": [\n"
-                + "    \"arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "    \"arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-                + "  ]\n"
-                + "}";
-
-        stubFor(post("/")
-                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
-                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
-                .withHeader("Accept-Encoding", equalTo("identity"))
-                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-                .withRequestBody(equalToJson(requestBody))
-                .willReturn(aResponse().withStatus(200).withBody(response)));
+        stubListTasks(cluster, null);
+        Map<String, String> tasksArnToIp = ImmutableMap.of(
+                "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a", "10.0.1.16",
+                "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207", "10.0.1.219");
+        stubDescribeTasks(tasksArnToIp, cluster);
 
         // when
-        List<String> tasks = awsEcsApi.listTaskPrivateAddresses(cluster, CREDENTIALS);
+        List<String> tasksPrivateIps = awsEcsApi.listTaskPrivateAddresses(cluster, CREDENTIALS);
 
         // then
-        assertThat(tasks, hasItems(
-                        "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-                        "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
-                )
-        );
+        assertThat(tasksPrivateIps, hasItems("10.0.1.16", "10.0.1.219"));
     }
 
     @Test
@@ -126,112 +108,61 @@ public class AwsEcsApiTest {
                 .build();
         AwsEcsApi awsEcsApi = new AwsEcsApi(endpoint, awsConfig, requestSigner, CLOCK);
 
-        //language=JSON
-        String requestBody = "{\n"
-                + "  \"cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
-                + "  \"family\": \"family-name\"\n"
-                + "}";
-
-        //language=JSON
-        String response = "{\n"
-                + "  \"taskArns\": [\n"
-                + "    \"arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "    \"arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-                + "  ]\n"
-                + "}";
-
-        stubFor(post("/")
-                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
-                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
-                .withHeader("Accept-Encoding", equalTo("identity"))
-                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-                .withRequestBody(equalToJson(requestBody))
-                .willReturn(aResponse().withStatus(200).withBody(response)));
+        stubListTasks("arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster", "family-name");
+        stubDescribeTasks(ImmutableMap.of(
+                        "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a", "10.0.1.16",
+                        "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207", "10.0.1.219"),
+                cluster);
 
         // when
-        List<String> tasks = awsEcsApi.listTasks(cluster, CREDENTIALS);
+        List<String> ips = awsEcsApi.listTaskPrivateAddresses(cluster, CREDENTIALS);
 
         // then
-        assertThat(tasks, hasItems(
-                        "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-                        "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
-                )
-        );
+        assertThat(ips, hasItems("10.0.1.16", "10.0.1.219"));
+    }
+
+    @Test
+    public void listTasksFilteredByTags() {
+        // given
+        String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
+        AwsConfig awsConfig = AwsConfig.builder()
+                .setTagKey("tag-key")
+                .setTagValue("51a01bdf-d00e-487e-ab14-7645330b6207")
+                .build();
+        AwsEcsApi awsEcsApi = new AwsEcsApi(endpoint, awsConfig, requestSigner, CLOCK);
+
+        stubListTasks("arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster", null);
+        stubDescribeTasks(ImmutableMap.of(
+                        "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a", "10.0.1.16",
+                        "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207", "10.0.1.219"),
+                cluster);
+
+        // when
+        List<String> ips = awsEcsApi.listTaskPrivateAddresses(cluster, CREDENTIALS);
+
+        // then
+        assertEquals(1, ips.size());
+        assertThat(ips, hasItems("10.0.1.219"));
     }
 
     @Test
     public void describeTasks() {
         // given
         String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
-        List<String> tasks = asList(
-                "arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-                "arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
-        );
-
-        //language=JSON
-        String requestBody = "{\n"
-                + "  \"cluster\" : \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
-                + "  \"include\" : [ \"TAGS\" ],"
-                + "  \"tasks\": [\n"
-                + "    \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "    \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-                + "  ]\n"
-                + "}";
-
-        //language=JSON
-        String response = "{\n"
-                + "  \"tasks\": [\n"
-                + "    {\n"
-                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "      \"availabilityZone\": \"eu-central-1a\",\n"
-                + "      \"containers\": [\n"
-                + "        {\n"
-                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "          \"networkInterfaces\": [\n"
-                + "            {\n"
-                + "              \"privateIpv4Address\": \"10.0.1.16\"\n"
-                + "            }\n"
-                + "          ]\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    {\n"
-                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
-                + "      \"availabilityZone\": \"eu-central-1a\",\n"
-                + "      \"containers\": [\n"
-                + "        {\n"
-                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
-                + "          \"networkInterfaces\": [\n"
-                + "            {\n"
-                + "              \"privateIpv4Address\": \"10.0.1.219\"\n"
-                + "            }\n"
-                + "          ]\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  ]\n"
-                + "}";
-
-        stubFor(post("/")
-                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.DescribeTasks"))
-                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
-                .withHeader("Accept-Encoding", equalTo("identity"))
-                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-                .withRequestBody(equalToJson(requestBody))
-                .willReturn(aResponse().withStatus(200).withBody(response)));
+        Map<String, String> tasks = ImmutableMap.of(
+                "arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a", "10.0.1.16",
+                "arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207", "10.0.1.219");
+        stubDescribeTasks(tasks, cluster);
 
         // when
-        List<Task> result = awsEcsApi.describeTasks(cluster, tasks, CREDENTIALS);
+        List<Task> result = awsEcsApi.describeTasks(cluster, new ArrayList<>(tasks.keySet()), CREDENTIALS);
 
         // then
-        assertEquals("10.0.1.16", result.get(0).getPrivateAddress());
-        assertEquals("eu-central-1a", result.get(0).getAvailabilityZone());
-        assertEquals("10.0.1.219", result.get(1).getPrivateAddress());
-        assertEquals("eu-central-1a", result.get(1).getAvailabilityZone());
+        assertEquals(2, result.size());
+        assertThat(
+                result.stream().map(Task::getPrivateAddress).collect(Collectors.toList()), hasItems("10.0.1.16", "10.0.1.219"));
+        assertThat(
+                result.stream().map(Task::getAvailabilityZone).collect(Collectors.toList()), hasItems("eu-central-1a", "eu-central-1a"));
     }
 
     @Test
@@ -243,75 +174,40 @@ public class AwsEcsApiTest {
                 .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
-        Exception exception = assertThrows(Exception.class, () -> awsEcsApi.listTasks("cluster-arn", CREDENTIALS));
+        Exception exception = assertThrows(
+                Exception.class, () -> awsEcsApi.listTaskPrivateAddresses("cluster-arn", CREDENTIALS));
 
         // then
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));
         assertTrue(exception.getMessage().contains(errorMessage));
     }
 
-    private void stubDescribeTasks(List<String> tasks, String cluster) {
-        // given
-//        String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
-//        List<String> tasks = asList(
-//                "arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-//                "arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
-//        );
-
+    private void stubDescribeTasks(Map<String, String> taskArnToIp, String cluster) {
         JsonArray tasksJson = new JsonArray();
-        tasks.forEach(tasksJson::add);
+        taskArnToIp.keySet().forEach(tasksJson::add);
         String requestBody = new JsonObject()
-                .add("cluster", cluster)
-                .add("include", new JsonArray().add("TAGS"))
                 .add("tasks", tasksJson)
+                .add("include", new JsonArray().add("TAGS"))
+                .add("cluster", cluster)
                 .toString();
-        //language=JSON
-//        String requestBody = "{\n"
-//                + "  \"cluster\" : \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
-//                + "  \"include\" : [ \"TAGS\" ],"
-//                + "  \"tasks\": [\n"
-//                + "    \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-//                + "    \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-//                + "  ]\n"
-//                + "}";
 
         JsonArray responseTasks = new JsonArray();
-        String response1 = new JsonObject()
-                .add("tasks", "")
+        for (Map.Entry<String, String> task : taskArnToIp.entrySet()) {
+            responseTasks.add(new JsonObject()
+                    .add("taskArn", task.getKey())
+                    .add("availabilityZone", "eu-central-1a")
+                    .add("containers", new JsonArray().add(new JsonObject()
+                            .add("taskArn", task.getKey())
+                            .add("networkInterfaces", new JsonArray().add(new JsonObject()
+                                    .add("privateIpv4Address", task.getValue())))))
+                    .add("tags", new JsonArray().add(new JsonObject()
+                            .add("key", "tag-key")
+                            .add("value", task.getKey().substring(task.getKey().lastIndexOf("/") + 1))))
+            );
+        }
+        String responseBody = new JsonObject()
+                .add("tasks", responseTasks)
                 .toString();
-        //language=JSON
-        String response = "{\n"
-                + "  \"tasks\": [\n"
-                + "    {\n"
-                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "      \"availabilityZone\": \"eu-central-1a\",\n"
-                + "      \"containers\": [\n"
-                + "        {\n"
-                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-                + "          \"networkInterfaces\": [\n"
-                + "            {\n"
-                + "              \"privateIpv4Address\": \"10.0.1.16\"\n"
-                + "            }\n"
-                + "          ]\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    {\n"
-                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
-                + "      \"availabilityZone\": \"eu-central-1a\",\n"
-                + "      \"containers\": [\n"
-                + "        {\n"
-                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
-                + "          \"networkInterfaces\": [\n"
-                + "            {\n"
-                + "              \"privateIpv4Address\": \"10.0.1.219\"\n"
-                + "            }\n"
-                + "          ]\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  ]\n"
-                + "}";
 
         stubFor(post("/")
                 .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
@@ -321,6 +217,30 @@ public class AwsEcsApiTest {
                 .withHeader("Accept-Encoding", equalTo("identity"))
                 .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
                 .withRequestBody(equalToJson(requestBody))
+                .willReturn(aResponse().withStatus(200).withBody(responseBody)));
+    }
+
+    private void stubListTasks(String cluster, String familyName) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.add("cluster", cluster);
+        if (!StringUtil.isNullOrEmptyAfterTrim(familyName)) {
+            requestBody.add("family", familyName);
+        }
+
+        String response = new JsonObject()
+                .add("taskArns", new JsonArray()
+                        .add("arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a")
+                        .add("arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"))
+                .toString();
+
+        stubFor(post("/")
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
+                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
+                .withHeader("Accept-Encoding", equalTo("identity"))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .withRequestBody(equalToJson(requestBody.toString()))
                 .willReturn(aResponse().withStatus(200).withBody(response)));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.aws;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.hazelcast.aws.AwsEcsApi.Task;
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,10 +54,10 @@ public class AwsEcsApiTest {
     private static final String AUTHORIZATION_HEADER = "authorization-header";
     private static final String TOKEN = "IQoJb3JpZ2luX2VjEFIaDGV1LWNlbnRyYWwtMSJGM==";
     private static final AwsCredentials CREDENTIALS = AwsCredentials.builder()
-        .setAccessKey("AKIDEXAMPLE")
-        .setSecretKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
-        .setToken(TOKEN)
-        .build();
+            .setAccessKey("AKIDEXAMPLE")
+            .setSecretKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+            .setToken(TOKEN)
+            .build();
 
     @Mock
     private AwsRequestSigner requestSigner;
@@ -83,35 +85,35 @@ public class AwsEcsApiTest {
 
         //language=JSON
         String requestBody = "{\n"
-            + "  \"cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\"\n"
-            + "}";
+                + "  \"cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\"\n"
+                + "}";
 
         //language=JSON
         String response = "{\n"
-            + "  \"taskArns\": [\n"
-            + "    \"arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-            + "    \"arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-            + "  ]\n"
-            + "}";
+                + "  \"taskArns\": [\n"
+                + "    \"arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "    \"arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
+                + "  ]\n"
+                + "}";
 
         stubFor(post("/")
-            .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-            .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-            .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
-            .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
-            .withHeader("Accept-Encoding", equalTo("identity"))
-            .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-            .withRequestBody(equalToJson(requestBody))
-            .willReturn(aResponse().withStatus(200).withBody(response)));
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
+                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
+                .withHeader("Accept-Encoding", equalTo("identity"))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .withRequestBody(equalToJson(requestBody))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
 
         // when
-        List<String> tasks = awsEcsApi.listTasks(cluster, CREDENTIALS);
+        List<String> tasks = awsEcsApi.listTaskPrivateAddresses(cluster, CREDENTIALS);
 
         // then
         assertThat(tasks, hasItems(
-            "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-            "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
-            )
+                        "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
+                        "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
+                )
         );
     }
 
@@ -120,42 +122,42 @@ public class AwsEcsApiTest {
         // given
         String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
         AwsConfig awsConfig = AwsConfig.builder()
-            .setFamily("family-name")
-            .build();
+                .setFamily("family-name")
+                .build();
         AwsEcsApi awsEcsApi = new AwsEcsApi(endpoint, awsConfig, requestSigner, CLOCK);
 
         //language=JSON
         String requestBody = "{\n"
-            + "  \"cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
-            + "  \"family\": \"family-name\"\n"
-            + "}";
+                + "  \"cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
+                + "  \"family\": \"family-name\"\n"
+                + "}";
 
         //language=JSON
         String response = "{\n"
-            + "  \"taskArns\": [\n"
-            + "    \"arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-            + "    \"arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-            + "  ]\n"
-            + "}";
+                + "  \"taskArns\": [\n"
+                + "    \"arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "    \"arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
+                + "  ]\n"
+                + "}";
 
         stubFor(post("/")
-            .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-            .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-            .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
-            .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
-            .withHeader("Accept-Encoding", equalTo("identity"))
-            .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-            .withRequestBody(equalToJson(requestBody))
-            .willReturn(aResponse().withStatus(200).withBody(response)));
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.ListTasks"))
+                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
+                .withHeader("Accept-Encoding", equalTo("identity"))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .withRequestBody(equalToJson(requestBody))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
 
         // when
         List<String> tasks = awsEcsApi.listTasks(cluster, CREDENTIALS);
 
         // then
         assertThat(tasks, hasItems(
-            "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-            "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
-            )
+                        "arn:aws:ecs:us-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
+                        "arn:aws:ecs:us-east-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
+                )
         );
     }
 
@@ -164,62 +166,63 @@ public class AwsEcsApiTest {
         // given
         String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
         List<String> tasks = asList(
-            "arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-            "arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
+                "arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
+                "arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
         );
 
         //language=JSON
         String requestBody = "{\n"
-            + "  \"cluster\" : \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
-            + "  \"tasks\": [\n"
-            + "    \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-            + "    \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
-            + "  ]\n"
-            + "}";
+                + "  \"cluster\" : \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
+                + "  \"include\" : [ \"TAGS\" ],"
+                + "  \"tasks\": [\n"
+                + "    \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "    \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
+                + "  ]\n"
+                + "}";
 
         //language=JSON
         String response = "{\n"
-            + "  \"tasks\": [\n"
-            + "    {\n"
-            + "      \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-            + "      \"availabilityZone\": \"eu-central-1a\",\n"
-            + "      \"containers\": [\n"
-            + "        {\n"
-            + "          \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
-            + "          \"networkInterfaces\": [\n"
-            + "            {\n"
-            + "              \"privateIpv4Address\": \"10.0.1.16\"\n"
-            + "            }\n"
-            + "          ]\n"
-            + "        }\n"
-            + "      ]\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
-            + "      \"availabilityZone\": \"eu-central-1a\",\n"
-            + "      \"containers\": [\n"
-            + "        {\n"
-            + "          \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
-            + "          \"networkInterfaces\": [\n"
-            + "            {\n"
-            + "              \"privateIpv4Address\": \"10.0.1.219\"\n"
-            + "            }\n"
-            + "          ]\n"
-            + "        }\n"
-            + "      ]\n"
-            + "    }\n"
-            + "  ]\n"
-            + "}";
+                + "  \"tasks\": [\n"
+                + "    {\n"
+                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "      \"availabilityZone\": \"eu-central-1a\",\n"
+                + "      \"containers\": [\n"
+                + "        {\n"
+                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "          \"networkInterfaces\": [\n"
+                + "            {\n"
+                + "              \"privateIpv4Address\": \"10.0.1.16\"\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
+                + "      \"availabilityZone\": \"eu-central-1a\",\n"
+                + "      \"containers\": [\n"
+                + "        {\n"
+                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
+                + "          \"networkInterfaces\": [\n"
+                + "            {\n"
+                + "              \"privateIpv4Address\": \"10.0.1.219\"\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
 
         stubFor(post("/")
-            .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-            .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-            .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.DescribeTasks"))
-            .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
-            .withHeader("Accept-Encoding", equalTo("identity"))
-            .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-            .withRequestBody(equalToJson(requestBody))
-            .willReturn(aResponse().withStatus(200).withBody(response)));
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.DescribeTasks"))
+                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
+                .withHeader("Accept-Encoding", equalTo("identity"))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .withRequestBody(equalToJson(requestBody))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
 
         // when
         List<Task> result = awsEcsApi.describeTasks(cluster, tasks, CREDENTIALS);
@@ -237,7 +240,7 @@ public class AwsEcsApiTest {
         int errorCode = 401;
         String errorMessage = "Error message retrieved from AWS";
         stubFor(post(urlMatching("/.*"))
-            .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
+                .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
         Exception exception = assertThrows(Exception.class, () -> awsEcsApi.listTasks("cluster-arn", CREDENTIALS));
@@ -245,5 +248,79 @@ public class AwsEcsApiTest {
         // then
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));
         assertTrue(exception.getMessage().contains(errorMessage));
+    }
+
+    private void stubDescribeTasks(List<String> tasks, String cluster) {
+        // given
+//        String cluster = "arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster";
+//        List<String> tasks = asList(
+//                "arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
+//                "arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207"
+//        );
+
+        JsonArray tasksJson = new JsonArray();
+        tasks.forEach(tasksJson::add);
+        String requestBody = new JsonObject()
+                .add("cluster", cluster)
+                .add("include", new JsonArray().add("TAGS"))
+                .add("tasks", tasksJson)
+                .toString();
+        //language=JSON
+//        String requestBody = "{\n"
+//                + "  \"cluster\" : \"arn:aws:ecs:eu-central-1:665466731577:cluster/rafal-test-cluster\",\n"
+//                + "  \"include\" : [ \"TAGS\" ],"
+//                + "  \"tasks\": [\n"
+//                + "    \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+//                + "    \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\"\n"
+//                + "  ]\n"
+//                + "}";
+
+        JsonArray responseTasks = new JsonArray();
+        String response1 = new JsonObject()
+                .add("tasks", "")
+                .toString();
+        //language=JSON
+        String response = "{\n"
+                + "  \"tasks\": [\n"
+                + "    {\n"
+                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "      \"availabilityZone\": \"eu-central-1a\",\n"
+                + "      \"containers\": [\n"
+                + "        {\n"
+                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1-east-1:012345678910:task/0b69d5c0-d655-4695-98cd-5d2d526d9d5a\",\n"
+                + "          \"networkInterfaces\": [\n"
+                + "            {\n"
+                + "              \"privateIpv4Address\": \"10.0.1.16\"\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
+                + "      \"availabilityZone\": \"eu-central-1a\",\n"
+                + "      \"containers\": [\n"
+                + "        {\n"
+                + "          \"taskArn\": \"arn:aws:ecs:eu-central-1:012345678910:task/51a01bdf-d00e-487e-ab14-7645330b6207\",\n"
+                + "          \"networkInterfaces\": [\n"
+                + "            {\n"
+                + "              \"privateIpv4Address\": \"10.0.1.219\"\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+
+        stubFor(post("/")
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Target", equalTo("AmazonEC2ContainerServiceV20141113.DescribeTasks"))
+                .withHeader("Content-Type", equalTo("application/x-amz-json-1.1"))
+                .withHeader("Accept-Encoding", equalTo("identity"))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .withRequestBody(equalToJson(requestBody))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -39,7 +39,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwsEcsClientTest {

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -63,12 +63,13 @@ public class AwsEcsClientTest {
     @Before
     public void setUp() {
         EcsMetadata ecsMetadata = mock(EcsMetadata.class);
+        AwsConfig awsConfig = AwsConfig.builder().build();
         given(ecsMetadata.getTaskArn()).willReturn(TASK_ARN);
         given(ecsMetadata.getClusterArn()).willReturn(CLUSTER);
         given(awsMetadataApi.metadataEcs()).willReturn(ecsMetadata);
         given(awsCredentialsProvider.credentials()).willReturn(CREDENTIALS);
 
-        awsEcsClient = new AwsEcsClient(CLUSTER, awsEcsApi, awsEc2Api, awsMetadataApi, awsCredentialsProvider);
+        awsEcsClient = new AwsEcsClient(CLUSTER, awsConfig, awsEcsApi, awsEc2Api, awsMetadataApi, awsCredentialsProvider);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -73,14 +73,10 @@ public class AwsEcsClientTest {
 
     @Test
     public void getAddressesWithAwsConfig() {
-        // TODO CN-62 test
         // given
-        List<String> taskArns = singletonList("task-arn");
         List<String> privateIps = singletonList("123.12.1.0");
-        List<Task> tasks = singletonList(new Task("123.12.1.0", null));
         Map<String, String> expectedResult = singletonMap("123.12.1.0", "1.4.6.2");
         given(awsEcsApi.listTaskPrivateAddresses(CLUSTER, CREDENTIALS)).willReturn(privateIps);
-//        given(awsEcsApi.describeTasks(CLUSTER, taskArns, CREDENTIALS)).willReturn(tasks);
         given(awsEc2Api.describeNetworkInterfaces(privateIps, CREDENTIALS)).willReturn(expectedResult);
 
         // when
@@ -92,15 +88,10 @@ public class AwsEcsClientTest {
 
     @Test
     public void getAddressesNoPublicAddresses() {
-        // TODO CN-62 test
         // given
-        List<String> taskArns = singletonList("task-arn");
         List<String> privateIps = singletonList("123.12.1.0");
         Map<String, String> privateToPublicIps = singletonMap("123.12.1.0", null);
-        List<Task> tasks = singletonList(new Task("123.12.1.0", null));
         given(awsEcsApi.listTaskPrivateAddresses(CLUSTER, CREDENTIALS)).willReturn(privateIps);
-//        given(awsEcsApi.describeTasks(CLUSTER, taskArns, CREDENTIALS)).willReturn(tasks);
-//        given(awsEc2Api.describeNetworkInterfaces(privateIps, CREDENTIALS)).willThrow(new RuntimeException());
         given(awsEc2Api.describeNetworkInterfaces(privateIps, CREDENTIALS)).willReturn(privateToPublicIps);
 
         // when


### PR DESCRIPTION
Add discovery for ECS client to ECS members and EC2 client to ECS members.

Backport of: #22411 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers, if possible
- [x] Send backports/forwardports if a fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

