### PR TITLE
Do not load old value for map set when map-store offload is enabled [HZ-1671] 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
@@ -38,6 +38,10 @@ public enum PutOpSteps implements Step<State> {
 
         @Override
         public Step nextStep(State state) {
+            if (!state.getStaticParams().isLoad()) {
+                return PutOpSteps.PROCESS;
+            }
+
             return state.getOldValue() == null
                     ? PutOpSteps.LOAD : PutOpSteps.PROCESS;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreOffloadedOperationMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreOffloadedOperationMetricsTest.java
@@ -79,6 +79,13 @@ public class MapStoreOffloadedOperationMetricsTest extends HazelcastTestSupport 
                 sleepMillis(100);
                 return randomString();
             }
+
+            @Override
+            public void store(String key, String value) {
+                // mimic a slow store operation
+                sleepMillis(100);
+                super.store(key, value);
+            }
         });
         config.getMapConfig(MAP_WITH_MAP_STORE_NAME)
                 .setMapStoreConfig(mapStoreConfig);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -147,6 +147,34 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test
+    public void map_set_does_not_load_old_value_when_offload_enabled() {
+        final AtomicBoolean loadCalled = new AtomicBoolean(false);
+
+        Config config = getConfig();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig
+                .setEnabled(true)
+                .setOffload(true)
+                .setImplementation(new MapStoreAdapter<String, String>() {
+                    @Override
+                    public String load(String key) {
+                        loadCalled.set(true);
+                        return null;
+                    }
+                });
+
+        String mapName = "default";
+        config.getMapConfig(mapName)
+                .setMapStoreConfig(mapStoreConfig);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<String, String> map = instance.getMap(mapName);
+
+        map.set("key", "value");
+        assertFalse(loadCalled.get());
+    }
+
+    @Test
     public void testNullValuesFromMapLoaderAreNotInsertedIntoMap() {
         Config config = newConfig(new NullLoader());
         HazelcastInstance node = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -147,14 +147,13 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void map_set_does_not_load_old_value_when_offload_enabled() {
+    public void map_set_does_not_trigger_load_of_old_value() {
         final AtomicBoolean loadCalled = new AtomicBoolean(false);
 
         Config config = getConfig();
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig
                 .setEnabled(true)
-                .setOffload(true)
                 .setImplementation(new MapStoreAdapter<String, String>() {
                     @Override
                     public String load(String key) {


### PR DESCRIPTION
Related with #22601

Backport of #22602