### PR TITLE
Fix returning "null" string instead of null value.

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/Operation.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/Operation.java
@@ -66,7 +66,7 @@ public enum Operation {
      * Returns the Debezium operation code as String.
      */
     public String code() {
-        return String.valueOf(id);
+        return id == null ? null : String.valueOf(id);
     }
 
     /**

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -435,8 +435,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
         try (MySQLContainer<?> container = mySqlContainer()) {
             container.start();
 
-            HazelcastInstance[] hazelcastInstances = createHazelcastInstances(1);
-            HazelcastInstance hz = hazelcastInstances[0];
+            HazelcastInstance hz = createHazelcastInstance();
             IList<ChangeRecord> changeRecordList = hz.getList("nullIsNotValidOperationId");
 
             StreamSource<ChangeRecord> source = mySqlSource(container);

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.cdc;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hazelcast.collection.IList;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
@@ -426,6 +427,35 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             hz.getJet().newJob(pipeline);
 
             assertTrueEventually(() -> assertThat(hz.getList("notFailWhenOldValueNotPresent")).isNotEmpty());
+        }
+    }
+
+    @Test
+    public void nullIsNotValidOperationId() {
+        try (MySQLContainer<?> container = mySqlContainer()) {
+            container.start();
+
+            HazelcastInstance[] hazelcastInstances = createHazelcastInstances(1);
+            HazelcastInstance hz = hazelcastInstances[0];
+            IList<ChangeRecord> changeRecordList = hz.getList("nullIsNotValidOperationId");
+
+            StreamSource<ChangeRecord> source = mySqlSource(container);
+            Pipeline p = Pipeline.create();
+            p
+                    .readFrom(source)
+                    .withIngestionTimestamps()
+                    .setLocalParallelism(1)
+                    .writeTo(Sinks.list(changeRecordList));
+
+            Job job = hz.getJet().newJob(p);
+
+            assertJobStatusEventually(job, JobStatus.RUNNING);
+
+            assertTrueEventually(() -> {
+                logger.info(String.format("List size: %s", changeRecordList.size()));
+                assertThat(changeRecordList).as("nullIsNotValidOperationId").isNotEmpty();
+                logger.info(changeRecordList.get(0).toString()); // <-- 'null' is not a valid operation id
+            });
         }
     }
 


### PR DESCRIPTION
Later in Lookup we treat that null means Operation#UNSPECIFIED, but value is serialized as string "null", so we get exception

Fixes #22587

Breaking changes (list specific methods/types/messages):
* serialized form - ChangeRecord#operation can now be null instead of string "null"

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
