### PR TITLE
Reset write behind store on clear [HZ-1671] 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ClearOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ClearOpSteps.java
@@ -78,6 +78,7 @@ public enum ClearOpSteps implements Step<State> {
             DefaultRecordStore recordStore = ((DefaultRecordStore) state.getRecordStore());
             Collection<Data> keys = state.getKeys();
             recordStore.getMapDataStore().removeAll(keys);
+            recordStore.getMapDataStore().reset();
         }
 
         @Override


### PR DESCRIPTION
closes #22601

Added missing reset to align behavior with not-offloaded clear op.